### PR TITLE
docs(releasing): version strings agree on the version, not on the text

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,15 +27,23 @@ rides the next weekly — CI is not a shipped artifact.
 
 ### Why `rc` is safe (verified, not assumed)
 
+All three claims were checked against the live services **after** cutting `v0.36.0rc1` — the first rc
+this project ever published — not merely predicted:
+
 - **The updater ignores it.** The desktop updater reads
   `releases/latest/download/latest.json`, and GitHub's *latest* is by definition "the most recent
   **non-prerelease**, non-draft release". A prerelease never becomes *latest*, so an `rc` is never
-  offered to installed apps. (Checked against the live API: `releases/latest` → `v0.34.0`,
+  offered to installed apps. (With `v0.36.0rc1` published, `releases/latest` still returned `v0.35.0`,
   `prerelease: false`.)
-- **pip ignores it.** `pip install chimera-agent` will not resolve to `0.35.0rc1`; only
-  `--pre` or an exact pin does.
+- **pip ignores it.** With `0.36.0rc1` live on PyPI, `pip install chimera-agent` still resolved to
+  `0.35.0`; only `--pre` or an exact pin reaches the rc.
 - The release CI still runs for a prerelease and attaches installers + a `latest.json` **to that rc's
-  own release page** — useful for testing, invisible to everyone else.
+  own release page** — useful for testing, invisible to everyone else. (All four platforms plus the
+  `.sig` files landed on the rc's page.)
+
+An rc is also the cheapest place to discover that a *release mechanism* is broken. `v0.36.0rc1` is what
+proved the semver prerelease spelling survives a real Cargo/Tauri build — a thing no local check in this
+repo can tell you, since the desktop is only ever built in CI.
 
 ## Before cutting a stable release
 
@@ -68,13 +76,18 @@ rides the next weekly — CI is not a shipped artifact.
 ## Cutting it
 
 ```bash
-# 1. bump all three version strings (they must agree)
-#    pyproject.toml · apps/desktop/src-tauri/Cargo.toml · apps/desktop/src-tauri/tauri.conf.json
+# 1. bump all three version strings — they must agree on the VERSION, not on the literal text.
+#    Python and Rust disagree on how a prerelease is spelled, and neither will accept the other's:
+#      pyproject.toml                       PEP 440   0.36.0   ·  0.36.0rc1
+#      apps/desktop/src-tauri/Cargo.toml    semver    0.36.0   ·  0.36.0-rc.1
+#      apps/desktop/src-tauri/tauri.conf.json  semver 0.36.0   ·  0.36.0-rc.1
+#    (For a stable the three strings do end up identical; only prereleases diverge.)
 # 2. refresh the installed metadata, then regenerate the shipped snapshots (they embed __version__)
 uv pip install -e . --no-deps
 uv run --no-sync python -m chimera.eval.maturity_snapshot
 uv run --no-sync python -m chimera.eval.benchmark_snapshot
-# 3. CHANGELOG: rename [Unreleased] -> [X.Y.Z] - <date>
+# 3. CHANGELOG: rename [Unreleased] -> [X.Y.Z] - <date>   (STABLE ONLY — an rc previews the
+#    [Unreleased] section and leaves it alone; the stable is what names and dates it)
 # 4. commit, push, then:
 gh release create vX.Y.0 --title "..." --notes "..."            # stable
 gh release create vX.Y.0rc1 --prerelease --title "..." --notes "..."   # rc


### PR DESCRIPTION
Corrige uma linha ambígua do `RELEASING.md` que **só apareceu ao rodar o fluxo de verdade** — cortando o primeiro `rc` do projeto.

## O problema
> `# 1. bump all three version strings (they must agree)`

"They must agree" lido ao pé da letra leva a escrever a mesma string nos três arquivos. Isso é **impossível** para um prerelease:

| arquivo | padrão | stable | prerelease |
|---|---|---|---|
| `pyproject.toml` | PEP 440 | `0.36.0` | `0.36.0rc1` |
| `src-tauri/Cargo.toml` | semver | `0.36.0` | `0.36.0-rc.1` |
| `src-tauri/tauri.conf.json` | semver | `0.36.0` | `0.36.0-rc.1` |

Nenhum dos dois aceita a forma do outro. Quem seguisse a linha literalmente escreveria uma versão Cargo inválida e **só descobriria quando o build da release rodasse na CI** — ou seja, com a release já pública.

## O que mais entrou
- **O rename do CHANGELOG é só para stable.** Um `rc` prevê a seção `[Unreleased]` e a deixa quieta; a stable é que nomeia e data.
- **A seção "Why `rc` is safe (verified, not assumed)" agora é verificada de fato.** Com a `v0.36.0rc1` publicada: `pip install chimera-agent` continuou resolvendo `0.35.0`, `releases/latest` continuou retornando `v0.35.0` (`prerelease: false`), e os instaladores das 4 plataformas + `.sig` foram parar na página do próprio rc. Antes eram previsões; agora são medições.
- **Registro do valor real de um rc:** é o lugar mais barato para descobrir que o *mecanismo* de release quebrou. A `v0.36.0rc1` é o que provou que a grafia semver de prerelease sobrevive a um build real do Cargo/Tauri — algo que **nenhuma checagem local neste repo consegue dizer**, já que o desktop só é buildado na CI.

Documentação apenas; nenhuma mudança de comportamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)