### PR TITLE
fix(scheduler): live-reload jobs.json, deliver cron results, configurable shell

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -466,21 +466,69 @@ def serve(
             cron_stop.set()
 
 
+def _record_cron_run(runs_log: Path, job: Any, answer: str, webhook_url: str | None) -> None:
+    """Persist a per-run record (delivery confirmation) and optionally deliver it.
+
+    The daemon otherwise only logs a cron's answer; this writes a structured line
+    to ``cron_runs.jsonl`` so an external watchdog can prove a must-fire job ran,
+    and — when ``CHIMERA_CRON_WEBHOOK_URL`` is set — POSTs the answer to that
+    webhook. Delivery is opt-in so it never double-posts jobs whose own prompt
+    already delivers (the recommended per-channel pattern).
+    """
+    import json
+    import time
+    import urllib.request
+
+    answer = answer or ""
+    rec: dict[str, Any] = {
+        "ts": time.time(),
+        "id": getattr(job, "id", None),
+        "name": getattr(job, "name", None),
+        "chars": len(answer),
+        "preview": answer.replace("\n", " ")[:280],
+        "delivered": None,
+    }
+    if webhook_url:
+        try:
+            body = json.dumps({"content": f"⏱️ cron **{rec['name']}**\n{answer[:1800]}"}).encode()
+            req = urllib.request.Request(
+                webhook_url, data=body, method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=15) as resp:  # noqa: S310 — user-set webhook
+                rec["delivered"] = resp.status
+        except Exception as exc:  # noqa: BLE001 — delivery failure must not kill the tick
+            rec["delivered"] = f"error: {exc}"
+    try:
+        runs_log.parent.mkdir(parents=True, exist_ok=True)
+        with runs_log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    except Exception:  # noqa: BLE001 — best-effort audit; never fatal
+        pass
+
+
 def _start_cron_daemon(
     backend: SupportsComplete, model: str | None, max_steps: int, workspace: Path, tick: int
 ) -> Any:
     """Start the cron daemon in a background thread; return its stop event."""
+    import os
+
     from chimera.core import Agent, AgentConfig
     from chimera.scheduler import CronDaemon, Scheduler, make_agent_dispatch
     from chimera.tools import default_registry
 
     scheduler = Scheduler(_cron_store())
+    runs_log = get_settings().home / "cron_runs.jsonl"
+    webhook_url = os.environ.get("CHIMERA_CRON_WEBHOOK_URL")
 
     def run_task(task: str) -> str:
         agent = Agent(backend, default_registry(workspace), AgentConfig(model=model, max_steps=max_steps))
         return agent.run(task).answer
 
-    daemon = CronDaemon(scheduler, make_agent_dispatch(run_task), tick_seconds=tick)
+    def on_result(job: Any, answer: str) -> None:
+        _record_cron_run(runs_log, job, answer, webhook_url)
+
+    daemon = CronDaemon(scheduler, make_agent_dispatch(run_task, on_result), tick_seconds=tick)
     _thread, stop = daemon.start()
     jobs = len(scheduler.store.list())
     console.print(f"[dim]cron daemon on (tick {tick}s, {jobs} job(s) scheduled)[/dim]")

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -148,13 +148,21 @@ class Scheduler:
         return job
 
     def mark_ran(self, job: CronJob, now: float) -> None:
-        job.last_run = now
-        if job.trigger == "cron":
-            job.next_run = _next_after(job.schedule, now)
-        self.store.add(job)
+        # Apply the runtime stamp onto the freshest on-disk copy so a concurrent
+        # out-of-band edit (e.g. `chimera cron disable` mid-tick) is not clobbered
+        # by our whole-store write. Falls back to the in-memory job if it's new.
+        self.store.reload_if_changed()
+        target = self.store.get_or_none(job.id) or job
+        target.last_run = now
+        if target.trigger == "cron":
+            target.next_run = _next_after(target.schedule, now)
+        self.store.add(target)
 
     def run_due(self, now: float, dispatch: Callable[[CronJob], None]) -> list[CronJob]:
         """Dispatch every due cron job and advance its schedule. Returns those run."""
+        # Pick up out-of-band edits (add/remove/enable/disable) before computing
+        # what's due, so a running daemon honours CLI changes without a restart.
+        self.store.reload_if_changed()
         ran: list[CronJob] = []
         for job in self.due(now):
             _log.debug("dispatching cron job %s (%s)", job.name, job.id)

--- a/chimera/scheduler/store.py
+++ b/chimera/scheduler/store.py
@@ -3,32 +3,67 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from chimera.scheduler.models import CronJob
 
 
 class CronStore:
-    """A JSON-file-backed collection of :class:`CronJob` objects."""
+    """A JSON-file-backed collection of :class:`CronJob` objects.
+
+    The file is the source of truth. A long-running daemon calls
+    :meth:`reload_if_changed` each tick so out-of-band edits (``chimera cron
+    add/remove/enable/disable``) take effect without a restart, instead of the
+    daemon firing a stale in-memory snapshot. Writes are atomic (temp + rename)
+    so a concurrent reader never sees a half-written file.
+    """
 
     def __init__(self, path: Path) -> None:
         self.path = Path(path)
         self._jobs: dict[str, CronJob] = {}
+        self._sig: tuple[float, int] | None = None
         self.load()
 
     def load(self) -> None:
         self._jobs = {}
         if not self.path.exists():
+            self._sig = None
             return
         raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
         for item in raw:
             job = CronJob.model_validate(item)
             self._jobs[job.id] = job
+        self._sig = self._stat_sig()
+
+    def reload_if_changed(self) -> bool:
+        """Reload from disk when the file changed since the last read.
+
+        Returns ``True`` if a reload happened. This is what makes a running
+        daemon honour CLI edits (the rollback primitive): disabling a job on
+        disk stops the daemon firing it on the next tick. Change is detected by
+        an ``(mtime, size)`` signature — size flips on enable/disable/add/remove,
+        which catches edits that land within one mtime resolution tick.
+        """
+        if self._stat_sig() != self._sig:
+            self.load()
+            return True
+        return False
 
     def save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         data = [job.model_dump() for job in self._jobs.values()]
-        self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, self.path)  # atomic; readers never see a partial file
+        self._sig = self._stat_sig()
+
+    def _stat_sig(self) -> tuple[float, int] | None:
+        try:
+            st = self.path.stat()
+        except OSError:
+            return None
+        return (st.st_mtime, st.st_size)
 
     def add(self, job: CronJob) -> None:
         self._jobs[job.id] = job
