### PR TITLE
ops: cite by number, because a headline mid-sentence is unreadable

### DIFF
--- a/ops/chimera_blog_writer.py
+++ b/ops/chimera_blog_writer.py
@@ -817,16 +817,24 @@ def translate(art: dict, lang: str, n_sources: int) -> dict | None:
     return None
 
 
-def link_sources(body: str, items: list[dict]) -> str:
-    """Troca cada marcador pelo link da fonte, com a manchete como texto do link.
+def link_sources(body: str, items: list[dict], numbered: bool = True) -> str:
+    """Troca cada marcador pelo link da fonte.
 
-    A manchete fica na língua do veículo, de propósito, nas nove versões: é o texto que a pessoa
-    vai encontrar quando clicar. Traduzir o texto de um link é entregar ao leitor um título que não
-    existe na página para onde ele vai.
+    Numerado, e não com a manchete como texto do link. A primeira versão inseria a manchete inteira,
+    porque ela é o título que a pessoa vai encontrar ao clicar — e traduzi-la seria entregar um
+    título que não existe na página de destino. O raciocínio continua certo; o efeito era ilegível:
+    uma manchete inglesa de treze palavras no meio de uma frase em português, oito vezes por texto.
+    Uma coluna cita por número e põe as manchetes na lista do fim, que é de onde a página as
+    renderiza de qualquer jeito, na língua do veículo.
+
+    `numbered=False` para o texto de release, que não tem bloco de fontes embaixo: ali um `[1]`
+    apontaria para uma lista que a página não mostra.
     """
     def troca(m: re.Match) -> str:
-        item = items[int(m.group(1)) - 1]
-        return f"[{item['headline']}]({item['url']})"
+        i = int(m.group(1))
+        item = items[i - 1]
+        texto = f"[{i}]" if numbered else item["headline"]
+        return f"[{texto}]({item['url']})"
 
     return MARKER.sub(troca, body)
 
@@ -874,7 +882,7 @@ def render(art: dict, day: str, category: str, items: list[dict], dropped: str, 
             ]
     if dropped:
         lines.append(f"dropped: {yaml_str(dropped)}")
-    lines += ["---", "", link_sources(art["body"].strip(), items), ""]
+    lines += ["---", "", link_sources(art["body"].strip(), items, numbered=category == "analysis"), ""]
     return "\n".join(lines)
 
 

--- a/tests/test_blog_writer_text.py
+++ b/tests/test_blog_writer_text.py
@@ -101,16 +101,19 @@ class TestForma:
 
 
 class TestMontagemDoLink:
-    def test_marcador_vira_link_da_fonte_verificada(self) -> None:
+    def test_marcador_vira_numero_ligado_a_fonte_verificada(self) -> None:
+        # Numerado porque a manchete inteira dentro da frase era ilegível: treze palavras em
+        # inglês no meio de um período em português, oito vezes por texto. As manchetes ficam na
+        # lista do fim, que é de onde a página as renderiza de qualquer jeito.
         saida = writer.link_sources(CORPO, FONTES)
-        assert "[Meta returns to open models](https://the-decoder.com/meta-open-models)" in saida
+        assert "[[1]](https://the-decoder.com/meta-open-models)" in saida
+        assert "[[2]](https://techcrunch.com/openai-cyber)" in saida
         assert "[S1]" not in saida and "[S2]" not in saida
 
-    def test_a_manchete_nao_e_traduzida(self) -> None:
-        # O texto do link é a manchete no idioma do veículo, nas nove versões. Traduzi-la entrega
-        # ao leitor um título que não existe na página para onde ele vai.
-        corpo_pt = "Conforme [S1], o cenário muda."
-        assert "Meta returns to open models" in writer.link_sources(corpo_pt, FONTES)
+    def test_o_texto_de_release_usa_a_manchete(self) -> None:
+        # Ali não há bloco de fontes embaixo: um `[1]` apontaria para uma lista que não existe.
+        saida = writer.link_sources("As notas [S1].", FONTES[:1], numbered=False)
+        assert "[Meta returns to open models](https://the-decoder.com/meta-open-models)" in saida
 
 
 # --------------------------------------------------------------------------- a redação


### PR DESCRIPTION
The first published article inlined the full source headline in all nine languages — thirteen English words dropped into the middle of a Portuguese clause, eight times per piece. A column cites by number and puts the headlines in the list at the end, which is where the page renders them anyway, in the outlet's own language.

The release post keeps the headline form: it has no sources block below it, so a `[1]` there would point at a list the page does not show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)