### PR TITLE
feat(blog): our own text, in nine languages, from one call per item

### DIFF
--- a/ops/chimera_blog_digest.py
+++ b/ops/chimera_blog_digest.py
@@ -408,43 +408,79 @@ def outlet_of(host: str) -> str:
 
 # --------------------------------------------------------------------------- comentário
 
-PROMPT = """Você escreve uma linha de comentário para um boletim de notícias de IA do projeto
-Chimera Agent — um framework open-source de agentes com governança e benchmarks honestos.
+# Os nove idiomas do site. A ordem é a do seletor de idioma, e `en` vem primeiro porque é a única
+# língua em que o modelo escreve sem ajuda: as outras oito saem melhor quando ele já formou a ideia.
+LANGS = ("en", "pt", "es", "fr", "de", "it", "pl", "zh", "ja")
+LANG_NAMES = {
+    "en": "English",
+    "pt": "português do Brasil",
+    "es": "español",
+    "fr": "français",
+    "de": "Deutsch",
+    "it": "italiano",
+    "pl": "polski",
+    "zh": "简体中文",
+    "ja": "日本語",
+}
 
-Recebe a MANCHETE e a DESCRIÇÃO de uma matéria. Escreva UMA a DUAS frases dizendo o que aquilo muda
-para quem constrói agentes de IA. Em {lang}.
+# Frases inteiras que modelos deixam escapar quando "pensam alto" na saída final. Uma delas está no
+# ar agora, num boletim em inglês: "(Alternatively, if shorter is preferred: …)". O modelo estava
+# oferecendo uma escolha ao operador, e o operador era um script.
+ARTIFACTS = re.compile(
+    # A oferta ao operador, no fim: "(Alternatively, if shorter is preferred: …)"
+    r"\s*\((?:alternatively|alternativamente|or,? if|se preferir|caso prefira)[^)]*\)\s*$"
+    # A cortesia de abertura: "Here's the comment:", "Aqui está o comentário:", "Comentário:".
+    # O dois-pontos tem de vir em até 40 caracteres depois do marcador, senão isto comeria uma
+    # frase legítima que só por acaso começa com "Claro" e tem um dois-pontos lá adiante.
+    r"|^\s*(?:aqui est[áa]|segue|here(?:'s| is)|sure|claro|coment[áa]rio|comment)\b[^:\n]{0,40}:\s*",
+    re.I,
+)
+
+PROMPT = """Você escreve o comentário de um boletim de notícias de IA do projeto Chimera Agent —
+um framework open-source de agentes com governança e benchmarks honestos.
+
+Recebe a MANCHETE de uma matéria e, quando existe, uma DESCRIÇÃO curta. Escreva UMA a DUAS frases
+dizendo o que aquilo muda para quem constrói agentes de IA — e escreva a MESMA ideia em cada um dos
+nove idiomas pedidos.
 
 REGRAS INVIOLÁVEIS:
