### PR TITLE
feat(app): the screen lives in the URL (P0)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { IconRail, type View } from "@/components/IconRail";
+import { useRoute } from "@/lib/router";
 import { Settings } from "@/components/Settings";
 import { Knowledge } from "@/components/Knowledge";
 import { Automation } from "@/components/Automation";
@@ -61,7 +62,10 @@ export default function App() {
   // never sees it). Session-local "skip" lets a GUI-first user jump to Settings without a key yet.
   const doctor = useQuery({ queryKey: ["doctor"], queryFn: getDoctor });
   const [skipOnboarding, setSkipOnboarding] = useState(false);
-  const [view, setView] = useState<View>("code");
+  // The screen lives in the URL now. It was a `useState`, which is enough until something outside
+  // this switch needs to point at a place — "open this file at line 42" from a diagnostic or a
+  // search hit — and until open editor tabs need to survive a reload and answer the back button.
+  const { view, navigate } = useRoute();
   const [paletteOpen, setPaletteOpen] = useState(false);
 
   // Every destination, plus every session by title. This is the long tail the rail no longer
@@ -72,21 +76,21 @@ export default function App() {
       id: `go-${v}`,
       label: t(`nav.${v}`),
       group: t("palette.group.go"),
-      run: () => setView(v),
+      run: () => navigate(v),
     }));
-  }, [t]);
+  }, [t, navigate]);
 
   useHotkeys({
     onPalette: () => setPaletteOpen((o) => !o),
-    onSettings: () => setView("settings"),
+    onSettings: () => navigate("settings"),
     // The conversation owns its own "new" now — it lives beside the list of past ones, which is
     // where someone looks for it. A global shortcut that jumps you to a screen AND clears it is two
     // actions wearing one key.
-    onNewChat: () => setView("code"),
+    onNewChat: () => navigate("code"),
     onNavigate: (i) => {
       const order: View[] = ["code", "work", "knowledge", "automation"];
       const target = order[i - 1];
-      if (target) setView(target);
+      if (target) navigate(target);
     },
   });
 
@@ -110,7 +114,7 @@ export default function App() {
       <Onboarding
         onSkip={() => {
           setSkipOnboarding(true);
-          setView("settings");
+          navigate("settings");
         }}
       />
     );
