### PR TITLE
fix(verify): Windows has no exit code for "command not found" (P0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,45 @@ jobs:
       - name: Pytest
         run: uv run pytest -q
 
+  quality-windows:
+    name: test (windows)
+    timeout-minutes: 30
+    runs-on: windows-latest
+    needs: quality
+    # The suite has never run on Windows, and the day it first did it failed three times — all from
+    # the same family of Unix assumption:
+    #
+    #   * `CommandVerifier` treated exit 127 as "command not found". `cmd.exe` answers 1, which is
+    #     also every test runner's "your tests failed", so a missing verify command was reported as
+    #     a FAILED verification: the attempt reverted and the receipt recorded a test failure that
+    #     never happened. A product bug, on the gate that decides keep-or-revert.
+    #   * A spec fixture used `true` / `false` as its check. Neither exists in `cmd.exe`, so a
+    #     project that was supposed to be already-satisfied sat at `running` forever.
+    #
+    # None of it was visible because `quality` is Ubuntu-only and the three-OS matrix below is a
+    # clean install plus an import — it proves the package installs, not that it works. Half this
+    # project's users are on Windows and the whole IDE roadmap (spawning agent CLIs, language
+    # servers, `npx.cmd`, `CREATE_NO_WINDOW`) lands there first.
+    #
+    # One Python version, tests only: ruff and mypy read the same source on every OS, so running
+    # them again here would buy a slower CI and nothing else.
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra desktop
+
+      - name: Pytest
+        run: uv run pytest -q
+
   integration:
     name: live integration (real provider)
     timeout-minutes: 20
@@ -267,7 +306,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     if: always()
-    needs: [quality, integration, install-smoke, desktop, mutation, supply-chain]
+    needs: [quality, quality-windows, integration, install-smoke, desktop, mutation, supply-chain]
     steps:
       # A run can go red without anything failing. On 2026-08-06 two of the three `quality` matrix
       # jobs were created, never assigned a runner, and were cancelled 15 minutes later; the third

--- a/chimera/core/verify.py
+++ b/chimera/core/verify.py
@@ -7,6 +7,9 @@ runs a command (tests, a build, a linter) and treats exit code 0 as success — 
 
 from __future__ import annotations
 
+import os
+import shlex
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,6 +25,59 @@ _MAX_OUTPUT_CHARS = 20_000
 #:       tests live outside the inferred path would otherwise have every change reverted by a
 #:       verifier that ran nothing.
 _NO_VERDICT = frozenset({5, 127})
+
+#: `cmd.exe` builtins, which have no executable on disk.
+#:
+#: `shutil.which` cannot find them, so without this list a builtin that exits non-zero would be
+#: mistaken for a command that does not exist — and the verifier would abstain on a real failure,
+#: which is the more dangerous direction of this bug.
+_CMD_BUILTINS = frozenset(
+    {
+        "assoc", "break", "call", "cd", "chdir", "cls", "color", "copy", "date", "del",
+        "dir", "echo", "endlocal", "erase", "exit", "for", "ftype", "goto", "if", "md",
+        "mkdir", "mklink", "move", "path", "pause", "popd", "prompt", "pushd", "rd",
+        "rem", "ren", "rename", "rmdir", "set", "setlocal", "shift", "start", "time",
+        "title", "type", "ver", "verify", "vol",
+    }
+)
+
+
+def program_missing(command: str) -> bool:
+    """True when the first token of ``command`` names a program that is nowhere to be found.
+
+    This exists because **Windows has no exit code for "command not found"**. `cmd.exe` answers 1 —
+    the same code every test runner uses for "your tests failed" — so the 127 convention below is
+    Unix-only, and on Windows a missing verify command was reported as a FAILED verification. That
+    reverts the attempt and writes a test failure into the receipt that never happened, which is
+    precisely the outcome the 127 handling was added to prevent.
+
+    Matching the shell's error message is not an option: `cmd.exe` localises it. On the machine
+    where this was found it read "não é reconhecido como um comando interno ou externo", so an
+    English pattern would have been a defence that works everywhere except where you are.
+
+    Asking whether the program exists is the only signal that is neither exit-code nor locale
+    dependent. Only the first token is examined: in a pipeline or an `&&` chain it is the one the
+    shell reports as missing, and it is the one the caller typed.
+    """
+    try:
+        # posix=False keeps Windows path quoting (`"C:\\Program Files\\..."`) in one piece; the
+        # posix lexer would eat the backslashes.
+        tokens = shlex.split(command, posix=False)
+    except ValueError:
+        # Unbalanced quotes. Not our question to answer — let the shell's own verdict stand.
+        return False
+    if not tokens:
+        return False
+
+    program = tokens[0].strip('"').strip("'")
+    if not program:
+        return False
+    if program.lower() in _CMD_BUILTINS:
+        return False
+    if os.sep in program or (os.altsep and os.altsep in program):
+        # An explicit path: existence is a direct question, and `which` does not answer it.
+        return not Path(program).exists()
+    return shutil.which(program) is None
 
 
 @dataclass
@@ -82,6 +138,11 @@ class CommandVerifier:
             # autonomous loop already demotes an abstention to the no-verifier path, so `evidence`
             # correctly stops being "verifier". We could not check it; we do not claim we did, and we
             # do not punish the work for our own inability.
+            return VerificationResult(True, output, abstained=True)
+        if proc.returncode != 0 and os.name == "nt" and program_missing(self.command):
+            # The Windows half of the same abstention. Checked only after a non-zero exit, so a
+            # command that exists and genuinely fails is never reinterpreted, and `which` is not
+            # paid on the happy path.
             return VerificationResult(True, output, abstained=True)
         return VerificationResult(proc.returncode == 0, output)
 

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -6,6 +6,7 @@ first: create it, or advance it. The HITL gate was on the screen; the loop it ga
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -14,15 +15,30 @@ from fastapi.testclient import TestClient
 
 from chimera.config import Settings
 
-SPEC = """
+
+def _spec(code: str) -> str:
+    """A one-requirement spec whose check runs `code` in this interpreter.
+
+    Not `true`/`false`. Those are Unix binaries, and on Windows `cmd.exe` has neither — so the
+    "already satisfied" spec was never satisfied there and both tests below sat at `running`
+    forever. The rest of the suite already reaches for `sys.executable` for exactly this reason
+    (`tests/test_verify.py:23`); this file had not caught up.
+
+    Single-quoted in YAML so a Windows path keeps its backslashes and the inner double quotes
+    survive.
+    """
+    return f"""
 name: demo
 requirements:
   - id: r1
     text: the check passes
     check: command
-    target: "true"
+    target: '"{sys.executable}" -c "{code}"'
     required: true
 """
+
+
+SPEC = _spec("pass")
 
 
 @pytest.fixture
@@ -54,7 +70,7 @@ def spec(tmp_path: Path) -> Path:
 def unaligned(tmp_path: Path) -> Path:
     """A spec with work to do: its check exits 1, so the project has a requirement to satisfy."""
     path = tmp_path / "unaligned.yaml"
-    path.write_text(SPEC.replace('target: "true"', 'target: "false"'), encoding="utf-8")
+    path.write_text(_spec("raise SystemExit(1)"), encoding="utf-8")
     return path
 
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -15,7 +15,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from chimera.core.verify import CommandVerifier, NullVerifier, VerificationResult
+from chimera.core.verify import (
+    CommandVerifier,
+    NullVerifier,
+    VerificationResult,
+    program_missing,
+)
 
 
 def _py(code: str) -> str:
@@ -123,11 +128,59 @@ def test_a_command_that_does_not_exist_abstains_rather_than_failing(tmp_path: Pa
     reverted the attempt and wrote a test failure into the receipt that never happened — survivable
     while a human typed the command and could see the typo, and not survivable once the command is
     inferred from the project.
+
+    This test passed on Linux and failed on Windows for as long as it existed, because nobody ran
+    the suite on Windows. `cmd.exe` answers 1, not 127 — see `program_missing`.
     """
     result = CommandVerifier("definitely-not-a-real-command-xyz", tmp_path).verify()
 
     assert result.abstained is True
     assert result.passed is True  # abstention is not a failure either — it is silence
+
+
+# --- "does this program exist" (the Windows half of the abstention) ------------------------
+#
+# `program_missing` is tested directly rather than only through `CommandVerifier`, because the
+# branch that uses it runs on Windows alone. Testing the predicate keeps the reasoning under test
+# on Linux and macOS too, where it would otherwise be dead code nobody exercises until it breaks.
+
+
+def test_a_name_that_resolves_to_nothing_is_missing() -> None:
+    assert program_missing("definitely-not-a-real-command-xyz --flag") is True
+
+
+def test_a_program_that_exists_is_not_missing() -> None:
+    # sys.executable is the one program guaranteed present wherever these tests run.
+    assert program_missing(_py("pass")) is False
+
+
+def test_only_the_first_token_is_judged() -> None:
+    """A pipeline's later stages are not the question. The shell reports the FIRST missing program,
+    and the first token is what the caller typed."""
+    assert program_missing(f"{_py('pass')} | definitely-not-a-real-command-xyz") is False
+
+
+def test_a_shell_builtin_is_not_missing() -> None:
+    """`echo` and `cd` have no executable on Windows; `which` cannot find them.
+
+    Without this, a builtin that exits non-zero would be read as "command not found" and the
+    verifier would abstain on a REAL failure — the dangerous direction, because abstention keeps
+    the work instead of reverting it.
+    """
+    assert program_missing("echo hello") is False
+    assert program_missing("CD nowhere") is False  # case-insensitive, like cmd.exe
+
+
+def test_an_explicit_path_that_does_not_exist_is_missing(tmp_path: Path) -> None:
+    """`which` only searches PATH, so a spelled-out path needs a different question."""
+    assert program_missing(f'"{tmp_path / "nope.exe"}" --version') is True
+
+
+def test_unbalanced_quotes_are_not_our_verdict_to_give() -> None:
+    """An unparseable command is the shell's complaint, not ours. Returning False leaves its own
+    exit code to speak — guessing "missing" here would abstain on a syntax error and keep work that
+    was never checked."""
+    assert program_missing('python -c "unterminated') is False
 
 
 def test_pytest_collecting_nothing_abstains(tmp_path: Path) -> None:


### PR DESCRIPTION
The suite had **never been run on Windows**. The first time it was, it failed three times — all one family of Unix assumption, and one is a product bug on the gate that decides keep-or-revert.

## The product bug

`CommandVerifier` treated exit **127** as "command does not exist" — the Unix convention. `cmd.exe` answers **1**, which is also every test runner's "your tests failed". So on Windows a missing verify command was reported as a FAILED verification: **the attempt reverted and the receipt recorded a test failure that never happened.** Exactly what the 127 handling exists to prevent, and its own docstring says it stops being survivable once the command is *inferred* rather than typed.

**Adding 1 to the abstention set would be worse than the bug** — every genuine failure would abstain, and abstention KEEPS the work.

**Matching the message is not available either:** `cmd.exe` localises it. Here it read *"não é reconhecido como um comando interno ou externo"* — an English pattern would be a defence that works everywhere except where you are standing.

So: ask whether the program exists. `program_missing` resolves the first token with `shutil.which`, excludes `cmd.exe` builtins (no executable on disk — mistaking one for missing would abstain on a real failure), checks explicit paths directly, and runs **only after a non-zero exit** so a command that exists and genuinely fails is never reinterpreted.

## The two fixtures

`tests/test_project_api.py` used `true`/`false` as its spec check — neither exists in `cmd.exe`, so the "already satisfied" spec never satisfied and both tests sat at `running`. The suite already reaches for `sys.executable` for this reason (`tests/test_verify.py:23`); this file hadn't caught up.

## The job that would have caught all three

`quality` is Ubuntu-only; the three-OS matrix is clean-install + import — it proves the package *installs*, not that it *works*. New `test (windows)` job: one Python, tests only (ruff/mypy read the same source everywhere), wired into `verdict` so it blocks.

This is **P0 of the IDE plan** and it earned its place on the first run — ACP CLIs, language servers, `npx.cmd` and `CREATE_NO_WINDOW` all land on Windows first.

**Non-vacuity:** revert the Windows branch and the abstention test fails again with the Portuguese cmd.exe message. `program_missing` is tested as a predicate so the reasoning stays under test on Linux/macOS, where the branch never runs.

Windows **2604 passed** · Linux **2605 passed**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)