### PR TITLE
feat(budget): the other two ceilings — one dispatch, and one day

### DIFF
--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -58,6 +58,30 @@ def load_usage(path: Path) -> list[UsageRecord]:
     return out
 
 
+def spent_today(path: Path, *, today: str) -> tuple[float, bool]:
+    """What has been spent on ``today`` (an ISO ``YYYY-MM-DD``), and whether any of it is unknown.
+
+    Returns ``(usd, has_unpriced)``. The second value is not a detail: a day containing one unpriced
+    turn has an unknown total, and a cap compared against the known part alone would be comparing
+    against a number that is confidently too low. The caller decides what to do with that — the
+    scheduler refuses, which is the same rule the per-run cap follows.
+
+    Reads the log rather than keeping a counter, so the answer survives a restart. The daemon runs
+    for weeks; a total held in memory would reset to zero every deploy, which is the one moment a
+    spend cap most needs to remember.
+    """
+    total = 0.0
+    unpriced = False
+    for record in load_usage(path):
+        if not record.ts.startswith(today):
+            continue
+        if record.usd is None:
+            unpriced = True
+        else:
+            total += record.usd
+    return round(total, 6), unpriced
+
+
 def summarize_usage(records: list[UsageRecord]) -> dict[str, Any]:
     """Aggregate usage records into the dashboard summary.
 

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1622,12 +1622,57 @@ def _start_cron_daemon(
     """Start the cron daemon in a background thread; return its stop event."""
     import json
     import time
+    from datetime import UTC, datetime
 
+    from chimera.api.usage import UsageRecord, append_usage, spent_today
     from chimera.core import Agent, AgentConfig
+    from chimera.orchestration.budget import BudgetExceeded
     from chimera.scheduler import CronDaemon, CronJob, Scheduler, make_agent_dispatch
     from chimera.tools import default_registry
 
     scheduler = Scheduler(_cron_store())
+    settings = get_settings()
+    usage_path = settings.home / "usage.jsonl"
+
+    def run_job(job: CronJob) -> str:
+        """One dispatch, inside whatever the money allows.
+
+        Three things happen here that did not before. The DAILY cap is checked before the job is
+        allowed to spend anything; the job's own cap is handed to the loop; and what the job spent
+        is written to the usage log — which is what makes the daily figure include cron at all. It
+        did not: the log was written only by the chat turn, so a daily cap read from it would have
+        been blind to exactly the spend it exists to bound.
+        """
+        cap = settings.daily_usd_cap
+        if cap and not job.critical:
+            today = datetime.now(UTC).strftime("%Y-%m-%d")
+            spent, unpriced = spent_today(usage_path, today=today)
+            if unpriced:
+                raise BudgetExceeded(
+                    f"today's spend cannot be known (an unpriced model ran); {job.name} refused. "
+                    "Price the model, or mark this job critical if it must run regardless"
+                )
+            if spent >= cap:
+                raise BudgetExceeded(f"daily cap reached: ${spent:.4f} of ${cap:.4f}")
+
+        agent = Agent(
+            backend,
+            default_registry(workspace),
+            AgentConfig(model=model, max_steps=max_steps, max_usd=job.max_usd),
+        )
+        result = agent.run(job.action)
+        append_usage(
+            usage_path,
+            UsageRecord(
+                ts=datetime.now(UTC).isoformat(),
+                session_id=f"cron:{job.id}",
+                model=result.model,
+                prompt_tokens=result.prompt_tokens,
+                completion_tokens=result.completion_tokens,
+                usd=result.usd,
+            ),
+        )
+        return result.answer
 
     def run_task(task: str) -> str:
         agent = Agent(backend, default_registry(workspace), AgentConfig(model=model, max_steps=max_steps))
@@ -1649,7 +1694,9 @@ def _start_cron_daemon(
         with results_path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, ensure_ascii=False) + "\n")
 
-    daemon = CronDaemon(scheduler, make_agent_dispatch(run_task, deliver), tick_seconds=tick)
+    daemon = CronDaemon(
+        scheduler, make_agent_dispatch(run_task, deliver, run_job=run_job), tick_seconds=tick
+    )
     _thread, stop = daemon.start()
     jobs = len(scheduler.store.list())
     console.print(f"[dim]cron daemon on (tick {tick}s, {jobs} job(s) scheduled)[/dim]")

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -435,6 +435,15 @@ class Settings(BaseSettings):
     )
     complete_budget_ms: int = Field(default=600, validation_alias="CHIMERA_COMPLETE_BUDGET_MS")
 
+    # Aggregate dollar ceiling for ONE day, across everything that writes to the usage log. Unset
+    # (the default) means no daily cap and therefore no new way for a scheduled job to be refused.
+    #
+    # Read from the log rather than a counter so it survives a restart, and refused LOUDLY: the job
+    # gets `last_status="budget"` with the numbers, because a refusal that only looked like "nothing
+    # happened" is indistinguishable from a dead daemon. A job marked `critical` is exempt — a
+    # position guardian silenced at 2 p.m. until midnight costs more than it saves.
+    daily_usd_cap: float | None = Field(default=None, validation_alias="CHIMERA_DAILY_USD_CAP")
+
     # Deployment-level tool allowlist/denylist (names). Empty allowlist = no restriction (all
     # tools); a non-empty allowlist grants only those. Denylist removes even if allowed.
     #

--- a/chimera/scheduler/daemon.py
+++ b/chimera/scheduler/daemon.py
@@ -27,8 +27,14 @@ def make_agent_dispatch(
     on_result: Callable[[CronJob, str], None] | None = None,
     *,
     delivery_retries: int = 2,
+    run_job: Callable[[CronJob], str] | None = None,
 ) -> Dispatch:
     """Build a dispatch that runs a job's ``action`` through ``run_task`` (task -> answer).
