### PR TITLE
perf(imports): stop four package __init__ files from importing the world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **The backend boots ~26% faster — four package `__init__` files stopped importing the world.**
+  `chimera.eval`, `chimera.governance`, `chimera.tools` and `chimera.core` re-exported their whole
+  surface eagerly. Python runs a package's `__init__` before *any* submodule, so
+  `from chimera.eval.benchmark_snapshot import snapshot_path` — a module whose own imports are `json`
+  and `pathlib` — dragged in `chained` → `continuous` → `evolution` → `governance` → `core` →
+  `autonomous` → `ecosystem`. The desktop sidecar paid all of it on every cold boot to serve screens
+  that never touch those modules. The re-exports are now resolved on first attribute access (PEP 562)
+  and cached, so `from chimera.core import Agent` still works and costs the same *when you use it*;
+  `TYPE_CHECKING` blocks keep mypy's view exact. Measured A/B (minimum of repeated runs, changes
+  stashed between sides): `import chimera.api.app` **836ms → 452ms (-46%)**, launch-to-`/api/health`
+  **1234ms → 915ms (-26%)**, and 627 → 554 modules loaded. The cost doesn't vanish, it moves: the
+  first request that genuinely needs a heavy module pays for it once (`/api/tools`, the worst case,
+  took 77ms on its first call and single-digit ms after).
+- **Fixed a real import cycle that the eager imports were hiding.** Making `chimera.governance` lazy
+  broke the app outright: `governance.ledger_tool` imports `chimera.tools.base`, which ran
+  `chimera/tools/__init__.py`, which imported `browser`/`documents`/`scrape` — each of which imports
+  `fence` back from the half-initialised `ledger_tool`. The cycle was always there; the *order* of a
+  sibling package's eager imports happened to mask it. Making `chimera.tools` lazy removes it at the
+  source rather than papering over it with a function-local import.
+
 ## [0.35.0] - 2026-07-22
 
 ### Added

--- a/chimera/core/__init__.py
+++ b/chimera/core/__init__.py
@@ -4,48 +4,138 @@ The minimal tool-calling loop (M1) plus the autonomous runner (M3): plan -> exec
 -> Manager review -> verify-or-revert, with an experience buffer. State is kept
 *outside* the LLM context (transcript + workspace snapshots) to resist
 continuous-evolution degradation.
