### PR TITLE
feat(rag): retrieval over a repository, and a bench that caught three of my own errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Local retrieval over a repository** (`chimera/rag/`): symbol-level chunking over Python's AST,
+  one SQLite file with an FTS5 index and optional vectors, and RRF fusion of the two rankings. The
+  embedder is injected, so a machine without one gets keyword retrieval rather than an error, and
+  the repository map's PageRank is a **tiebreak only** — a central file is not evidence that it
+  answers this question.
+- **A pre-registered A/B for it** (`chimera/eval/rag_bench.py`, baseline in `bench/rag/`). Probes
+  are derived mechanically from docstrings with the symbol's own name removed, and the docstrings
+  are stripped from what gets indexed. Measured on this repository: keyword-only recall@10 of
+  **0.4925** over 400 probes on 2,691 chunks — so the ceiling a semantic layer could add is 50.75
+  points. The baseline was taken before any embedder was wired, which is what makes it a
+  pre-registration rather than a number chosen after the fact.
+
 - **Search across the workspace.** `POST /api/fs/search` and a panel beside the file tree: hits
   grouped by file, the matched span highlighted from offsets the server measured, and a click that
   opens the file. ripgrep where it exists, a bounded Python walk where it does not — and the answer

--- a/bench/rag/baseline.json
+++ b/bench/rag/baseline.json
@@ -1,0 +1,15 @@
+{
+  "probes": 400,
+  "chunks": 2691,
+  "k": 10,
+  "keyword_recall": 0.4925,
+  "vector_recall": null,
+  "hybrid_recall": null,
+  "headroom": 0.5075,
+  "notes": [
+    "no embedder supplied \u2014 the ceiling below is what one could add at most"
+  ],
+  "corpus": "chimera/ (this repository)",
+  "date": "2026-08-13",
+  "preregistered": "Baseline taken BEFORE any embedder was wired, so the semantic number cannot be chosen after seeing what would look good. headroom is the ceiling: the most a semantic layer could add."
+}

--- a/chimera/eval/rag_bench.py
+++ b/chimera/eval/rag_bench.py
@@ -1,0 +1,301 @@
+"""Does retrieval over this repository actually find the right code?
+
+The pre-registered A/B for :mod:`chimera.rag`, and it is deliberately built to be able to say NO.
+
+**The probes are derived, not written.** For every documented Python symbol, the query is the first
+line of its docstring with the symbol's own name-tokens stripped out. `resolve_verify` documented as
+"The verify command actually used" becomes the query "the command actually used" — a question about
+the function that does not contain its name. That is mechanical, reproducible, and free of the bias
+of an author writing queries for a system they built.
+
+**And the docstring is removed from what gets indexed.** Without that, the corpus contains the
+question: the target chunk holds the very sentence the query is made of, so keyword retrieval finds
+it by matching a string to itself. Measured before the fix — recall@10 of **1.00** across 400 probes
+on 2,690 chunks, a perfect score for a question nobody asked. What is indexed is the CODE, which is
+the honest shape of the real task: somebody describes a behaviour, and the implementation does not
+contain their description.
+
+It is still not a real user question. A docstring shares an author and a vocabulary with the code
+below it, so a keyword retriever does better here than it will in the field — and that direction is
+the safe one, because it makes this a hard test for the vectors and an easy one for the baseline.
+
+**Measure the ceiling before building the machine.** ``headroom`` is the share of probes keyword
+retrieval already misses. It needs no embedder and no provider, and it bounds everything the
+vectors could possibly add. If it is small, the honest answer is that this whole layer is not worth
+its cost — which is a thing this file is allowed to conclude.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+from chimera.rag.chunks import Chunk, walk
+from chimera.rag.hybrid import reciprocal_rank_fusion
+from chimera.rag.store import ChunkStore, EmbedFn
+
+#: Words too common to make a query about anything.
+_STOP = frozenset((
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "has",
+    "have",
+    "in",
+    "is",
+    "it",
+    "its",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "this",
+    "to",
+    "was",
+    "were",
+    "with",
+    "when",
+    "where",
+    "which",
+    "while",
+    "what",
+    "how",
+    "why",
+    "not",
+    "no",
+    "if",
+    "then",
+    "than",
+    "into",
+    "out",
+    "up",
+    "down",
+    "over",
+    "under",
+    "only",
+    "rather",
+    "never",
+    "always",
+    "must",
+    "can",
+    "cannot",
+    "does",
+    "do",
+    "done",
+    "use",
+    "used",
+    "using",
+    "make",
+    "makes",
+    "made",
+    "one",
+    "two",
+    "both",
+    "each",
+    "every",
+    "any",
+    "all",
+    "some",
+    "more",
+    "most",
+    "less",
+    "least",
+    "same",
+    "other",
+    "another",
+    "such",
+    "so",
+    "because",
+    "since",
+    "about",
+))
+
+_WORD = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+@dataclass
+class Probe:
+    """One question with a known answer."""
+
+    query: str
+    #: The chunk id that answers it.
+    target: str
+    path: str
+
+
+@dataclass
+class RagReport:
+    """What retrieval found, per retriever."""
+
+    probes: int = 0
+    chunks: int = 0
+    keyword_recall: float = 0.0
+    #: None when no embedder was supplied — never 0.0, which would read as "the vectors failed".
+    vector_recall: float | None = None
+    hybrid_recall: float | None = None
+    #: Share of probes keyword retrieval misses: the ceiling on what any semantic layer can add.
+    headroom: float = 0.0
+    k: int = 10
+    notes: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "probes": self.probes,
+            "chunks": self.chunks,
+            "k": self.k,
+            "keyword_recall": round(self.keyword_recall, 4),
+            "vector_recall": None if self.vector_recall is None else round(self.vector_recall, 4),
+            "hybrid_recall": None if self.hybrid_recall is None else round(self.hybrid_recall, 4),
+            "headroom": round(self.headroom, 4),
+            "notes": list(self.notes),
+        }
+
+
+def _name_tokens(symbol: str) -> set[str]:
+    """Every token of a symbol name: `resolve_verify` and `Gateway.send` both split fully.
+
+    Stripped from the query so the probe cannot be answered by echoing the name back — which would
+    measure whether the retriever can match a string to itself.
+    """
+    parts: set[str] = set()
+    for piece in re.split(r"[._]", symbol):
+        if not piece:
+            continue
+        parts.add(piece.lower())
+        # camelCase and PascalCase, so `resolveVerify` splits too.
+        parts.update(m.group(0).lower() for m in re.finditer(r"[A-Z]?[a-z]+|[A-Z]+(?![a-z])", piece))
+    return parts
+
+
+def build_probes(chunks: list[Chunk], *, min_words: int = 4) -> list[Probe]:
+    """One probe per documented symbol whose docstring survives having its own name removed."""
+    probes: list[Probe] = []
+    for chunk in chunks:
+        if chunk.kind not in ("function", "class") or not chunk.symbol:
+            continue
+        summary = _docstring_summary(chunk.text)
+        if not summary:
+            continue
+        banned = _name_tokens(chunk.symbol) | _name_tokens(Path(chunk.path).stem)
+        words = [
+            w for w in _WORD.findall(summary)
+            if w.lower() not in banned and w.lower() not in _STOP and len(w) > 2
+        ]
+        if len(words) < min_words:
+            # Too little left to be a question. Keeping it would measure retrieval against noise.
+            continue
+        probes.append(Probe(query=" ".join(words), target=chunk.ident, path=chunk.path))
+    return probes
+
+
+def _without_docstring(chunk: Chunk) -> Chunk:
+    """The same chunk with its docstring lines removed, id and span unchanged.
+
+    Textual rather than AST-based: the chunk has to keep the identity it was stored under, and
+    re-parsing then unparsing would rewrite formatting the retriever indexes. Removing the
+    triple-quoted block at the top of the body is the whole job.
+    """
+    lines = chunk.text.splitlines(keepends=True)
+    out: list[str] = []
+    inside = False
+    fence = ""
+    for line in lines:
+        stripped = line.strip()
+        if not inside:
+            for quote in ('"""', "'''"):
+                if stripped.startswith(quote) or stripped.startswith(f"r{quote}"):
+                    body = stripped.split(quote, 1)[1]
+                    # A one-line docstring opens and closes on the same line.
+                    if not body.endswith(quote) or len(stripped) <= len(quote):
+                        inside, fence = True, quote
+                    break
+            else:
+                out.append(line)
+                continue
+            continue
+        if fence in line:
+            inside = False
+    text = "".join(out)
+    return replace(chunk, text=text if text.strip() else chunk.text)
+
+
+def _docstring_summary(text: str) -> str:
+    """The first line of the chunk's docstring, or "" when it has none."""
+    try:
+        tree = ast.parse(text.strip())
+    except (SyntaxError, ValueError):
+        return ""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            doc = ast.get_docstring(node)
+            if doc:
+                return doc.strip().splitlines()[0].strip()
+    return ""
+
+
+def run_rag_bench(
+    root: Path,
+    *,
+    index_path: Path,
+    embed: EmbedFn | None = None,
+    k: int = 10,
+    max_probes: int = 400,
+) -> RagReport:
+    """Index ``root``, probe it, and report recall for each retriever.
+
+    ``embed`` is optional. Without it the vector and hybrid figures are None rather than zero: an
+    embedder that was never called did not fail, and a bench that reports 0.0 for it invites exactly
+    the wrong conclusion.
+    """
+    chunks = walk(root)
+    probes = build_probes(chunks)[:max_probes]
+    # Indexed WITHOUT the docstrings the probes are made from. Leaving them in puts the question
+    # inside the corpus, and the measurement becomes "can FTS match a string to itself" — which it
+    # can, at recall@10 = 1.00.
+    store = ChunkStore(index_path)
+    store.replace_all([_without_docstring(c) for c in chunks])
+    report = RagReport(probes=len(probes), chunks=len(chunks), k=k)
+    if not probes:
+        report.notes.append("no documented symbols to probe")
+        return report
+
+    embedded = 0
+    if embed is not None:
+        embedded = store.embed_missing(embed)
+        if embedded == 0:
+            report.notes.append("the embedder produced no vectors; semantic figures are unavailable")
+
+    keyword_hits = vector_hits = hybrid_hits = 0
+    for probe in probes:
+        keyword = store.search_keyword(probe.query, k=k)
+        if any(h.chunk.ident == probe.target for h in keyword):
+            keyword_hits += 1
+        if embedded:
+            query_vector = embed([probe.query])[0] if embed else []
+            vector = store.search_vector(query_vector, k=k)
+            if any(h.chunk.ident == probe.target for h in vector):
+                vector_hits += 1
+            fused = reciprocal_rank_fusion([keyword, vector], limit=k)
+            if any(h.chunk.ident == probe.target for h in fused):
+                hybrid_hits += 1
+
+    total = len(probes)
+    report.keyword_recall = keyword_hits / total
+    report.headroom = 1.0 - report.keyword_recall
+    if embedded:
+        report.vector_recall = vector_hits / total
+        report.hybrid_recall = hybrid_hits / total
+    else:
+        report.notes.append("no embedder supplied — the ceiling below is what one could add at most")
+    store.close()
+    return report

