### PR TITLE
fix(context): the task survives compaction, because it did not

### DIFF
--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -295,6 +295,16 @@ class Agent:
         # silently.
         if self.config.instructions:
             system_prompt = f"{system_prompt}\n\n{self.config.instructions}"
+        # Remembered here so a compaction can put it back. The task arrives as the last user message
+        # and, after enough turns, falls out of the tail that compaction keeps — leaving the agent
+        # executing a plan whose purpose was deleted. Set at the loop rather than by each caller
+        # because the caller that compacts most (the conversational coding turn) set only the open
+        # file, and the fix has to reach the callers nobody remembered.
+        #
+        # Not overwritten: `/api/runs` fills `current_state` with a richer framing before calling in,
+        # and a later turn of a conversation should not relabel the run as its own latest message.
+        if not self.run_state.task:
+            self.run_state.task = task
         # The system message is rebuilt every turn rather than carried in ``history``: skills are
         # retrieved for THIS task and the project instructions follow the file now in focus, so a
         # stale system message would pin both to whatever the first turn happened to be about.

--- a/chimera/core/context_budget.py
+++ b/chimera/core/context_budget.py
@@ -95,6 +95,23 @@ class RunState:
     implicitly on every step, and that a naive summary silently drops.
     """
 
+    #: What the run was ASKED to do, verbatim.
+    #:
+    #: The first thing a naive compactor drops and the last thing an agent can do without. The task
+    #: arrives as a user message at the end of the initial prompt; after enough turns it falls out
+    #: of the kept tail, and `_structural_note` deliberately does not summarise content — so the
+    #: agent is left executing a plan whose purpose was deleted, with a note saying N messages were
+    #: removed. A file it can re-read; an instruction it cannot.
+    #:
+    #: Set by :meth:`Agent.run` itself rather than by each caller, because the callers that most
+    #: need it are the ones nobody remembered to update: `/api/runs` populates plan and tasks, and
+    #: the conversational coding turn — the screen that compacts most — set only ``open_file``.
+    #:
+    #: Two independent papers measure this failure class (arXiv 2608.11242: compactors retain 17%
+    #: of injected session constraints; 2608.11392: rule-form items survive a compaction far better
+    #: than facts). Our system message already survives verbatim, which is the half those papers
+    #: find missing; this is the other half.
+    task: str = ""
     #: Path of the file currently being worked on, and its content — re-read, not remembered.
     open_file: tuple[str, str] | None = None
     #: The plan the run is executing.
@@ -107,6 +124,10 @@ class RunState:
     def as_message(self) -> MessageLike | None:
         """Render as a single user message, or None when there is nothing to restore."""
         parts: list[str] = []
+        # First, because it is what everything else is in service of. A restored plan under a
+        # forgotten task is an agent carrying out steps it can no longer justify.
+        if self.task:
+            parts.append(f"The task you were given:\n{self.task}")
         if self.current_state:
             parts.append(f"Current state:\n{self.current_state}")
         if self.plan:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -207,3 +207,44 @@ def test_loop_compacts_once_the_prompt_crosses_the_trigger() -> None:
     # starts contradicting its earlier self.
     assert any(s.compacted for s in result.steplog.steps)
     assert result.answer == "done"
+
+
+# --- the task survives compaction (arXiv 2608.11242 / 2608.11392) --------------------------------
+
+
+def test_the_task_is_restored_after_compaction() -> None:
+    """The first thing a naive compactor drops and the last thing an agent can do without.
+
+    The task arrives as a user message at the end of the initial prompt. After enough turns it falls
+    out of the tail compaction keeps, and `_structural_note` deliberately does not summarise content
+    — so without this the agent is left executing a plan whose purpose was deleted, holding a note
+    that says N messages were removed. A file it can re-read; an instruction it cannot.
+    """
+    state = RunState(task="Make the failing test in tests/test_auth.py pass")
+    messages: list[Any] = [{"role": "system", "content": "SYS"}]
+    messages += [{"role": "user", "content": f"turn {i}"} for i in range(20)]
+
+    compacted, changed = compact(messages, keep_recent=4, state=state)
+
+    assert changed is True
+    restored = "\n".join(str(m.get("content", "")) for m in compacted)
+    assert "Make the failing test in tests/test_auth.py pass" in restored
+
+
+def test_the_task_leads_the_restored_message() -> None:
+    # A restored plan under a forgotten task is an agent carrying out steps it can no longer justify.
+    message = RunState(task="ship the release", plan="1. bump 2. tag").as_message()
+
+    assert message is not None
+    content = str(message["content"])
+    assert content.index("ship the release") < content.index("1. bump 2. tag")
+
+
+def test_a_state_with_only_a_task_still_restores() -> None:
+    # The conversational coding turn sets nothing else, so this is the shape that actually ships.
+    assert RunState(task="rename the module").as_message() is not None
+
+
+def test_an_empty_state_restores_nothing() -> None:
+    # Unchanged: a compaction with nothing to say must not append an empty ceremonial message.
+    assert RunState().as_message() is None


### PR DESCRIPTION
Found while reading the batch of papers — the one item in nineteen links that turned out to be a defect in our own loop.

## The evidence

Two independent measurements of the same failure class:

- **arXiv 2608.11242** — compactors retain **17%** of injected session constraints on average
- **arXiv 2608.11392** — rule-form items survive a single compaction far better than facts

Our compaction already does the half those papers find missing: the system message is never touched, so governance rules, posture and `AGENTS.md` survive verbatim. This is the other half.

## The hole

`RunState` is the active-restoration seam. It carried the plan, the tasks, the open file and a state paragraph. **It did not carry the task.**

The task arrives as the last user message of the initial prompt. After enough turns it falls out of the tail compaction keeps, and `_structural_note` deliberately does not summarise content — so what remains is an agent executing a plan whose purpose was deleted, holding a note saying "N earlier messages were removed". A file it can re-read. An instruction it cannot.

Worse where it matters most:

| surface | restored before this change |
|---|---|
| `/api/runs` (autonomous) | `current_state`, `plan`, `tasks` ✅ |
| `/api/code/turn` (the conversation) | `open_file` only |

The surface most likely to hit a compaction — the screen people leave open — was restoring the least.

## The fix

Set in `Agent.run`, not at each call site, because the call site that needed it is precisely the one nobody remembered to update. Not overwritten when already present, so `/api/runs`' richer framing wins and a later turn does not relabel the run as its own latest message.

Four tests, checked by disabling the restoration and watching three go red.

## Gates

2722 tests · ruff · `mypy --strict` on 284 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)