+
+**Why the re-exports are lazy.** See :mod:`chimera.eval`. This package's ``__init__`` is the one that
+cost the desktop sidecar most: importing ``chimera.core.agent`` — which the chat endpoint genuinely
+needs, and whose own imports are cheap — ran this ``__init__`` and so also pulled ``autonomous`` →
+``chimera.ecosystem`` → ``meta_agent`` → ``chimera.evolution.experience``, none of which a chat turn
+touches. Names resolve on first access (PEP 562) and are cached; ``from chimera.core import Agent``
+still works, and the ``TYPE_CHECKING`` block keeps mypy's view exact.
 """
 
-from chimera.core.agent import (
-    DEFAULT_SYSTEM_PROMPT,
-    Agent,
-    AgentConfig,
-    AgentResult,
-)
-from chimera.core.autonomous import (
-    Attempt,
-    AutonomousAgent,
-    AutonomousConfig,
-    AutonomousResult,
-    Worker,
-)
-from chimera.core.checklist import RequirementChecklist
-from chimera.core.checkpoint import FileSnapshot, WorkspaceGuard
-from chimera.core.contract import CompletionContract, ContractResult, parse_check
-from chimera.core.events import AgentEvent, EventKind, EventSink
-from chimera.core.explorer import (
-    ContextExplorer,
-    Evidence,
-    ExploreRepositoryTool,
-    ExplorerResult,
-    parse_evidence,
-)
-from chimera.core.ledger import ProgressAssessment, ProgressLedger, TaskLedger
-from chimera.core.planner import Plan, Planner
-from chimera.core.repomap import build_repo_map
-from chimera.core.runstate import RunCheckpointer
-from chimera.core.spec_test import SpecTestGenerator, SpecTestVerifier, workspace_digest
-from chimera.core.spine import assemble_spine
-from chimera.core.strong_verify import StrongVerifier
-from chimera.core.subagent import SubAgentTool
-from chimera.core.supervisor import Manager, Review
-from chimera.core.verify import (
-    CommandVerifier,
-    NullVerifier,
-    VerificationResult,
-    Verifier,
-)
-from chimera.providers import SupportsComplete
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chimera.core.agent import (
+        DEFAULT_SYSTEM_PROMPT,
+        Agent,
+        AgentConfig,
+        AgentResult,
+    )
+    from chimera.core.autonomous import (
+        Attempt,
+        AutonomousAgent,
+        AutonomousConfig,
+        AutonomousResult,
+        Worker,
+    )
+    from chimera.core.checklist import RequirementChecklist
+    from chimera.core.checkpoint import FileSnapshot, WorkspaceGuard
+    from chimera.core.contract import CompletionContract, ContractResult, parse_check
+    from chimera.core.events import AgentEvent, EventKind, EventSink
+    from chimera.core.explorer import (
+        ContextExplorer,
+        Evidence,
+        ExploreRepositoryTool,
+        ExplorerResult,
+        parse_evidence,
+    )
+    from chimera.core.ledger import ProgressAssessment, ProgressLedger, TaskLedger
+    from chimera.core.planner import Plan, Planner
+    from chimera.core.repomap import build_repo_map
+    from chimera.core.runstate import RunCheckpointer
+    from chimera.core.spec_test import (
+        SpecTestGenerator,
+        SpecTestVerifier,
+        workspace_digest,
+    )
+    from chimera.core.spine import assemble_spine
+    from chimera.core.strong_verify import StrongVerifier
+    from chimera.core.subagent import SubAgentTool
+    from chimera.core.supervisor import Manager, Review
+    from chimera.core.verify import (
+        CommandVerifier,
+        NullVerifier,
+        VerificationResult,
+        Verifier,
+    )
+    from chimera.providers import SupportsComplete
+
+# Exported name -> (module path relative to this package, attribute). ``SupportsComplete`` is the one
+# entry that lives outside `chimera.core`, so it carries an absolute path (leading dot-free marker).
+_LAZY: dict[str, tuple[str, str]] = {
+    "Agent": ("agent", "Agent"),
+    "AgentConfig": ("agent", "AgentConfig"),
+    "AgentResult": ("agent", "AgentResult"),
+    "DEFAULT_SYSTEM_PROMPT": ("agent", "DEFAULT_SYSTEM_PROMPT"),
+    "Attempt": ("autonomous", "Attempt"),
+    "AutonomousAgent": ("autonomous", "AutonomousAgent"),
+    "AutonomousConfig": ("autonomous", "AutonomousConfig"),
+    "AutonomousResult": ("autonomous", "AutonomousResult"),
+    "Worker": ("autonomous", "Worker"),
+    "RequirementChecklist": ("checklist", "RequirementChecklist"),
+    "FileSnapshot": ("checkpoint", "FileSnapshot"),
+    "WorkspaceGuard": ("checkpoint", "WorkspaceGuard"),
+    "CompletionContract": ("contract", "CompletionContract"),
+    "ContractResult": ("contract", "ContractResult"),
+    "parse_check": ("contract", "parse_check"),
+    "AgentEvent": ("events", "AgentEvent"),
+    "EventKind": ("events", "EventKind"),
+    "EventSink": ("events", "EventSink"),
+    "ContextExplorer": ("explorer", "ContextExplorer"),
+    "Evidence": ("explorer", "Evidence"),
+    "ExploreRepositoryTool": ("explorer", "ExploreRepositoryTool"),
+    "ExplorerResult": ("explorer", "ExplorerResult"),
+    "parse_evidence": ("explorer", "parse_evidence"),
+    "ProgressAssessment": ("ledger", "ProgressAssessment"),
+    "ProgressLedger": ("ledger", "ProgressLedger"),
+    "TaskLedger": ("ledger", "TaskLedger"),
+    "Plan": ("planner", "Plan"),
+    "Planner": ("planner", "Planner"),
+    "build_repo_map": ("repomap", "build_repo_map"),
+    "RunCheckpointer": ("runstate", "RunCheckpointer"),
+    "SpecTestGenerator": ("spec_test", "SpecTestGenerator"),
+    "SpecTestVerifier": ("spec_test", "SpecTestVerifier"),
+    "workspace_digest": ("spec_test", "workspace_digest"),
+    "assemble_spine": ("spine", "assemble_spine"),
+    "StrongVerifier": ("strong_verify", "StrongVerifier"),
+    "SubAgentTool": ("subagent", "SubAgentTool"),
+    "Manager": ("supervisor", "Manager"),
+    "Review": ("supervisor", "Review"),
+    "CommandVerifier": ("verify", "CommandVerifier"),
+    "NullVerifier": ("verify", "NullVerifier"),
+    "VerificationResult": ("verify", "VerificationResult"),
+    "Verifier": ("verify", "Verifier"),
+}
+
+# Re-exported from a sibling package rather than a submodule of this one.
+_LAZY_EXTERNAL: dict[str, tuple[str, str]] = {
+    "SupportsComplete": ("chimera.providers", "SupportsComplete"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a re-exported name on first use, then cache it (PEP 562)."""
+    external = _LAZY_EXTERNAL.get(name)
+    if external is not None:
+        module_path, attribute = external
+    else:
+        target = _LAZY.get(name)
+        if target is None:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+        submodule, attribute = target
+        module_path = f"{__name__}.{submodule}"
+    value = getattr(import_module(module_path), attribute)
+    globals()[name] = value  # subsequent lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "Agent",

