### PR TITLE
fix(api): a malformed path gets the app, not a 500

### DIFF
--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -1620,7 +1620,26 @@ def _mount_spa(app: FastAPI, static_dir: Path) -> None:
         if full_path.startswith("api/"):
             raise HTTPException(status_code=404, detail="not found")
         # Any other path that isn't a real asset falls back to the SPA entrypoint (client routing).
-        candidate = (static_dir / full_path).resolve()
-        if candidate.is_file() and static_dir.resolve() in candidate.parents:
-            return FileResponse(candidate)
+        #
+        # Inside the guard because asking the filesystem about a path is not a safe question. A
+        # request path can carry bytes no filesystem accepts: `%00` decodes to a NUL and `stat`
+        # raises **ValueError**, which "is this a file" does not catch — so a request for a page
+        # that does not exist became a 500, reading as the server being broken rather than the URL
+        # being wrong. Reproduced, and the two `%00` cases in the tests fail without this.
+        #
+        # `OSError` is caught beside it for the platform shapes that raise instead of returning
+        # False — some Windows paths are documented to. That branch is defensive: on the CPython
+        # and Windows build measured here, `:` and `|` came back as a plain miss, so it is guarding
+        # a case I did not manage to reproduce rather than one I watched happen.
+        #
+        # The traversal guard is the line below and it is doing its job — `..` and an absolute path
+        # both resolve outside `static_dir` and are refused. This is robustness, not a hole: what
+        # was missing is that a malformed path should reach the same answer as any other unknown
+        # path, which is the app.
+        try:
+            candidate = (static_dir / full_path).resolve()
+            if candidate.is_file() and static_dir.resolve() in candidate.parents:
+                return FileResponse(candidate)
+        except (OSError, ValueError):
+            pass
         return _index_html(index, request)

--- a/tests/test_api_spa_paths.py
+++ b/tests/test_api_spa_paths.py
@@ -1,0 +1,109 @@
+"""The SPA fallback, against paths a filesystem refuses to be asked about.
+
+The handler answers any unknown path with the app's entrypoint, so client-side routing works. To
+know whether a path is a real asset it has to ask the filesystem — and that question is not always
+safe to ask. `%00` decodes to a NUL and makes `stat` raise `ValueError`, which "is this a file"
+does not catch — so a request for a page that does not exist became a 500: the server reading as
+broken instead of the URL as wrong. Removing the guard fails the two `%00` cases below and no
+others, which is the honest extent of what was reproduced.
+
+The `:` and `|` cases are here as regression cover for path shapes some platforms are documented to
+raise on. They pass either way on the interpreter measured here, so they are not evidence for the
+fix — they are there so a future change that starts raising on them is caught.
+
+The traversal guard is a separate line and was already correct — `..` and an absolute path both
+resolve outside the static dir and are refused. These tests hold both facts at once, because
+"we fixed the path handling" is exactly the change that could quietly widen the other one.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sse_starlette")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from chimera.config import Settings  # noqa: E402
+from chimera.interface import ChatSession  # noqa: E402
+
+
+class _FakeAgent:
+    def answer(self, message: str) -> str:  # pragma: no cover - trivial
+        return message
+
+
+def _client(tmp_path: Path) -> TestClient:
+    from chimera.api import build_api_app
+
+    static = tmp_path / "dist"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("<html><head></head><body>app</body></html>", encoding="utf-8")
+    (static / "assets" / "app.js").write_text("console.log(1)", encoding="utf-8")
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"))
+    app = build_api_app(
+        lambda: ChatSession(_FakeAgent()), settings=settings, static_dir=static
+    )
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_a_real_asset_is_served(tmp_path: Path) -> None:
+    r = _client(tmp_path).get("/assets/app.js")
+    assert r.status_code == 200
+    assert "console.log" in r.text
+
+
+def test_an_unknown_page_gets_the_app(tmp_path: Path) -> None:
+    """Client-side routing: /settings is a route in the app, not a file on disk."""
+    r = _client(tmp_path).get("/settings")
+    assert r.status_code == 200
+    assert "app" in r.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/x%00y",  # NUL — `stat` raises ValueError, not OSError
+        "/a%00",
+        "/c:/windows/win.ini",  # a colon: OSError on Windows, a plain miss elsewhere
+        "/x|y",
+        "/https://exemplo.com",
+    ],
+)
+def test_a_path_the_filesystem_refuses_gets_the_app_not_a_500(tmp_path: Path, path: str) -> None:
+    """The whole fix. A malformed path is an unknown path, and unknown paths get the app."""
+    r = _client(tmp_path).get(path)
+    assert r.status_code == 200, f"{path} answered {r.status_code}"
+    assert "app" in r.text
+
+
+@pytest.mark.parametrize("path", ["/../pyproject.toml", "/../../etc/passwd", "/..%2f..%2fetc/passwd"])
+def test_traversal_is_still_refused(tmp_path: Path, path: str) -> None:
+    """The guard that was already right, asserted so that widening it later is loud.
+
+    Never a 200 carrying the file: either the router never matches, or the handler resolves the
+    path outside `static_dir` and falls through to the app.
+    """
+    r = _client(tmp_path).get(path)
+    assert "[project]" not in r.text, "the repo's pyproject leaked through the SPA handler"
+    assert "root:" not in r.text
+
+
+def test_an_unknown_api_path_is_a_404_not_the_app(tmp_path: Path) -> None:
+    """Answering the SPA on /api/* would mask a wrong URL or a stale generated client as a 200."""
+    r = _client(tmp_path).get("/api/nao-existe")
+    assert r.status_code == 404
+
+
+def test_a_malformed_api_path_is_still_a_404(tmp_path: Path) -> None:
+    """The new guard must not turn an unknown API route into the app because the path was odd."""
+    r = _client(tmp_path).get("/api/x%00y")
+    assert r.status_code == 404
+
+
+def _unused(_: Any) -> None:  # pragma: no cover - keeps the Any import honest
+    return None


### PR DESCRIPTION
`%00` in a request path decodes to a NUL, `stat` raises `ValueError`, and the SPA fallback answered 500 instead of the app.

**Not a traversal hole.** The `static_dir.resolve() in candidate.parents` guard was already correct and I verified that before touching anything — `..` and absolute paths are refused. The tests now hold both facts, because this is exactly the change that could widen the other one.

Removing the try/except fails the two `%00` cases and no others; the `:`/`|` cases pass either way on the interpreter measured here and are regression cover rather than evidence. Said in the comment too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)