### PR TITLE
feat(kanban): the board works several cards at once, each in its own worktree

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -2302,6 +2302,11 @@
             ],
             "title": "Model"
           },
+          "workers": {
+            "default": 1,
+            "title": "Workers",
+            "type": "integer"
+          },
           "workspace": {
             "anyOf": [
               {

--- a/apps/desktop/src/components/Tasks.parallel.test.tsx
+++ b/apps/desktop/src/components/Tasks.parallel.test.tsx
@@ -1,0 +1,89 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Tasks } from "@/components/Tasks";
+import { renderWithProviders as render } from "@/test/utils";
+
+/**
+ * Working several cards at once, from the board.
+ *
+ * The number is remembered because it is a property of this board and this machine, not of one
+ * press — and the conflict notice stays after the run because those cards went green and not all
+ * of their edits survived the merge, which is the one thing a finished board would otherwise hide.
+ */
+vi.mock("@/lib/api", () => ({
+  addKanbanCard: vi.fn(),
+  approveProject: vi.fn(),
+  denyProject: vi.fn(),
+  getAgentRegistry: vi.fn(),
+  getKanban: vi.fn(),
+  getProject: vi.fn(),
+  getProjects: vi.fn(),
+  moveKanbanCard: vi.fn(),
+  removeKanbanCard: vi.fn(),
+  startProject: vi.fn(),
+  stepProject: vi.fn(),
+  streamKanbanRun: vi.fn(),
+}));
+
+const api = await import("@/lib/api");
+
+describe("dispatching the board in parallel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.mocked(api.getKanban).mockResolvedValue({ backlog: [], doing: [], review: [], done: [] });
+    vi.mocked(api.getProjects).mockResolvedValue([]);
+    vi.mocked(api.getAgentRegistry).mockResolvedValue([]);
+  });
+
+  it("sends the chosen number of workers, and remembers it", async () => {
+    vi.mocked(api.streamKanbanRun).mockImplementation(async (_req, h) => h.onDone?.({ worked: 0 }));
+    const user = userEvent.setup();
+    render(<Tasks />);
+
+    const seletor = await screen.findByRole("combobox");
+    await user.selectOptions(seletor, "4");
+    await user.click(screen.getByRole("button", { name: /run/i }));
+
+    await waitFor(() =>
+      expect(api.streamKanbanRun).toHaveBeenCalledWith(
+        expect.objectContaining({ workers: 4 }),
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+    expect(localStorage.getItem("chimera.kanban.workers")).toBe("4");
+  });
+
+  it("defaults to one, which is the board that shipped", async () => {
+    vi.mocked(api.streamKanbanRun).mockImplementation(async (_req, h) => h.onDone?.({ worked: 0 }));
+    const user = userEvent.setup();
+    render(<Tasks />);
+
+    await user.click(await screen.findByRole("button", { name: /run/i }));
+    await waitFor(() =>
+      expect(api.streamKanbanRun).toHaveBeenCalledWith(
+        expect.objectContaining({ workers: 1 }),
+        expect.anything(),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("keeps the conflict notice up after the run finishes", async () => {
+    // Two cards succeeded and both changed the same file. The board is green; only this says that
+    // one of those versions is gone.
+    vi.mocked(api.streamKanbanRun).mockImplementation(async (_req, h) => {
+      h.onConflict?.(["src/app.ts", "README.md"]);
+      h.onDone?.({ worked: 2 });
+    });
+    const user = userEvent.setup();
+    render(<Tasks />);
+
+    await user.click(await screen.findByRole("button", { name: /run/i }));
+    expect(await screen.findByText(/more than one card/i)).toBeInTheDocument();
+    expect(screen.getByText(/src\/app\.ts/)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/Tasks.tsx
+++ b/apps/desktop/src/components/Tasks.tsx
@@ -259,6 +259,8 @@ function StartProject({ onStart }: { onStart: (spec: string) => void }) {
   );
 }
 
+const WORKERS_KEY = "chimera.kanban.workers";
+
 /** The board's live dispatch: start it, stop it, and say what it is doing while it runs.
  *
  * A dispatch calls models for as long as the backlog has cards, so the button has to be a Stop as
@@ -269,7 +271,19 @@ function useDispatch(onCard: () => void) {
   const t = useT();
   const [running, setRunning] = useState(false);
   const [line, setLine] = useState("");
+  const [conflicts, setConflicts] = useState<string[]>([]);
+  // Remembered, because the answer is a property of this board and this machine, not of one press.
+  const [workers, setWorkers] = useState(() => Number(localStorage.getItem(WORKERS_KEY) ?? 1) || 1);
   const abort = useRef<AbortController | null>(null);
+
+  const changeWorkers = (n: number) => {
+    setWorkers(n);
+    try {
+      localStorage.setItem(WORKERS_KEY, String(n));
+    } catch {
+      /* private mode — the choice just does not survive the launch */
+    }
+  };
 
   const toggle = () => {
     if (running) {
@@ -283,13 +297,17 @@ function useDispatch(onCard: () => void) {
     abort.current = controller;
     setRunning(true);
     setLine(t("tasks.dispatching"));
+    setConflicts([]);
     void streamKanbanRun(
-      {},
+      { workers },
       {
         onCard: (outcome) => {
           setLine(`${outcome.card_id} → ${outcome.moved_to}`);
           onCard();
         },
+        // Kept on screen after the run: those cards succeeded and not all of their edits survived
+        // the merge, which is the one thing a green board would otherwise hide.
+        onConflict: setConflicts,
         onDone: (summary) => {
           setRunning(false);
           // The count of cards actually WORKED, which is not the count that was queued: a card
@@ -307,7 +325,7 @@ function useDispatch(onCard: () => void) {
     );
   };
 
-  return { running, line, toggle };
+  return { running, line, toggle, workers, changeWorkers, conflicts };
 }
 
 export function Tasks({ embedded = false }: { embedded?: boolean } = {}) {
@@ -401,6 +419,24 @@ export function Tasks({ embedded = false }: { embedded?: boolean } = {}) {
                   {dispatch.line}
                 </span>
               )}
+              {/* How many cards at once. Hidden while running, because changing it mid-dispatch
+                  would set a number for the next run and read as if it applied to this one. */}
+              {!dispatch.running && (
+                <label className="flex items-center gap-1 text-xs text-muted-foreground">
+                  {t("tasks.workers")}
+                  <select
+                    className="rounded-chip border border-hairline bg-transparent px-1.5 py-0.5"
+                    value={dispatch.workers}
+                    onChange={(e) => dispatch.changeWorkers(Number(e.target.value))}
+                  >
+                    {[1, 2, 3, 4, 6, 8].map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
               <Button size="sm" variant={dispatch.running ? "outline" : "ghost"} onClick={dispatch.toggle}>
                 {dispatch.running ? (
                   <>
@@ -424,6 +460,12 @@ export function Tasks({ embedded = false }: { embedded?: boolean } = {}) {
           <>
             {/* Cards are added to the board, never to a project: a project's cards come from its
                 spec, and one typed in by hand would be work its drift check does not know about. */}
+            {dispatch.conflicts.length > 0 && (
+              <p className="mb-3 rounded-chip border border-warn/30 bg-warn/10 px-3 py-2 text-xs text-warn-foreground">
+                {t("tasks.conflicts", { n: dispatch.conflicts.length })}{" "}
+                <span className="font-mono">{dispatch.conflicts.slice(0, 4).join(", ")}</span>
+              </p>
+            )}
             {!selected && <AddCard onAdd={(card) => add.mutate(card)} known={knownAgents} />}
             <Board
               columns={(selected ? project.data?.columns : kanban.data) ?? {}}

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -2360,6 +2360,11 @@ export interface components {
             limit?: number | null;
             /** Model */
             model?: string | null;
+            /**
+             * Workers
+             * @default 1
+             */
+            workers: number;
             /** Workspace */
             workspace?: string | null;
         };

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -277,9 +277,17 @@ export interface DispatchOutcome {
  * and a refactor that arrives with a feature is a refactor nobody can review separately from it.
  */
 export async function streamKanbanRun(
-  req: { limit?: number | null; workspace?: string | null; model?: string | null },
+  req: {
+    limit?: number | null;
+    workspace?: string | null;
+    model?: string | null;
+    /** Cards worked at once. Above 1 each gets its own git worktree; see the backend's dispatch. */
+    workers?: number;
+  },
   handlers: {
     onCard?: (outcome: DispatchOutcome) => void;
+    /** Files two successful cards both changed. Only one version came back. */
+    onConflict?: (paths: string[]) => void;
     onDone?: (summary: { worked: number; error?: string }) => void;
     onError?: (message: string) => void;
   },
@@ -322,6 +330,7 @@ export async function streamKanbanRun(
       try {
         const data = JSON.parse(payload);
         if (event === "card") handlers.onCard?.(data as DispatchOutcome);
+        else if (event === "conflict") handlers.onConflict?.((data as { paths: string[] }).paths);
         else if (event === "done") handlers.onDone?.(data as { worked: number; error?: string });
       } catch {
         // A frame we cannot parse is one frame lost, not a broken dispatch: the board is the

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -676,6 +676,8 @@ const en: Dict = {
   "server.errUnreachable": "Could not reach it. Either the address is wrong, or that instance has not been told to allow this app — the browser cannot tell those apart. Set CHIMERA_ALLOWED_ORIGINS={origin} there.",
   "server.errUnauthorized": "The token was refused.",
   "server.errNotChimera": "Something answered, but it is not a Chimera.",
+  "tasks.workers": "at once",
+  "tasks.conflicts": "{n} file(s) were changed by more than one card, so only one version came back:",
 };
 
 const pt: Dict = {
@@ -1327,6 +1329,8 @@ const pt: Dict = {
   "server.errUnreachable": "Não consegui alcançar. Ou o endereço está errado, ou aquela instância não foi avisada para permitir este app — o navegador não distingue os dois casos. Defina lá CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "O token foi recusado.",
   "server.errNotChimera": "Alguma coisa respondeu, mas não é um Chimera.",
+  "tasks.workers": "de cada vez",
+  "tasks.conflicts": "{n} arquivo(s) foram alterados por mais de um cartão, então só uma versão voltou:",
 };
 
 const es: Dict = {
@@ -1978,6 +1982,8 @@ const es: Dict = {
   "server.errUnreachable": "No pude alcanzarlo. O la dirección es incorrecta, o esa instancia no ha sido configurada para permitir esta app — el navegador no distingue ambos casos. Define allí CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "El token fue rechazado.",
   "server.errNotChimera": "Algo respondió, pero no es un Chimera.",
+  "tasks.workers": "a la vez",
+  "tasks.conflicts": "{n} archivo(s) fueron modificados por más de una tarjeta, así que solo volvió una versión:",
 };
 
 const fr: Dict = {
@@ -2629,6 +2635,8 @@ const fr: Dict = {
   "server.errUnreachable": "Impossible de l'atteindre. Soit l'adresse est fausse, soit cette instance n'autorise pas cette application — le navigateur ne distingue pas les deux. Définissez-y CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "Le jeton a été refusé.",
   "server.errNotChimera": "Quelque chose a répondu, mais ce n'est pas un Chimera.",
+  "tasks.workers": "à la fois",
+  "tasks.conflicts": "{n} fichier(s) ont été modifiés par plus d'une carte ; une seule version est revenue :",
 };
 
 const de: Dict = {
@@ -3280,6 +3288,8 @@ const de: Dict = {
   "server.errUnreachable": "Nicht erreichbar. Entweder ist die Adresse falsch, oder diese Instanz erlaubt diese App nicht — der Browser kann beides nicht unterscheiden. Setzen Sie dort CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "Das Token wurde abgelehnt.",
   "server.errNotChimera": "Etwas hat geantwortet, aber es ist kein Chimera.",
+  "tasks.workers": "gleichzeitig",
+  "tasks.conflicts": "{n} Datei(en) wurden von mehr als einer Karte geändert, also kam nur eine Fassung zurück:",
 };
 
 const zh: Dict = {
@@ -3928,6 +3938,8 @@ const zh: Dict = {
   "server.errUnreachable": "无法连接。可能是地址不对，也可能是那个实例没有被允许接受本应用——浏览器无法区分这两种情况。请在那边设置 CHIMERA_ALLOWED_ORIGINS={origin}。",
   "server.errUnauthorized": "令牌被拒绝。",
   "server.errNotChimera": "有东西响应了，但它不是 Chimera。",
+  "tasks.workers": "并行",
+  "tasks.conflicts": "有 {n} 个文件被多张卡片修改，因此只有一个版本被合并回来：",
 };
 
 const ja: Dict = {
@@ -4577,6 +4589,8 @@ const ja: Dict = {
   "server.errUnreachable": "到達できませんでした。アドレスが違うか、そのインスタンスがこのアプリを許可していないかです —— ブラウザはこの二つを区別できません。向こう側で CHIMERA_ALLOWED_ORIGINS={origin} を設定してください。",
   "server.errUnauthorized": "トークンが拒否されました。",
   "server.errNotChimera": "何かが応答しましたが、Chimera ではありません。",
+  "tasks.workers": "同時に",
+  "tasks.conflicts": "{n} 個のファイルが複数のカードから変更されたため、戻ったのは一方だけです:",
 };
 
 const it: Dict = {
@@ -5203,6 +5217,8 @@ const it: Dict = {
   "server.errUnreachable": "Non sono riuscito a raggiungerlo. O l'indirizzo è sbagliato, o quell'istanza non è stata configurata per consentire questa app — il browser non distingue i due casi. Imposta lì CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "Il token è stato rifiutato.",
   "server.errNotChimera": "Qualcosa ha risposto, ma non è un Chimera.",
+  "tasks.workers": "alla volta",
+  "tasks.conflicts": "{n} file sono stati modificati da più di una scheda, quindi è tornata una sola versione:",
 };
 
 const pl: Dict = {
@@ -5829,6 +5845,8 @@ const pl: Dict = {
   "server.errUnreachable": "Nie udało się połączyć. Albo adres jest błędny, albo tamta instancja nie zezwala tej aplikacji — przeglądarka nie odróżnia tych przypadków. Ustaw tam CHIMERA_ALLOWED_ORIGINS={origin}.",
   "server.errUnauthorized": "Token został odrzucony.",
   "server.errNotChimera": "Coś odpowiedziało, ale to nie jest Chimera.",
+  "tasks.workers": "naraz",
+  "tasks.conflicts": "{n} plik(ów) zmieniła więcej niż jedna karta, więc wróciła tylko jedna wersja:",
 };
 
 export const DICTS: Record<Lang, Dict> = { en, pt, es, fr, de, it, pl, zh, ja };

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -2219,6 +2219,18 @@
               ],
               "required": false,
               "type": "str"
+            },
+            {
+              "default": "1",
+              "help": "Work this many cards at once, each in its own git worktree.",
+              "kind": "option",
+              "name": "workers",
+              "opts": [
+                "--workers",
+                "-j"
+              ],
+              "required": false,
+              "type": "int"
             }
           ],
           "path": "kanban run"

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -333,6 +333,14 @@ def register_features(
         queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
+        def emit_conflict(paths: list[str]) -> None:
+            # A file two successful cards both changed. Only one version can come back, so the run
+            # says which files that happened to instead of picking one and reporting two successes.
+            loop.call_soon_threadsafe(
+                queue.put_nowait,
+                {"event": "conflict", "data": json.dumps({"paths": paths})},
+            )
+
         def emit(outcome: Any) -> None:
             loop.call_soon_threadsafe(
                 queue.put_nowait,
@@ -352,7 +360,15 @@ def register_features(
         def work() -> None:
             done: dict[str, Any]
             try:
-                outcomes = dispatch(board, runners, limit=req.limit, on_outcome=emit)
+                outcomes = dispatch(
+                    board,
+                    runners,
+                    limit=req.limit,
+                    on_outcome=emit,
+                    workers=req.workers,
+                    workspace=ws,
+                    on_conflict=emit_conflict,
+                )
                 done = {"worked": len(outcomes)}
             except Exception as exc:  # noqa: BLE001 — a dispatch failure is a frame, not a 500
                 done = {"worked": 0, "error": str(exc)}

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -539,6 +539,14 @@ class KanbanRunIn(BaseModel):
     model: str | None = None
     """A model for the lanes that have none pinned. An agent's own pin still wins over it."""
 
+    workers: int = 1
+    """How many cards to work at once. 1 is the sequential board this endpoint has always been.
+
+    Above 1 each card gets its own git worktree and the edits are merged back afterwards, because
+    two of the lanes run the autonomous verify-or-revert loop against the workspace and would
+    otherwise undo each other's files. A file two cards both changed arrives as a `conflict` frame
+    rather than being silently resolved to one of them."""
+
 
 class ProjectStateOut(BaseModel):
     id: str

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -4154,6 +4154,9 @@ def kanban_run(
     limit: int = typer.Option(None, "--limit", "-n", help="Max backlog cards to dispatch."),
     workspace: str = typer.Option(".", "--workspace", "-w", help="Workspace for the solve lane."),
     model: str = typer.Option(None, "--model", "-m", help="Override the model slug."),
+    workers: int = typer.Option(
+        1, "--workers", "-j", help="Work this many cards at once, each in its own git worktree."
+    ),
 ) -> None:
     """Dispatch backlog cards through their lanes (solve/crew). Requires a key."""
     from chimera.core.registry import load as load_agents
@@ -4173,7 +4176,21 @@ def kanban_run(
         "solve": SolveLane(workspace=Path(workspace), model=model),
         "crew": CrewLane(model=model),
     }
-    outcomes = dispatch(board, runners, limit=limit)
+    def conflitos(paths: list[str]) -> None:
+        # Said before the per-card lines, because it changes how they should be read: those cards
+        # succeeded, and not all of their edits survived the merge.
+        console.print(f"[yellow]{len(paths)} file(s) changed by more than one card:[/yellow]")
+        for path in paths[:10]:
+            console.print(f"  [dim]{path}[/dim]")
+
+    outcomes = dispatch(
+        board,
+        runners,
+        limit=limit,
+        workers=workers,
+        workspace=Path(workspace),
+        on_conflict=conflitos,
+    )
     if not outcomes:
         console.print("[dim]nothing in backlog to run[/dim]")
         return

--- a/chimera/kanban/board.py
+++ b/chimera/kanban/board.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import uuid
 from pathlib import Path
 
@@ -13,11 +14,20 @@ _log = get_logger("kanban.board")
 
 
 class KanbanBoard:
-    """A JSON-file board of cards, addressable by id and groupable by column."""
+    """A JSON-file board of cards, addressable by id and groupable by column.
+
+    Mutations are serialised by a lock. Every one of them ends in :meth:`save`, which rewrites the
+    whole file — so two threads finishing a card at the same moment can interleave a read of
+    ``_cards`` with another thread's write and persist a board missing somebody's result. That was
+    unreachable while dispatch ran one card at a time; it stops being unreachable the moment it
+    runs several, and a lost result on a board is a task that silently never happened.
+    """
 
     def __init__(self, path: Path) -> None:
         self.path = Path(path)
         self._cards: dict[str, KanbanCard] = {}
+        # Re-entrant: the public mutators call `save()`, which takes it again.
+        self._lock = threading.RLock()
         self.load()
 
     def load(self) -> None:
@@ -36,6 +46,10 @@ class KanbanBoard:
             self._cards[card.id] = card
 
     def save(self) -> None:
+        with self._lock:
+            self._save_locked()
+
+    def _save_locked(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         data = [card.model_dump() for card in self._cards.values()]
         # Atomic write: a crash mid-write must not truncate the board and lose every card.
@@ -49,35 +63,43 @@ class KanbanBoard:
         card = KanbanCard(
             id=uuid.uuid4().hex[:8], title=title, action=action, lane=lane, verify=verify
         )
-        self._cards[card.id] = card
-        self.save()
+        with self._lock:
+            self._cards[card.id] = card
+            self._save_locked()
         return card
 
     def get(self, card_id: str) -> KanbanCard | None:
         return self._cards.get(card_id)
 
     def cards(self, column: Column | None = None) -> list[KanbanCard]:
-        items = list(self._cards.values())
+        # Snapshot under the lock: iterating the live dict while another thread finishes a card
+        # raises "dictionary changed size during iteration" — a crash in the reader, caused by a
+        # writer, in a place with nothing to do with either.
+        with self._lock:
+            items = list(self._cards.values())
         return [c for c in items if c.column == column] if column else items
 
     def move(self, card_id: str, column: Column) -> KanbanCard:
-        card = self._cards[card_id]
-        card.column = column
-        self.save()
-        return card
+        with self._lock:
+            card = self._cards[card_id]
+            card.column = column
+            self._save_locked()
+            return card
 
     def record_result(self, card_id: str, *, success: bool, result: str) -> KanbanCard:
-        card = self._cards[card_id]
-        card.success = success
-        card.result = result
-        self.save()
-        return card
+        with self._lock:
+            card = self._cards[card_id]
+            card.success = success
+            card.result = result
+            self._save_locked()
+            return card
 
     def remove(self, card_id: str) -> bool:
-        existed = card_id in self._cards
-        self._cards.pop(card_id, None)
-        if existed:
-            self.save()
+        with self._lock:
+            existed = card_id in self._cards
+            self._cards.pop(card_id, None)
+            if existed:
+                self._save_locked()
         return existed
 
     def __len__(self) -> int:

--- a/chimera/kanban/dispatch.py
+++ b/chimera/kanban/dispatch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 from chimera.kanban.board import KanbanBoard
@@ -26,7 +27,13 @@ class LaneResult:
 
 
 class LaneRunner(Protocol):
-    """Anything that can work a card and report success (a solve/crew lane)."""
+    """Anything that can work a card and report success (a solve/crew lane).
+
+    A lane that writes files may also offer ``for_workspace(path) -> LaneRunner``, returning itself
+    bound to another directory. Parallel dispatch calls it to give each card its own git worktree;
+    a lane without it runs as-is, which is right for one that only calls a model. It is optional
+    rather than required so that somebody's own lane keeps working without knowing this exists.
+    """
 
     def run(self, card: KanbanCard) -> LaneResult: ...
 
@@ -45,32 +52,109 @@ def dispatch(
     *,
     limit: int | None = None,
     on_outcome: Callable[[DispatchOutcome], None] | None = None,
+    workers: int = 1,
+    workspace: Path | None = None,
+    on_conflict: Callable[[list[str]], None] | None = None,
 ) -> list[DispatchOutcome]:
     """Run queued backlog cards through their lanes; returns one outcome per card run.
 
     ``on_outcome`` fires as each card finishes, for a caller that is streaming rather than waiting.
     Without it the behaviour is byte-identical — a board dispatched from a terminal has nobody to
     tell, and a callback nobody passed should cost nothing.
+
+    ``workers`` > 1 works several cards at once. It is not a thread pool around this loop: two of
+    the three lanes run the autonomous plan / execute / verify-or-revert loop **against the
+    workspace**, so running them together as-is would have each one reverting files the other had
+    just written. Parallel therefore means *isolated* — one git worktree per card, edits merged
+    back afterwards, and a file two successful cards both changed reported through ``on_conflict``
+    rather than silently taking one of them.
+
+    ``workspace`` is where those worktrees are cut from; without it, or outside a git repo, cards
+    share the directory and the caller owns that decision. ``workers=1`` is the default and is the
+    old path exactly — the sequential loop below, unchanged.
     """
-    outcomes: list[DispatchOutcome] = []
     queued = board.cards("backlog")
     if limit is not None:
         queued = queued[:limit]
+    runnable = [(card, runners[card.lane]) for card in queued if card.lane in runners]
     for card in queued:
-        runner = runners.get(card.lane)
-        if runner is None:
+        if card.lane not in runners:
             _log.warning("no runner for lane %r; leaving card %s in backlog", card.lane, card.id)
-            continue
-        board.move(card.id, "doing")
-        try:
-            result = runner.run(card)
-        except Exception as exc:  # noqa: BLE001 — a lane failure parks the card for review
-            result = LaneResult(success=False, answer=f"error: {exc}")
-        board.record_result(card.id, success=result.success, result=result.answer)
-        target: Column = "done" if result.success else "review"
-        board.move(card.id, target)
-        outcome = DispatchOutcome(card.id, card.lane, result.success, target)
-        outcomes.append(outcome)
-        if on_outcome is not None:
-            on_outcome(outcome)
+
+    if workers > 1 and len(runnable) > 1:
+        return _dispatch_parallel(board, runnable, on_outcome, workers, workspace, on_conflict)
+
+    outcomes: list[DispatchOutcome] = []
+    for card, runner in runnable:
+        outcomes.append(_work(board, card, runner, on_outcome))
+    return outcomes
+
+
+def _work(
+    board: KanbanBoard,
+    card: KanbanCard,
+    runner: LaneRunner,
+    on_outcome: Callable[[DispatchOutcome], None] | None,
+) -> DispatchOutcome:
+    """One card, start to finish. The board's own lock makes this safe from several threads."""
+    board.move(card.id, "doing")
+    try:
+        result = runner.run(card)
+    except Exception as exc:  # noqa: BLE001 — a lane failure parks the card for review
+        result = LaneResult(success=False, answer=f"error: {exc}")
+    board.record_result(card.id, success=result.success, result=result.answer)
+    target: Column = "done" if result.success else "review"
+    board.move(card.id, target)
+    outcome = DispatchOutcome(card.id, card.lane, result.success, target)
+    if on_outcome is not None:
+        on_outcome(outcome)
+    return outcome
+
+
+def _dispatch_parallel(
+    board: KanbanBoard,
+    runnable: list[tuple[KanbanCard, LaneRunner]],
+    on_outcome: Callable[[DispatchOutcome], None] | None,
+    workers: int,
+    workspace: Path | None,
+    on_conflict: Callable[[list[str]], None] | None,
+) -> list[DispatchOutcome]:
+    from chimera.orchestration.isolation import run_isolated
+
+    def unit(card: KanbanCard, runner: LaneRunner) -> Callable[[Path], DispatchOutcome]:
+        def go(isolated: Path) -> DispatchOutcome:
+            # A lane that writes files says so by offering `for_workspace`; one that only calls a
+            # model (the crew lane) has nothing to rebind and runs as it is. Asking the object
+            # rather than listing the classes here keeps a user's own lane working too.
+            bound = runner
+            rebind = getattr(runner, "for_workspace", None)
+            if callable(rebind):
+                bound = rebind(isolated)
+            return _work(board, card, bound, on_outcome)
+
+        return go
+
+    batch = run_isolated(
+        workspace or Path.cwd(),
+        [(card.id, unit(card, runner)) for card, runner in runnable],
+        # Every unit reports its own success on the card; a unit that raised is already recorded as
+        # a failed card by `_work`, so nothing here should re-judge it.
+        succeeded=lambda _outcome: True,
+        max_workers=workers,
+    )
+    if batch.conflicts and on_conflict is not None:
+        on_conflict(batch.conflicts)
+    if batch.conflicts:
+        _log.warning("kanban dispatch: %d file(s) changed by more than one card", len(batch.conflicts))
+
+    outcomes: list[DispatchOutcome] = []
+    for card, _runner in runnable:
+        result = next((r for r in batch.results if r.name == card.id), None)
+        if result is not None and result.value is not None:
+            outcomes.append(result.value)
+        else:
+            # The unit itself died (a timeout, or a crash outside the lane's own try). The card is
+            # still in `doing`, which is honest — nothing finished it — and saying so beats
+            # reporting a card that never ran as done.
+            outcomes.append(DispatchOutcome(card.id, card.lane, False, "doing"))
     return outcomes

--- a/chimera/kanban/lanes.py
+++ b/chimera/kanban/lanes.py
@@ -36,6 +36,17 @@ class SolveLane:
         self.model = model
         self.max_attempts = max_attempts
 
+    def for_workspace(self, workspace: Path) -> SolveLane:
+        """The same lane bound to another directory — how a card gets run in isolation.
+
+        Parallel dispatch gives each card its own git worktree, and a lane that writes files has to
+        be told about it or every card would edit the one real workspace at once: two autonomous
+        loops running plan / execute / verify-or-revert over the same files, each reverting work the
+        other had just done. Rebinding is a new instance, not a mutation, because the caller keeps
+        using the original for the next batch.
+        """
+        return SolveLane(workspace=workspace, model=self.model, max_attempts=self.max_attempts)
+
     def run(self, card: KanbanCard) -> LaneResult:
         from chimera.config import get_settings
         from chimera.core import (
@@ -111,6 +122,12 @@ class AgentLane:
         # model on an agent said something more specific than the flag that dispatched the board.
         self.model = agent.model or model
         self.max_attempts = max_attempts
+
+    def for_workspace(self, workspace: Path) -> AgentLane:
+        """The same agent bound to another directory. See ``SolveLane.for_workspace``."""
+        return AgentLane(
+            self.agent, workspace=workspace, model=self.model, max_attempts=self.max_attempts
+        )
 
     def run(self, card: KanbanCard) -> LaneResult:
         from chimera.config import get_settings

--- a/tests/test_kanban_parallel.py
+++ b/tests/test_kanban_parallel.py
@@ -1,0 +1,239 @@
+"""Working several cards at once, without them running over each other.
+
+The board dispatched one card at a time. Making that parallel is not a thread pool around the loop:
+two of the three lanes run the autonomous plan / execute / verify-or-revert loop **against the
+workspace**, so N of them in one directory means each reverting files another had just written —
+silent loss of work, reported as N successes.
+
+So parallel means isolated, and these tests are about the two things that makes true: each card
+sees its own directory, and a file two cards both changed is reported instead of quietly taking
+one. The third is the board itself, which rewrites its whole JSON on every mutation and had no
+lock — unreachable while dispatch was sequential, and reachable the moment it is not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.kanban.board import KanbanBoard
+from chimera.kanban.dispatch import DispatchOutcome, LaneResult, dispatch
+from chimera.kanban.models import KanbanCard
+
+
+def _git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True)
+    (path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=path, check=True)
+
+
+class WritingLane:
+    """A lane that writes a file, like the two real ones that touch the workspace do."""
+
+    def __init__(self, workspace: Path, *, name_for: Any = None, body: str = "x") -> None:
+        self.workspace = workspace
+        self.name_for = name_for or (lambda card: f"{card.id}.txt")
+        self.body = body
+        self.seen: list[Path] = []
+
+    def for_workspace(self, workspace: Path) -> WritingLane:
+        clone = WritingLane(workspace, name_for=self.name_for, body=self.body)
+        clone.seen = self.seen  # shared, so the test can see every path handed out
+        return clone
+
+    def run(self, card: KanbanCard) -> LaneResult:
+        self.seen.append(self.workspace)
+        (self.workspace / self.name_for(card)).write_text(self.body, encoding="utf-8")
+        return LaneResult(success=True, answer="done")
+
+
+class ModelOnlyLane:
+    """A lane with nothing to rebind — the crew lane's shape."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, card: KanbanCard) -> LaneResult:
+        self.calls += 1
+        return LaneResult(success=True, answer=card.action)
+
+
+def _board(tmp_path: Path, n: int, lane: str = "w") -> KanbanBoard:
+    board = KanbanBoard(tmp_path / "kanban.json")
+    for i in range(n):
+        board.add(f"card {i}", f"do {i}", lane=lane)
+    return board
+
+
+def test_one_worker_is_the_old_path(tmp_path: Path) -> None:
+    """The default must not change for anyone. Same lane, same board, sequential."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    lane = WritingLane(ws)
+    board = _board(tmp_path, 3)
+    outcomes = dispatch(board, {"w": lane}, workspace=ws)
+
+    assert [o.moved_to for o in outcomes] == ["done"] * 3
+    # Every card ran against the REAL workspace: no worktree was cut, nothing was rebound.
+    # (`seen` records the directory of every run, not only the rebound ones — the first version of
+    # this assertion read it as "rebinds" and failed on its own bookkeeping.)
+    assert lane.seen == [ws, ws, ws]
+    assert sorted(p.name for p in ws.glob("*.txt")) == sorted(
+        f"{c.id}.txt" for c in board.cards("done")
+    )
+
+
+def test_each_card_gets_its_own_directory(tmp_path: Path) -> None:
+    """The point of the whole feature. Two cards, two worktrees, neither is the real workspace."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+    lane = WritingLane(ws)
+    board = _board(tmp_path, 3)
+
+    outcomes = dispatch(board, {"w": lane}, workers=3, workspace=ws)
+
+    assert [o.success for o in outcomes] == [True] * 3
+    assert len(lane.seen) == 3
+    assert len({str(p) for p in lane.seen}) == 3, "two cards shared a directory"
+    assert ws.resolve() not in {p.resolve() for p in lane.seen}, "a card ran in the real workspace"
+
+
+def test_the_edits_come_back(tmp_path: Path) -> None:
+    """Isolation that does not merge back is isolation that threw the work away."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+    board = _board(tmp_path, 3)
+
+    dispatch(board, {"w": WritingLane(ws)}, workers=3, workspace=ws)
+
+    # Minus the repo's own seed file, which `_git_repo` commits so the worktrees have a base.
+    escritos = sorted(p.name for p in ws.glob("*.txt") if p.name != "seed.txt")
+    assert escritos == sorted(f"{c.id}.txt" for c in board.cards("done"))
+
+
+def test_a_file_two_cards_changed_is_reported_not_swallowed(tmp_path: Path) -> None:
+    """The failure isolation cannot prevent, only surface.
+
+    Two cards told to edit the same file both succeed in their own worktree, and only one version
+    can come back. Picking one silently is the version of this that loses work and says it did not.
+    """
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+    board = _board(tmp_path, 2)
+    lane = WritingLane(ws, name_for=lambda _card: "shared.txt")
+
+    conflitos: list[list[str]] = []
+    dispatch(board, {"w": lane}, workers=2, workspace=ws, on_conflict=conflitos.append)
+
+    assert conflitos, "two cards wrote the same file and nobody was told"
+    assert "shared.txt" in conflitos[0][0]
+
+
+def test_a_lane_with_nothing_to_rebind_still_runs(tmp_path: Path) -> None:
+    """The crew lane calls a model and touches no files; it must not need to know any of this."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+    lane = ModelOnlyLane()
+    board = _board(tmp_path, 3, lane="crew")
+
+    outcomes = dispatch(board, {"crew": lane}, workers=3, workspace=ws)
+
+    assert lane.calls == 3
+    assert [o.moved_to for o in outcomes] == ["done"] * 3
+
+
+def test_outside_a_git_repo_it_still_works(tmp_path: Path) -> None:
+    """No repo, no worktrees — the cards share the directory and the run still completes.
+
+    Refusing here would make the feature unavailable to anyone whose workspace is not a repo, which
+    is most first uses. The docstring says whose decision that is.
+    """
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    board = _board(tmp_path, 2)
+
+    outcomes = dispatch(board, {"w": WritingLane(ws)}, workers=2, workspace=ws)
+    assert [o.success for o in outcomes] == [True, True]
+
+
+def test_a_failing_card_goes_to_review_not_done(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+
+    class Explode:
+        def run(self, card: KanbanCard) -> LaneResult:
+            raise RuntimeError("estourou")
+
+    board = _board(tmp_path, 2)
+    outcomes = dispatch(board, {"w": Explode()}, workers=2, workspace=ws)
+
+    assert [o.moved_to for o in outcomes] == ["review", "review"]
+    assert all("estourou" in (c.result or "") for c in board.cards("review"))
+
+
+def test_the_board_survives_being_written_from_several_threads(tmp_path: Path) -> None:
+    """The lock, tested against what it is for.
+
+    Every mutation rewrites the whole JSON file. Two threads finishing at the same moment can
+    interleave one's read of the card dict with the other's write and persist a board missing a
+    result — a task that silently never happened. Reverting the lock makes this fail.
+    """
+    board = KanbanBoard(tmp_path / "kanban.json")
+    ids = [board.add(f"c{i}", "x").id for i in range(40)]
+    erros: list[BaseException] = []
+
+    def finish(card_id: str) -> None:
+        try:
+            for _ in range(10):
+                board.move(card_id, "doing")
+                board.record_result(card_id, success=True, result="ok")
+                board.move(card_id, "done")
+                board.cards("done")
+        except BaseException as exc:  # noqa: BLE001 - the point is that nothing escapes
+            erros.append(exc)
+
+    threads = [threading.Thread(target=finish, args=(i,)) for i in ids]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not erros, f"a concurrent board raised: {erros[:3]}"
+    # And the file on disk still holds every card, which is what a lost write would break.
+    reread = KanbanBoard(tmp_path / "kanban.json")
+    assert len(reread.cards()) == 40
+    assert all(c.column == "done" for c in reread.cards())
+
+
+@pytest.mark.parametrize("workers", [1, 4])
+def test_a_lane_nobody_registered_leaves_the_card_alone(tmp_path: Path, workers: int) -> None:
+    board = _board(tmp_path, 2, lane="inexistente")
+    outcomes = dispatch(board, {"w": WritingLane(tmp_path)}, workers=workers)
+    assert outcomes == []
+    assert len(board.cards("backlog")) == 2
+
+
+def test_outcomes_are_reported_as_each_card_finishes(tmp_path: Path) -> None:
+    """The app streams these; collecting them at the end would make a parallel board look frozen."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _git_repo(ws)
+    board = _board(tmp_path, 4)
+    vistos: list[DispatchOutcome] = []
+
+    dispatch(board, {"w": WritingLane(ws)}, workers=4, workspace=ws, on_outcome=vistos.append)
+
+    assert len(vistos) == 4
+    assert {o.card_id for o in vistos} == {c.id for c in board.cards("done")}


### PR DESCRIPTION
The Kanban board dispatched one card at a time while the Agents screen beside it had run parallel isolated batches for three releases.

Parallel here means **isolated**, not a thread pool: two of the three lanes run the autonomous verify-or-revert loop against the workspace, so N of them in one directory would have each reverting files another had just written. Each card gets its own git worktree; edits merge back; a file two successful cards both changed is reported rather than silently resolved.

`workers=1` is the default and is the old sequential path exactly.

Also: the board got a lock. Every mutation rewrites the whole JSON, so concurrent finishes could persist a board missing a result — unreachable while dispatch was sequential, reachable now.

Surfaces: `--workers/-j`, `workers` on `POST /api/kanban/run` with a `conflict` frame, and a picker on the board that remembers the number.

2565 Python tests, 387 desktop, nine languages, no schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)