@@ -36,6 +71,9 @@ class CronStore:
 
     def get(self, job_id: str) -> CronJob:
         return self._jobs[job_id]
+
+    def get_or_none(self, job_id: str) -> CronJob | None:
+        return self._jobs.get(job_id)
 
     def list(self) -> list[CronJob]:
         return list(self._jobs.values())

--- a/chimera/tools/shell.py
+++ b/chimera/tools/shell.py
@@ -1,12 +1,20 @@
 """Shell execution tool.
 
-Powerful by design: it runs commands in the workspace directory. For now safety
-is limited to a timeout and the workspace cwd; the governance kernel (M5) will gate
+Powerful by design: it runs commands in a working directory. For now safety
+is limited to a timeout and the cwd; the governance kernel (M5) will gate
 it (allow/warn/block/review) and the sandbox layer (M3/M5) will isolate it.
+
+Defaults are tunable via the environment so a scheduled/agent run can execute
+longer scripts and resolve paths from a fixed root:
+
+- ``CHIMERA_SHELL_TIMEOUT``    default per-command timeout in seconds (default 180)
+- ``CHIMERA_SHELL_MAX_OUTPUT`` max characters of output kept (default 40000)
+- ``CHIMERA_SHELL_CWD``        default working directory when no workspace is given
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -15,27 +23,44 @@ from chimera.tools.base import Tool
 if TYPE_CHECKING:
     from chimera.sandbox.base import Sandbox
 
-_MAX_OUTPUT_CHARS = 20_000
-_DEFAULT_TIMEOUT = 60
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name) or default)
+    except ValueError:
+        return default
+
+
+_MAX_OUTPUT_CHARS = _env_int("CHIMERA_SHELL_MAX_OUTPUT", 40_000)
+_DEFAULT_TIMEOUT = _env_int("CHIMERA_SHELL_TIMEOUT", 180)
 
 
 class RunShellTool(Tool):
     name = "run_shell"
     description = (
-        "Run a shell command in the workspace directory and return its output. "
-        "Use with care: this can modify the system."
+        "Run a shell command and return its output. Optionally set 'cwd' and a "
+        "longer 'timeout' for slow scripts. Use with care: this can modify the system."
     )
     parameters = {
         "type": "object",
         "properties": {
             "command": {"type": "string", "description": "The shell command to run."},
-            "timeout": {"type": "integer", "description": "Timeout in seconds (default 60)."},
+            "timeout": {
+                "type": "integer",
+                "description": f"Timeout in seconds (default {_DEFAULT_TIMEOUT}).",
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Working directory to run in (defaults to the workspace).",
+            },
         },
         "required": ["command"],
     }
 
     def __init__(self, workspace: Path | None = None, sandbox: Sandbox | None = None) -> None:
-        self.workspace = (workspace or Path.cwd()).resolve()
+        env_cwd = os.environ.get("CHIMERA_SHELL_CWD")
+        base = workspace or (Path(env_cwd) if env_cwd else Path.cwd())
+        self.workspace = base.resolve()
         self._sandbox = sandbox
 
     def run(self, **kwargs: Any) -> str:
@@ -43,8 +68,10 @@ class RunShellTool(Tool):
 
         command = str(kwargs["command"])
         timeout = int(kwargs.get("timeout") or _DEFAULT_TIMEOUT)
+        cwd_arg = kwargs.get("cwd")
+        cwd = Path(cwd_arg).resolve() if cwd_arg else self.workspace
         sandbox = self._sandbox or LocalSandbox()
-        result = sandbox.run(command, timeout=timeout, cwd=self.workspace)
+        result = sandbox.run(command, timeout=timeout, cwd=cwd)
         if result.timed_out:
             return f"error: command timed out after {timeout}s"
         out = result.output

--- a/tests/test_cron_reload.py
+++ b/tests/test_cron_reload.py
@@ -1,0 +1,122 @@
+"""Tests for the daemon-safe scheduler behaviour: live reload of jobs.json,
+clobber-safe run stamps, a configurable shell tool, and cron-run delivery records.
+
+These cover the fixes that make a running ``chimera serve --cron`` honour
+out-of-band CLI edits (the rollback primitive), run slow scripts, and leave a
+delivery-confirmation trail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from chimera.sandbox.base import SandboxResult
+from chimera.scheduler import CronStore, Scheduler
+from chimera.tools.shell import RunShellTool
+
+NOW = 1_000_000.0
+
+
+# --- live reload / rollback primitive ----------------------------------------
+
+def test_reload_if_changed_picks_up_external_disable(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    daemon_view = Scheduler(CronStore(path))
+    job = daemon_view.schedule_cron("j", "* * * * *", "x", now=NOW)
+
+    # A separate process (the CLI) disables the job on disk.
+    cli_view = Scheduler(CronStore(path))
+    cli_view.disable(job.id)
+
+    assert daemon_view.store.get(job.id).enabled is True  # stale in-memory copy
+    assert daemon_view.store.reload_if_changed() is True
+    assert daemon_view.store.get(job.id).enabled is False  # now honoured
+
+
+def test_run_due_honours_external_disable_without_restart(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    daemon_view = Scheduler(CronStore(path))
+    job = daemon_view.schedule_cron("j", "* * * * *", "x", now=NOW)
+    due_at = job.next_run
+    assert due_at is not None
+
+    Scheduler(CronStore(path)).disable(job.id)  # CLI disables it out-of-band
+
+    fired: list[str] = []
+    ran = daemon_view.run_due(due_at, lambda j: fired.append(j.id))
+    assert fired == []  # rollback primitive works: the disabled job does not fire
+    assert ran == []
+
+
+def test_mark_ran_does_not_clobber_external_disable(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    daemon_view = Scheduler(CronStore(path))
+    job = daemon_view.schedule_cron("j", "* * * * *", "x", now=NOW)
+
+    Scheduler(CronStore(path)).disable(job.id)  # disabled mid-tick by the CLI
+
+    daemon_view.mark_ran(job, NOW)  # daemon stamps the run it just executed
+    assert CronStore(path).get(job.id).enabled is False  # disable survived
+    assert CronStore(path).get(job.id).last_run == NOW  # run was still recorded
+
+
+def test_save_is_atomic_and_leaves_no_tmp(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    store = Scheduler(CronStore(path)).schedule_cron  # trigger a save via schedule
+    store("j", "* * * * *", "x", now=NOW)
+    assert path.exists()
+    json.loads(path.read_text(encoding="utf-8"))  # valid, complete JSON
+    assert not path.with_suffix(path.suffix + ".tmp").exists()
+
+
+# --- configurable shell tool -------------------------------------------------
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def run(self, command: str, *, timeout: int = 60, cwd: Path | None = None) -> SandboxResult:
+        self.calls.append({"command": command, "timeout": timeout, "cwd": cwd})
+        return SandboxResult(exit_code=0, stdout="ok")
+
+
+def test_shell_default_timeout_is_raised(tmp_path: Path) -> None:
+    fake = _FakeSandbox()
+    tool = RunShellTool(workspace=tmp_path, sandbox=fake)
+    tool.run(command="echo hi")  # no explicit timeout
+    assert fake.calls[0]["timeout"] >= 180  # slow scripts (e.g. 170s) survive
+
+
+def test_shell_accepts_cwd_argument(tmp_path: Path) -> None:
+    fake = _FakeSandbox()
+    tool = RunShellTool(workspace=tmp_path, sandbox=fake)
+    target = tmp_path / "sub"
+    target.mkdir()
+    tool.run(command="ls", cwd=str(target))
+    assert fake.calls[0]["cwd"] == target.resolve()
+
+
+def test_shell_cwd_defaults_from_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CHIMERA_SHELL_CWD", str(tmp_path))
+    fake = _FakeSandbox()
+    tool = RunShellTool(sandbox=fake)  # no explicit workspace -> env
+    assert tool.workspace == tmp_path.resolve()
+
+
+# --- cron-run delivery record ------------------------------------------------
+
+def test_record_cron_run_writes_confirmation_line(tmp_path: Path) -> None:
+    from chimera.cli.main import _record_cron_run
+
+    runs_log = tmp_path / "cron_runs.jsonl"
+    job = SimpleNamespace(id="abc123", name="etoro-heartbeat")
+    _record_cron_run(runs_log, job, "line one\nline two", webhook_url=None)
+
+    lines = runs_log.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["name"] == "etoro-heartbeat"
+    assert rec["preview"] == "line one line two"
+    assert rec["delivered"] is None  # no webhook configured -> confirmation only

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -100,7 +100,7 @@ def test_run_shell_uses_injected_sandbox() -> None:
     fake = FakeSandbox()
     out = RunShellTool(sandbox=fake).run(command="echo hi")
     assert "[exit 0]" in out and "hi" in out
-    assert fake.seen == ("echo hi", 60)
+    assert fake.seen == ("echo hi", 180)  # default timeout raised for slow scripts
 
 
 def test_run_shell_reports_timeout() -> None:


### PR DESCRIPTION
## What
Makes a running `chimera serve --cron` production-safe for scheduled work — the three gaps that block using Chimera's cron for real, must-fire jobs.

## Why
Deploying Chimera as a 24/7 scheduler surfaced three defects:
1. **The running daemon never reloads `jobs.json`** → `chimera cron disable/enable` was a no-op on the live daemon (broke rollback), and concurrent CLI-vs-daemon writes were last-writer-wins.
2. **Cron answers went nowhere** — logged only, no delivery/confirmation.
3. **`run_shell` capped at 60s / cwd `/app`** → slow scripts (e.g. a 170s analysis) timed out and scripts assuming a fixed root broke.

## Changes
- **`scheduler/store`** — `reload_if_changed()` via an `(mtime,size)` signature; atomic save (temp + `os.replace`).
- **`scheduler/engine`** — `run_due` reloads before computing due jobs (the rollback primitive); `mark_ran` stamps onto the freshest on-disk copy so a concurrent disable isn't clobbered.
- **`cli/main`** — wire the existing `on_result` hook: record every run to `cron_runs.jsonl` (confirmation for an external watchdog) and, when `CHIMERA_CRON_WEBHOOK_URL` is set, deliver it (opt-in, no double-post).
- **`tools/shell`** — default timeout 60→180s; `CHIMERA_SHELL_TIMEOUT` / `_MAX_OUTPUT` / `_CWD` envs + a per-call `cwd` argument.

## Tests
Adds `tests/test_cron_reload.py` (reload, no-clobber rollback, shell config, run record); updates the sandbox test for the new default. Full unit suite green (463 passed), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)