--- a/chimera/rag/__init__.py
+++ b/chimera/rag/__init__.py
@@ -1,0 +1,34 @@
+"""Local retrieval over a repository.
+
+Cross-file search (:mod:`chimera.core.search`) answers "where does this string appear". This answers
+the question that has no string: "where do we decide whether to keep a change", asked of a codebase
+that calls it `verify-or-revert` and never uses the word "decide".
+
+Three parts, and the seam between them is the point:
+
+* :mod:`chimera.rag.chunks` cuts the repository at symbol boundaries, because the unit of retrieval
+  decides what retrieval can answer;
+* :mod:`chimera.rag.store` keeps them in one SQLite file with an FTS5 index and optional vectors,
+  the embedder injected so a machine without one degrades to keyword search instead of failing;
+* :mod:`chimera.rag.hybrid` fuses the two rankings by rank rather than by score, so there is no
+  weight to tune per repository.
+
+What this is NOT: a claim that it helps. :mod:`chimera.eval.rag_bench` measures retrieval against
+probes with known answers, keyword-only versus hybrid, and the honest thing to do with that number
+is publish it either way.
+"""
+
+from chimera.rag.chunks import Chunk, chunk_source, walk
+from chimera.rag.hybrid import reciprocal_rank_fusion
+from chimera.rag.store import ChunkStore, EmbedFn, Hit, default_index_path
+
+__all__ = [
+    "Chunk",
+    "ChunkStore",
+    "EmbedFn",
+    "Hit",
+    "chunk_source",
+    "default_index_path",
+    "reciprocal_rank_fusion",
+    "walk",
+]