--- a/chimera/eval/__init__.py
+++ b/chimera/eval/__init__.py
@@ -2,78 +2,172 @@
 
 The continuous-evolution benchmark measures degradation over chained tasks — the
 key proof that Chimera resists the EvoClaw problem.
+
+**Why the re-exports are lazy.** Importing this package used to pull ``chained`` → ``continuous`` →
+``chimera.evolution`` → ``chimera.governance`` → ``chimera.core`` eagerly — ~600ms — and Python runs a
+package's ``__init__`` before *any* submodule, so even ``from chimera.eval.benchmark_snapshot import
+snapshot_path`` (a module whose own imports are just ``json``/``pathlib``) paid the full bill. The
+desktop sidecar paid it on every cold boot just to read a JSON file. Names below now resolve on first
+attribute access (PEP 562) and are cached into the module globals, so ``from chimera.eval import
+EvalTask`` still works and costs the same as before *when you actually use it*. The ``TYPE_CHECKING``
+block keeps mypy seeing the real types rather than ``Any``.
 """
 
-from chimera.eval.bench_ab import ABResult, Arm, format_report
-from chimera.eval.bench_ab import compare as compare_ab
-from chimera.eval.chained import ChainStep, demo_chain, run_chain
-from chimera.eval.continuous import (
-    CostingSolver,
-    EvalTask,
-    EvolutionReport,
-    RoundedEvolutionReport,
-    SingleModelSolver,
-    Solver,
-    TaskOutcome,
-    demo_tasks,
-    run_continuous,
-    run_evolution,
-)
-from chimera.eval.evoclaw import (
-    EvoComparison,
-    EvoStep,
-    compare,
-    counter_chain,
-    run_guarded,
-    run_naive,
-)
-from chimera.eval.hard import (
-    HARD_CHAIN_OPS,
-    HARD_CHAIN_START,
-    hard_chain,
-    hard_tasks,
-)
-from chimera.eval.injection import (
-    AttackOutcome,
-    InjectionAttack,
-    RedTeamReport,
-    default_attacks,
-    run_redteam,
-)
-from chimera.eval.memory_bench import (
-    MemoryProbe,
-    RecallReport,
-    run_memory_bench,
-    synthetic_facts_and_probes,
-)
-from chimera.eval.memory_bench import sweep as memory_sweep
-from chimera.eval.rubric import (
-    Dimension,
-    RubricResult,
-    cascade_dimensions,
-    evaluate_cascade,
-    model_judge,
-)
-from chimera.eval.rubric_grade import (
-    Criterion,
-    GradedOutcome,
-    Rubric,
-    RubricGrader,
-    grade_batch,
-    model_grader,
-)
-from chimera.eval.scenarios import Scenario, daily_scenarios, run_scenarios
-from chimera.eval.spec_tuning import scenario_scorer
-from chimera.eval.swe_bench import (
-    SWEInstance,
-    compare_arms,
-    load_instances,
-    parse_report,
-    report_to_trials,
-)
-from chimera.eval.swe_bench import (
-    build_solve_command as swe_build_solve_command,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chimera.eval.bench_ab import ABResult, Arm, format_report
+    from chimera.eval.bench_ab import compare as compare_ab
+    from chimera.eval.chained import ChainStep, demo_chain, run_chain
+    from chimera.eval.continuous import (
+        CostingSolver,
+        EvalTask,
+        EvolutionReport,
+        RoundedEvolutionReport,
+        SingleModelSolver,
+        Solver,
+        TaskOutcome,
+        demo_tasks,
+        run_continuous,
+        run_evolution,
+    )
+    from chimera.eval.evoclaw import (
+        EvoComparison,
+        EvoStep,
+        compare,
+        counter_chain,
+        run_guarded,
+        run_naive,
+    )
+    from chimera.eval.hard import (
+        HARD_CHAIN_OPS,
+        HARD_CHAIN_START,
+        hard_chain,
+        hard_tasks,
+    )
+    from chimera.eval.injection import (
+        AttackOutcome,
+        InjectionAttack,
+        RedTeamReport,
+        default_attacks,
+        run_redteam,
+    )
+    from chimera.eval.memory_bench import (
+        MemoryProbe,
+        RecallReport,
+        run_memory_bench,
+        synthetic_facts_and_probes,
+    )
+    from chimera.eval.memory_bench import sweep as memory_sweep
+    from chimera.eval.rubric import (
+        Dimension,
+        RubricResult,
+        cascade_dimensions,
+        evaluate_cascade,
+        model_judge,
+    )
+    from chimera.eval.rubric_grade import (
+        Criterion,
+        GradedOutcome,
+        Rubric,
+        RubricGrader,
+        grade_batch,
+        model_grader,
+    )
+    from chimera.eval.scenarios import Scenario, daily_scenarios, run_scenarios
+    from chimera.eval.spec_tuning import scenario_scorer
+    from chimera.eval.swe_bench import (
+        SWEInstance,
+        compare_arms,
+        load_instances,
+        parse_report,
+        report_to_trials,
+    )
+    from chimera.eval.swe_bench import (
+        build_solve_command as swe_build_solve_command,
+    )
+
+# Exported name -> (submodule, attribute in that submodule). The attribute differs from the exported
+# name only where the original re-export renamed it (`compare as compare_ab`, etc.).
+_LAZY: dict[str, tuple[str, str]] = {
+    "ABResult": ("bench_ab", "ABResult"),
+    "Arm": ("bench_ab", "Arm"),
+    "format_report": ("bench_ab", "format_report"),
+    "compare_ab": ("bench_ab", "compare"),
+    "ChainStep": ("chained", "ChainStep"),
+    "demo_chain": ("chained", "demo_chain"),
+    "run_chain": ("chained", "run_chain"),
+    "CostingSolver": ("continuous", "CostingSolver"),
+    "EvalTask": ("continuous", "EvalTask"),
+    "EvolutionReport": ("continuous", "EvolutionReport"),
+    "RoundedEvolutionReport": ("continuous", "RoundedEvolutionReport"),
+    "SingleModelSolver": ("continuous", "SingleModelSolver"),
+    "Solver": ("continuous", "Solver"),
+    "TaskOutcome": ("continuous", "TaskOutcome"),
+    "demo_tasks": ("continuous", "demo_tasks"),
+    "run_continuous": ("continuous", "run_continuous"),
+    "run_evolution": ("continuous", "run_evolution"),
+    "EvoComparison": ("evoclaw", "EvoComparison"),
+    "EvoStep": ("evoclaw", "EvoStep"),
+    "compare": ("evoclaw", "compare"),
+    "counter_chain": ("evoclaw", "counter_chain"),
+    "run_guarded": ("evoclaw", "run_guarded"),
+    "run_naive": ("evoclaw", "run_naive"),
+    "HARD_CHAIN_OPS": ("hard", "HARD_CHAIN_OPS"),
+    "HARD_CHAIN_START": ("hard", "HARD_CHAIN_START"),
+    "hard_chain": ("hard", "hard_chain"),
+    "hard_tasks": ("hard", "hard_tasks"),
+    "AttackOutcome": ("injection", "AttackOutcome"),
+    "InjectionAttack": ("injection", "InjectionAttack"),
+    "RedTeamReport": ("injection", "RedTeamReport"),
+    "default_attacks": ("injection", "default_attacks"),
+    "run_redteam": ("injection", "run_redteam"),
+    "MemoryProbe": ("memory_bench", "MemoryProbe"),
+    "RecallReport": ("memory_bench", "RecallReport"),
+    "run_memory_bench": ("memory_bench", "run_memory_bench"),
+    "synthetic_facts_and_probes": ("memory_bench", "synthetic_facts_and_probes"),
+    "memory_sweep": ("memory_bench", "sweep"),
+    "Dimension": ("rubric", "Dimension"),
+    "RubricResult": ("rubric", "RubricResult"),
+    "cascade_dimensions": ("rubric", "cascade_dimensions"),
+    "evaluate_cascade": ("rubric", "evaluate_cascade"),
+    "model_judge": ("rubric", "model_judge"),
+    "Criterion": ("rubric_grade", "Criterion"),
+    "GradedOutcome": ("rubric_grade", "GradedOutcome"),
+    "Rubric": ("rubric_grade", "Rubric"),
+    "RubricGrader": ("rubric_grade", "RubricGrader"),
+    "grade_batch": ("rubric_grade", "grade_batch"),
+    "model_grader": ("rubric_grade", "model_grader"),
+    "Scenario": ("scenarios", "Scenario"),
+    "daily_scenarios": ("scenarios", "daily_scenarios"),
+    "run_scenarios": ("scenarios", "run_scenarios"),
+    "scenario_scorer": ("spec_tuning", "scenario_scorer"),
+    "SWEInstance": ("swe_bench", "SWEInstance"),
+    "compare_arms": ("swe_bench", "compare_arms"),
+    "load_instances": ("swe_bench", "load_instances"),
+    "parse_report": ("swe_bench", "parse_report"),
+    "report_to_trials": ("swe_bench", "report_to_trials"),
+    "swe_build_solve_command": ("swe_bench", "build_solve_command"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a re-exported name on first use, then cache it (PEP 562)."""
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    submodule, attribute = target
+    value = getattr(import_module(f"{__name__}.{submodule}"), attribute)
+    globals()[name] = value  # subsequent lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "EvalTask",

