### PR TITLE
feat(scheduler): record the outcome, and let somebody ask what never ran

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -1388,6 +1388,11 @@
             "title": "Action",
             "type": "string"
           },
+          "consecutive_failures": {
+            "default": 0,
+            "title": "Consecutive Failures",
+            "type": "integer"
+          },
           "created_by": {
             "title": "Created By",
             "type": "string"
@@ -1400,6 +1405,17 @@
             "title": "Id",
             "type": "string"
           },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Error"
+          },
           "last_run": {
             "anyOf": [
               {
@@ -1410,6 +1426,17 @@
               }
             ],
             "title": "Last Run"
+          },
+          "last_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Status"
           },
           "name": {
             "title": "Name",

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -2001,14 +2001,23 @@ export interface components {
         CronJobOut: {
             /** Action */
             action: string;
+            /**
+             * Consecutive Failures
+             * @default 0
+             */
+            consecutive_failures: number;
             /** Created By */
             created_by: string;
             /** Enabled */
             enabled: boolean;
             /** Id */
             id: string;
+            /** Last Error */
+            last_error?: string | null;
             /** Last Run */
             last_run: number | null;
+            /** Last Status */
+            last_status?: string | null;
             /** Name */
             name: string;
             /** Next Run */

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -933,6 +933,26 @@
         },
         {
           "deprecated": false,
+          "help": "Ask the schedule what it is not telling you: what never ran, and what ran and lost.\n\nEvery other honesty mechanism here sits downstream of a run having happened. This is the one\nquestion about the run that did not \u2014 and about the one that happens on time, forever, and\nfails every time, which looks healthier than the first from any field that existed before.\n\nIt is a question, not a watcher: nothing notices while this process is down, for the same\nreason a crashed process cannot log its own crash. What it gives you is an honest answer the\nmoment you ask.",
+          "hidden": false,
+          "name": "doctor",
+          "params": [
+            {
+              "default": "10.0",
+              "help": "How late a job may be before it counts as missed.",
+              "kind": "option",
+              "name": "grace_minutes",
+              "opts": [
+                "--grace"
+              ],
+              "required": false,
+              "type": "float"
+            }
+          ],
+          "path": "cron doctor"
+        },
+        {
+          "deprecated": false,
           "help": "Enable a job (e.g. an agent-proposed one) and schedule its next run.",
           "hidden": false,
           "name": "enable",

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -65,6 +65,11 @@ def _job_dict(job: Any) -> dict[str, Any]:
         "enabled": job.enabled,
         "next_run": job.next_run,
         "last_run": job.last_run,
+        # The attempt and the outcome, side by side. `last_run` alone made a job that has failed on
+        # every tick for a month read as one that just worked a minute ago.
+        "last_status": job.last_status,
+        "last_error": job.last_error,
+        "consecutive_failures": job.consecutive_failures,
         "created_by": job.created_by,
     }
 

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -450,6 +450,12 @@ class CronJobOut(BaseModel):
     enabled: bool
     next_run: float | None
     last_run: float | None
+    """When a dispatch was last ATTEMPTED — not whether it worked. See the three fields below."""
+    last_status: str | None = None
+    """`ok`, `error` or `timeout`. None on a job that has never been dispatched."""
+    last_error: str | None = None
+    consecutive_failures: int = 0
+    """Since the last success. One failure is weather; forty is a broken job."""
     created_by: str
 
 

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -3868,6 +3868,78 @@ def cron_list() -> None:
         )
     console.print(table)
 
+    # A line, not a column. This table was already at its width budget with six columns; a seventh
+    # truncated the name, which is the column people read — and a truncated warning is a warning
+    # somebody scrolls past. What this has to fix is that `enabled` and `schedule` together read as
+    # health while saying nothing about whether the last dispatch won.
+    falhando = [job for job in store.list() if job.enabled and job.consecutive_failures]
+    if falhando:
+        pior = max(job.consecutive_failures for job in falhando)
+        console.print(
+            f"[red]{len(falhando)} enabled job(s) failing[/red] "
+            f"[dim](worst: {pior} in a row) — `chimera cron doctor`[/dim]"
+        )
+
+
+@cron_app.command("doctor")
+def cron_doctor(
+    grace_minutes: float = typer.Option(
+        10.0, "--grace", help="How late a job may be before it counts as missed."
+    ),
+) -> None:
+    """Ask the schedule what it is not telling you: what never ran, and what ran and lost.
+
+    Every other honesty mechanism here sits downstream of a run having happened. This is the one
+    question about the run that did not — and about the one that happens on time, forever, and
+    fails every time, which looks healthier than the first from any field that existed before.
+
+    It is a question, not a watcher: nothing notices while this process is down, for the same
+    reason a crashed process cannot log its own crash. What it gives you is an honest answer the
+    moment you ask.
+    """
+    import time
+
+    from chimera.scheduler.engine import Scheduler
+
+    sched = Scheduler(_cron_store())
+    now = time.time()
+
+    atrasados = sched.overdue(now, grace=grace_minutes * 60)
+    falhando = sched.failing(at_least=1)
+
+    if atrasados:
+        console.print(f"[yellow]{len(atrasados)} job(s) due and never dispatched:[/yellow]")
+        for job, behind in atrasados:
+            console.print(f"  [cyan]{job.id}[/cyan] {job.name} — [yellow]{_ago(behind)} late[/yellow]")
+        console.print(
+            "[dim]Nothing ran. That is about the daemon, not the jobs: check that `chimera serve "
+            "--cron` is up and has been.[/dim]"
+        )
+
+    if falhando:
+        console.print(f"[red]{len(falhando)} job(s) dispatched on time and failing:[/red]")
+        for job in falhando:
+            console.print(
+                f"  [cyan]{job.id}[/cyan] {job.name} — [red]{job.last_status} "
+                f"x{job.consecutive_failures}[/red]: {job.last_error or ''}"
+            )
+        console.print("[dim]These ran. That is about the jobs, not the daemon.[/dim]")
+
+    if not atrasados and not falhando:
+        console.print("[green]every enabled job is on schedule and its last dispatch won[/green]")
+        console.print(
+            "[dim]Said about what this can see: a job that has never been due yet has nothing to "
+            "report, and nothing here watches while this process is not running.[/dim]"
+        )
+
+
+def _ago(seconds: float) -> str:
+    if seconds < 3600:
+        return f"{seconds / 60:.0f}m"
+    if seconds < 86400:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
 
 @cron_app.command("add")
 def cron_add(

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from croniter import croniter
 
 from chimera.concurrency import call_with_deadline
-from chimera.scheduler.models import CreatedBy, CronJob
+from chimera.scheduler.models import CreatedBy, CronJob, DispatchStatus
 from chimera.scheduler.store import CronStore
 from chimera.telemetry import get_logger
 
@@ -146,6 +146,50 @@ class Scheduler:
             and job.next_run <= now
         ]
 
+    def overdue(self, now: float, *, grace: float = 0.0) -> list[tuple[CronJob, float]]:
+        """Enabled cron jobs whose time passed more than ``grace`` ago, and by how much.
+
+        This is the silence nothing else in the project can see. Every honesty mechanism here sits
+        downstream of a run having happened — the verifier judges a result, the diff gate measures a
+        change, the receipt names who approved it. None of them gets a turn when the run never
+        occurred, and a schedule that produces no receipt reads as a schedule with nothing due.
+
+        The expectation was already on disk: ``next_run`` is computed from the cron expression and
+        only moves when the job fires. What was missing was somebody asking.
+
+        **What this cannot do, stated because the alternative is implying otherwise.** It is a
+        question, not a watcher. Nothing here notices while the process is down, for the same reason
+        a crashed process cannot log its own crash — a check that lives in the daemon is dead when
+        the daemon is. What it gives you is an honest answer the moment anything asks: the CLI, the
+        app, the next start. A real watcher needs its own clock and its own liveness, and that is a
+        separate decision (issue #26) rather than something to fake here.
+
+        ``grace`` exists because "due a second ago" is a tick in progress, not a miss. Pass the
+        deployment's tick interval, or a multiple of it.
+        """
+        late: list[tuple[CronJob, float]] = []
+        for job in self.store.list():
+            if not job.enabled or job.trigger != "cron" or job.next_run is None:
+                continue
+            behind = now - job.next_run
+            if behind > grace:
+                late.append((job, behind))
+        return sorted(late, key=lambda pair: pair[1], reverse=True)
+
+    def failing(self, *, at_least: int = 1) -> list[CronJob]:
+        """Enabled jobs that have failed ``at_least`` times in a row since their last success.
+
+        The second silence, and the one that looks healthiest: these jobs ARE running. ``last_run``
+        is recent, the daemon is alive, the schedule is advancing — and every dispatch has lost.
+        Told apart from :meth:`overdue` because the responses have nothing in common: one says look
+        at the daemon, the other says look at the job.
+        """
+        return [
+            job
+            for job in self.store.list()
+            if job.enabled and job.consecutive_failures >= at_least
+        ]
+
     def jobs_for_event(self, event: str) -> list[CronJob]:
         """Enabled event jobs registered for ``event``."""
         return [
@@ -193,18 +237,32 @@ class Scheduler:
         ran: list[CronJob] = []
         for job in self.due(now):
             _log.debug("dispatching cron job %s (%s)", job.name, job.id)
+            # The outcome is recorded HERE, inside the guard, and `mark_ran` still runs outside it.
+            # Those are two different facts and folding them into one field is what made a job that
+            # has failed on every tick for a month look healthy: `last_run` is a minute ago, because
+            # the attempt happened, and nothing anywhere said the attempt lost.
             try:
                 _dispatch_bounded(job, dispatch, job_timeout)
+                self._record(job, "ok", None)
             except TimeoutError:
                 _log.warning(
                     "cron job %s (%s) exceeded %ss and was abandoned; the schedule continues",
                     job.name, job.id, job_timeout,
                 )
+                self._record(job, "timeout", f"exceeded {job_timeout}s and was abandoned")
             except Exception as exc:  # a failing job must not break the scheduler
                 _log.warning("cron job %s failed: %s", job.id, exc)
+                self._record(job, "error", f"{type(exc).__name__}: {exc}")
             self.mark_ran(job, now)
             ran.append(job)
         return ran
+
+    @staticmethod
+    def _record(job: CronJob, status: DispatchStatus, error: str | None) -> None:
+        """Set the outcome on the job. `mark_ran` persists it a moment later, in the same tick."""
+        job.last_status = status
+        job.last_error = (error or "")[:300] or None
+        job.consecutive_failures = 0 if status == "ok" else job.consecutive_failures + 1
 
     def fire_event(self, event: str, now: float, dispatch: Callable[[CronJob], None]) -> list[CronJob]:
         """Dispatch every job registered for ``event``. Returns those run."""

--- a/chimera/scheduler/models.py
+++ b/chimera/scheduler/models.py
@@ -9,6 +9,19 @@ from pydantic import BaseModel, Field
 Trigger = Literal["cron", "event", "webhook"]
 CreatedBy = Literal["human", "agent"]
 
+DispatchStatus = Literal["ok", "error", "timeout"]
+"""What happened on the last dispatch — which is not the same question as whether one happened.
+
+``last_run`` records the ATTEMPT: the scheduler sets it outside the try/except on purpose, so a job
+that raises or overruns still has its schedule advanced and the tick moves on. That is right for
+the scheduler and misleading for anyone reading the field to find out whether the job is working —
+a job that has failed on every tick for a month has a `last_run` of a minute ago.
+
+So the outcome is recorded beside it rather than folded into it. Two silences look identical from
+`last_run` alone and need completely different responses: *nothing ran* means look at the daemon,
+*everything ran and failed* means look at the job.
+"""
+
 
 class CronJob(BaseModel):
     """A scheduled job.
@@ -27,6 +40,15 @@ class CronJob(BaseModel):
     enabled: bool = True
     next_run: float | None = None
     last_run: float | None = None
+    """When a dispatch was last ATTEMPTED. Says nothing about whether it worked — see
+    :data:`DispatchStatus`."""
+    last_status: DispatchStatus | None = None
+    """How that attempt ended. ``None`` on a job that has never been dispatched."""
+    last_error: str | None = None
+    """The failure, in one line, for the two statuses that have one."""
+    consecutive_failures: int = 0
+    """Failures since the last success. One failure is weather; forty is a broken job, and the
+    difference is not visible from a single ``last_status``."""
     deliver_to: str | None = None
     """Optional delivery target for the job's result (e.g. a chat conversation id)."""
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -116,6 +116,39 @@ docker compose exec chimera chimera cron add "morning-brief" "0 8 * * *" "..."
 The daemon ticks every `--cron-tick` seconds (default 30) and dispatches each job's action
 through the agent when it's due. A failing job is logged and never stops the daemon.
 
+### Asking what the schedule is not telling you
+
+```bash
+chimera cron doctor
+```
+
+A schedule can go quiet in two ways, and until you ask, both look the same — like a schedule with
+nothing due:
+
+- **Nothing ran.** The daemon died, the container was never restarted, the host slept. No
+  exception, no log line, no verdict. Every other honesty mechanism here sits *downstream of a run
+  having happened*, so none of them gets a turn.
+- **Everything ran and lost.** The daemon is alive, `last_run` is a minute ago, the schedule is
+  advancing — and every dispatch has failed for a month. This one reads as *healthier* than the
+  first, because the field that looks like health is recording the attempt, not the outcome.
+
+`cron doctor` asks both questions and gives different advice, because the fixes have nothing in
+common: overdue is about the daemon, failing is about the job. `chimera cron list` prints a line
+when anything is failing, so you do not have to know the command exists to find out.
+
+**What it is not.** It is a question, not a watcher: nothing here notices while the process is
+down, for the same reason a crashed process cannot log its own crash. It answers honestly the
+moment anything asks — a shell, the app, the next start. A real watchdog needs its own clock and
+its own liveness, which is a separate decision and is
+[tracked as issue #26](https://github.com/brcampidelli/chimera-agent/issues/26). If you want an
+alert rather than an answer, run it from the host's own cron:
+
+```cron
+*/30 * * * * cd /opt/chimera && .venv/bin/chimera cron doctor | mail -s "chimera" you@example.com
+```
+
+That works because it is supervised by something other than Chimera — which is the whole point.
+
 ---
 
 ## 4. Health, backups, security

--- a/tests/test_scheduler_silence.py
+++ b/tests/test_scheduler_silence.py
@@ -1,0 +1,288 @@
+"""The two silences a schedule can produce, and telling them apart.
+
+Every honesty mechanism in this project sits downstream of a run having happened: the verifier
+judges a result, the diff gate measures a change, the receipt names who approved it. None of them
+gets a turn when the run never occurred — and a schedule that produces no receipt reads as a
+schedule with nothing due.
+
+There are two of those silences and they look identical from `last_run`:
+
+  * **Nothing ran.** The daemon is down, the container was not restarted, the machine slept. No
+    exception, no receipt, no verdict, not even an `unknown`.
+  * **Everything ran and lost.** The daemon is alive, `last_run` is a minute ago, the schedule is
+    advancing, and every dispatch has failed for a month. This one looks *healthier* than the first.
+
+`last_run` cannot distinguish them, because the scheduler sets it OUTSIDE the try/except on purpose
+— a failing job must not stall the tick. So the outcome is recorded beside it, and each silence has
+its own question: `overdue()` and `failing()`.
+
+Credit: the framing is u/MediaPositive4282's, in the thread quoted in issue #26 — "a schedule that
+produces no receipt invites the reader to assume nothing was due".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("croniter")
+
+from chimera.scheduler.engine import Scheduler  # noqa: E402
+from chimera.scheduler.models import CronJob  # noqa: E402
+from chimera.scheduler.store import CronStore  # noqa: E402
+
+HOUR = 3600.0
+DAY = 24 * HOUR
+
+
+def _scheduler(tmp_path: Path) -> Scheduler:
+    return Scheduler(CronStore(tmp_path / "cron.json"))
+
+
+def _hourly(sched: Scheduler, name: str, now: float) -> CronJob:
+    return sched.schedule_cron(name, "0 * * * *", f"do {name}", now=now)
+
+
+def _cli_scheduler(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Scheduler:
+    """A scheduler pointed at the file the CLI will actually open.
+
+    Two things have to line up or the command reads an empty store and every assertion below
+    passes for the wrong reason: the path is `home/scheduler/jobs.json`, not a name of my choosing,
+    and `get_settings()` is cached — setting the env var after the first read changes nothing.
+    """
+    from chimera.config import get_settings
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path))
+    get_settings.cache_clear()
+    return Scheduler(CronStore(tmp_path / "scheduler" / "jobs.json"))
+
+
+# --------------------------------------------------------------- the outcome, beside the attempt
+
+
+def test_a_successful_dispatch_records_that_it_won(tmp_path: Path) -> None:
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    sched.run_due(job.next_run or 0.0, lambda _job: None)
+
+    fresh = sched.store.get(job.id)
+    assert fresh.last_status == "ok"
+    assert fresh.last_error is None
+    assert fresh.consecutive_failures == 0
+
+
+def test_a_failing_dispatch_still_advances_the_schedule_and_now_says_it_failed(
+    tmp_path: Path,
+) -> None:
+    """The behaviour that was already right, plus the fact that was missing.
+
+    Advancing the schedule on failure is deliberate — a broken job must not stall every other one.
+    What made it dishonest is that `last_run` was the only record, so the job looked like it had
+    just worked.
+    """
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    when = job.next_run or 0.0
+
+    def explode(_job: CronJob) -> None:
+        raise RuntimeError("o provedor caiu")
+
+    sched.run_due(when, explode)
+    fresh = sched.store.get(job.id)
+
+    assert fresh.last_run == when, "the tick must still move on"
+    assert fresh.next_run is not None and fresh.next_run > when
+    assert fresh.last_status == "error"
+    assert "o provedor caiu" in (fresh.last_error or "")
+    assert fresh.consecutive_failures == 1
+
+
+def test_an_abandoned_job_is_a_timeout_not_an_error(tmp_path: Path) -> None:
+    """Different cause, different fix: a hung provider call is not a raising job."""
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "slow", 0.0)
+
+    def hang(_job: CronJob) -> None:
+        import time
+
+        time.sleep(5)
+
+    sched.run_due(job.next_run or 0.0, hang, job_timeout=0.05)
+    fresh = sched.store.get(job.id)
+    assert fresh.last_status == "timeout"
+    assert "abandoned" in (fresh.last_error or "")
+
+
+def test_failures_accumulate_and_a_success_clears_them(tmp_path: Path) -> None:
+    """One failure is weather; forty is a broken job, and one `last_status` cannot tell them apart."""
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    falha = True
+
+    def flaky(_job: CronJob) -> None:
+        if falha:
+            raise RuntimeError("x")
+
+    for _ in range(3):
+        sched.run_due(sched.store.get(job.id).next_run or 0.0, flaky)
+    assert sched.store.get(job.id).consecutive_failures == 3
+
+    falha = False
+    sched.run_due(sched.store.get(job.id).next_run or 0.0, flaky)
+    fresh = sched.store.get(job.id)
+    assert fresh.consecutive_failures == 0
+    assert fresh.last_status == "ok"
+    assert fresh.last_error is None
+
+
+# --------------------------------------------------------------------------- silence one: nothing ran
+
+
+def test_a_job_nobody_dispatched_is_overdue_by_how_long(tmp_path: Path) -> None:
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    tres_dias_depois = (job.next_run or 0.0) + 3 * DAY
+
+    atrasados = sched.overdue(tres_dias_depois, grace=HOUR)
+    assert len(atrasados) == 1
+    atrasado, quanto = atrasados[0]
+    assert atrasado.id == job.id
+    assert quanto == pytest.approx(3 * DAY, abs=1)
+
+
+def test_a_tick_in_progress_is_not_a_miss(tmp_path: Path) -> None:
+    """`grace` is why this is usable: due a second ago is the daemon working, not the daemon gone."""
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    assert sched.overdue((job.next_run or 0.0) + 30, grace=HOUR) == []
+
+
+def test_a_disabled_job_is_not_overdue(tmp_path: Path) -> None:
+    """Nothing was due. Reporting it would train the reader to ignore the report."""
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    sched.disable(job.id)
+    assert sched.overdue((job.next_run or 0.0) + 3 * DAY, grace=HOUR) == []
+
+
+def test_an_event_job_is_never_overdue(tmp_path: Path) -> None:
+    """It has no next_run. A job waiting for an event that has not happened is not late."""
+    sched = _scheduler(tmp_path)
+    sched.schedule_event("on-push", "push", "do it")
+    assert sched.overdue(9e9, grace=HOUR) == []
+
+
+def test_the_latest_comes_first(tmp_path: Path) -> None:
+    """Sorted by how long it has been missing, worst first.
+
+    The hourly job's slot came round at hour 1 and the daily one's at hour 24, so with nothing
+    running since, the hourly job has been unrun the longest — even though it is the one that
+    "should" have run most recently. The first version of this assertion had the order backwards
+    for exactly that reason, which is the confusion the sort exists to settle.
+    """
+    sched = _scheduler(tmp_path)
+    a = _hourly(sched, "a", 0.0)
+    b = sched.schedule_cron("b", "0 0 * * *", "do b", now=0.0)
+    quando = max(a.next_run or 0.0, b.next_run or 0.0) + 10 * DAY
+
+    atrasados = sched.overdue(quando, grace=HOUR)
+    assert [job.name for job, _ in atrasados] == ["a", "b"]
+    assert atrasados[0][1] > atrasados[1][1]
+
+
+# ------------------------------------------------------- silence two: it ran, and lost, every time
+
+
+def test_a_job_that_ran_and_failed_every_time_is_not_overdue_but_is_failing(tmp_path: Path) -> None:
+    """The pair that is the whole point.
+
+    This job is dispatched on time, forever, and has never once succeeded. `overdue` says nothing —
+    correctly, the schedule is being honoured — and it is exactly the job somebody needs to hear
+    about. The two questions do not overlap and neither one alone is enough.
+    """
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+
+    def explode(_job: CronJob) -> None:
+        raise RuntimeError("todo dia")
+
+    agora = job.next_run or 0.0
+    for _ in range(24):
+        agora = sched.store.get(job.id).next_run or agora
+        sched.run_due(agora, explode)
+
+    assert sched.overdue(agora + 60, grace=HOUR) == [], "the schedule was honoured"
+    falhando = sched.failing(at_least=5)
+    assert [j.id for j in falhando] == [job.id]
+    assert sched.store.get(job.id).consecutive_failures == 24
+
+
+def test_a_healthy_job_is_in_neither_list(tmp_path: Path) -> None:
+    sched = _scheduler(tmp_path)
+    job = _hourly(sched, "brief", 0.0)
+    agora = job.next_run or 0.0
+    sched.run_due(agora, lambda _job: None)
+
+    assert sched.overdue(agora + 60, grace=HOUR) == []
+    assert sched.failing() == []
+
+
+# ------------------------------------------------------------------------------ the surfaces
+
+
+def test_cron_list_says_when_jobs_are_failing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`enabled` and `schedule` together read as health and say nothing about the last dispatch.
+
+    A line rather than a column: the table was already at its width budget with six, and adding a
+    seventh truncated the name — which broke an existing test and would have made the warning the
+    easiest thing on screen to scroll past.
+    """
+    from typer.testing import CliRunner
+
+    from chimera.cli.main import app
+
+    sched = _cli_scheduler(tmp_path, monkeypatch)
+    job = _hourly(sched, "brief", 0.0)
+
+    def explode(_job: CronJob) -> None:
+        raise RuntimeError("x")
+
+    for _ in range(3):
+        sched.run_due(sched.store.get(job.id).next_run or 0.0, explode)
+
+    out = CliRunner().invoke(app, ["cron", "list"]).output
+    assert "failing" in out
+    assert "3 in a row" in out
+
+
+def test_cron_doctor_separates_the_two_silences(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The command exists to give different advice for the two, because the fixes differ."""
+    from typer.testing import CliRunner
+
+    from chimera.cli.main import app
+
+    sched = _cli_scheduler(tmp_path, monkeypatch)
+    # One that ran and lost, one that was never dispatched at all.
+    perdedor = _hourly(sched, "perdedor", 0.0)
+    sched.run_due(perdedor.next_run or 0.0, lambda _job: (_ for _ in ()).throw(RuntimeError("x")))
+    sched.schedule_cron("esquecido", "0 * * * *", "do it", now=0.0)
+
+    out = CliRunner().invoke(app, ["cron", "doctor"]).output
+    assert "never dispatched" in out
+    assert "about the daemon" in out
+    assert "failing" in out
+    assert "about the jobs" in out
+
+
+def test_cron_doctor_says_what_it_cannot_see(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A green report that does not state its blind spot is the silence this issue is about."""
+    from typer.testing import CliRunner
+
+    from chimera.cli.main import app
+
+    _cli_scheduler(tmp_path, monkeypatch)
+
+    out = CliRunner().invoke(app, ["cron", "doctor"]).output
+    assert "on schedule" in out
+    assert "nothing here watches while this process is not running" in out


### PR DESCRIPTION
First steps on #26 — the two the issue itself named as smaller and independently useful, and not the one it left undecided.

**The outcome recorded beside the attempt.** `last_run` is set outside the try/except on purpose (a failing job must not stall the tick), which made a job failing every hour for a month show a healthy-looking timestamp. `last_status`, `last_error` and `consecutive_failures` now say what happened.

**Two questions for two silences.** `overdue()` — enabled jobs whose time passed and nobody dispatched. `failing()` — jobs dispatched on time, forever, losing every time. A job in one is usually not in the other, and the fixes have nothing in common: overdue is about the daemon, failing is about the job. Surfaced as `chimera cron doctor`, a line on `cron list`, and three fields on the API.

**What it is not:** a question, not a watcher. Nothing notices while the process is down. The docstring, the command's own green output and `deploy.md` all say so, and a test asserts the green report states its blind spot. The host-cron one-liner in the docs is the alert you can have today, precisely because something other than Chimera supervises it.

**Not done:** the `nobody-ran` provenance value on `Attempt` — #26 is undecided about whether a receipt for a run that did not happen is a coherent object, and a wrong verdict label invites the wrong follow-up.

Verified the issue's three code claims before acting on them; all three hold. 2579 Python tests, 387 desktop, ruff/mypy clean, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)