### PR TITLE
release: v0.35.0 — the desktop app wakes up, remembers, and can reach you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-07-22
+
 ### Added
+- **The desktop app is proactive — it wakes up on a schedule.** `chimera app` now runs the cron daemon
+  in-process (previously only `chimera serve --cron` did), so a job you schedule actually fires while
+  the app is open, runs a real agent turn, and appends the result to
+  `<home>/scheduler/cron_results.jsonl` — a durable sink, so nothing is silently lost. On by default
+  (`CHIMERA_APP_CRON`; `--no-cron` makes the app purely reactive). Verified end-to-end: a job set two
+  minutes out fired on the minute and its answer landed in the results file. **Note:** cron expressions
+  are evaluated in **UTC**, not local time.
+- **Create a schedule from the UI — no terminal.** The Agenda screen could only toggle and delete;
+  creating one meant `chimera cron add`. It now has a form (name · what Chimera should do · when) with
+  quick picks for the common cases, on a new `POST /api/cron`. Jobs created by a human come back
+  enabled, matching the scheduler's own invariant.
+- **The chat can build durable memory — opt-in and explicit-only.** With "Lembrar do chat" on
+  (`CHIMERA_CHAT_MEMORY`, **off** by default), an explicit "remember that …" in a conversation writes a
+  lasting fact through the same consolidation path the CLI uses. Deliberately conservative: only an
+  explicit request is captured, never ambient extraction from whatever you happened to type — automatic
+  memory is a privacy decision, so it is yours to make, and visible when it happens.
+- **The agent can reach you on Discord — configured and run from the app.** The adapters existed but
+  were CLI/env-only. Settings now has a Messaging card (bot token + a run toggle), backed by a
+  `MessagingManager` that runs the adapter in a background thread inside the app process, plus
+  `GET/POST /api/messaging`. Starting a platform with no token fails with a clear message instead of a
+  crash, and a dead adapter surfaces its error in the UI. Auto-starts with the app when
+  `CHIMERA_APP_MESSAGING` is on. Discord is wired end-to-end; Telegram is a small extension of the same
+  manager.
 - **OpenAI-compatible endpoint — point any LLM client or benchmark at the agent.**
   `POST /v1/chat/completions` and `GET /v1/models` (in the `[desktop]` extra) speak the OpenAI wire
   format, but the thing behind them is the whole Chimera loop — tools, steps, retries — not one model
@@ -91,6 +116,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   execution and gated too. (Desktop/API keep their own approval flow — a follow-up wires this there.)
 
 ### Fixed
+- **The desktop app no longer spins for seconds on nearly every screen — and never spins forever.**
+  The endpoints were never the problem (measured: `/api/tools` ~9ms, almost everything under 20ms, one
+  request per screen — no refetch loop). Two things stretched the wait: React Query's default retry
+  backoff is 1s → 2s → 4s, so while the frozen backend sidecar was still booting the first screen sat
+  there ~7s waiting it out; and twelve screens gated their spinner on `isLoading || !data`, which on an
+  *error* leaves `isLoading` false and `data` undefined — so the spinner stayed up forever, with no
+  message and no way to retry. Now: a bounded fast retry (250ms → 1.5s) behind a single "Starting
+  Chimera…" gate, `staleTime` raised 5s → 30s so revisiting a screen doesn't refetch-and-respin, and a
+  shared error state (message + "try again") on every screen that loads data. Verified live: with the
+  backend killed a screen showed the error and its retry, and recovered on click once it was back.
+  The sidecar's own cold-boot cost is untouched — this makes the wait short and honest, not zero.
 - **`CHIMERA_HOST_EXEC=deny` is now actually enforceable — `code_interpreter` was an ungated third
   door.** The shell and `execute_code` tools honoured the posture, but `code_interpreter` `exec()`s
   in-process on the host, bypasses the sandbox entirely, and was registered with no gate: under

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.35.0-dev"
+version = "0.35.0"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.35.0-dev",
+  "version": "0.35.0",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -16,7 +16,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.34.0",
+  "generated_for": "0.35.0",
   "internal_lift": {
     "baseline_rate": 0.09,
     "ci": [

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.34.0",
+  "generated_for": "0.35.0",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.35.0-dev"
+version = "0.35.0"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.35.0.dev0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Prepara a **v0.35.0**. Segue o `RELEASING.md` à risca.

## Mudanças
- Bump das **três** versões que devem concordar: `pyproject.toml` · `src-tauri/Cargo.toml` · `src-tauri/tauri.conf.json` → `0.35.0` (+ `uv.lock`)
- Snapshots regenerados (embutem `__version__`): `_maturity_snapshot.json` e `_benchmark_snapshot.json` — só o campo `generated_for` mudou; os dados seguem 37/37 GA e lift 9%→15% (n=100, significativo)
- CHANGELOG: `[Unreleased]` → `[0.35.0] - 2026-07-22`, **e** registra as entregas de desktop desta rodada que ainda não estavam escritas

## Pré-voo (todos os passos exigidos, verdes)
| Passo | Resultado |
|---|---|
| Dry-run `desktop-release.yml` | 4 plataformas buildadas e assinadas |
| `latest.json` alvo a alvo | `windows-x86_64` → `.exe` · `darwin-aarch64` → `_aarch64.app.tar.gz` · `darwin-x86_64` → `_x86_64.app.tar.gz` · `linux-x86_64` → **`.AppImage`** (não o `.deb`) |
| ruff · mypy · pytest | limpo · 253 arquivos · 1806 passaram |
| desktop | 100 testes · build OK |
| Drift OpenAPI | 2º dump byte-idêntico |

O dry-run rodou da `main` antes deste bump, então os nomes dos artefatos mostram `0.35.0-dev` — ele valida a **mecânica** de mapeamento, não a string de versão.

Ao mergear, publico a release `v0.35.0`, que dispara `publish.yml` (PyPI via OIDC) e `desktop-release.yml` (instaladores + updater assinado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)