--- a/chimera/governance/__init__.py
+++ b/chimera/governance/__init__.py
@@ -3,58 +3,131 @@
 A self-improving trust layer (lexical rules + optional semantic judge). Never
 hard-blocks a benign action. Self-modification is only accepted through a
 statically-validated edit surface.
+
+**Why the re-exports are lazy.** See :mod:`chimera.eval` for the full rationale. In short: Python runs
+this ``__init__`` before any submodule, so ``from chimera.governance.ledger import TaintLedger`` used
+to drag in ``drift`` → ``chimera.core`` → ``autonomous`` → ``chimera.ecosystem`` as well. Names below
+resolve on first access (PEP 562) and are cached, so ``from chimera.governance import TrustKernel``
+still works; the ``TYPE_CHECKING`` block keeps mypy's view exact.
 """
 
-from chimera.governance.actors import (
-    ActorResult,
-    ChangeProposal,
-    FourActorGovernance,
-    GovernanceDecision,
-)
-from chimera.governance.aggregate_monitor import AggregateMonitor, CollusionFinding
-from chimera.governance.allowlist import restrict_registry
-from chimera.governance.audit import AuditLog
-from chimera.governance.drift import (
-    DriftReport,
-    Requirement,
-    Spec,
-    check_drift,
-    load_spec,
-)
-from chimera.governance.governed_tool import GovernedTool, govern_registry
-from chimera.governance.kernel import TrustKernel
-from chimera.governance.ledger import (
-    CapabilityEvent,
-    SequenceAssessment,
-    SharedTaint,
-    TaintLedger,
-    assess_action,
-)
-from chimera.governance.ledger_tool import (
-    DANGEROUS_WHEN_TAINTED,
-    FENCE_CLOSE,
-    FENCE_OPEN,
-    LedgeredTool,
-    fence,
-    ledger_registry,
-)
-from chimera.governance.policy import Decision, Rule, RuleSet, Verdict
-from chimera.governance.precedent import PrecedentStore
-from chimera.governance.quarantine import (
-    QuarantinedReader,
-    QuarantineResult,
-    fields_schema,
-)
-from chimera.governance.sanitize import (
-    has_control_tokens,
-    sanitize_untrusted,
-    strip_leaked_control_tokens,
-)
-from chimera.governance.validator import (
-    ScheduleValidator,
-    SkillValidator,
-    ValidationResult,
-)
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chimera.governance.actors import (
+        ActorResult,
+        ChangeProposal,
+        FourActorGovernance,
+        GovernanceDecision,
+    )
+    from chimera.governance.aggregate_monitor import AggregateMonitor, CollusionFinding
+    from chimera.governance.allowlist import restrict_registry
+    from chimera.governance.audit import AuditLog
+    from chimera.governance.drift import (
+        DriftReport,
+        Requirement,
+        Spec,
+        check_drift,
+        load_spec,
+    )
+    from chimera.governance.governed_tool import GovernedTool, govern_registry
+    from chimera.governance.kernel import TrustKernel
+    from chimera.governance.ledger import (
+        CapabilityEvent,
+        SequenceAssessment,
+        SharedTaint,
+        TaintLedger,
+        assess_action,
+    )
+    from chimera.governance.ledger_tool import (
+        DANGEROUS_WHEN_TAINTED,
+        FENCE_CLOSE,
+        FENCE_OPEN,
+        LedgeredTool,
+        fence,
+        ledger_registry,
+    )
+    from chimera.governance.policy import Decision, Rule, RuleSet, Verdict
+    from chimera.governance.precedent import PrecedentStore
+    from chimera.governance.quarantine import (
+        QuarantinedReader,
+        QuarantineResult,
+        fields_schema,
+    )
+    from chimera.governance.sanitize import (
+        has_control_tokens,
+        sanitize_untrusted,
+        strip_leaked_control_tokens,
+    )
+    from chimera.governance.validator import (
+        ScheduleValidator,
+        SkillValidator,
+        ValidationResult,
+    )
+
+# Exported name -> (submodule, attribute). No renames here, but the shape matches chimera.eval's.
+_LAZY: dict[str, tuple[str, str]] = {
+    "ActorResult": ("actors", "ActorResult"),
+    "ChangeProposal": ("actors", "ChangeProposal"),
+    "FourActorGovernance": ("actors", "FourActorGovernance"),
+    "GovernanceDecision": ("actors", "GovernanceDecision"),
+    "AggregateMonitor": ("aggregate_monitor", "AggregateMonitor"),
+    "CollusionFinding": ("aggregate_monitor", "CollusionFinding"),
+    "restrict_registry": ("allowlist", "restrict_registry"),
+    "AuditLog": ("audit", "AuditLog"),
+    "DriftReport": ("drift", "DriftReport"),
+    "Requirement": ("drift", "Requirement"),
+    "Spec": ("drift", "Spec"),
+    "check_drift": ("drift", "check_drift"),
+    "load_spec": ("drift", "load_spec"),
+    "GovernedTool": ("governed_tool", "GovernedTool"),
+    "govern_registry": ("governed_tool", "govern_registry"),
+    "TrustKernel": ("kernel", "TrustKernel"),
+    "CapabilityEvent": ("ledger", "CapabilityEvent"),
+    "SequenceAssessment": ("ledger", "SequenceAssessment"),
+    "SharedTaint": ("ledger", "SharedTaint"),
+    "TaintLedger": ("ledger", "TaintLedger"),
+    "assess_action": ("ledger", "assess_action"),
+    "DANGEROUS_WHEN_TAINTED": ("ledger_tool", "DANGEROUS_WHEN_TAINTED"),
+    "FENCE_CLOSE": ("ledger_tool", "FENCE_CLOSE"),
+    "FENCE_OPEN": ("ledger_tool", "FENCE_OPEN"),
+    "LedgeredTool": ("ledger_tool", "LedgeredTool"),
+    "fence": ("ledger_tool", "fence"),
+    "ledger_registry": ("ledger_tool", "ledger_registry"),
+    "Decision": ("policy", "Decision"),
+    "Rule": ("policy", "Rule"),
+    "RuleSet": ("policy", "RuleSet"),
+    "Verdict": ("policy", "Verdict"),
+    "PrecedentStore": ("precedent", "PrecedentStore"),
+    "QuarantinedReader": ("quarantine", "QuarantinedReader"),
+    "QuarantineResult": ("quarantine", "QuarantineResult"),
+    "fields_schema": ("quarantine", "fields_schema"),
+    "has_control_tokens": ("sanitize", "has_control_tokens"),
+    "sanitize_untrusted": ("sanitize", "sanitize_untrusted"),
+    "strip_leaked_control_tokens": ("sanitize", "strip_leaked_control_tokens"),
+    "ScheduleValidator": ("validator", "ScheduleValidator"),
+    "SkillValidator": ("validator", "SkillValidator"),
+    "ValidationResult": ("validator", "ValidationResult"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a re-exported name on first use, then cache it (PEP 562)."""
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    submodule, attribute = target
+    value = getattr(import_module(f"{__name__}.{submodule}"), attribute)
+    globals()[name] = value  # subsequent lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "Decision",

