### PR TITLE
release: v0.36.0rc1 — first prerelease, carrying the boot-time work

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.35.0"
+version = "0.36.0-rc.1"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.35.0",
+  "version": "0.36.0-rc.1",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -16,7 +16,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.35.0",
+  "generated_for": "0.36.0rc1",
   "internal_lift": {
     "baseline_rate": 0.09,
     "ci": [

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.35.0",
+  "generated_for": "0.36.0rc1",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.35.0"
+version = "0.36.0rc1"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a

--- a/uv.lock
+++ b/uv.lock
@@ -508,7 +508,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.35.0"
+version = "0.36.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Prepara o **primeiro `rc` do projeto**, levando o ganho de boot que ficou pronto depois da v0.35.0.

## Por que um rc, e não uma stable
- A **v0.35.0 é imutável** (PyPI recusa re-upload; tag e instaladores assinados já distribuídos), então o ganho precisa de versão nova.
- O `RELEASING.md` limita stable a **1 por semana**, e a v0.35.0 saiu hoje. Uma segunda stable no mesmo dia é exatamente o padrão que a política foi escrita para impedir.
- Um `rc` é permitido **em qualquer dia** e é invisível para quem usa: o updater só lê a última release **não-prerelease**, e o `pip install` não resolve para rc sem `--pre`.

## Detalhe das versões
As três strings concordam em **versão**, não em sintaxe — porque não podem:
| arquivo | valor | padrão |
|---|---|---|
| `pyproject.toml` | `0.36.0rc1` | PEP 440 |
| `src-tauri/Cargo.toml` | `0.36.0-rc.1` | semver |
| `src-tauri/tauri.conf.json` | `0.36.0-rc.1` | semver |

`0.36.0rc1` validado: prerelease, ordena acima de `0.35.0`. Snapshots regenerados (embutem `__version__`).

O CHANGELOG **mantém** a seção `[Unreleased]` — o rc a prevê; a stable é que vai nomeá-la e datá-la.

## Verificação
Um **dry-run do `desktop-release.yml` foi disparado nesta branch** — é o que valida a string semver através do build real do Cargo/Tauri, que eu não consigo checar localmente (sem `cargo` no ambiente). Só publico o rc se ele fechar verde.

O conteúdo de código é o do #8, que já passou na CI completa (ruff · mypy 253 · 1806 testes · install limpo nas 3 plataformas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)