### PR TITLE
chore: the donation link moves to the new Stripe payment link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # Enables the "Sponsor" button on the GitHub repo.
 # Chimera is free and open-source; donations support its development.
-custom: ["https://donate.stripe.com/9B63cofM491m4SBfe177O00"]
+custom: ["https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01"]

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,7 +10,7 @@ this repo — and this document exists to make it addressable rather than merely
 | Maintainers with commit rights | **1** (@brcampidelli) |
 | Maintainers who can publish a release | **1** |
 | Bus factor | **1** |
-| Funding | donations only ([Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)) |
+| Funding | donations only ([Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)) |
 | Governance model | BDFL, by default rather than by design |
 
 If the maintainer stops, the project stops: no one else can merge a security fix, cut a release, or

--- a/README.de.md
+++ b/README.de.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-beitreten-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <b>Deutsch</b> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -477,7 +477,7 @@ Lieber Reddit? Folge **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAgent/)*
 Chimera ist kostenlos und open source, offen entwickelt. Wenn es dir hilft, kannst du die Entwicklung
 mit einer einmaligen Spende unterstützen — jeder Beitrag zählt und wird sehr geschätzt. 💜
 
-**[💜 Über Stripe spenden](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Über Stripe spenden](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Lizenz
 

--- a/README.es.md
+++ b/README.es.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <b>Español</b> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -473,7 +473,7 @@ añadir tu propia **herramienta, skill o receta** (con ejemplos listos para copi
 Chimera es gratuito y de código abierto, desarrollado de forma abierta. Si te resulta útil, puedes
 ayudar a financiar su desarrollo con una donación única — cada aporte cuenta y se agradece muchísimo. 💜
 
-**[💜 Donar con Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Donar con Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <b>Français</b> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -477,7 +477,7 @@ Plutôt Reddit ? Suivez **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAgent
 Chimera est gratuit et open-source, développé au grand jour. S'il vous est utile, vous pouvez aider à
 financer son développement par un don unique — chaque contribution compte et est très appréciée. 💜
 
-**[💜 Faire un don via Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Faire un don via Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Licence
 

--- a/README.it.md
+++ b/README.it.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <b>Italiano</b> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -480,7 +480,7 @@ Preferisci Reddit? Segui **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAgen
 Chimera è gratuito e open-source, costruito allo scoperto. Se ti è utile, puoi aiutare a finanziarne
 lo sviluppo con una donazione una tantum — ogni contributo aiuta ed è enormemente apprezzato. 💜
 
-**[💜 Dona con Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Dona con Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Licenza
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <b>日本語</b></sub>
 
@@ -453,7 +453,7 @@ Reddit 派ですか？ アップデートやディスカッションは **[r/Chi
 
 Chimera は無料のオープンソースで、オープンに開発されています。もし役に立ったら、一度きりの寄付で開発を応援していただけます —— どんな支援もとても励みになり、心から感謝します。💜
 
-**[💜 Stripe で寄付する](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Stripe で寄付する](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><b>English</b> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -463,7 +463,7 @@ Prefer Reddit? Follow **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAgent/)
 Chimera is free and open-source, built in the open. If it's useful to you, you can help fund
 its development with a one-time donation — every bit helps and is hugely appreciated. 💜
 
-**[💜 Donate via Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Donate via Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## License
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <b>Polski</b> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -475,7 +475,7 @@ Wolisz Reddita? Śledź **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAgent
 Chimera jest darmowa i otwartoźródłowa, budowana na widoku. Jeśli jest dla ciebie przydatna, możesz
 pomóc sfinansować jej rozwój jednorazową darowizną — każda złotówka pomaga i jest ogromnie doceniana. 💜
 
-**[💜 Wesprzyj przez Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Wesprzyj przez Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Licencja
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <b>Português</b> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <a href="README.zh-CN.md">中文</a> · <a href="README.ja.md">日本語</a></sub>
 
@@ -466,7 +466,7 @@ Prefere Reddit? Acompanhe **[r/ChimeraAgent](https://www.reddit.com/r/ChimeraAge
 O Chimera é gratuito e open-source, feito de forma aberta. Se ele te for útil, você pode ajudar a
 financiar o desenvolvimento com uma doação única — toda ajuda faz diferença e é muito bem-vinda. 💜
 
-**[💜 Doar via Stripe](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 Doar via Stripe](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## Licença
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg?logo=discord&logoColor=white)](https://discord.gg/ACvBbrmguV)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2FChimeraAgent-FF4500.svg?logo=reddit&logoColor=white)](https://www.reddit.com/r/ChimeraAgent/)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-orange.svg)
-[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://donate.stripe.com/9B63cofM491m4SBfe177O00)
+[![Donate](https://img.shields.io/badge/Donate-Stripe-635BFF.svg?logo=stripe&logoColor=white)](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)
 
 <sub><a href="README.md">English</a> · <a href="README.pt-BR.md">Português</a> · <a href="README.es.md">Español</a> · <a href="README.de.md">Deutsch</a> · <a href="README.fr.md">Français</a> · <a href="README.it.md">Italiano</a> · <a href="README.pl.md">Polski</a> · <b>中文</b> · <a href="README.ja.md">日本語</a></sub>
 
@@ -434,7 +434,7 @@ uv run pytest -q         # 测试套件
 Chimera 完全免费、开源，公开开发。如果它对你有帮助，欢迎通过一次性捐赠来资助
 它的开发 —— 每一份支持都很重要，我们万分感激。💜
 
-**[💜 通过 Stripe 捐赠](https://donate.stripe.com/9B63cofM491m4SBfe177O00)**
+**[💜 通过 Stripe 捐赠](https://buy.stripe.com/9B6aEQ57q91m1Gp7Lz77O01)**
 
 ## 许可证
 


### PR DESCRIPTION
Twenty occurrences across `.github/FUNDING.yml`, `GOVERNANCE.md` and the nine READMEs (badge + closing ask in each).

Verified the new link is live and shows "Donation to the Chimera Agent project" before replacing anything.

Pairs with the same change in chimera-site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)