--- a/chimera/tools/__init__.py
+++ b/chimera/tools/__init__.py
@@ -1,20 +1,75 @@
-"""Native tools — primitive, hand-written capabilities the agent can invoke."""
+"""Native tools — primitive, hand-written capabilities the agent can invoke.
 
-from chimera.tools.base import Tool
-from chimera.tools.browser import BrowserTool, Element, render_elements
-from chimera.tools.builtin import EchoTool, default_registry
-from chimera.tools.documents import ReadDocumentTool
-from chimera.tools.edit import ApplyPatchTool, EditFileTool
-from chimera.tools.files import ListDirTool, ReadFileTool, WriteFileTool
-from chimera.tools.http import HttpGetTool
-from chimera.tools.registry import (
-    DuplicateToolError,
-    ToolNotFoundError,
-    ToolRegistry,
-)
-from chimera.tools.search import GlobTool, GrepTool
-from chimera.tools.shell import RunShellTool
-from chimera.tools.workspace import PathEscapesWorkspaceError, resolve_in_workspace
+**Why the re-exports are lazy.** See :mod:`chimera.eval` for the rationale. There is a second reason
+here: eagerly importing every tool from this ``__init__`` created a genuine import cycle that only the
+*order* of a sibling package's eager imports was hiding. ``chimera.governance.ledger_tool`` needs
+``chimera.tools.base.Tool``; importing it ran this ``__init__``, which pulled ``browser`` / ``documents``
+/ ``scrape``, each of which imports ``fence`` back from ``ledger_tool`` — half-initialised. Resolving
+names on first access (PEP 562) means ``from chimera.tools.base import Tool`` costs exactly that module,
+so the cycle cannot form. ``from chimera.tools import BrowserTool`` still works.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from chimera.tools.base import Tool
+    from chimera.tools.browser import BrowserTool, Element, render_elements
+    from chimera.tools.builtin import EchoTool, default_registry
+    from chimera.tools.documents import ReadDocumentTool
+    from chimera.tools.edit import ApplyPatchTool, EditFileTool
+    from chimera.tools.files import ListDirTool, ReadFileTool, WriteFileTool
+    from chimera.tools.http import HttpGetTool
+    from chimera.tools.registry import (
+        DuplicateToolError,
+        ToolNotFoundError,
+        ToolRegistry,
+    )
+    from chimera.tools.search import GlobTool, GrepTool
+    from chimera.tools.shell import RunShellTool
+    from chimera.tools.workspace import PathEscapesWorkspaceError, resolve_in_workspace
+
+_LAZY: dict[str, tuple[str, str]] = {
+    "Tool": ("base", "Tool"),
+    "BrowserTool": ("browser", "BrowserTool"),
+    "Element": ("browser", "Element"),
+    "render_elements": ("browser", "render_elements"),
+    "EchoTool": ("builtin", "EchoTool"),
+    "default_registry": ("builtin", "default_registry"),
+    "ReadDocumentTool": ("documents", "ReadDocumentTool"),
+    "ApplyPatchTool": ("edit", "ApplyPatchTool"),
+    "EditFileTool": ("edit", "EditFileTool"),
+    "ListDirTool": ("files", "ListDirTool"),
+    "ReadFileTool": ("files", "ReadFileTool"),
+    "WriteFileTool": ("files", "WriteFileTool"),
+    "HttpGetTool": ("http", "HttpGetTool"),
+    "DuplicateToolError": ("registry", "DuplicateToolError"),
+    "ToolNotFoundError": ("registry", "ToolNotFoundError"),
+    "ToolRegistry": ("registry", "ToolRegistry"),
+    "GlobTool": ("search", "GlobTool"),
+    "GrepTool": ("search", "GrepTool"),
+    "RunShellTool": ("shell", "RunShellTool"),
+    "PathEscapesWorkspaceError": ("workspace", "PathEscapesWorkspaceError"),
+    "resolve_in_workspace": ("workspace", "resolve_in_workspace"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a re-exported name on first use, then cache it (PEP 562)."""
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    submodule, attribute = target
+    value = getattr(import_module(f"{__name__}.{submodule}"), attribute)
+    globals()[name] = value  # subsequent lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
 
 __all__ = [
     "Tool",


### PR DESCRIPTION
Ataca a raiz do boot lento do sidecar — a peça que ficou de fora da v0.35.0.

## O diagnóstico mudou no meio do caminho
A leitura ingênua do `-X importtime` dizia "`benchmarks_api` custa 617ms". **Falso:** os números *cumulativos* atribuem o custo de dependências compartilhadas a quem importa **primeiro**. Parar ali teria rendido ~100ms, não 600.

A causa real: **quatro `__init__.py` de pacote com re-exports avidos**. Python roda o `__init__` do pacote antes de *qualquer* submódulo, então `from chimera.eval.benchmark_snapshot import snapshot_path` — módulo cujos imports são `json` e `pathlib` — arrastava `chained → continuous → evolution → governance → core → autonomous → ecosystem`.

## Mudança
`chimera.eval`, `chimera.governance`, `chimera.tools` e `chimera.core` resolvem os re-exports no primeiro acesso (PEP 562) e cacheiam. `from chimera.core import Agent` continua funcionando e custa o mesmo **quando você usa**; os blocos `TYPE_CHECKING` mantêm a visão do mypy exata (não `Any`).

## Números (A/B honesto: mínimo de 7 execuções por lado, com `git stash` entre eles)
| | baseline | lazy | |
|---|---|---|---|
| `import chimera.api.app` | 836ms | **452ms** | **−46%** |
| lançamento → `/api/health` | 1234ms | **915ms** | **−26%** |
| módulos carregados | 627 | **554** | −73 |

O custo **se move, não some**: a primeira requisição que precisa de um módulo pesado paga uma vez. `/api/tools` (pior caso) levou 77ms na primeira chamada e ms de um dígito depois.

## Um import circular real que os imports avidos escondiam
Tornar `governance` preguiçoso **quebrou o app**: `governance.ledger_tool` → `chimera.tools.base` → `tools/__init__` → `tools.browser` → `fence` do `ledger_tool` **pela metade**. O ciclo sempre existiu; só a *ordem* dos imports avidos de um pacote irmão o mascarava. Tornar `chimera.tools` preguiçoso remove o ciclo na origem, em vez de contornar com import dentro de função.

## Verificação
- ruff limpo · mypy 253 arquivos · **1806 testes** (mesmos números de antes, zero regressão)
- App subido de verdade: **21/21 endpoints 200**, com os caminhos preguiçosos exercitados em runtime
- Turno de chat real (SSE streaming + contabilidade de tokens) ponta a ponta

⚠️ Medições feitas em dev (`uv run`, projeto em `/mnt/c` via WSL). O sidecar congelado importa mais devagar, então o ganho absoluto lá tende a ser **maior** — mas isso não foi medido e não está sendo afirmado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)