-- NÃO afirme nenhum fato que não esteja na manchete ou na descrição. Nada de números, nomes,
-  datas ou citações que não estejam ali.
-- É comentário, não reportagem. Opinião e implicação, não recontagem da notícia.
-- No máximo {cap} caracteres. Sem markdown, sem aspas ao redor, sem prefixo.
-- PULAR é só para matéria que não trata de IA, de LLM ou de agentes. Se trata, há o que dizer:
-  toda notícia da área muda alguma coisa para quem constrói — custo, risco, expectativa, mercado.
+- NÃO afirme nenhum fato que não esteja na manchete ou na descrição. Nada de números, nomes, datas
+  ou citações que não estejam ali. O que você acrescenta é implicação, nunca informação.
+- Uma descrição curta, ou ausente, NÃO é motivo para pular. A manchete já basta para dizer o que
+  aquilo muda — implicação não depende de detalhe, depende do assunto.
+- É comentário, não reportagem. Não reconte a notícia: diga o que ela significa para quem constrói.
+- Os nove idiomas dizem a MESMA coisa. São traduções de um comentário, não nove opiniões diferentes.
+- No máximo {cap} caracteres por idioma. Sem markdown, sem aspas ao redor, sem prefixo, sem oferecer
+  versões alternativas — quem lê a sua resposta é um script, não uma pessoa que possa escolher.
+- PULAR é só para matéria que não trata de IA, de LLM ou de agentes.
+
+Responda APENAS com um objeto JSON, sem cercas de código, exatamente nesta forma:
+{{"en": "...", "pt": "...", "es": "...", "fr": "...", "de": "...", "it": "...", "pl": "...", "zh": "...", "ja": "..."}}
+
+Para pular, responda apenas: {{"skip": true}}
 
 MANCHETE: {headline}
 DESCRIÇÃO: {description}"""
 
 
-def comment_for(item: dict, lang: str) -> str:
+def _clean(text: str) -> str:
+    """Uma linha, sem aspas de embrulho e sem os restos que o modelo dirige ao operador."""
+    text = " ".join(str(text).replace("\n", " ").split())
+    text = ARTIFACTS.sub("", text).strip()
+    return text.strip('"').strip("'").strip()
+
+
+def _ask(prompt: str, max_tokens: int) -> dict | None:
+    """Uma chamada ao modelo que devolve JSON, ou None. Nunca levanta."""
     key = env("OPENROUTER_API_KEY")
     if not key:
-        return ""
+        return None
     body = {
         "model": env("CHIMERA_DIGEST_MODEL") or "deepseek/deepseek-chat",
-        "messages": [
-            {
-                "role": "user",
-                "content": PROMPT.format(
-                    lang="português do Brasil" if lang == "pt" else "English",
-                    cap=COMMENT_MAX - 40,
-                    headline=item["headline"],
-                    description=item["description"] or "(sem descrição)",
-                ),
-            }
-        ],
-        "max_tokens": 260,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
         "temperature": 0.3,
+        "response_format": {"type": "json_object"},
     }
     req = urllib.request.Request(
         "https://openrouter.ai/api/v1/chat/completions",
@@ -458,17 +494,53 @@ def comment_for(item: dict, lang: str) -> str:
         },
     )
     try:
-        with urllib.request.urlopen(req, timeout=90) as resp:
+        with urllib.request.urlopen(req, timeout=120) as resp:
             data = json.load(resp)
-        text = data["choices"][0]["message"]["content"].strip()
+        raw = data["choices"][0]["message"]["content"].strip()
     except Exception as exc:  # noqa: BLE001
-        log(f"comentário {lang}: {type(exc).__name__} {str(exc)[:70]}")
-        return ""
+        log(f"modelo: {type(exc).__name__} {str(exc)[:70]}")
+        return None
+    # Alguns modelos ignoram response_format e devolvem a cerca de código mesmo assim.
+    raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw).strip()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        log(f"modelo: resposta não é JSON ({raw[:70]})")
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
-    text = " ".join(text.replace("\n", " ").split()).strip('"').strip()
-    if text.upper().startswith("PULAR") or not text:
-        return ""
-    return fit(text, lang)
+
+def comments_for(item: dict) -> dict[str, str]:
+    """Os nove comentários de um item, numa chamada só.
+
+    Uma chamada por idioma custaria nove vezes mais e produziria nove opiniões diferentes sobre a
+    mesma matéria — o leitor alemão leria outra coisa que o brasileiro. Pedir os nove de uma vez é
+    mais barato E é o que torna o boletim o mesmo boletim em toda língua.
+
+    Devolve {} quando o modelo pula, quando falha, ou quando algum idioma não veio: um boletim com
+    buraco em quatro línguas é pior que um item a menos.
+    """
+    parsed = _ask(
+        PROMPT.format(
+            cap=COMMENT_MAX - 40,
+            headline=item["headline"],
+            description=item["description"] or "(sem descrição — use a manchete)",
+        ),
+        max_tokens=1400,
+    )
+    if parsed is None or parsed.get("skip"):
+        return {}
+
+    out: dict[str, str] = {}
+    for lang in LANGS:
+        text = _clean(parsed.get(lang, ""))
+        if not text or text.upper().startswith("PULAR"):
+            log(f"comentário: idioma {lang} veio vazio — item descartado")
+            return {}
+        out[lang] = fit(text, lang)
+        if not out[lang]:
+            return {}
+    return out
 
 
 def fit(text: str, lang: str) -> str:
@@ -507,16 +579,67 @@ def slugify(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
 
 
-def render(lang: str, day: str, slot: str, items: list[dict], dropped: str) -> str:
-    label = {
-        "pt": {"meio-dia": "meio-dia", "fim-do-dia": "fim do dia"},
-        "en": {"meio-dia": "midday", "fim-do-dia": "evening"},
-    }[lang][slot]
-    title = f"Boletim — {day}, {label}" if lang == "pt" else f"Digest — {day}, {label}"
-    # Todos os itens, não só o primeiro: o resumo é o que aparece no índice do blog e no card
-    # social, e um resumo que nomeia uma das três notícias descreve o post errado.
+SUMMARY_PROMPT = """Você escreve a linha de resumo de um boletim de notícias de IA do projeto
+Chimera Agent. Ela aparece no índice do blog e no card compartilhado — é o que decide se alguém abre.
+
+Recebe as manchetes do boletim de hoje. Escreva UMA frase dizendo do que trata este boletim como um
+todo, em cada um dos nove idiomas pedidos.
+
+REGRAS INVIOLÁVEIS:
+- NÃO afirme nenhum fato que não esteja nas manchetes. Nada de números, nomes ou datas novos.
+- Uma frase que descreve o CONJUNTO. Não é lugar de nomear uma das notícias e ignorar as outras.
+- Os nove idiomas dizem a MESMA coisa.
+- No máximo 200 caracteres por idioma. Sem markdown, sem aspas ao redor, sem prefixo.
+
+Responda APENAS com um objeto JSON:
+{{"en": "...", "pt": "...", "es": "...", "fr": "...", "de": "...", "it": "...", "pl": "...", "zh": "...", "ja": "..."}}
+
+MANCHETES:
+{headlines}"""
+
+# O título do post, por idioma, e o rótulo do horário. Sai daqui e não de um if de duas línguas.
+TITLE_WORD = {
+    "en": "Digest", "pt": "Boletim", "es": "Boletín", "fr": "Bulletin", "de": "Bulletin",
+    "it": "Bollettino", "pl": "Biuletyn", "zh": "简报", "ja": "ダイジェスト",
+}
+SLOT_LABEL = {
+    "meio-dia": {
+        "en": "midday", "pt": "meio-dia", "es": "mediodía", "fr": "midi", "de": "Mittag",
+        "it": "mezzogiorno", "pl": "południe", "zh": "午间", "ja": "昼",
+    },
+    "fim-do-dia": {
+        "en": "evening", "pt": "fim do dia", "es": "final del día", "fr": "fin de journée",
+        "de": "Tagesende", "it": "fine giornata", "pl": "koniec dnia", "zh": "日终", "ja": "夕方",
+    },
+}
+
+
+def summaries_for(items: list[dict]) -> dict[str, str]:
+    """A linha de resumo nos nove idiomas, ou {} — e aí o chamador usa as manchetes.
+
+    Era a concatenação das manchetes, que vêm no idioma do veículo. Um boletim em inglês abria com
+    uma frase em português porque a primeira fonte do dia era brasileira, e o card compartilhado
+    saía bilíngue sem que ninguém tivesse decidido isso.
+    """
+    parsed = _ask(
+        SUMMARY_PROMPT.format(headlines="\n".join(f"- {i['headline']}" for i in items)),
+        max_tokens=900,
+    )
+    if parsed is None:
+        return {}
+    out = {lang: _clean(parsed.get(lang, ""))[:280] for lang in LANGS}
+    return out if all(out.values()) else {}
+
+
+def render(
+    lang: str, day: str, slot: str, items: list[dict], dropped: str, summaries: dict[str, str]
+) -> str:
+    title = f"{TITLE_WORD[lang]} — {day}, {SLOT_LABEL[slot][lang]}"
+    # Nosso texto quando o modelo o escreveu; as manchetes como reserva, para o post nunca sair sem
+    # resumo. A reserva é a versão antiga, com a mistura de idiomas que ela sempre teve — visível,
+    # e só quando a chamada falhou.
     heads = " · ".join(i["headline"] for i in items)
-    summary = (heads[:277] + "…") if len(heads) > 280 else heads
+    summary = summaries.get(lang) or ((heads[:277] + "…") if len(heads) > 280 else heads)
     lines = [
         "---",
         f"title: {yaml_str(title)}",
@@ -777,15 +900,16 @@ def main() -> int:
     for item in ordered:
         if len(accepted) >= args.max_items:
             break
-        item["comment_pt"] = comment_for(item, "pt")
-        item["comment_en"] = comment_for(item, "en")
-        if not item["comment_pt"] or not item["comment_en"]:
+        comments = comments_for(item)
+        if not comments:
             reasons.append("sem comentário utilizável")
             log(
-                f"  sem comentário ({'pt' if not item['comment_pt'] else 'en'}): "
-                f"{item['headline'][:70]} | descrição {len(item['description'])} car."
+                f"  sem comentário: {item['headline'][:70]} "
+                f"| descrição {len(item['description'])} car."
             )
             continue
+        for lang, text in comments.items():
+            item[f"comment_{lang}"] = text
         accepted.append(item)
 
     tally: dict[str, int] = {}
@@ -817,9 +941,12 @@ def main() -> int:
 
     day = datetime.now(UTC).strftime("%Y-%m-%d")
     slug = f"boletim-{day}-{args.slot}"
+    summaries = summaries_for(accepted)
+    if not summaries:
+        log("resumo: o modelo não devolveu as nove linhas — usando as manchetes como reserva")
     files = {
-        f"content/blog/pt/{slug}.md": render("pt", day, args.slot, accepted, dropped),
-        f"content/blog/en/{slug}.md": render("en", day, args.slot, accepted, dropped),
+        f"content/blog/{lang}/{slug}.md": render(lang, day, args.slot, accepted, dropped, summaries)
+        for lang in LANGS
     }
 
     if args.dry_run:

--- a/tests/test_blog_digest_text.py
+++ b/tests/test_blog_digest_text.py
@@ -1,0 +1,129 @@
+"""O texto do boletim: nosso, nos nove idiomas, sem os restos que o modelo dirige ao operador.
+
+Três defeitos concretos motivaram estes testes, todos observados no que estava publicado:
+
+1. Um `"(Alternatively, if shorter is preferred: …)"` no ar num boletim em inglês. O modelo ofereceu
+   uma escolha ao operador, e o operador era um script.
+2. Um boletim em inglês cuja linha de resumo estava em português, porque o resumo era a
+   concatenação das manchetes e a primeira fonte do dia era brasileira.
+3. Um dry-run em que 6 de 6 itens foram descartados por "sem comentário utilizável" — o prompt
+   tratava a descrição da fonte como insumo necessário, e descrições de 51 a 204 caracteres não
+   davam. Implicação não depende de detalhe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SRC = Path(__file__).resolve().parent.parent / "ops" / "chimera_blog_digest.py"
+_spec = importlib.util.spec_from_file_location("chimera_blog_digest_text", _SRC)
+assert _spec and _spec.loader
+digest = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(digest)
+
+ITEM = {
+    "headline": "Meta returns to open models",
+    "description": "",  # o caso que zerou o boletim: sem descrição alguma
+    "url": "https://the-decoder.com/x",
+    "outlet": "The Decoder",
+    "published": "2026-08-10",
+}
+
+
+def _modelo(monkeypatch: pytest.MonkeyPatch, resposta: Any) -> None:
+    monkeypatch.setattr(digest, "_ask", lambda *_a, **_k: resposta)
+
+
+class TestArtefatos:
+    def test_remove_a_alternativa_oferecida_ao_operador(self) -> None:
+        sujo = "Isso muda o custo de rodar agentes. (Alternatively, if shorter is preferred: muda o custo.)"
+        assert digest._clean(sujo) == "Isso muda o custo de rodar agentes."
+
+    def test_remove_o_prefixo_de_cortesia(self) -> None:
+        assert digest._clean("Here's the comment: baixa a barreira.") == "baixa a barreira."
+        assert digest._clean("Comentário: baixa a barreira.") == "baixa a barreira."
+
+    def test_nao_come_uma_frase_que_so_tem_dois_pontos(self) -> None:
+        # O risco do conserto: uma regra ampla demais para prefixos apagaria texto de verdade.
+        bom = "O ponto é simples: isso baixa a barreira para quem constrói."
+        assert digest._clean(bom) == bom
+        outro = "Claro que isso muda o custo de rodar agentes em produção."
+        assert digest._clean(outro) == outro
+
+    def test_nao_mutila_um_parenteses_legitimo(self) -> None:
+        # A regra caça uma oferta ao operador, não qualquer parêntese — um aposto no fim da frase
+        # é texto do comentário.
+        bom = "Isso muda o custo (e o risco) de rodar agentes."
+        assert digest._clean(bom) == bom
+
+    def test_desembrulha_aspas_e_junta_linhas(self) -> None:
+        assert digest._clean('"linha um\nlinha dois"') == "linha um linha dois"
+
+
+class TestComentarios:
+    def test_uma_manchete_sem_descricao_ainda_rende_comentario(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # O gargalo medido no dry-run: 6 de 6 descartados por descrição magra.
+        _modelo(monkeypatch, {lang: f"texto {lang}" for lang in digest.LANGS})
+        out = digest.comments_for(ITEM)
+        assert set(out) == set(digest.LANGS)
+        assert out["ja"] == "texto ja"
+
+    def test_um_idioma_faltando_descarta_o_item_inteiro(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Um boletim com buraco em quatro línguas é pior que um item a menos.
+        parcial = {lang: f"texto {lang}" for lang in digest.LANGS}
+        del parcial["pl"]
+        _modelo(monkeypatch, parcial)
+        assert digest.comments_for(ITEM) == {}
+
+    def test_skip_do_modelo_e_respeitado(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _modelo(monkeypatch, {"skip": True})
+        assert digest.comments_for(ITEM) == {}
+
+    def test_falha_do_modelo_nao_levanta(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _modelo(monkeypatch, None)
+        assert digest.comments_for(ITEM) == {}
+
+
+class TestResumo:
+    def test_o_resumo_sai_nos_nove_idiomas(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _modelo(monkeypatch, {lang: f"resumo {lang}" for lang in digest.LANGS})
+        out = digest.summaries_for([ITEM])
+        assert set(out) == set(digest.LANGS)
+
+    def test_resumo_incompleto_e_descartado_inteiro(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        parcial = {lang: f"resumo {lang}" for lang in digest.LANGS}
+        parcial["zh"] = ""
+        _modelo(monkeypatch, parcial)
+        assert digest.summaries_for([ITEM]) == {}
+
+
+class TestRender:
+    def test_usa_o_nosso_resumo_quando_existe(self) -> None:
+        item = {**ITEM, **{f"comment_{lang}": f"c-{lang}" for lang in digest.LANGS}}
+        md = digest.render("de", "2026-08-11", "fim-do-dia", [item], "", {"de": "Unsere Zeile"})
+        assert "summary: Unsere Zeile" in md or "Unsere Zeile" in md
+        assert "Bulletin — 2026-08-11, Tagesende" in md
+        assert "c-de" in md
+
+    def test_cai_para_as_manchetes_quando_o_resumo_falhou(self) -> None:
+        # A reserva é a versão antiga, com a mistura de idiomas que ela sempre teve — e só aparece
+        # quando a chamada falhou, o que o log diz.
+        item = {**ITEM, **{f"comment_{lang}": f"c-{lang}" for lang in digest.LANGS}}
+        md = digest.render("en", "2026-08-11", "meio-dia", [item], "", {})
+        assert ITEM["headline"] in md
+        assert "Digest — 2026-08-11, midday" in md
+
+    def test_cada_idioma_tem_titulo_e_rotulo_proprios(self) -> None:
+        item = {**ITEM, **{f"comment_{lang}": f"c-{lang}" for lang in digest.LANGS}}
+        for lang in digest.LANGS:
+            md = digest.render(lang, "2026-08-11", "meio-dia", [item], "", {})
+            assert digest.TITLE_WORD[lang] in md
+            assert digest.SLOT_LABEL["meio-dia"][lang] in md


### PR DESCRIPTION
Three defects, one cause: the bulletin borrowed the outlet's words, and had nowhere to go when the outlet was terse.

## What changes

**The summary was the headlines, concatenated.** An English bulletin opened with a sentence in Portuguese because the first source of the day was Brazilian, and the shared card came out bilingual without anyone deciding that. It is now our own line, written per language. The headlines remain as the fallback for when the call fails — visible, and only then.

**A thin description killed the item.** The prompt treated the outlet's summary as required input; descriptions of 51–204 characters did not qualify, and a dry-run dropped **six of six**. But the rule that matters — assert no fact that is not in the source — never needed it. What we add is implication, and implication does not depend on detail.

**Model artifacts reached readers.** An `"(Alternatively, if shorter is preferred: …)"` is live in an English bulletin right now: the model was offering the operator a choice, and the operator was a script.

## Nine languages, one call

Nine calls per item would cost nine times as much and produce nine different opinions about the same article — the German reader would get a different argument from the Brazilian. One call returning all nine is cheaper **and** is what makes it the same bulletin in every language. A missing language discards the whole item: a bulletin with a hole in four languages is worse than one item fewer.

The headline, outlet, date and link stay the source's own, in the source's language. That is what must remain quotable rather than rewritten, and the anti-hallucination design rests on it.

## Verified where it runs

A dry-run **inside the sidecar** produced all nine files with their own titles, slot labels and summaries, and published two from eight examined where the previous run published none.

⚠️ Worth recording: my first two dry-runs ran on the VPS *host*, where `/opt/data` does not exist — so there was no API key, `_ask` returned `None`, and every item was dropped. I read that as "descriptions too thin" and told the owner so. It was a path mistake, and the silent `return ""` is what let it pass for a product defect.

## Not in this diff

`sidecar/jobs.json` on the VPS is not in any repository. `blog-digest-meio-dia` is now `enabled: false` and `blog-digest-fim-do-dia` has `timeout: 1800` — the CI wait added earlier can take up to 15 minutes, and the old 900s timeout would have killed the job right at the boundary. Backed up as `jobs.json.bak-blog-1xdia-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)