+
+    ``run_job`` is the job-aware form and wins when given: a caller that has to honour the job's own
+    settings — its spend cap, whether it is exempt from the daily one — needs the job, not just the
+    action string. ``run_task`` stays for every caller that does not, which is most of them, and is
+    what the tests drive.
 
     ``on_result`` (optional) receives ``(job, answer)`` — e.g. to deliver the result to a
     chat platform or a durable sink. Delivery is *confirmed*: it is retried up to
@@ -38,7 +44,7 @@ def make_agent_dispatch(
     """
 
     def dispatch(job: CronJob) -> None:
-        answer = run_task(job.action)
+        answer = run_job(job) if run_job is not None else run_task(job.action)
         _log.info("cron '%s' ran -> %s", job.name, (answer or "").replace("\n", " ")[:200])
         if on_result is None:
             return

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from croniter import croniter
 
 from chimera.concurrency import call_with_deadline
+from chimera.orchestration.budget import BudgetExceeded
 from chimera.scheduler.models import CreatedBy, CronJob, DispatchStatus
 from chimera.scheduler.store import CronStore
 from chimera.telemetry import get_logger
@@ -250,6 +251,12 @@ class Scheduler:
                     job.name, job.id, job_timeout,
                 )
                 self._record(job, "timeout", f"exceeded {job_timeout}s and was abandoned")
+            except BudgetExceeded as exc:
+                # Not a failure: the job was refused because the money said no. Loud on purpose —
+                # a refusal that only showed up as "nothing happened" is indistinguishable from a
+                # stopped daemon, and this path runs jobs that watch real positions.
+                _log.warning("cron job %s refused on budget: %s", job.name, exc)
+                self._record(job, "budget", str(exc))
             except Exception as exc:  # a failing job must not break the scheduler
                 _log.warning("cron job %s failed: %s", job.id, exc)
                 self._record(job, "error", f"{type(exc).__name__}: {exc}")
@@ -262,7 +269,13 @@ class Scheduler:
         """Set the outcome on the job. `mark_ran` persists it a moment later, in the same tick."""
         job.last_status = status
         job.last_error = (error or "")[:300] or None
-        job.consecutive_failures = 0 if status == "ok" else job.consecutive_failures + 1
+        # A budget refusal does not count as a failure: the job never ran, so nothing about it
+        # failed, and letting it climb this counter would make a spending decision look like forty
+        # broken dispatches to anyone reading `failing()`.
+        if status in ("ok", "budget"):
+            job.consecutive_failures = 0
+        else:
+            job.consecutive_failures += 1
 
     def fire_event(self, event: str, now: float, dispatch: Callable[[CronJob], None]) -> list[CronJob]:
         """Dispatch every job registered for ``event``. Returns those run."""

--- a/chimera/scheduler/models.py
+++ b/chimera/scheduler/models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 Trigger = Literal["cron", "event", "webhook"]
 CreatedBy = Literal["human", "agent"]
 
-DispatchStatus = Literal["ok", "error", "timeout"]
+DispatchStatus = Literal["ok", "error", "timeout", "budget"]
 """What happened on the last dispatch — which is not the same question as whether one happened.
 
 ``last_run`` records the ATTEMPT: the scheduler sets it outside the try/except on purpose, so a job
@@ -20,6 +20,11 @@ a job that has failed on every tick for a month has a `last_run` of a minute ago
 So the outcome is recorded beside it rather than folded into it. Two silences look identical from
 `last_run` alone and need completely different responses: *nothing ran* means look at the daemon,
 *everything ran and failed* means look at the job.
+
+``budget`` is its own status and not an ``error`` for the same reason: a job refused because the day
+is spent is not broken, and the two need opposite responses — one is a code fix, the other is a
+number in the configuration. Folding them together would also let a spend refusal ride the
+``consecutive_failures`` counter into looking like a job that has been failing for a week.
 """
 
 
@@ -51,4 +56,17 @@ class CronJob(BaseModel):
     difference is not visible from a single ``last_status``."""
     deliver_to: str | None = None
     """Optional delivery target for the job's result (e.g. a chat conversation id)."""
+    max_usd: float | None = None
+    """Dollar ceiling for ONE dispatch of this job. None = no per-job cap.
+
+    Separate from the daily aggregate below: this one bounds a single runaway run (a retry loop on
+    an expensive model), the other bounds the day. A job can hit its own cap every time and still be
+    well inside the day's, which is the case where only this field says anything."""
+    critical: bool = False
+    """Exempt from the DAILY cap — never from its own.
+
+    For the job whose absence costs more than its spend: a position guardian, a fills check. Without
+    this, a daily cap tripped at 2 p.m. leaves the account unwatched until midnight, which is a worse
+    outcome than the money it saved. Deliberately not the default: a job is ordinary until someone
+    decides, in writing, that it is not."""
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_cron_budget.py
+++ b/tests/test_cron_budget.py
@@ -1,0 +1,135 @@
+"""The other two levels of the spend cap: one dispatch, and one day.
+
+The run-level cap bounds a single loop. Neither of the other two is derivable from it. A job can sit
+inside its own ceiling on every dispatch and still spend the month by tea-time, which is what the
+daily aggregate is for; and a daily aggregate cannot stop the single runaway retry loop that empties
+the balance between two ticks, which is what the per-job ceiling is for.
+
+Two decisions are recorded here as behaviour rather than as prose. A refusal is **not a failure** —
+it gets its own status and does not climb the failure counter, because "the money said no" and "this
+job is broken" need opposite responses. And a job can be marked **critical** to escape the daily cap,
+because a position guardian silenced at 2 p.m. until midnight costs more than it saves.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from chimera.api.usage import UsageRecord, append_usage, spent_today
+from chimera.orchestration.budget import BudgetExceeded
+from chimera.scheduler import CronStore, Scheduler
+from chimera.scheduler.models import CronJob
+
+TODAY = datetime.now(UTC).strftime("%Y-%m-%d")
+
+
+def _scheduler(tmp_path: Path) -> Scheduler:
+    return Scheduler(CronStore(tmp_path / "cron.json"))
+
+
+def _usage(path: Path, *, usd: float | None, day: str = TODAY) -> None:
+    append_usage(path, UsageRecord(ts=f"{day}T12:00:00+00:00", model="m", usd=usd))
+
+
+# --- what the day cost -------------------------------------------------------------------------
+
+
+def test_spent_today_counts_only_today(tmp_path: Path) -> None:
+    log = tmp_path / "usage.jsonl"
+    _usage(log, usd=1.0)
+    _usage(log, usd=99.0, day="2020-01-01")
+
+    assert spent_today(log, today=TODAY) == (1.0, False)
+
+
+def test_an_unpriced_turn_makes_the_day_unknown_rather_than_cheap(tmp_path: Path) -> None:
+    """The same rule as the per-run cap. Summing only the known part gives a total that is
+    confidently too low, and too low in the direction that flatters whatever ran unpriced."""
+    log = tmp_path / "usage.jsonl"
+    _usage(log, usd=0.10)
+    _usage(log, usd=None)
+
+    spent, unpriced = spent_today(log, today=TODAY)
+
+    assert spent == 0.10
+    assert unpriced is True
+
+
+def test_a_missing_log_is_zero_not_an_error(tmp_path: Path) -> None:
+    # First run on a fresh machine. A cap that raised here would make the daemon refuse to start.
+    assert spent_today(tmp_path / "nothing.jsonl", today=TODAY) == (0.0, False)
+
+
+# --- the job's own ceiling ---------------------------------------------------------------------
+
+
+def test_a_job_carries_its_own_cap_and_is_ordinary_by_default() -> None:
+    plain = CronJob(id="a", name="a", schedule="* * * * *", action="x")
+    assert plain.max_usd is None
+    assert plain.critical is False, "a job must not exempt itself from the day's budget by default"
+
+    capped = CronJob(id="b", name="b", schedule="* * * * *", action="x", max_usd=0.5, critical=True)
+    assert capped.max_usd == 0.5
+    assert capped.critical is True
+
+
+# --- what a refusal looks like from outside ----------------------------------------------------
+
+
+def test_a_refused_job_gets_its_own_status_not_error(tmp_path: Path) -> None:
+    """`budget` and `error` need opposite responses: one is a number in the configuration, the other
+    is a code fix. A refusal reported as an error sends whoever reads it to the wrong place."""
+    sch = _scheduler(tmp_path)
+    sch.schedule_cron("j", "* * * * *", "do X", now=0)
+
+    def refuse(_job: CronJob) -> None:
+        raise BudgetExceeded("daily cap reached: $5.0000 of $5.0000")
+
+    ran = sch.run_due(now=120, dispatch=refuse)
+
+    assert [j.last_status for j in ran] == ["budget"]
+    assert "daily cap reached" in (ran[0].last_error or "")
+
+
+def test_a_refusal_does_not_climb_the_failure_counter(tmp_path: Path) -> None:
+    # Otherwise a spending decision reads as forty broken dispatches to anyone looking at
+    # `failing()`, and the genuinely broken job hides behind it.
+    sch = _scheduler(tmp_path)
+    sch.schedule_cron("j", "* * * * *", "do X", now=0)
+
+    def refuse(_job: CronJob) -> None:
+        raise BudgetExceeded("daily cap reached")
+
+    for minute in (120, 180, 240):
+        sch.run_due(now=minute, dispatch=refuse)
+
+    assert sch.store.list()[0].consecutive_failures == 0
+
+
+def test_a_real_failure_still_counts(tmp_path: Path) -> None:
+    # The counterpart: making budget refusals free must not make failures free too.
+    sch = _scheduler(tmp_path)
+    sch.schedule_cron("j", "* * * * *", "do X", now=0)
+
+    def boom(_job: CronJob) -> None:
+        raise RuntimeError("broken")
+
+    sch.run_due(now=120, dispatch=boom)
+    sch.run_due(now=180, dispatch=boom)
+
+    job = sch.store.list()[0]
+    assert job.last_status == "error"
+    assert job.consecutive_failures == 2
+
+
+def test_the_schedule_still_advances_after_a_refusal(tmp_path: Path) -> None:
+    """A refused job must not be due forever. If the cap holds all day, a schedule that never
+    advanced would re-refuse on every tick and fill the log with the same line."""
+    sch = _scheduler(tmp_path)
+    job = sch.schedule_cron("j", "* * * * *", "do X", now=0)
+    before = job.next_run
+
+    sch.run_due(now=120, dispatch=lambda _j: (_ for _ in ()).throw(BudgetExceeded("nope")))
+
+    assert (sch.store.list()[0].next_run or 0) > (before or 0)


### PR DESCRIPTION
Fecha o item 2 do plano. O teto por **run** já tinha saído no #67; faltavam o teto **por job** e o
**agregado diário**, e nenhum dos dois é derivável do primeiro: um job pode caber no próprio teto em
todo despacho e ainda assim gastar o mês até a hora do café — é para isso que serve o diário; e o
diário não segura o único laço de retry desgovernado que esvazia o saldo entre dois ticks — é para
isso que serve o por-job.

## O buraco que o diário expôs

O `usage.jsonl` era escrito por **um único** chamador: o turno de chat (`api/app.py`). Um teto diário
lido dali seria cego justamente ao gasto que ele existe para limitar. O despacho do cron passa a
registrar uso a cada job.

E a leitura é do **log**, não de um contador em memória: o daemon roda por semanas, e um total em
memória zera a cada deploy — que é exatamente o momento em que um teto mais precisa lembrar.

## Duas decisões que viraram comportamento, não comentário

**Recusa não é falha.** `budget` é um `DispatchStatus` próprio e **não** sobe o
`consecutive_failures`. "O dinheiro disse não" e "este job está quebrado" pedem respostas opostas —
um é um número na configuração, o outro é conserto de código — e juntar os dois faria uma decisão de
gasto parecer quarenta despachos quebrados para quem olha o `failing()`.

**Um job pode ser `critical`** e escapar do teto **diário**, nunca do próprio. Isso veio da crítica
adversarial do estudo: um teto que dispara às 14h deixa um guardião de posições sem vigilância até
meia-noite — pior que o dinheiro que economiza. Não é o padrão: um job é comum até alguém decidir,
por escrito, que não é.

**Turno sem preço torna o dia inteiro desconhecido, e dia desconhecido recusa** — mesma regra do teto
por run, pelo mesmo motivo: somar só a parte conhecida dá um total confiantemente baixo demais.

## Verificação

`ruff` e `mypy --strict` limpos · **2851 testes** (8 novos) · desktop verde · OpenAPI regerado.

Três mutações. A primeira tentativa de uma delas **estava quebrada, não o teste**: `except Exception
as exc:` aparece antes no arquivo, dentro do `fire_webhook`, então fatiar entre âncoras duplicou um
bloco em vez de remover a cláusula — e a mutação "que deveria falhar" deixou o código intacto.
Refeita com âncora única, falha como devia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)