--- a/chimera/rag/chunks.py
+++ b/chimera/rag/chunks.py
@@ -1,0 +1,188 @@
+"""Cutting a repository into pieces worth retrieving.
+
+The unit of retrieval decides what retrieval can answer. Fixed-size windows — the default
+everywhere — cut through the middle of functions, so a hit lands on half a body with no signature
+and the model receives code it cannot attribute. Whole files go the other way: one 800-line module
+is one embedding, and its vector is the average of everything it does, which is close to nothing.
+
+So the unit here is the **symbol**: a function, a method, a class, with its decorators and its
+docstring, spanning the lines the parser says it spans. That is also the unit a person names when
+they ask, which is what makes a hit answerable — "it is in `resolve_verify`, lines 61-94" rather
+than "somewhere in app.py".
+
+Python is parsed with :mod:`ast` — no dependency, exact spans, and the same module `repomap`
+already uses. Everything else falls back to overlapping line windows and SAYS so, because a
+TypeScript chunk cut by line count is not the same kind of object as a Python chunk cut by span,
+and a caller that cannot tell them apart will eventually reason about one as if it were the other.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+#: Characters above which a symbol is split into windows anyway. A 3000-line generated class is a
+#: symbol by the parser's reckoning and a haystack by every other measure.
+MAX_CHUNK_CHARS = 6000
+
+#: Lines per window in the fallback, and how many of them overlap. The overlap exists so a match
+#: that straddles a boundary is whole in at least one window — without it, the one thing a window
+#: cut reliably destroys is the thing that spanned the cut.
+WINDOW_LINES = 60
+WINDOW_OVERLAP = 15
+
+#: Suffixes worth indexing. Deliberately short: a repository's value for retrieval is its source and
+#: its prose, and indexing lockfiles and minified bundles spends the budget on text nobody asks
+#: about in words.
+SOURCE_SUFFIXES = frozenset(
+    {".py", ".pyi", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".rs", ".go", ".java", ".rb", ".md"}
+)
+
+#: Directories never descended into. Same list as the search engines use, and for the same reason.
+SKIP_DIRS = frozenset(
+    {
+        ".git", ".hg", ".svn", "node_modules", "__pycache__", ".venv", "venv", ".mypy_cache",
+        ".pytest_cache", ".ruff_cache", "dist", "build", "target", ".next", ".cache", ".tox",
+        "site-packages", ".idea", ".vscode", "coverage", ".gradle",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Chunk:
+    """One retrievable piece of the repository."""
+
+    path: str  # workspace-relative, forward slashes
+    #: The symbol's dotted name (`ClassName.method`), or "" for a window chunk.
+    symbol: str
+    #: "function" | "class" | "window". Carried because a window is a weaker object than a symbol:
+    #: it has no name, its boundaries are arbitrary, and a caller ranking the two together should
+    #: know which it is holding.
+    kind: str
+    start_line: int  # 1-based, inclusive
+    end_line: int  # inclusive
+    text: str
+
+    @property
+    def ident(self) -> str:
+        """A stable id: the same symbol at the same lines is the same chunk across runs."""
+        return f"{self.path}:{self.start_line}-{self.end_line}"
+
+    @property
+    def label(self) -> str:
+        """What a person would call this. Used in the FTS text so a query naming a symbol hits it."""
+        return f"{self.path} {self.symbol}".strip()
+
+
+def _window(path: str, lines: list[str], first: int, last: int, symbol: str = "") -> list[Chunk]:
+    """Cut `lines[first-1:last]` into overlapping windows."""
+    out: list[Chunk] = []
+    step = max(1, WINDOW_LINES - WINDOW_OVERLAP)
+    for start in range(first, last + 1, step):
+        end = min(last, start + WINDOW_LINES - 1)
+        text = "".join(lines[start - 1 : end])
+        if text.strip():
+            out.append(Chunk(path, symbol, "window", start, end, text))
+        if end >= last:
+            break
+    return out
+
+
+def _python_chunks(path: str, source: str) -> list[Chunk] | None:
+    """Symbol chunks from Python source, or None when it does not parse.
+
+    None rather than an empty list, and the difference matters: a file with no symbols is
+    legitimately empty of them, while a file that failed to parse still has content worth
+    retrieving — it just has to be cut a dumber way.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return None
+
+    lines = source.splitlines(keepends=True)
+    chunks: list[Chunk] = []
+
+    def take(node: ast.AST, name: str, kind: str) -> None:
+        start = getattr(node, "lineno", 0)
+        end = getattr(node, "end_lineno", start)
+        if not start:
+            return
+        # Decorators sit ABOVE `lineno` and are part of what the symbol IS — a `@app.post("/x")`
+        # is most of what makes the function below it findable by someone asking about routes.
+        decorators = getattr(node, "decorator_list", [])
+        if decorators:
+            start = min(start, min(getattr(d, "lineno", start) for d in decorators))
+        text = "".join(lines[start - 1 : end])
+        if not text.strip():
+            return
+        if len(text) > MAX_CHUNK_CHARS:
+            chunks.extend(_window(path, lines, start, end, name))
+            return
+        chunks.append(Chunk(path, name, kind, start, end, text))
+
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            # The class AND its methods. Both, deliberately: a question about the class's purpose is
+            # answered by the class header and its docstring, and a question about one behaviour is
+            # answered by one method. Indexing only the class buries the method in an average;
+            # indexing only the methods loses the thing that says what they are for.
+            header_end = min(
+                (m.lineno - 1 for m in node.body if isinstance(m, ast.FunctionDef | ast.AsyncFunctionDef)),
+                default=node.end_lineno or node.lineno,
+            )
+            head = "".join(lines[node.lineno - 1 : header_end])
+            if head.strip():
+                chunks.append(Chunk(path, node.name, "class", node.lineno, header_end, head))
+            for member in node.body:
+                if isinstance(member, ast.FunctionDef | ast.AsyncFunctionDef):
+                    take(member, f"{node.name}.{member.name}", "function")
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            take(node, node.name, "function")
+
+    if not chunks:
+        # Module-level code only (a script, a settings file). Real content, no symbols.
+        return _window(path, lines, 1, len(lines)) if lines else []
+    return chunks
+
+
+def chunk_source(path: str, source: str) -> list[Chunk]:
+    """Cut one file. Never raises; an unparseable file becomes windows."""
+    if not source.strip():
+        return []
+    if path.endswith((".py", ".pyi")):
+        parsed = _python_chunks(path, source)
+        if parsed is not None:
+            return parsed
+    lines = source.splitlines(keepends=True)
+    return _window(path, lines, 1, len(lines))
+
+
+def walk(root: Path, *, max_files: int = 5000, max_bytes: int = 500_000) -> list[Chunk]:
+    """Every chunk in a workspace.
+
+    Bounded twice, and both bounds are the same judgement: an index that takes minutes to build is
+    an index nobody rebuilds, and a stale index is worse than none because it answers confidently
+    about code that has moved.
+    """
+    root = Path(root).resolve()
+    out: list[Chunk] = []
+    seen = 0
+    for path in sorted(root.rglob("*")):
+        if seen >= max_files:
+            break
+        if not path.is_file() or path.suffix.lower() not in SOURCE_SUFFIXES:
+            continue
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        try:
+            if path.stat().st_size > max_bytes:
+                continue
+            source = path.read_text(encoding="utf-8", errors="strict")
+        except (OSError, UnicodeDecodeError):
+            continue
+        seen += 1
+        rel = path.relative_to(root).as_posix()
+        out.extend(chunk_source(rel, source))
+    return out