@@ -131,11 +135,11 @@ export default function App() {
         viewKey={view}
         viewLabel={t(`nav.${view}`)}
         // Usage lives in Settings now; the cost chip still takes you straight there.
-        onOpenUsage={() => setView("settings")}
+        onOpenUsage={() => navigate("settings")}
         rail={
           <IconRail
             view={view}
-            onSelect={setView}
+            onSelect={navigate}
             dark={dark}
             onToggleTheme={toggle}
             ignite={ignite}

--- a/apps/desktop/src/components/IconRail.tsx
+++ b/apps/desktop/src/components/IconRail.tsx
@@ -15,13 +15,24 @@ import { focusRing } from "@/components/ui/focus";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useT } from "@/lib/i18n";
 
-export type View =
-  | "knowledge"
-  | "automation"
-  | "work"
-  | "code"
-  | "maturity"
-  | "settings";
+/**
+ * Every destination, as data.
+ *
+ * The type used to be a bare union, which the router cannot check a URL against — a hash arrives as
+ * a string and something has to say whether it names a real screen. Deriving the type FROM the list
+ * keeps one source of truth: adding a screen to the array is what makes it a valid `View`, and a
+ * second hand-maintained list cannot drift out of step with the first.
+ */
+export const VIEWS = [
+  "knowledge",
+  "automation",
+  "work",
+  "code",
+  "maturity",
+  "settings",
+] as const;
+
+export type View = (typeof VIEWS)[number];
 
 /** Maturity reports the Chimera project's OWN test coverage, so it needs a source checkout — in
  *  an installed build it renders an empty state. Shipping a permanently blank screen is a trust

--- a/apps/desktop/src/lib/router.test.ts
+++ b/apps/desktop/src/lib/router.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_VIEW, formatHash, parseHash, useRoute } from "@/lib/router";
+
+/**
+ * The router is two pure functions and a hook over `hashchange`.
+ *
+ * The pure half carries the judgement — what counts as a screen, what a stale URL falls back to —
+ * so it is tested directly and without a DOM. The hook is tested for the three things that are
+ * genuinely about the browser: reading the initial hash, following the back button, and not filling
+ * history with steps nobody wants to retrace.
+ */
+
+afterEach(() => {
+  window.location.hash = "";
+});
+
+describe("parseHash", () => {
+  it("reads a bare screen", () => {
+    expect(parseHash("#/work").view).toBe("work");
+  });
+
+  it("tolerates the shapes a URL actually arrives in", () => {
+    // Vite, Tauri and a hand-typed address bar do not agree on the leading characters.
+    expect(parseHash("#work").view).toBe("work");
+    expect(parseHash("work").view).toBe("work");
+  });
+
+  it("falls back to the default rather than rendering nothing", () => {
+    // A stale bookmark, a renamed screen, a typo. Landing somewhere real beats a blank app.
+    expect(parseHash("#/does-not-exist").view).toBe(DEFAULT_VIEW);
+    expect(parseHash("").view).toBe(DEFAULT_VIEW);
+    expect(parseHash("#/").view).toBe(DEFAULT_VIEW);
+  });
+
+  it("carries params", () => {
+    const route = parseHash("#/code?file=src%2Fapi.ts&line=42");
+    expect(route.view).toBe("code");
+    expect(route.params.get("file")).toBe("src/api.ts");
+    expect(route.params.get("line")).toBe("42");
+  });
+
+  it("gives an empty params bag rather than null when there are none", () => {
+    // So callers can read `.get()` without a guard at every site.
+    expect([...parseHash("#/work").params.keys()]).toEqual([]);
+  });
+
+  it("refuses a dev-only screen in a shipped build", () => {
+    // Maturity needs a source checkout. Parsing it in a release would land on a blank screen, which
+    // reads as a broken app rather than a link that no longer applies.
+    expect(parseHash("#/maturity", true).view).toBe("maturity");
+    expect(parseHash("#/maturity", false).view).toBe(DEFAULT_VIEW);
+  });
+});
+
+describe("formatHash", () => {
+  it("keeps the common URL readable", () => {
+    expect(formatHash("code")).toBe("#/code");
+    expect(formatHash("code", {})).toBe("#/code");
+  });
+
+  it("encodes params", () => {
+    expect(formatHash("code", { file: "src/api.ts" })).toBe("#/code?file=src%2Fapi.ts");
+  });
+
+  it("round-trips", () => {
+    const params = { file: "a b/c.ts", line: "7" };
+    const back = parseHash(formatHash("work", params));
+    expect(back.view).toBe("work");
+    expect(back.params.get("file")).toBe("a b/c.ts");
+    expect(back.params.get("line")).toBe("7");
+  });
+});
+
+describe("useRoute", () => {
+  it("starts from the URL, not from a default", () => {
+    window.location.hash = "#/knowledge";
+    const { result } = renderHook(() => useRoute());
+    expect(result.current.view).toBe("knowledge");
+  });
+
+  it("follows the back button", () => {
+    // The whole reason for a router: history is the browser's job, not a stack we maintain.
+    const { result } = renderHook(() => useRoute());
+
+    act(() => result.current.navigate("automation"));
+    expect(result.current.view).toBe("automation");
+
+    act(() => {
+      window.location.hash = "#/work";
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+    expect(result.current.view).toBe("work");
+  });
+
+  it("navigate writes the address", () => {
+    const { result } = renderHook(() => useRoute());
+    act(() => result.current.navigate("code", { file: "x.ts" }));
+    expect(window.location.hash).toBe("#/code?file=x.ts");
+    expect(result.current.route.params.get("file")).toBe("x.ts");
+  });
+
+  it("setParams stays on the screen and does not push history", () => {
+    // A cursor move or a tab switch changes params constantly. Pushing each one would make the back
+    // button walk through every keystroke instead of returning to the previous screen.
+    window.location.hash = "#/code";
+    const { result } = renderHook(() => useRoute());
+    const before = window.history.length;
+
+    act(() => result.current.setParams({ file: "y.ts" }));
+
+    expect(result.current.view).toBe("code");
+    expect(result.current.route.params.get("file")).toBe("y.ts");
+    expect(window.history.length).toBe(before);
+  });
+});

--- a/apps/desktop/src/lib/router.ts
+++ b/apps/desktop/src/lib/router.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { VIEWS, type View } from "@/components/IconRail";
+
+/**
+ * Where you are, in the URL.
+ *
+ * The app navigated with `useState<View>`, which works until something outside the switch needs to
+ * point at a place: "open this file at line 42" from a diagnostic, a search hit, or a tool event.
+ * With no address for a screen, every one of those becomes a callback threaded through the shell.
+ * The editor makes it unavoidable — open tabs and the active file are exactly the state that has to
+ * survive a reload and answer the back button, and re-implementing history by hand is how that ends.
+ *
+ * **Hash, not path.** A path router needs the server to send index.html for unknown URLs. That works
+ * here (`app.py` has an SPA fallback) but the app also runs from a Tauri webview origin and against
+ * a REMOTE Chimera (`src/lib/server.ts`), and each is a different chance for the fallback to be
+ * wrong. The hash never reaches a server, so there is no configuration to get wrong.
+ *
+ * **Hand-rolled, not react-router.** Six destinations and one params bag. The library is 12 KB and a
+ * whole mental model for something the platform already does with `hashchange`.
+ */
+
+/** The screen shown when the URL says nothing, or says something that is not a screen. */
+export const DEFAULT_VIEW: View = "code";
+
+export interface Route {
+  readonly view: View;
+  /** Everything after `?` in the hash. Empty for a bare `#/code`. */
+  readonly params: URLSearchParams;
+}
+
+/**
+ * `maturity` reports this project's own test coverage and needs a source checkout; the rail hides it
+ * outside development and `App` refuses to render it. Without this it would still PARSE in a shipped
+ * build, so a link to `#/maturity` would land on a blank screen — worse than the URL simply not
+ * working, because a blank screen looks like a broken app rather than a stale link.
+ */
+const DEV_ONLY: ReadonlySet<string> = new Set(["maturity"]);
+
+function isView(value: string, allowDev: boolean): value is View {
+  if (DEV_ONLY.has(value) && !allowDev) return false;
+  return (VIEWS as readonly string[]).includes(value);
+}
+
+/**
+ * Read a hash into a route. Never throws and never returns something that is not a screen — a stale
+ * or hand-edited URL lands on the default rather than rendering nothing.
+ */
+export function parseHash(hash: string, allowDev: boolean = import.meta.env.DEV): Route {
+  const raw = hash.replace(/^#\/?/, "");
+  const [path = "", query = ""] = raw.split("?", 2);
+  const view = decodeURIComponent(path);
+  return {
+    view: isView(view, allowDev) ? view : DEFAULT_VIEW,
+    params: new URLSearchParams(query),
+  };
+}
+
+/** The inverse. Empty params produce a bare `#/code`, so the common URL stays readable. */
+export function formatHash(view: View, params?: Record<string, string>): string {
+  const query = new URLSearchParams(params ?? {}).toString();
+  return query ? `#/${view}?${query}` : `#/${view}`;
+}
+
+export interface Router {
+  readonly route: Route;
+  /** Convenience: `route.view`, which is what almost every caller wants. */
+  readonly view: View;
+  /** Push a new location. Back/forward then work because the browser owns the history. */
+  navigate: (view: View, params?: Record<string, string>) => void;
+  /** Change params without leaving the screen — replaces rather than pushes, so a cursor move or a
+   *  tab switch does not fill the back button with steps nobody wants to retrace. */
+  setParams: (params: Record<string, string>) => void;
+}
+
+export function useRoute(): Router {
+  const [route, setRoute] = useState<Route>(() => parseHash(window.location.hash));
+
+  useEffect(() => {
+    const onChange = () => setRoute(parseHash(window.location.hash));
+    window.addEventListener("hashchange", onChange);
+    // The hash can change between the first render and this effect attaching — a deep link that the
+    // shell rewrites, or a second tab restoring state. Re-read once so the two cannot disagree.
+    onChange();
+    return () => window.removeEventListener("hashchange", onChange);
+  }, []);
+
+  const navigate = useCallback((view: View, params?: Record<string, string>) => {
+    const next = formatHash(view, params);
+    window.location.hash = next;
+    // Set the state too, rather than waiting to hear about our own navigation.
+    //
+    // `hashchange` is ASYNCHRONOUS — the browser queues it, so between the click and the event the
+    // screen would still be the old one. Rare enough to look like a flicker and impossible to
+    // reproduce on demand, which is the worst kind of bug to be handed. Assigning an unchanged hash
+    // also fires no event at all, so a repeat click would have gone nowhere.
+    //
+    // The listener stays: it is what makes back/forward and an externally-edited URL work, and
+    // arriving at the same value twice costs nothing.
+    setRoute(parseHash(next));
+  }, []);
+
+  const setParams = useCallback((params: Record<string, string>) => {
+    const current = parseHash(window.location.hash);
+    const next = formatHash(current.view, params);
+    const url = `${window.location.pathname}${window.location.search}${next}`;
+    window.history.replaceState(null, "", url);
+    setRoute(parseHash(next));
+  }, []);
+
+  return { route, view: route.view, navigate, setParams };
+}


### PR DESCRIPTION
`App.tsx` held the screen in a `useState<View>` — enough until something outside that switch needs to point at a place. The editor makes it unavoidable: **"open this file at line 42"** from a diagnostic, a search hit or a tool event has no address to aim at, and open tabs are exactly the state that must survive a reload and answer the back button.

**Hash, not path.** A path router needs the server to serve index.html for unknown URLs. It does — but the app also runs from a Tauri webview origin and against a *remote* Chimera (`src/lib/server.ts`). Three chances for that fallback to be wrong. A hash never reaches a server.

**Hand-rolled, not react-router.** Six destinations and a params bag, against 12 KB and a whole mental model for what `hashchange` already does.

**`View` is now derived from a list.** A router must ask whether a string names a real screen, and a bare type union can't answer at runtime. `VIEWS` is the array, the type is `(typeof VIEWS)[number]` — one source of truth, no second list to drift.

## Two things the tests caught that I had wrong

**`hashchange` is asynchronous.** v1 set `location.hash` and waited to hear about its own navigation, leaving the old screen up in between — a flicker impossible to reproduce on demand. `navigate` now sets state directly; the listener keeps the job it's actually for (back/forward, externally-edited URL).

**A dev-only screen must not parse in a shipped build.** `#/maturity` in a release would have landed on a blank screen — reads as a broken app, not a stale link. `parseHash` rejects it there.

## Verified in a browser, not only jsdom

Rail click writes `#/work` and moves `aria-current` · back returns with the highlight following · forward returns · cold load of `#/automation?file=src%2Fapi.ts&line=42` lands correctly with both params decoded — the exact shape P1 needs.

404 desktop tests (13 new), build green. Python gate untouched: 2605 passed, ruff + mypy clean, snapshots and OpenAPI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)