### PR TITLE
skills(i18n): translated descriptions, in a sidecar that leaves the card untouched

### DIFF
--- a/skills/i18n/de.json
+++ b/skills/i18n/de.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Ein Generator, der abstürzt, sagt dir, dass er gescheitert ist; einer, der plausible Ausgabe liefert, sagt dir nichts. Prüfe, was er gefunden hat, nie dass er gelaufen ist.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Eine Prüfung, die nach dem eingeführt wird, was sie schützt, ist eine Prüfung, die jemand zum Ausliefern abschaltet. Schließe sie, solange es nichts zu blockieren gibt.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Eine Einstellung, die erfolgreich speichert und bis zum Neustart nichts ändert, ist schlimmer als eine, die fehlschlägt. Sag, wann sie greift, und leite das davon ab, wo sie gelesen wird.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Alles, was von Hand aus einer anderen Datei kopiert wurde, ist genau einmal richtig. Wenn es generierbar ist, generiere es — und lass den Build scheitern, sobald die Kopie veraltet.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Ein leerer Screen, Tab oder eine leere Kategorie ist ein Versprechen, das das Produkt nicht hält. Blende sie aus, bis sie Inhalt hat, oder baue sie noch nicht.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Eine Zahl und ihr Vorbehalt müssen ein Artefakt sein. Zwei Absätze driften auseinander; eine Komponente kann das nicht.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Wenn eine Prüfung beim falschen Ziel anschlägt, macht der Fix sie schwächer. Halte den Fehlalarm im selben Commit als Test fest, sonst erodiert die Regel still.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Veröffentliche das Experiment, das gescheitert ist, bewahre das überholte unverändert auf und würfle nie neu, um Signifikanz zu erreichen. Die Verzerrung liegt in der Auswahl, nicht in der Zahl.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Bevor du eine Aufgabe als erledigt meldest, führe die Prüfung aus, die fehlschlagen würde, wenn sie es nicht wäre — eine Erklärung ist keine Behebung.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Ein Warnhinweis nach der Handlung, die er betrifft, kommt an, wenn die lesende Person längst entschieden hat. Setze ihn darüber und mache ihn unabweisbar, wenn es darauf ankommt.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/es.json
+++ b/skills/i18n/es.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Un generador que se cae te dice que falló; uno que emite salida plausible no te dice nada. Prueba lo que encontró, nunca que se ejecutó.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Una comprobación añadida después de lo que protege es una comprobación que alguien apaga para poder entregar. Déjala cerrada mientras no hay nada que bloquear.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Un control que guarda correctamente y no cambia nada hasta reiniciar es peor que uno que falla. Di cuándo se aplica, y deriva eso de dónde se lee el valor.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Todo lo copiado a mano desde otro archivo es correcto exactamente una vez. Si se puede generar, genéralo, y haz fallar la compilación cuando la copia quede desactualizada.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Una pantalla, pestaña o categoría vacía es una promesa que el producto no está cumpliendo. Ocúltala hasta que tenga contenido, o no la construyas todavía.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Una cifra y su matiz deben ser un único artefacto. Dos párrafos se separan; un componente no puede.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Cuando una comprobación salta sobre el objetivo equivocado, el arreglo la debilita. Captura el falso positivo como prueba en el mismo commit, o la regla se erosiona en silencio.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Publica el experimento que falló, conserva sin cambios el que quedó superado, y nunca repitas la tirada buscando significancia. El sesgo está en la selección, no en el número.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Antes de informar que una tarea está hecha, ejecuta la comprobación que fallaría si no lo estuviera: una explicación no es un arreglo.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Una advertencia colocada después de la acción a la que se refiere llega cuando el lector ya decidió. Ponla arriba y, cuando importa, haz que no se pueda descartar.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/fr.json
+++ b/skills/i18n/fr.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Un générateur qui plante vous dit qu'il a échoué ; un qui produit une sortie plausible ne vous dit rien. Testez ce qu'il a trouvé, jamais qu'il s'est exécuté.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Un contrôle ajouté après ce qu'il protège est un contrôle que quelqu'un désactive pour livrer. Fermez-le pendant qu'il n'y a rien à bloquer.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Un réglage qui s'enregistre correctement et ne change rien jusqu'au redémarrage est pire qu'un réglage qui échoue. Dites quand il s'applique, et déduisez-le de l'endroit où il est lu.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Tout ce qui est recopié à la main depuis un autre fichier est correct exactement une fois. Si cela peut être généré, générez-le, et faites échouer le build quand la copie a vieilli.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Un écran, un onglet ou une catégorie vide est une promesse que le produit ne tient pas. Masquez-le jusqu'à ce qu'il ait du contenu, ou ne le construisez pas encore.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Un chiffre et sa réserve doivent former un seul artefact. Deux paragraphes s'éloignent l'un de l'autre ; un composant ne le peut pas.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Quand un contrôle se déclenche sur la mauvaise cible, le correctif l'affaiblit. Capturez le faux positif sous forme de test dans le même commit, sinon la règle s'érode en silence.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Publiez l'expérience qui a échoué, conservez telle quelle celle qui a été remplacée, et ne relancez jamais pour obtenir la significativité. Le biais est dans la sélection, pas dans le chiffre.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Avant d'annoncer qu'une tâche est terminée, lancez le contrôle qui échouerait si elle ne l'était pas — une explication n'est pas un correctif.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Un avertissement placé après l'action qu'il concerne arrive alors que le lecteur a déjà décidé. Mettez-le au-dessus et, quand cela compte, rendez-le impossible à ignorer.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/it.json
+++ b/skills/i18n/it.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Un generatore che va in crash ti dice che ha fallito; uno che produce output plausibile non ti dice nulla. Verifica ciò che ha trovato, mai che è stato eseguito.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Un controllo aggiunto dopo ciò che protegge è un controllo che qualcuno spegne per consegnare. Chiudilo finché non c'è nulla da bloccare.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Un controllo che salva con successo e non cambia nulla fino al riavvio è peggio di uno che fallisce. Di' quando si applica, e ricavalo da dove viene letto.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Tutto ciò che viene copiato a mano da un altro file è corretto esattamente una volta. Se può essere generato, generalo, e fai fallire la build quando la copia è vecchia.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Una schermata, una scheda o una categoria vuota è una promessa che il prodotto non sta mantenendo. Nascondila finché non ha contenuto, o non costruirla ancora.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Una cifra e la sua precisazione devono essere un solo artefatto. Due paragrafi si allontanano; un componente non può.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Quando un controllo scatta sul bersaglio sbagliato, la correzione lo indebolisce. Fissa il falso positivo come test nello stesso commit, o la regola si erode in silenzio.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Pubblica l'esperimento fallito, conserva invariato quello superato, e non ripetere mai la prova per ottenere significatività. Il bias sta nella selezione, non nel numero.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Prima di dichiarare conclusa un'attività, esegui il controllo che fallirebbe se non lo fosse — una spiegazione non è una correzione.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Un avviso messo dopo l'azione a cui si riferisce arriva quando chi legge ha già deciso. Mettilo sopra e, quando conta, rendilo impossibile da ignorare.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/ja.json
+++ b/skills/i18n/ja.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "クラッシュするジェネレーターは失敗したと教えてくれますが、もっともらしい出力を返すものは何も教えてくれません。実行されたことではなく、何を見つけたかをテストしてください。",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "守る対象より後から追加したチェックは、リリースのために誰かが切るチェックです。まだ止めるものが何もないうちに閉じておいてください。",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "保存には成功するのに再起動まで何も変わらない設定は、失敗する設定より悪いものです。いつ効くのかを明示し、それを読み取り箇所から導いてください。",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "他のファイルから手で写したものは、ちょうど一度だけ正しいものです。生成できるなら生成し、写しが古くなったらビルドを失敗させてください。",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "空の画面・タブ・カテゴリは、製品が守っていない約束です。中身が入るまで隠すか、まだ作らないでください。",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "数値とその但し書きは、ひとつの成果物でなければなりません。段落がふたつあれば離れていきますが、コンポーネントひとつなら離れようがありません。",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "チェックが誤った対象で発火したとき、その修正はチェックを弱めます。同じコミットで誤検知をテストとして固定してください。さもないとルールは静かに擦り減ります。",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "失敗した実験も公表し、置き換えられた結果は手を加えずに残し、有意性を求めて振り直さないでください。バイアスは数値ではなく、選択にあります。",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "タスクを完了と報告する前に、完了していなければ失敗するはずの検査を実行してください。説明は修正ではありません。",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "対象となる操作の後に置かれた注意書きは、読み手がすでに決めた後に届きます。上に置き、重要な場面では消せないようにしてください。",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/pl.json
+++ b/skills/i18n/pl.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Generator, który się wywala, mówi ci, że zawiódł; taki, który zwraca wiarygodne wyjście, nie mówi nic. Testuj to, co znalazł, nigdy to, że się wykonał.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Kontrola dodana po tym, co ma strzec, to kontrola, którą ktoś wyłączy, żeby wydać. Zamknij ją, póki nie ma czego blokować.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Ustawienie, które zapisuje się poprawnie i nic nie zmienia aż do restartu, jest gorsze od takiego, które zawodzi. Powiedz, kiedy zaczyna działać, i wyprowadź to z miejsca, w którym jest odczytywane.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Wszystko, co przepisane ręcznie z innego pliku, jest poprawne dokładnie raz. Jeśli da się to wygenerować, wygeneruj — i wywal build, gdy kopia się zdezaktualizuje.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Pusty ekran, zakładka czy kategoria to obietnica, której produkt nie dotrzymuje. Ukryj ją, dopóki nie ma treści, albo jeszcze jej nie buduj.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Liczba i jej zastrzeżenie muszą być jednym artefaktem. Dwa akapity się rozjeżdżają; jeden komponent nie może.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Gdy kontrola zadziała na złym celu, poprawka ją osłabia. Utrwal fałszywy alarm jako test w tym samym commicie, albo reguła po cichu się wykruszy.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Opublikuj eksperyment, który się nie powiódł, zachowaj niezmieniony ten zastąpiony i nigdy nie powtarzaj losowania dla istotności. Błąd tkwi w selekcji, nie w liczbie.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Zanim zgłosisz zadanie jako zrobione, uruchom kontrolę, która by nie przeszła, gdyby nie było — wyjaśnienie to nie naprawa.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Ostrzeżenie umieszczone po czynności, której dotyczy, dociera, gdy czytelnik już podjął decyzję. Umieść je wyżej, a gdy sprawa jest poważna — nie pozwól go zamknąć.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/pt.json
+++ b/skills/i18n/pt.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Um gerador que quebra avisa que falhou; um que emite saída plausível não avisa nada. Teste o que ele encontrou, nunca que ele rodou.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Uma checagem acrescentada depois daquilo que ela guarda é uma checagem que alguém desliga para entregar. Feche-a enquanto não há nada para bloquear.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Um controle que salva com sucesso e não muda nada até reiniciar é pior que um que falha. Diga quando ele passa a valer, e derive isso de onde o valor é lido.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Tudo o que é copiado à mão de outro arquivo está correto exatamente uma vez. Se dá para gerar, gere — e quebre o build quando a cópia envelhecer.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Uma tela, aba ou categoria vazia é uma promessa que o produto não está cumprindo. Esconda-a até ter conteúdo, ou ainda não a construa.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Um número e sua ressalva têm de ser um único artefato. Dois parágrafos se afastam; um componente não tem como.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Quando uma checagem dispara no alvo errado, o conserto a enfraquece. Registre o falso positivo como teste no mesmo commit, ou a regra se corrói em silêncio.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Publique o experimento que falhou, preserve o que foi superado sem alterá-lo, e nunca repita a rodada atrás de significância. O viés está na seleção, não no número.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Antes de relatar uma tarefa como concluída, rode a checagem que falharia se não estivesse — uma explicação não é um conserto.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Um alerta colocado depois da ação a que se refere chega quando o leitor já decidiu. Ponha-o acima e, quando importa, torne-o impossível de dispensar.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/zh.json
+++ b/skills/i18n/zh.json
@@ -1,0 +1,45 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "会崩溃的生成器告诉你它失败了；输出看似合理的生成器什么也没告诉你。测试它找到了什么，而不是它跑过了。",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "在被守护的东西之后才加的检查，是有人为了发布而关掉的检查。趁还没有东西要拦，就把它接死。",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "保存成功却要重启才生效的设置，比保存失败还糟。说明它何时生效，并从读取它的地方推导出来。",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "任何从别处手抄过来的东西，只正确一次。能生成就生成，并在副本过期时让构建失败。",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "空的界面、标签页或分类，是产品没有兑现的承诺。有内容之前先藏起来，或者干脆先别做。",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "数字和它的限定条件必须是同一个产物。两个段落会各走各的；一个组件做不到。",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "当一项检查打在错误的目标上，修复会让它变弱。在同一个提交里把这个误报固定成测试，否则规则会悄悄被磨掉。",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "把失败的实验也发出来，把被取代的那次原样保留，绝不为了显著性重跑。偏差在于挑选，不在于那个数字。",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "在报告任务完成之前，先跑那个「若未完成就会失败」的检查——解释不是修复。",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "放在所涉动作之后的提醒，到达时读者已经做了决定。把它放在前面；重要的时候，别让它能被关掉。",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}


### PR DESCRIPTION
The ten card descriptions in the eight other languages the site serves — and nothing else about the card, which is the point.

## Why not the body

A card's body is not prose about the product:

- `card_retrieval.py` injects it into the **agent's prompt at runtime**;
- the site publishes a **SHA-256 of its exact bytes** and invites importers to check it;
- `chimera skills-import` reads it **by path**, and `triggers` feed a lexical BM25 match.

Translating it breaks all three at once. The page would show a hash that does not match what the reader is reading, translated triggers would silently defeat the retrieval match, and the translation would never reach the agent anyway — the CLI only ever imports `skills/`. Decoration bought with three guarantees.

## What this does instead

`skills/i18n/<locale>.json`, a sidecar. `SKILL.md` stays byte-identical, so the hash on the page keeps meaning what it says. Each entry declares the SHA-256 of the English description it was made from — same mechanism as the documentation translations — so a description whose English has changed falls back to English instead of paraphrasing a sentence that no longer exists.

The renderer half is in chimera-site and should merge after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)