--- a/chimera/rag/hybrid.py
+++ b/chimera/rag/hybrid.py
@@ -1,0 +1,80 @@
+"""Two retrievers, one ranking.
+
+Keyword search and vector search fail in opposite directions, which is the entire argument for
+running both. FTS finds `resolve_verify` when you type `resolve_verify` and nothing when you type
+"how do we decide whether to keep the change". Embeddings do the reverse: they bridge the
+paraphrase and they routinely rank a chunk that talks *about* the concept above the one that
+implements it — and they cannot find a rare identifier at all, because a token seen twice in
+training has no useful vector.
+
+**Reciprocal Rank Fusion, not score blending.** A bm25 score and a cosine similarity are not
+comparable numbers: one is unbounded and corpus-dependent, the other is bounded in [-1, 1]. Any
+weighted sum of the two is a weight that has to be tuned per corpus and will be tuned once, by
+somebody, on one repository. RRF throws the magnitudes away and keeps only the ORDER each retriever
+produced, so there is nothing to calibrate and no corpus on which the arithmetic quietly inverts.
+
+The one knob (`k`) damps how much the top of a list dominates. 60 is the value from the original
+paper and there is no measurement here that would justify choosing another, so it stays as it is
+until a bench says otherwise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from chimera.rag.store import Hit
+
+#: The RRF damping constant. Larger = flatter, so a confident first place counts for less.
+RRF_K = 60
+
+
+def reciprocal_rank_fusion(
+    lists: list[list[Hit]], *, k: int = RRF_K, limit: int = 10, prior: dict[str, float] | None = None
+) -> list[Hit]:
+    """Fuse ranked lists into one, by rank alone.
+
+    ``prior`` is an optional per-path weight — the repository map's PageRank, when the caller has
+    it. It is a **tiebreak only**: it orders results the fusion scored identically and can never
+    reorder ones it separated.
+
+    That is stricter than it first looks, and the strictness is the point. A first draft multiplied
+    the fused score by the prior, on the reasoning that importance should be "subordinate to
+    relevance" — and its own test caught that it was not. Consecutive RRF scores are 1/61 and 1/62,
+    a 1.6% gap, which any prior worth having flips. So the multiplying version let a central file
+    outrank an exact match, which is precisely the case retrieval is most useful for: a rare
+    identifier in an unimportant file.
+
+    A central file is not evidence that it answers this question. It is evidence that if two
+    candidates are otherwise indistinguishable, one of them matters more.
+    """
+    scores: dict[str, float] = {}
+    best: dict[str, Hit] = {}
+    sources: dict[str, set[str]] = {}
+
+    for ranked in lists:
+        for rank, hit in enumerate(ranked, start=1):
+            ident = hit.chunk.ident
+            scores[ident] = scores.get(ident, 0.0) + 1.0 / (k + rank)
+            sources.setdefault(ident, set()).add(hit.source)
+            # Keep the hit whose own retriever ranked it best, so the surviving `score` is a real
+            # number some retriever produced rather than a fused one nothing can explain.
+            if ident not in best or rank == 1:
+                best[ident] = hit
+
+    # Sorted on (fused score, prior) so the prior is consulted only where the first key is equal.
+    # Arithmetic — adding or multiplying it in — cannot express "only on a tie": whatever epsilon is
+    # chosen is either big enough to reorder a real difference or small enough to be nothing.
+    weights = prior or {}
+    order = sorted(
+        scores.items(),
+        key=lambda pair: (pair[1], weights.get(best[pair[0]].chunk.path, 0.0)),
+        reverse=True,
+    )
+    out: list[Hit] = []
+    for ident, score in order[:limit]:
+        found = sources.get(ident, set())
+        # "hybrid" only when both retrievers actually found it — the label is evidence about how the
+        # result was reached, and calling a keyword-only hit hybrid would make it useless.
+        source = "hybrid" if len(found) > 1 else next(iter(found), "hybrid")
+        out.append(replace(best[ident], score=score, source=source))
+    return out

--- a/chimera/rag/store.py
+++ b/chimera/rag/store.py
@@ -1,0 +1,306 @@
+"""The index: chunks, an FTS5 table, and vectors — in one SQLite file.
+
+Three decisions worth naming.
+
+**One file, not a service.** The whole product is local-first, and a retrieval layer that needs a
+daemon running is a retrieval layer that is down half the time. SQLite is already how memory is
+stored here; this is the same file format, the same backup story, and the same absence of a port.
+
+**Vectors behind brute force, not in front of it.** `sqlite-vec` is an optional extension that may
+be absent, may fail to load against a given SQLite build, and is not present on the machine this was
+written on. So the exact path — cosine over every vector — is the one that always works, and the
+extension is an accelerator asked for by name. Ten thousand chunks of 384 floats is a few million
+multiplications: slower than an index and far faster than the model call it precedes.
+
+**Nothing is embedded here.** The embedder is injected (`EmbedFn`, the same seam
+:mod:`chimera.memory.semantic` already uses), so this module never decides whether that means
+Ollama, a hosted API, or a fake in a test — and a machine with no embedder gets keyword retrieval
+instead of an error.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import struct
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from chimera.rag.chunks import Chunk
+from chimera.telemetry import get_logger
+
+_log = get_logger("rag.store")
+
+#: A batched embedder — the same shape as :data:`chimera.memory.semantic.EmbedFn`.
+EmbedFn = Callable[[list[str]], list[list[float]]]
+
+#: Rows embedded per call. Large enough that a repository is a handful of round trips, small enough
+#: that a failure loses seconds rather than the whole index.
+EMBED_BATCH = 64
+
+#: Word tokens for an FTS query. Anything else a person types is punctuation, not syntax.
+_TOKEN = re.compile(r"[A-Za-z0-9_]+")
+
+#: Below this bm25 score, the whole result matched only on words common to every document.
+#: Corpus-dependent by nature — bm25 scales with corpus size and document length — but the SEPARATION
+#: is not: measured here, real matches score 0.8 to 1.6 and ubiquitous-term matches 1e-06. A floor
+#: anywhere in that gap behaves identically, which is why a round number three orders below the
+#: weakest real match is defensible rather than tuned.
+_NOISE_FLOOR = 1e-3
+
+#: Kept relative to the best hit, so a long tail of near-misses does not pad the candidate list.
+_RELATIVE_FLOOR = 1e-3
+
+
+@dataclass(frozen=True)
+class Hit:
+    """One retrieved chunk, with the score that retrieved it."""
+
+    chunk: Chunk
+    score: float
+    #: "fts" | "vector" | "hybrid" — which retriever produced it. Kept because a hybrid result that
+    #: cannot say where a hit came from cannot be debugged when it is wrong.
+    source: str
+
+
+def _pack(vector: Sequence[float]) -> bytes:
+    return struct.pack(f"{len(vector)}f", *vector)
+
+
+def _unpack(blob: bytes) -> list[float]:
+    return list(struct.unpack(f"{len(blob) // 4}f", blob))
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = na = nb = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 0.0
+    return float(dot / ((na**0.5) * (nb**0.5)))
+
+
+class ChunkStore:
+    """Chunks on disk, searchable by keyword and — when embedded — by meaning."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self.path))
+        self._conn.row_factory = sqlite3.Row
+        self.fts_available = self._init_schema()
+
+    # --- schema ---------------------------------------------------------------------------
+
+    def _init_schema(self) -> bool:
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS chunks ("
+            "ident TEXT PRIMARY KEY, path TEXT, symbol TEXT, kind TEXT, "
+            "start_line INTEGER, end_line INTEGER, text TEXT, vector BLOB)"
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS chunks_path ON chunks(path)")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)"
+        )
+        try:
+            self._conn.execute(
+                "CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5("
+                "ident UNINDEXED, label, text)"
+            )
+            self._conn.commit()
+            return True
+        except sqlite3.OperationalError:
+            # FTS5 is compiled into most Python builds and absent from a few. Keyword search then
+            # falls back to LIKE, which is worse and works — the same trade the memory store makes.
+            self._conn.commit()
+            return False
+
+    def close(self) -> None:
+        self._conn.close()
+
+    # --- writing --------------------------------------------------------------------------
+
+    def replace_all(self, chunks: list[Chunk]) -> int:
+        """Rebuild the index from scratch. Returns how many chunks were stored.
+
+        Wholesale rather than incremental, and that is the honest shape for now: an incremental
+        index needs to know which files changed AND which chunks those files used to produce, and a
+        stale row that nobody deleted answers confidently about code that has moved. Rebuilding a
+        few thousand chunks takes under a second; the embeddings are what cost, and those are
+        preserved per chunk id below.
+        """
+        keep = {
+            row["ident"]: row["vector"]
+            for row in self._conn.execute("SELECT ident, vector FROM chunks WHERE vector IS NOT NULL")
+        }
+        self._conn.execute("DELETE FROM chunks")
+        if self.fts_available:
+            self._conn.execute("DELETE FROM chunks_fts")
+        rows = [
+            (c.ident, c.path, c.symbol, c.kind, c.start_line, c.end_line, c.text, keep.get(c.ident))
+            for c in chunks
+        ]
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO chunks "
+            "(ident, path, symbol, kind, start_line, end_line, text, vector) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        if self.fts_available:
+            self._conn.executemany(
+                "INSERT INTO chunks_fts (ident, label, text) VALUES (?, ?, ?)",
+                [(c.ident, c.label, c.text) for c in chunks],
+            )
+        self._conn.commit()
+        return len(rows)
+
+    def embed_missing(self, embed: EmbedFn, *, limit: int = 100_000) -> int:
+        """Embed the chunks that have no vector yet. Returns how many were embedded.
+
+        Resumable by construction: a run that dies halfway leaves the vectors it wrote, and the next
+        call picks up the rest. Nothing here retries a failed batch — a provider that is down should
+        surface as "some chunks are not embedded" rather than as a loop nobody can stop.
+        """
+        pending = self._conn.execute(
+            "SELECT ident, text FROM chunks WHERE vector IS NULL LIMIT ?", (limit,)
+        ).fetchall()
+        done = 0
+        for start in range(0, len(pending), EMBED_BATCH):
+            batch = pending[start : start + EMBED_BATCH]
+            try:
+                vectors = embed([row["text"] for row in batch])
+            except Exception as exc:  # noqa: BLE001 — a dead embedder is a degraded index, not a crash
+                _log.warning("embedding failed after %d chunks: %s", done, exc)
+                break
+            if len(vectors) != len(batch):
+                _log.warning("embedder returned %d vectors for %d texts", len(vectors), len(batch))
+                break
+            self._conn.executemany(
+                "UPDATE chunks SET vector = ? WHERE ident = ?",
+                [(_pack(v), row["ident"]) for row, v in zip(batch, vectors, strict=True)],
+            )
+            self._conn.commit()
+            done += len(batch)
+        return done
+
+    def set_meta(self, key: str, value: str) -> None:
+        self._conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", (key, value))
+        self._conn.commit()
+
+    def get_meta(self, key: str) -> str:
+        row = self._conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+        return str(row["value"]) if row else ""
+
+    # --- reading --------------------------------------------------------------------------
+
+    def stats(self) -> dict[str, int]:
+        total = self._conn.execute("SELECT COUNT(*) AS n FROM chunks").fetchone()["n"]
+        embedded = self._conn.execute(
+            "SELECT COUNT(*) AS n FROM chunks WHERE vector IS NOT NULL"
+        ).fetchone()["n"]
+        files = self._conn.execute("SELECT COUNT(DISTINCT path) AS n FROM chunks").fetchone()["n"]
+        return {"chunks": int(total), "embedded": int(embedded), "files": int(files)}
+
+    def _row_to_chunk(self, row: sqlite3.Row) -> Chunk:
+        return Chunk(
+            path=row["path"],
+            symbol=row["symbol"],
+            kind=row["kind"],
+            start_line=int(row["start_line"]),
+            end_line=int(row["end_line"]),
+            text=row["text"],
+        )
+
+    def search_keyword(self, query: str, k: int = 10) -> list[Hit]:
+        """Keyword retrieval: FTS5 where available, LIKE where it is not."""
+        if not query.strip():
+            return []
+        if self.fts_available:
+            # Each WORD quoted, then OR'd — not the whole query quoted as one phrase.
+            #
+            # Quoting the whole string was the safe-looking version and it made every multi-word
+            # query an exact-phrase search. `rag_bench` measured the result before anything was
+            # built on top of it: recall@10 of 0.5%, which reads as "keyword search is useless" and
+            # was really "this function is broken". Quoting is still per token, because an
+            # unbalanced quote or a bare `AND` in a search box is otherwise a 500, and `NEAR(` is
+            # not what someone typing "near the top" is asking for.
+            words = _TOKEN.findall(query)
+            if not words:
+                return []
+            phrase = " OR ".join(f'"{w}"' for w in words)
+            try:
+                rows = self._conn.execute(
+                    "SELECT c.*, bm25(chunks_fts) AS rank FROM chunks_fts "
+                    "JOIN chunks c ON c.ident = chunks_fts.ident "
+                    "WHERE chunks_fts MATCH ? ORDER BY rank LIMIT ?",
+                    (phrase, k),
+                ).fetchall()
+            except sqlite3.OperationalError as exc:
+                _log.debug("fts query failed, falling back to LIKE: %s", exc)
+                rows = []
+            if rows:
+                # bm25 returns a NEGATIVE score where lower is better. Flipped so every score in
+                # this module means the same direction; a mixed convention is how a fusion silently
+                # ranks the worst result first.
+                #
+                # Noise is dropped, symmetrically with the vector side. The query is an OR of its
+                # words, so "discard the edits" matches every chunk containing "the" — and handing
+                # the fusion four confident non-answers means a retriever that found nothing still
+                # produces a rank-1 result.
+                #
+                # Measured on a four-chunk corpus: a real single-term match scores 0.81, a
+                # whole-phrase match 1.63, and a match on a term present in every document
+                # 1.4e-06 — six orders of magnitude apart, which is what makes a threshold
+                # possible at all. (Not zero: an earlier version of this filter said "score > 0"
+                # on the assumption that bm25 zeroes a zero-IDF term, and it does not.)
+                scored = [Hit(self._row_to_chunk(r), -float(r["rank"]), "fts") for r in rows]
+                best = max((h.score for h in scored), default=0.0)
+                if best < _NOISE_FLOOR:
+                    return []  # everything matched only on ubiquitous words
+                return [h for h in scored if h.score >= best * _RELATIVE_FLOOR]
+
+        like = f"%{query}%"
+        rows = self._conn.execute(
+            "SELECT * FROM chunks WHERE text LIKE ? OR symbol LIKE ? LIMIT ?", (like, like, k)
+        ).fetchall()
+        return [Hit(self._row_to_chunk(r), 1.0, "fts") for r in rows]
+
+    def search_vector(self, vector: Sequence[float], k: int = 10) -> list[Hit]:
+        """Nearest chunks by cosine. Exact, over every embedded row.
+
+        No index. `sqlite-vec` would make this sub-linear and it is absent from the machine this was
+        written on — so the path that always works is the one that ships, and an accelerator can sit
+        in front of it later without changing what a caller sees. At ten thousand chunks this is a
+        few million multiplications: slower than an index, and far faster than the model call it
+        precedes.
+        """
+        if not vector:
+            return []
+        rows = self._conn.execute("SELECT * FROM chunks WHERE vector IS NOT NULL").fetchall()
+        scored = [(_cosine(vector, _unpack(r["vector"])), r) for r in rows]
+        scored.sort(key=lambda pair: pair[0], reverse=True)
+        return [Hit(self._row_to_chunk(r), score, "vector") for score, r in scored[:k] if score > 0]
+
+
+def default_index_path(home: Path, workspace: Path) -> Path:
+    """Where a workspace's index lives — under the app's home, keyed by the workspace path.
+
+    Not inside the workspace: an index file in someone's repository is a file they have to gitignore
+    and a diff they have to explain, for a cache they did not ask to store there.
+    """
+    digest = str(abs(hash(str(Path(workspace).resolve()))))[:16]
+    return Path(home) / "rag" / f"{Path(workspace).name}-{digest}.sqlite3"
+
+
+def load_json_meta(raw: str) -> dict[str, object]:
+    try:
+        parsed = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/tests/test_rag_bench.py
+++ b/tests/test_rag_bench.py
@@ -1,0 +1,123 @@
+"""The pre-registered A/B for retrieval (:mod:`chimera.eval.rag_bench`).
+
+A bench is a measuring instrument, and an instrument that cannot be wrong is not one. Two of the
+three properties below were added because the first two runs of this bench produced numbers that
+were artifacts rather than findings:
+
+* recall@10 of **0.005**, which read as "keyword search is useless" and was a broken FTS query
+  (the whole phrase quoted, so every multi-word search was an exact-phrase match);
+* recall@10 of **1.00**, which read as "keyword search is perfect" and was the corpus containing
+  the question — the docstring the probe is made from sat inside the chunk it pointed at.
+
+The third run measured 0.4925 over 400 probes on 2,691 chunks of this repository. These tests are
+what stop the instrument drifting back to either artifact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.eval.rag_bench import _without_docstring, build_probes, run_rag_bench
+from chimera.rag.chunks import Chunk, chunk_source
+
+SOURCE = '''\
+def resolve_verify(root):
+    """The verify command actually used, and where it came from."""
+    return "pytest -q"
+
+
+def spend(budget):
+    """Count the tokens a run is permitted to consume before compaction."""
+    return budget * 2
+'''
+
+
+def test_a_probe_does_not_contain_the_name_it_is_looking_for() -> None:
+    """Otherwise it measures whether a retriever can match a string to itself."""
+    probes = build_probes(chunk_source("core/verify.py", SOURCE))
+
+    probe = next(p for p in probes if "resolve_verify" in p.target or "spend" not in p.query)
+    assert "resolve" not in probe.query.lower()
+    assert "verify" not in probe.query.lower()
+
+
+def test_the_probe_keeps_enough_words_to_be_a_question() -> None:
+    probes = build_probes(chunk_source("core/verify.py", SOURCE))
+    assert probes and all(len(p.query.split()) >= 4 for p in probes)
+
+
+def test_an_undocumented_symbol_produces_no_probe() -> None:
+    # There is nothing to ask about it that is not its own name.
+    assert build_probes(chunk_source("x.py", "def bare():\n    return 1\n")) == []
+
+
+def test_the_indexed_text_loses_the_docstring() -> None:
+    """The fix for the 1.00 run: what is indexed is the CODE.
+
+    Somebody describes a behaviour and the implementation does not contain their description — that
+    is the real shape of the task, and leaving the docstring in makes the corpus hold the question.
+    """
+    chunk = next(c for c in chunk_source("core/verify.py", SOURCE) if c.symbol == "resolve_verify")
+
+    stripped = _without_docstring(chunk)
+
+    assert "actually used" not in stripped.text
+    assert "def resolve_verify" in stripped.text
+    assert 'return "pytest -q"' in stripped.text
+    # Identity and span are untouched: the chunk has to stay the row it was stored under.
+    assert stripped.ident == chunk.ident
+
+
+def test_stripping_a_one_line_docstring_leaves_the_body() -> None:
+    chunk = Chunk("a.py", "f", "function", 1, 3, 'def f():\n    """One line."""\n    return 1\n')
+    assert "One line" not in _without_docstring(chunk).text
+    assert "return 1" in _without_docstring(chunk).text
+
+
+def test_a_chunk_that_is_only_a_docstring_keeps_its_text() -> None:
+    # Removing everything would index an empty document, which is worse than indexing prose: an
+    # empty row can never be retrieved and silently shrinks the corpus.
+    chunk = Chunk("a.py", "f", "function", 1, 2, 'def f():\n    """Only this."""\n')
+    assert _without_docstring(chunk).text.strip()
+
+
+def test_the_bench_reports_a_ceiling_without_an_embedder(tmp_path: Path) -> None:
+    """`headroom` needs no provider and bounds everything a semantic layer could add.
+
+    Measuring it first is what makes this bench able to say the whole layer is not worth its cost.
+    """
+    (tmp_path / "core").mkdir()
+    (tmp_path / "core" / "verify.py").write_text(SOURCE, encoding="utf-8")
+
+    report = run_rag_bench(tmp_path, index_path=tmp_path / "i.sqlite3")
+
+    assert report.probes > 0
+    assert 0.0 <= report.keyword_recall <= 1.0
+    assert report.headroom == 1.0 - report.keyword_recall
+    # Absent, not zero: an embedder that was never called did not fail.
+    assert report.vector_recall is None
+    assert report.hybrid_recall is None
+    assert any("no embedder" in note for note in report.notes)
+
+
+def test_the_bench_measures_the_semantic_side_when_given_an_embedder(tmp_path: Path) -> None:
+    (tmp_path / "core").mkdir()
+    (tmp_path / "core" / "verify.py").write_text(SOURCE, encoding="utf-8")
+    vocabulary = ["command", "tokens", "run", "compaction", "permitted", "consume", "count"]
+
+    def embed(texts: list[str]) -> list[list[float]]:
+        return [[float(t.lower().count(w)) for w in vocabulary] for t in texts]
+
+    report = run_rag_bench(tmp_path, index_path=tmp_path / "i.sqlite3", embed=embed)
+
+    assert report.vector_recall is not None
+    assert report.hybrid_recall is not None
+    # The fusion may not beat either side on a two-function corpus; what it must never do is lose
+    # everything both retrievers found.
+    assert report.hybrid_recall >= min(report.keyword_recall, report.vector_recall)
+
+
+def test_an_empty_repository_says_so_rather_than_dividing_by_zero(tmp_path: Path) -> None:
+    report = run_rag_bench(tmp_path, index_path=tmp_path / "i.sqlite3")
+    assert report.probes == 0
+    assert any("no documented symbols" in note for note in report.notes)

