### PR TITLE
feat(budget): a dollar ceiling that stops on a price it does not know

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -1838,6 +1838,16 @@
             "title": "Sandbox",
             "type": "string"
           },
+          "spend": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EditorCapabilityOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "tiers": {
             "$ref": "#/components/schemas/TiersOut"
           }

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -2377,6 +2377,7 @@ export interface components {
             memory_backend: string;
             /** Sandbox */
             sandbox: string;
+            spend?: components["schemas"]["EditorCapabilityOut"] | null;
             tiers: components["schemas"]["TiersOut"];
         };
         /**

--- a/chimera/api/config_api.py
+++ b/chimera/api/config_api.py
@@ -304,10 +304,39 @@ def doctor(settings: Settings) -> dict[str, Any]:
         # machine nobody looked at, so "the adapter should be there" stops being evidence at exactly
         # the point a user needs the answer — and `npx` missing reads identically to a bug in us.
         "external_agents": available_agents(),
+        # Whether a spend cap could even work here — see pricing_capability.
+        "spend": pricing_capability(settings),
         # The editor's own capabilities, measured on THIS machine. Same reason as the agents above:
         # a downloaded app is the exact place where "it should be installed" stops being evidence,
         # and the answer a new user needs is "what do I install", not "something is unavailable".
         "editor": editor_capabilities(settings),
+    }
+
+
+def pricing_capability(settings: Settings) -> dict[str, object]:
+    """Whether this machine's default model can be priced at all.
+
+    A dollar cap stops the run when it meets a call it cannot price — the safe rule, and the one
+    that turns an unpriced default model into a feature that refuses to work. The moment to learn
+    that is while reading `doctor`, not when a 3 a.m. cron job halts. So the answer is reported
+    before anyone sets a cap, with the model named.
+    """
+    from chimera.fusion.receipts import resolve_price
+
+    model = settings.default_model
+    priced = resolve_price(model) is not None
+    return {
+        "key": "spend_cap",
+        "label": "Spend cap (dollar ceiling)",
+        "available": priced,
+        "probed": True,  # the price table either resolves this model or it does not
+        "detail": model,
+        "hint": (
+            ""
+            if priced
+            else f"no list price known for {model}: a spend cap would stop on its first call. "
+            "Register one with chimera.fusion.receipts.set_price, or cap a priced model."
+        ),
     }
 
 

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -514,6 +514,9 @@ class DoctorOut(BaseModel):
     sandbox: str
     external_agents: list[ExternalAgentOut] = []
     editor: list[EditorCapabilityOut] = []
+    #: Whether the default model can be priced. A spend cap stops on a call it cannot price,
+    #: so an unpriced default is a cap that refuses to work — said here, before one is set.
+    spend: EditorCapabilityOut | None = None
 
 
 class ConfigTestOut(BaseModel):

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -408,13 +408,13 @@ def doctor(
     # external agents actually work on their machine — and, when they do not, the command that
     # changes that. "Unavailable" without a remedy is a shrug.
     from chimera.acp.agents import available_agents
-    from chimera.api.config_api import editor_capabilities
+    from chimera.api.config_api import editor_capabilities, pricing_capability
 
     caps = Table(title="Capabilities", show_header=True, header_style="bold")
     caps.add_column("Capability")
     caps.add_column("Status")
     caps.add_column("How to get it")
-    for row in [*editor_capabilities(settings), *available_agents()]:
+    for row in [pricing_capability(settings), *editor_capabilities(settings), *available_agents()]:
         ready = bool(row.get("available"))
         # "configured" and "available" are different claims and get different words. A completion
         # model nobody has reached is not available; saying so here would be a promise the editor

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -24,6 +24,7 @@ from chimera.core.context_budget import ContextBudget, RunState, compact
 from chimera.core.steplog import StepLog, StepRecord, clip, tool_record
 from chimera.core.tool_loop import ToolLoopDetector
 from chimera.governance.ledger import WRITE_TOOLS
+from chimera.orchestration.budget import BudgetExceeded, SpendBudget
 from chimera.providers.gateway import CompletionResult, MessageLike, SupportsComplete
 from chimera.telemetry import get_logger
 from chimera.tools.registry import ToolNotFoundError, ToolRegistry
@@ -119,6 +120,16 @@ class AgentConfig:
     # the prompt, compacting once the prompt crosses `trigger` of it. Off by default because
     # compaction discards messages, and a caller that has not asked for that should not get it.
     context_budget: float | None = None
+    # Dollar ceiling for the whole run. None (the default) keeps the historical behaviour: no cap,
+    # and therefore no new way for a run to stop. Set it and the loop refuses the next model call
+    # once the spend reaches it — checked BEFORE the call, so the money is never spent to discover
+    # it was over budget.
+    #
+    # A call whose model has no known price also stops the run, by the owner's decision: a ceiling
+    # that skips what it cannot price shows green while the real spend climbs. Local models are
+    # priced at zero rather than unknown, so `ollama/` runs are unaffected. See
+    # chimera.orchestration.budget.SpendBudget.
+    max_usd: float | None = None
     #: Turns kept verbatim at the tail when compacting — where the current sub-task lives.
     keep_recent: int = 6
     # The workspace whose AGENTS.md the run should follow. None = read no project instructions,
@@ -173,7 +184,7 @@ class AgentResult:
 
     answer: str
     steps: int
-    stopped_reason: str  # "final" | "max_steps" | "tool_loop"
+    stopped_reason: str  # "final" | "max_steps" | "tool_loop" | "budget"
     transcript: list[MessageLike] = field(default_factory=list)
     tool_calls_made: int = 0
     # Token/cost accounting, summed across every model call in the run (0 when the backend reported
@@ -325,6 +336,10 @@ class Agent:
         tool_calls_made = 0
         tool_names: list[str] = []
         usage = _UsageTally()
+        # Per RUN, not per Agent: the same Agent object serves several runs (a conversation, a
+        # scheduler dispatching jobs), and a cap that carried across them would refuse the second
+        # task because the first one used its allowance.
+        spend = SpendBudget(self.config.max_usd) if self.config.max_usd else None
         steplog = StepLog()
         nudged = False
         loop_detector = ToolLoopDetector() if self.config.detect_tool_loops else None
@@ -339,7 +354,19 @@ class Agent:
             # model. Measuring around the whole iteration would fold the tool calls into the rate
             # and report a shell command as slow generation.
             call_started = time.monotonic()
-            result = self._step(messages, tools=tool_schema, on_token=on_token, usage=usage)
+            try:
+                result = self._step(messages, tools=tool_schema, on_token=on_token, usage=usage, spend=spend)
+            except BudgetExceeded as exc:
+                # Not an error: the run did what it was told to do with the money it was given. The
+                # partial answer is kept — the transcript up to here is the work already paid for,
+                # and throwing it away would spend the budget for nothing.
+                _log.info("run stopped on budget: %s", exc)
+                # `self.config.model`, not the answering model: the call that would have named one
+                # is the call that did not happen.
+                return self._result(
+                    str(exc), step - 1, "budget", messages, tool_calls_made, tool_names, usage,
+                    self.config.model or "", None, steplog, task,
+                )
             call_ms = int((time.monotonic() - call_started) * 1000)
             # `result.prompt_tokens` is the provider's own count for the prompt we just sent — which
             # is exactly the live size of the context. Keeping it per step (instead of only summing
@@ -435,14 +462,14 @@ class Agent:
                     f"Stop — you are repeating the same action ({tripped}). Do not call more tools. "
                     "Give your best final answer now with what you already have."
                 )
-                final = self._step([*messages, {"role": "user", "content": nudge}],
+                final = self._step([*messages, {"role": "user", "content": nudge}], spend=spend,
                                    tools=None, on_token=on_token, usage=usage)
                 messages.append({"role": "assistant", "content": final.content})
                 return self._result(final.content, step, "tool_loop", messages, tool_calls_made,
                                     tool_names, usage, final.model, steplog=steplog, task=task)
 
         # Budget exhausted: ask once more, without tools, for a final answer.
-        final = self._step([*messages, {"role": "user", "content": "Provide your final answer now."}],
+        final = self._step([*messages, {"role": "user", "content": "Provide your final answer now."}], spend=spend,
                            tools=None, on_token=on_token, usage=usage)
         messages.append({"role": "assistant", "content": final.content})
         return self._result(final.content, self.config.max_steps, "max_steps", messages,
@@ -456,10 +483,20 @@ class Agent:
         tools: list[dict[str, Any]] | None,
         on_token: Callable[[str], None] | None,
         usage: _UsageTally,
+        spend: SpendBudget | None = None,
     ) -> CompletionResult:
         """One model call. Streams (with live token deltas) when a token callback is given AND the
         backend supports ``stream_complete``; otherwise a plain blocking ``complete``. Either way the
-        call's token usage is folded into the run-level tally."""
+        call's token usage is folded into the run-level tally.
+
+        The spend cap is enforced HERE because this is the only place in the loop that spends money.
+        Checked before the call and charged after it: a cap consulted afterwards would be a receipt,
+        not a ceiling.
+        """
+        if spend is not None:
+            reason = spend.blocked()
+            if reason is not None:
+                raise BudgetExceeded(reason)
         result: CompletionResult
         if on_token is not None and hasattr(self.backend, "stream_complete"):
             result = self.backend.stream_complete(  # type: ignore[attr-defined]
@@ -471,6 +508,14 @@ class Agent:
                 messages, model=self.config.model, temperature=self.config.temperature, tools=tools,
             )
         usage.add(result)
+        if spend is not None:
+            # The model that ANSWERED: a cascade or a failover can reply on a different one, and
+            # charging the requested model invents a price for a call that never happened.
+            spend.record(
+                str(getattr(result, "model", "") or self.config.model or ""),
+                result.prompt_tokens,
+                result.completion_tokens,
+            )
         return result
 
     def _result(

--- a/chimera/fusion/receipts.py
+++ b/chimera/fusion/receipts.py
@@ -67,12 +67,25 @@ def set_price(pattern: str, price: ModelPrice) -> None:
     _PRICES.insert(0, (pattern.lower(), price))
 
 
+#: Priced at zero, and that is a measurement rather than a default. A model on `ollama/`, `vllm/` or
+#: an LM Studio endpoint bills nothing to any provider — the cost is electricity, which is not what
+#: a dollar figure in a receipt is about. Treating it as *unknown* would be the more cautious-looking
+#: answer and the wrong one: it makes every local run unpriceable, and a spend cap that stops on
+#: unknown prices would refuse to run the one configuration that cannot possibly overspend.
+_LOCAL_ZERO = ModelPrice(0.0, 0.0)
+
+
 def resolve_price(model: str) -> ModelPrice | None:
     """The list price for ``model`` by family substring, or ``None`` if unknown (never guessed)."""
+    from chimera.providers.gateway import _is_local_model
+
     norm = model.lower()
     for pattern, price in _PRICES:
         if pattern in norm:
             return price
+    # After the table, not before: an explicit `set_price` for a local model must still win.
+    if _is_local_model(norm):
+        return _LOCAL_ZERO
     return None
 
 

--- a/chimera/orchestration/budget.py
+++ b/chimera/orchestration/budget.py
@@ -28,6 +28,78 @@ class BudgetExceeded(RuntimeError):
     """Raised (hard mode) when a call would exceed the delegation's token budget."""
 
 
+class SpendBudget:
+    """A dollar ceiling for one run, and a rule about what to do when the price is unknown.
+
+    Tokens and dollars are different axes and this is deliberately a sibling of
+    :class:`TokenBudget` rather than a second mechanism elsewhere: a project with two spend limiters
+    is a project where the two disagree, and the disagreement surfaces at 3 a.m. on the machine that
+    trades money.
+
+    **An unpriced call stops the run.** That is the owner's decision, and it is the only one that
+    does not lie: a ceiling that skips what it cannot price still shows green while the real spend
+    climbs, and it climbs fastest on exactly the models nobody bothered to price. The stop names the
+    model so the fix is one line of :func:`~chimera.fusion.receipts.set_price` away.
+
+    A **local** model is priced at zero rather than treated as unknown, because it is not unknown —
+    an Ollama run spends electricity, and a dollar cap is not about electricity. That distinction is
+    resolved in :func:`~chimera.fusion.receipts.resolve_price`, so every consumer of the price table
+    gets it, not just this class.
+    """
+
+    def __init__(self, max_usd: float) -> None:
+        if max_usd <= 0:
+            raise ValueError("max_usd must be positive")
+        self.max_usd = max_usd
+        self._spent = 0.0
+        self._unpriced_model: str | None = None
+
+    @property
+    def spent(self) -> float:
+        return round(self._spent, 6)
+
+    @property
+    def remaining(self) -> float:
+        return max(0.0, round(self.max_usd - self._spent, 6))
+
+    @property
+    def unpriced_model(self) -> str | None:
+        """The first model whose price could not be resolved, if any. Sticky: once the run has spent
+        an unknown amount, every later total is unknown too, and clearing it would restore a
+        confidence the run no longer has."""
+        return self._unpriced_model
+
+    def blocked(self) -> str | None:
+        """Why the next call must not happen, or None to proceed.
+
+        Checked BEFORE the call, so the money is never spent to discover it was over budget.
+        """
+        if self._unpriced_model is not None:
+            return (
+                f"the price of {self._unpriced_model} is unknown, so the spend so far cannot be "
+                "known either; set a price for it or run without a budget"
+            )
+        if self._spent >= self.max_usd:
+            return f"spend cap reached: ${self._spent:.4f} of ${self.max_usd:.4f}"
+        return None
+
+    def record(self, model: str, prompt_tokens: int | None, completion_tokens: int | None) -> None:
+        """Charge one completed call at its own model's rate.
+
+        The model that ANSWERED, not the one requested — a cascade, a fusion panel or a failover can
+        reply on a different model, and pricing the requested one invents a number for a call that
+        never happened. Same convention as :class:`~chimera.orchestration.metering.MeteredBackend`.
+        """
+        from chimera.orchestration.receipts import price_delegation
+
+        usd = price_delegation(model, prompt_tokens, completion_tokens) if model else None
+        if usd is None:
+            if self._unpriced_model is None:
+                self._unpriced_model = model or "(unnamed model)"
+            return
+        self._spent += usd
+
+
 class TokenBudget:
     """A mutable token allowance for one delegation.
 

--- a/tests/test_editor_capabilities.py
+++ b/tests/test_editor_capabilities.py
@@ -76,3 +76,29 @@ def test_the_completion_model_is_editable_from_the_app() -> None:
     """Otherwise the only way to set it is a file the user has to be told about — and the thing they
     need to know (it must be a base tag) lives on the screen that cannot save it."""
     assert is_editable("CHIMERA_COMPLETE_MODEL")
+
+
+def test_doctor_says_whether_a_spend_cap_could_work_here(tmp_path: Path) -> None:
+    """The footgun this answers: the shipped default model has no list price, so a dollar cap would
+    stop on its first call. Learning that from `doctor` costs nothing; learning it when a 3 a.m.
+    cron job halts costs the job."""
+    from chimera.api.config_api import pricing_capability
+
+    unpriced = pricing_capability(_settings(tmp_path, CHIMERA_DEFAULT_MODEL="brand-new-model"))
+    assert unpriced["available"] is False
+    assert "brand-new-model" in unpriced["hint"]
+
+    priced = pricing_capability(
+        _settings(tmp_path, CHIMERA_DEFAULT_MODEL="openrouter/deepseek/deepseek-chat")
+    )
+    assert priced["available"] is True
+    assert priced["hint"] == ""
+
+
+def test_a_local_model_counts_as_priceable(tmp_path: Path) -> None:
+    # It costs no provider dollars, so a cap over it is trivially satisfiable rather than broken.
+    from chimera.api.config_api import pricing_capability
+
+    found = pricing_capability(_settings(tmp_path, CHIMERA_DEFAULT_MODEL="ollama/llama3"))
+
+    assert found["available"] is True

--- a/tests/test_spend_budget.py
+++ b/tests/test_spend_budget.py
@@ -1,0 +1,217 @@
+"""The dollar ceiling, and the one decision that makes it honest.
+
+A cap that skips what it cannot price is worse than no cap: it shows green while the real spend
+climbs, and it climbs fastest on exactly the models nobody bothered to price. So an unpriced call
+stops the run — the owner's decision, recorded here as behaviour rather than as a comment.
+
+The counterpart matters just as much: a LOCAL model is not unpriced, it is free. Getting that wrong
+would make a spend cap refuse the one configuration that cannot overspend.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chimera.core.agent import Agent, AgentConfig
+from chimera.orchestration.budget import SpendBudget
+from chimera.providers.gateway import ToolCall
+from chimera.tools.registry import Tool, ToolRegistry
+
+
+class _Result:
+    """The shape `Agent._step` reads off a completion."""
+
+    def __init__(self, content: str, model: str, prompt: int = 1000, completion: int = 1000) -> None:
+        self.content = content
+        self.model = model
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.tool_calls: list[Any] = []
+        self.finish_reason = "stop"
+        self.route_meta: dict[str, Any] | None = None
+
+
+class _Ping(Tool):
+    """A tool that does nothing, so the loop has a reason to keep going.
+
+    Without it the fake backend answers prose on step 1 and the run ends `final` before any budget
+    can bite — which would make every assertion below pass for the wrong reason.
+    """
+
+    name = "ping"
+    description = "does nothing"
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def run(self, **kwargs: Any) -> str:
+        return "pong"
+
+
+class _Backend:
+    """Calls `ping` forever, on a model of the caller's choosing — so only a cap can end the run."""
+
+    def __init__(self, model: str = "openrouter/deepseek/deepseek-chat") -> None:
+        self.model = model
+        self.calls = 0
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> _Result:
+        self.calls += 1
+        result = _Result(f"answer {self.calls}", self.model)
+        result.tool_calls = [ToolCall(id=f"c{self.calls}", name="ping", arguments={})]
+        return result
+
+
+def _registry() -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(_Ping())
+    return registry
+
+
+# --- the budget object itself -----------------------------------------------------------------
+
+
+def test_an_unpriced_model_stops_the_budget_rather_than_being_skipped() -> None:
+    budget = SpendBudget(max_usd=10.0)
+
+    budget.record("some-model-nobody-priced", 1000, 1000)
+
+    assert budget.unpriced_model == "some-model-nobody-priced"
+    assert "unknown" in (budget.blocked() or "")
+
+
+def test_the_unknown_is_sticky() -> None:
+    """One unpriced call poisons the total, and a later priced call must not clear it.
+
+    Otherwise the run resumes with a spend figure that is confidently too low — too low in exactly
+    the direction that flatters whichever configuration used the unpriced model.
+    """
+    budget = SpendBudget(max_usd=10.0)
+    budget.record("some-model-nobody-priced", 1000, 1000)
+
+    budget.record("openrouter/deepseek/deepseek-chat", 1000, 1000)
+
+    assert budget.blocked() is not None
+
+
+def test_a_local_model_is_free_not_unknown() -> None:
+    # An Ollama run bills nothing to any provider. Treating it as unknown would make the cap refuse
+    # the single configuration that cannot possibly overspend.
+    budget = SpendBudget(max_usd=1.0)
+
+    budget.record("ollama/llama3", 100_000, 100_000)
+
+    assert budget.blocked() is None
+    assert budget.spent == 0.0
+
+
+def test_a_free_tier_slug_is_also_zero() -> None:
+    budget = SpendBudget(max_usd=1.0)
+
+    budget.record("openrouter/meta-llama/llama-3.3-70b-instruct:free", 100_000, 100_000)
+
+    assert budget.blocked() is None
+
+
+def test_it_blocks_once_the_cap_is_reached_and_says_the_numbers() -> None:
+    budget = SpendBudget(max_usd=0.001)
+
+    budget.record("openrouter/deepseek/deepseek-chat", 1_000_000, 1_000_000)  # $0.42
+
+    reason = budget.blocked() or ""
+    assert "0.4200" in reason and "0.0010" in reason
+
+
+def test_a_budget_must_be_positive() -> None:
+    with pytest.raises(ValueError):
+        SpendBudget(max_usd=0)
+
+
+# --- wired into the loop ----------------------------------------------------------------------
+
+
+def test_the_loop_stops_on_the_cap_and_says_so() -> None:
+    """`stopped_reason` is its own value, distinct from `max_steps`.
+
+    A budget stop reported as `max_steps` would send whoever reads the receipt looking for a loop
+    that never happened, and would hide the one fact that needs acting on.
+    """
+    backend = _Backend()
+    agent = Agent(
+        backend,
+        _registry(),
+        AgentConfig(model="openrouter/deepseek/deepseek-chat", max_steps=20, max_usd=0.0005),
+    )
+
+    result = agent.run("do something long")
+
+    assert result.stopped_reason == "budget"
+    assert "spend cap reached" in result.answer
+    # The first call is allowed: the cap is checked before each call, and before the first one
+    # nothing has been spent. Refusing at zero spend would make any cap unusable.
+    assert backend.calls >= 1
+    assert backend.calls < 20, "the loop kept paying after the cap"
+
+
+def test_the_loop_stops_when_it_cannot_price_the_model() -> None:
+    # The owner's rule, end to end: unknown price is a stop, not a skip.
+    backend = _Backend(model="brand-new-model-with-no-price")
+    agent = Agent(
+        backend,
+        _registry(),
+        AgentConfig(model="brand-new-model-with-no-price", max_steps=20, max_usd=100.0),
+    )
+
+    result = agent.run("do something")
+
+    assert result.stopped_reason == "budget"
+    assert "brand-new-model-with-no-price" in result.answer
+    assert backend.calls == 1, "it paid for a second call it could not price"
+
+
+def test_no_cap_means_no_new_way_to_stop() -> None:
+    """The default has to be inert. This runs on a production machine, and a limiter that changes
+    behaviour for people who did not ask for one is a regression shipped as a feature."""
+    backend = _Backend(model="brand-new-model-with-no-price")
+    agent = Agent(backend, _registry(), AgentConfig(model="brand-new-model-with-no-price", max_steps=3))
+
+    result = agent.run("do something")
+
+    assert result.stopped_reason != "budget"
+    assert backend.calls >= 1
+
+
+def test_two_runs_of_one_agent_get_separate_budgets() -> None:
+    # A scheduler dispatches many jobs through one Agent. A cap carried across runs would refuse the
+    # second task because the first spent its allowance — a limiter that behaves differently
+    # depending on what ran before it is one nobody can reason about.
+    backend = _Backend()
+    agent = Agent(
+        backend,
+        _registry(),
+        AgentConfig(model="openrouter/deepseek/deepseek-chat", max_steps=4, max_usd=0.0005),
+    )
+
+    first = agent.run("task one")
+    second = agent.run("task two")
+
+    assert first.stopped_reason == "budget"
+    assert second.stopped_reason == "budget", "the second run started already over budget"
+
+
+def test_the_partial_answer_survives_the_stop() -> None:
+    """The transcript up to the stop is work already paid for. Discarding it would spend the whole
+    budget and hand back nothing."""
+    backend = _Backend()
+    agent = Agent(
+        backend,
+        _registry(),
+        AgentConfig(model="openrouter/deepseek/deepseek-chat", max_steps=20, max_usd=0.0005),
+    )
+
+    result = agent.run("do something long")
+
+    assert result.transcript
+    assert result.prompt_tokens > 0


### PR DESCRIPTION
Item 2 do plano pós-estudo. Era o único da lista com **perda ilimitada e sem piso**: `max_steps` e
`max_attempts` são contadores, e um job em laço de retry gasta até o saldo do provedor acabar.

## A sua decisão, implementada

**Chamada sem preço → o run para.** Um teto que pula o que não sabe precificar continua mostrando
verde enquanto o gasto real sobe — e sobe mais rápido justamente nos modelos que ninguém precificou.
O desconhecido é **grudento**: uma chamada precificada depois não limpa, porque o total já é
impossível de saber desde a primeira que não foi.

## Duas correções ao que eu havia te dito

**1. Não era greenfield.** Eu reportei "não existe teto em lugar nenhum" com base num grep por
variáveis com nome de dólar. O `chimera/orchestration/budget.py` sempre teve `BudgetedBackend` com
modos hard/soft/count_only e `BudgetExceeded` tipado — em tokens de delegação. Quem executasse o meu
texto escreveria um segundo mecanismo, e dois limitadores de gasto são duas regras que um dia
divergem, às 3 da manhã, na máquina que opera dinheiro. O teto estende o que existia.

**2. `:free` já tinha preço.** Minha preocupação de que a produção rodaria sem preço estava errada:
a tabela põe `:free` em primeiro lugar, a zero, de propósito.

**Mas apareceu o problema real:** modelo **local** não tem preço na tabela — e um `ollama/` não custa
dólar nenhum, custa eletricidade. Tratá-lo como desconhecido faria o teto recusar exatamente a
configuração que não tem como estourar. Agora resolve como zero, dentro do `resolve_price`, então
todo consumidor da tabela herda.

## O tiro no pé que sobra, e que ficou visível

O modelo padrão de fábrica **não tem preço**. Um teto sobre ele pararia na primeira chamada. O
`chimera doctor` passa a dizer isso **antes** de alguém configurar um teto, nomeando o modelo e a
correção. Descobrir por um cron derrubado às 3 da manhã custa o cron.

## Verificação

Três mutações, cada uma reprovando os testes certos: preço desconhecido virando "pula" em vez de
"para"; modelo local voltando a "desconhecido"; e o teto deixando de ser checado **antes** da
chamada. O backend de mentira chama uma ferramenta a cada turno de propósito — com prosa ele retorna
`final` no passo 1 e todas as asserções passariam sem o orçamento fazer nada.

`ruff` e `mypy --strict` limpos · **2843 testes** (13 novos) · OpenAPI regerado.

Só o nível de **run**. Os níveis por job e o agregado diário vêm em seguida; o encanamento de que
precisam está aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)