--- a/tests/test_rag_chunks.py
+++ b/tests/test_rag_chunks.py
@@ -1,0 +1,176 @@
+"""Cutting a repository into retrievable pieces (:mod:`chimera.rag.chunks`).
+
+The unit of retrieval decides what retrieval can answer, so these tests are about boundaries: that
+a symbol arrives whole, that its decorators come with it, that a class is indexed both as itself and
+as its methods, and that a file which cannot be parsed still yields something rather than nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.rag.chunks import MAX_CHUNK_CHARS, chunk_source, walk
+
+SAMPLE = '''\
+"""Module docstring."""
+
+import os
+
+
+def connect(dsn: str) -> str:
+    """Open the connection."""
+    return os.environ[dsn]
+
+
+class Gateway:
+    """Talks to the provider."""
+
+    TIMEOUT = 30
+
+    def send(self, body: str) -> str:
+        """Send one request."""
+        return body
+
+    async def stream(self, body: str) -> str:
+        return body
+'''
+
+
+def test_a_function_arrives_whole() -> None:
+    """A window cut through the middle of a body gives the model code it cannot attribute."""
+    chunks = chunk_source("app.py", SAMPLE)
+    found = next(c for c in chunks if c.symbol == "connect")
+
+    assert found.kind == "function"
+    assert "def connect(dsn: str) -> str:" in found.text
+    assert "return os.environ[dsn]" in found.text
+    assert found.start_line < found.end_line
+
+
+def test_a_class_is_indexed_as_itself_and_as_its_methods() -> None:
+    """Both, deliberately.
+
+    A question about the class's purpose is answered by its header and docstring; a question about
+    one behaviour is answered by one method. Indexing only the class buries the method in an
+    average; indexing only the methods loses the thing that says what they are for.
+    """
+    symbols = {c.symbol: c for c in chunk_source("app.py", SAMPLE)}
+
+    assert symbols["Gateway"].kind == "class"
+    assert "Talks to the provider." in symbols["Gateway"].text
+    assert "TIMEOUT = 30" in symbols["Gateway"].text
+    assert "Gateway.send" in symbols
+    assert "Gateway.stream" in symbols  # async counts
+
+
+def test_the_class_header_stops_before_its_methods() -> None:
+    # Otherwise the class chunk is the whole file again and its vector is the average of everything.
+    header = next(c for c in chunk_source("app.py", SAMPLE) if c.symbol == "Gateway")
+    assert "def send" not in header.text
+
+
+def test_decorators_come_with_the_function() -> None:
+    """`@app.post("/api/x")` is most of what makes the function below it findable by someone asking
+    about routes — and it sits ABOVE the line the parser calls the definition."""
+    source = '@app.post("/api/things")\ndef create_thing():\n    return 1\n'
+    chunk = next(c for c in chunk_source("api.py", source) if c.symbol == "create_thing")
+
+    assert '@app.post("/api/things")' in chunk.text
+    assert chunk.start_line == 1
+
+
+def test_a_file_that_does_not_parse_still_yields_content() -> None:
+    """A syntax error is a fact about one file, not a reason to make it unfindable."""
+    chunks = chunk_source("broken.py", "def oops(:\n    this is not python\n" * 5)
+
+    assert chunks
+    assert all(c.kind == "window" for c in chunks)
+
+
+def test_a_module_with_no_symbols_is_windowed() -> None:
+    # A settings file or a script: real content, no definitions.
+    chunks = chunk_source("settings.py", "DEBUG = True\nHOSTS = ['a', 'b']\n")
+    assert chunks and chunks[0].kind == "window"
+
+
+def test_a_non_python_file_is_windowed_and_says_so() -> None:
+    """A TypeScript chunk cut by line count is not the same kind of object as a Python chunk cut by
+    span, and a caller that cannot tell them apart will reason about one as if it were the other."""
+    chunks = chunk_source("app.ts", "export function hi() {\n  return 1;\n}\n")
+    assert chunks and chunks[0].kind == "window"
+    assert chunks[0].symbol == ""
+
+
+def test_windows_overlap_so_a_straddling_match_survives_somewhere() -> None:
+    lines = "".join(f"line {i}\n" for i in range(1, 200))
+    chunks = chunk_source("big.txt.ts", lines)
+
+    assert len(chunks) > 1
+    # The second window starts before the first one ended.
+    assert chunks[1].start_line <= chunks[0].end_line
+
+
+def test_an_enormous_symbol_is_split_rather_than_stored_whole() -> None:
+    """A three-thousand-line generated class is a symbol by the parser's reckoning and a haystack by
+    every other measure."""
+    body = "".join(f"    x{i} = {i}\n" for i in range(MAX_CHUNK_CHARS // 8))
+    chunks = chunk_source("huge.py", f"def enormous():\n{body}")
+
+    assert len(chunks) > 1
+    assert all(len(c.text) <= MAX_CHUNK_CHARS * 2 for c in chunks)
+
+
+def test_an_empty_file_yields_nothing() -> None:
+    assert chunk_source("empty.py", "   \n\n") == []
+
+
+def test_the_identifier_is_stable_across_runs() -> None:
+    # The index reuses embeddings by id; an id that changed per run would re-embed everything on
+    # every rebuild, which is the difference between a cache and a bill.
+    first = chunk_source("app.py", SAMPLE)
+    second = chunk_source("app.py", SAMPLE)
+    assert [c.ident for c in first] == [c.ident for c in second]
+    assert all(":" in c.ident and "-" in c.ident for c in first)
+
+
+def test_the_label_carries_the_path_and_the_symbol() -> None:
+    # It goes into the FTS text, so a query naming either one hits the chunk.
+    chunk = next(c for c in chunk_source("src/app.py", SAMPLE) if c.symbol == "connect")
+    assert "src/app.py" in chunk.label and "connect" in chunk.label
+
+
+# --- walking a workspace ---------------------------------------------------------------------
+
+
+def test_walk_indexes_source_and_skips_the_noise(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text(SAMPLE, encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Title\n\nProse.\n", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "junk.js").write_text("var x = 1;\n", encoding="utf-8")
+    (tmp_path / "logo.png").write_bytes(b"\x89PNG\x00\x00")
+
+    paths = {c.path for c in walk(tmp_path)}
+
+    assert "src/app.py" in paths
+    assert "README.md" in paths
+    assert not any(p.startswith("node_modules") for p in paths)
+    assert "logo.png" not in paths
+
+
+def test_walk_stops_at_its_file_budget(tmp_path: Path) -> None:
+    """An index that takes minutes to build is an index nobody rebuilds, and a stale index answers
+    confidently about code that has moved."""
+    for i in range(20):
+        (tmp_path / f"m{i}.py").write_text(f"def f{i}():\n    return {i}\n", encoding="utf-8")
+
+    assert len({c.path for c in walk(tmp_path, max_files=5)}) == 5
+
+
+def test_walk_skips_a_file_over_the_size_cap(tmp_path: Path) -> None:
+    (tmp_path / "small.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "huge.py").write_text("x = 1\n" * 200_000, encoding="utf-8")
+
+    paths = {c.path for c in walk(tmp_path, max_bytes=10_000)}
+
+    assert paths == {"small.py"}

--- a/tests/test_rag_store.py
+++ b/tests/test_rag_store.py
@@ -1,0 +1,246 @@
+"""The index and the fusion (:mod:`chimera.rag.store`, :mod:`chimera.rag.hybrid`).
+
+The embedder is a deterministic fake: a bag-of-words vector over a fixed vocabulary. That is enough
+to make "the same words land close together" true, which is the only property the ranking depends
+on — and it makes these tests run without a provider, a key, or a network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.rag.chunks import Chunk
+from chimera.rag.hybrid import reciprocal_rank_fusion
+from chimera.rag.store import ChunkStore, Hit
+
+VOCAB = ["verify", "revert", "keep", "change", "token", "budget", "search", "index", "cat", "dog"]
+
+
+def fake_embed(texts: list[str]) -> list[list[float]]:
+    """A bag-of-words vector. Deterministic, offline, and enough for cosine to mean something."""
+    out = []
+    for text in texts:
+        low = text.lower()
+        out.append([float(low.count(word)) for word in VOCAB])
+    return out
+
+
+def chunk(path: str, symbol: str, text: str, start: int = 1) -> Chunk:
+    return Chunk(path, symbol, "function", start, start + 3, text)
+
+
+CORPUS = [
+    chunk("core/verify.py", "verify", "def verify(): decide whether to keep or revert the change"),
+    chunk("core/budget.py", "spend", "def spend(): count the token budget for a run", 20),
+    chunk("core/search.py", "find", "def find(): search the index for a string", 40),
+    chunk("pets.py", "adopt", "def adopt(): the cat and the dog go home", 60),
+]
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> ChunkStore:
+    s = ChunkStore(tmp_path / "index.sqlite3")
+    s.replace_all(CORPUS)
+    return s
+
+
+# --- storing --------------------------------------------------------------------------------
+
+
+def test_the_index_reports_what_is_in_it(store: ChunkStore) -> None:
+    stats = store.stats()
+    assert stats["chunks"] == 4
+    assert stats["files"] == 4
+    assert stats["embedded"] == 0  # nothing embedded yet, and it says so rather than implying it
+
+
+def test_rebuilding_keeps_the_embeddings_it_already_paid_for(store: ChunkStore) -> None:
+    """The difference between a cache and a bill.
+
+    A rebuild is wholesale because a stale row answers confidently about code that has moved — but
+    re-embedding an unchanged chunk costs money for a vector we already have. Chunk ids are stable
+    across runs precisely so this is possible.
+    """
+    store.embed_missing(fake_embed)
+    assert store.stats()["embedded"] == 4
+
+    store.replace_all(CORPUS)  # same code, rebuilt
+
+    assert store.stats()["embedded"] == 4, "an unchanged chunk was re-embedded"
+
+
+def test_a_changed_chunk_loses_its_vector_and_is_re_embedded(store: ChunkStore) -> None:
+    # The other direction: a chunk whose lines moved is a different id, so it must NOT inherit a
+    # vector describing code that is no longer there.
+    store.embed_missing(fake_embed)
+    moved = [chunk("core/verify.py", "verify", "def verify(): now it says something else", 99)]
+
+    store.replace_all(moved)
+
+    assert store.stats()["embedded"] == 0
+
+
+def test_embedding_is_resumable(store: ChunkStore) -> None:
+    """A provider that dies halfway leaves what it wrote, and the next call picks up the rest."""
+    calls = {"n": 0}
+
+    def flaky(texts: list[str]) -> list[list[float]]:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("provider down")
+        return fake_embed(texts)
+
+    from chimera.rag import store as store_module
+
+    original = store_module.EMBED_BATCH
+    store_module.EMBED_BATCH = 2
+    try:
+        store.embed_missing(flaky)
+        assert store.stats()["embedded"] == 2  # the first batch survived the failure
+        store.embed_missing(fake_embed)
+        assert store.stats()["embedded"] == 4
+    finally:
+        store_module.EMBED_BATCH = original
+
+
+def test_an_embedder_that_returns_the_wrong_count_is_refused(store: ChunkStore) -> None:
+    # Zipping mismatched lists would attach vectors to the wrong chunks — an index that is silently
+    # wrong is worse than one that is visibly incomplete.
+    store.embed_missing(lambda texts: fake_embed(texts)[:-1])
+    assert store.stats()["embedded"] == 0
+
+
+# --- keyword retrieval ------------------------------------------------------------------------
+
+
+def test_keyword_finds_the_exact_identifier(store: ChunkStore) -> None:
+    hits = store.search_keyword("revert", k=5)
+    assert hits and hits[0].chunk.path == "core/verify.py"
+    assert hits[0].source == "fts"
+
+
+def test_keyword_misses_the_paraphrase(store: ChunkStore) -> None:
+    """The gap the vectors exist to close, asserted rather than assumed.
+
+    Nothing in the corpus contains "discard", so a keyword search cannot reach the function that
+    decides whether to revert — no shared token, no hit.
+    """
+    assert store.search_keyword("discard edits", k=5) == []
+    assert store.search_keyword("throw away what was written", k=5) == []
+
+
+def test_a_match_on_a_word_in_every_chunk_is_not_a_hit(store: ChunkStore) -> None:
+    """Since the query is an OR of its words, "discard THE edits" matches every chunk containing
+    "the" — and bm25 scores those 0, because a term in every document carries no information.
+
+    Returning them anyway hands the fusion four confident non-answers to rank, which is how a
+    retriever that found nothing produces a top result.
+    """
+    assert store.search_keyword("discard the edits", k=5) == []
+
+
+def test_a_search_box_query_cannot_break_the_fts_syntax(store: ChunkStore) -> None:
+    """`AND`, a stray quote and `NEAR(` are things people type, not FTS operators they meant."""
+    for query in ['verify AND revert', 'say "hello', "NEAR(", "*"]:
+        store.search_keyword(query, k=5)  # must not raise
+
+
+def test_an_empty_query_finds_nothing(store: ChunkStore) -> None:
+    assert store.search_keyword("", k=5) == []
+
+
+# --- vector retrieval -------------------------------------------------------------------------
+
+
+def test_vectors_bridge_the_paraphrase(store: ChunkStore) -> None:
+    store.embed_missing(fake_embed)
+    # "keep or revert the change" — the words are in the target and not in the query's phrasing of
+    # the question; the fake embedder makes the overlap the ranking signal.
+    query = fake_embed(["should we keep the change or revert it"])[0]
+
+    hits = store.search_vector(query, k=2)
+
+    assert hits and hits[0].chunk.path == "core/verify.py"
+    assert hits[0].source == "vector"
+
+
+def test_vector_search_over_an_unembedded_index_returns_nothing(store: ChunkStore) -> None:
+    # Rather than raising. A machine with no embedder gets keyword retrieval, not an error.
+    assert store.search_vector(fake_embed(["anything"])[0], k=5) == []
+
+
+def test_zero_similarity_is_not_a_hit(store: ChunkStore) -> None:
+    store.embed_missing(fake_embed)
+    # A query sharing no vocabulary with anything: cosine 0 everywhere. Returning the corpus in
+    # arbitrary order would present noise as the four best answers.
+    assert store.search_vector([0.0] * len(VOCAB), k=5) == []
+
+
+# --- fusion ----------------------------------------------------------------------------------
+
+
+def _hit(path: str, source: str, score: float) -> Hit:
+    return Hit(chunk(path, "x", "text"), score, source)
+
+
+def test_fusion_ranks_by_position_not_by_score() -> None:
+    """A bm25 score and a cosine similarity are not comparable numbers.
+
+    Any weighted sum needs a per-corpus weight that somebody will tune once, on one repository. RRF
+    keeps only the order — so a keyword score of 40 does not out-shout a cosine of 0.9.
+    """
+    keyword = [_hit("a.py", "fts", 40.0), _hit("b.py", "fts", 39.0)]
+    vector = [_hit("b.py", "vector", 0.91), _hit("c.py", "vector", 0.90)]
+
+    fused = reciprocal_rank_fusion([keyword, vector], limit=3)
+
+    # b.py is second in both lists and first overall: agreement beats a single confident opinion.
+    assert fused[0].chunk.path == "b.py"
+
+
+def test_a_hit_both_retrievers_found_is_labelled_hybrid() -> None:
+    fused = reciprocal_rank_fusion([[_hit("a.py", "fts", 1)], [_hit("a.py", "vector", 1)]])
+    assert fused[0].source == "hybrid"
+
+
+def test_a_hit_only_one_retriever_found_keeps_that_name() -> None:
+    # Calling a keyword-only hit "hybrid" would make the label useless for working out why a result
+    # is wrong.
+    fused = reciprocal_rank_fusion([[_hit("a.py", "fts", 1)], []])
+    assert fused[0].source == "fts"
+
+
+def test_the_prior_never_overrules_the_retriever() -> None:
+    """Importance is not a retrieval opinion.
+
+    A first draft multiplied the fused score by the prior and this test caught it: consecutive RRF
+    scores are 1/61 and 1/62, a 1.6% gap that any useful prior flips. The multiplying version let a
+    central file outrank an exact match — the case retrieval is most useful for.
+    """
+    ranked = [_hit("core/verify.py", "fts", 1), _hit("scripts/tiny.py", "fts", 1)]
+    prior = {"scripts/tiny.py": 0.9, "core/verify.py": 0.1}
+
+    fused = reciprocal_rank_fusion([ranked], prior=prior, limit=2)
+
+    assert fused[0].chunk.path == "core/verify.py", "a prior overruled the retriever's own ranking"
+
+
+def test_the_prior_decides_when_the_retrievers_do_not() -> None:
+    """The other half: on a genuine tie it is the only signal there is.
+
+    Both chunks are rank 1 of their own list, so RRF scores them identically — and answering an
+    arbitrary one of the two would make the same query return different answers between runs.
+    """
+    fused = reciprocal_rank_fusion(
+        [[_hit("core/verify.py", "fts", 1)], [_hit("scripts/tiny.py", "vector", 1)]],
+        prior={"core/verify.py": 0.9, "scripts/tiny.py": 0.1},
+        limit=2,
+    )
+
+    assert fused[0].chunk.path == "core/verify.py"
+
+
+def test_fusion_of_nothing_is_nothing() -> None:
+    assert reciprocal_rank_fusion([[], []]) == []


### PR DESCRIPTION
P4 of the IDE plan: symbol-level chunking over the AST, one SQLite file with FTS5 and optional vectors, RRF fusion, PageRank as a prior — and a pre-registered A/B.

## The unit of retrieval decides what retrieval can answer

Fixed windows cut through the middle of functions; whole files average everything a module does into one vector. So the unit is the **symbol**, with its decorators, spanning the lines the parser says it spans — the same unit a person names when they ask. A class is indexed **both** as itself and as its methods: only the class buries the method in an average, only the methods loses the thing that says what they are for.

## Vectors behind brute force, not in front

`sqlite-vec` may be absent, may fail to load, and is not on the machine this was written on. The exact path ships; an accelerator can go in front later. The embedder is injected (same seam as `memory/semantic.py`), so a machine without one degrades to keyword retrieval rather than failing.

## The bench earned its place three times

`rag_bench` derives probes mechanically — each documented symbol's docstring, with the symbol's own name stripped — and reports `headroom`, the share keyword retrieval already misses. It needs no embedder and it is allowed to conclude this layer is not worth its cost.

| run | recall@10 | what it actually was |
|---|---|---|
| 1 | **0.005** | a broken retriever — quoting the query made every multi-word search an exact-phrase match |
| 2 | **1.00** | the corpus contained the question — the probe's docstring sat inside the chunk it pointed at |
| 3 | **0.4925** | credible: 400 probes, 2,691 chunks |

Recorded in `bench/rag/baseline.json` **before any embedder was wired**, so the semantic number cannot be chosen after seeing what would look good. Ceiling for a semantic layer: **+50.75 points**.

## Two corrections the tests forced

- **The PageRank prior was a multiplier**, and its own test caught that consecutive RRF scores differ by 1.6% — which any useful prior flips. A central file could outrank an exact match: the case retrieval is most useful for. Now a tiebreak in the sort key, which provably cannot reorder what the fusion separated.
- **A noise floor from measurement**, not intuition: a real match scores 0.8–1.6, a match on a word in every document scores 1.4e-06. An earlier filter used `score > 0` assuming bm25 zeroes a zero-IDF term. It does not.

## Not done here

Not wired to the agent or the app. That should follow a measured hybrid number rather than precede it — and measuring it needs an embedder (no Ollama running, no local embedding model on this machine).

## Gates

2765 tests · ruff · `mypy --strict` on 289 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)