### PR TITLE
feat(trace): a run the log can name, on the path that runs the most

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1658,14 +1658,24 @@ def _start_cron_daemon(
         agent = Agent(
             backend,
             default_registry(workspace),
-            AgentConfig(model=model, max_steps=max_steps, max_usd=job.max_usd),
+            AgentConfig(
+                model=model,
+                max_steps=max_steps,
+                max_usd=job.max_usd,
+                # The path that runs the most was the one with no step-level record at all. Without
+                # it there is no success-versus-context curve, no replay of a job that went wrong,
+                # and no reliability bench for the 24/7 loop — every one of those reads this file.
+                trace_path=settings.home / "scheduler" / "cron_traces.jsonl",
+            ),
         )
         result = agent.run(job.action)
         append_usage(
             usage_path,
             UsageRecord(
                 ts=datetime.now(UTC).isoformat(),
-                session_id=f"cron:{job.id}",
+                # `run_id` in the session field is what joins this row to the trace line and to the
+                # job: three records, one run, one key.
+                session_id=f"cron:{job.id}:{result.run_id}",
                 model=result.model,
                 prompt_tokens=result.prompt_tokens,
                 completion_tokens=result.completion_tokens,

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -194,6 +194,10 @@ class AgentResult:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     usd: float | None = None
+    #: The id this run was written to the trace under, or "" when no trace was written. It is what
+    #: lets a receipt, a usage record and a trace line be joined back into one run — the join that
+    #: was impossible while the trace was keyed by a truncated task.
+    run_id: str = ""
     tool_names: list[str] = field(default_factory=list)  # names of the tools actually called, in order
     model: str = ""  # the model slug that actually answered (for a per-model usage breakdown)
     #: Per-step record: context size at each step, and what each tool was asked and answered.
@@ -537,11 +541,12 @@ class Agent:
         from chimera.orchestration.receipts import price_delegation
 
         log = steplog if steplog is not None else StepLog()
+        run_id = ""
         if self.config.trace_path is not None and log.steps:
             # Best-effort: a trace that cannot be written must never take the run down with it. The
             # answer is the product; the trace is evidence about how it was reached.
             try:
-                log.write(self.config.trace_path, task=task, stopped_reason=stopped_reason)
+                run_id = log.write(self.config.trace_path, task=task, stopped_reason=stopped_reason)
             except OSError as exc:  # pragma: no cover - disk-shaped failure
                 _log.debug("could not write trace to %s: %s", self.config.trace_path, exc)
 
@@ -560,6 +565,7 @@ class Agent:
             cache_read_tokens=usage.cache_read,
             cache_write_tokens=usage.cache_write,
             usd=usd,
+            run_id=run_id,
             tool_names=tool_names,
             model=model,
             route_meta=route_meta,

--- a/chimera/core/redact.py
+++ b/chimera/core/redact.py
@@ -1,0 +1,70 @@
+"""Keep secrets out of anything written to disk.
+
+The trace records what each tool was called with and what came back. On the 24/7 path those tools
+talk to a broker, a database and a payment processor, so the text is exactly the kind that carries a
+bearer token — and the trace is a file that lives for weeks on a machine nobody logs into.
+
+**What this guarantees, and what it does not.** It guarantees that a secret *this process knows about*
+never reaches the file: every environment value whose variable name looks like a credential is
+replaced verbatim wherever it appears. That is a complete guarantee over the set that matters most,
+because those are the strings the agent could plausibly echo.
+
+It does **not** guarantee that no secret ever survives. A token minted at runtime by a remote API, a
+password typed into a prompt, a key in a file the agent read — none of those are in the environment
+and no pattern list finds all of them. The regexes below catch the shapes that are cheap to catch;
+they are a second net, not the guarantee. Anyone reading this should treat a trace as sensitive,
+which is why it is also size-capped and rotated rather than kept forever.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+#: Same markers the sandbox uses to strip the child environment. One list, one meaning of "secret".
+from chimera.sandbox.local import _SECRET_MARKERS
+
+MASK = "[redacted]"
+
+#: Below this, a value is too short to be a credential and too likely to be a common word — an env
+#: var set to `1` or `true` would otherwise mask every digit in the file.
+_MIN_SECRET_LEN = 8
+
+#: High-confidence shapes, as a second net. Deliberately narrow: a greedy pattern that redacted
+#: ordinary output would make the trace useless, and a useless trace gets turned off.
+_PATTERNS = (
+    re.compile(r"\b(?:sk|pk|rk)-[A-Za-z0-9_-]{16,}"),  # OpenAI-style
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9]{20,}"),  # GitHub
+    re.compile(r"\bsbp_[A-Za-z0-9]{20,}"),  # Supabase personal token
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}"),  # Slack
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{20,}", re.IGNORECASE),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"),  # JWT
+)
+
+
+def known_secrets() -> list[str]:
+    """Every environment value whose NAME marks it a credential, longest first.
+
+    Longest first matters: when one secret is a prefix of another (a base token and the same token
+    with a suffix), replacing the short one first would leave the tail of the long one in the file,
+    which looks redacted and is not.
+    """
+    found = [
+        value
+        for name, value in os.environ.items()
+        if value
+        and len(value) >= _MIN_SECRET_LEN
+        and any(marker in name.upper() for marker in _SECRET_MARKERS)
+    ]
+    return sorted(set(found), key=len, reverse=True)
+
+
+def redact(text: str) -> str:
+    """Replace known secrets and credential-shaped strings in ``text``."""
+    if not text:
+        return text
+    for secret in known_secrets():
+        text = text.replace(secret, MASK)
+    for pattern in _PATTERNS:
+        text = pattern.sub(MASK, text)
+    return text

--- a/chimera/core/steplog.py
+++ b/chimera/core/steplog.py
@@ -19,9 +19,13 @@ produce will be turned off, and a trace that is turned off explains nothing.
 from __future__ import annotations
 
 import json
+import uuid
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from chimera.core.redact import redact
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from chimera.core.context_drift import DriftReport
@@ -30,6 +34,28 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # 20k-char file dump. Diffs and verifier output already have their own richer receipts.
 _ARG_CHARS = 400
 _OBS_CHARS = 800
+
+
+#: A trace that grows without bound on a machine that runs for weeks stops being a diagnostic and
+#: becomes a disk problem — and the first symptom is a daemon that cannot write anything at all.
+#: One previous generation is kept: enough to span a rotation while investigating an incident,
+#: bounded enough that the cap means what it says.
+MAX_TRACE_BYTES = 32 * 1024 * 1024
+
+
+def _rotate_if_large(path: Path) -> None:
+    """Move the trace aside once it passes the cap, keeping exactly one previous generation.
+
+    Rename rather than trim: rewriting the file to drop old lines would have to read all of it, and
+    a crash mid-rewrite loses the whole history instead of the oldest part of it.
+    """
+    try:
+        if path.exists() and path.stat().st_size >= MAX_TRACE_BYTES:
+            path.replace(path.with_suffix(path.suffix + ".1"))
+    except OSError:  # pragma: no cover - disk-shaped failure
+        # A rotation that fails must not take the run down: the answer is the product, the trace is
+        # evidence about it.
+        pass
 
 
 def clip(text: str, limit: int) -> str:
@@ -213,16 +239,37 @@ class StepLog:
             "steps": [s.as_dict() for s in self.steps],
         }
 
-    def write(self, path: Path, *, task: str, stopped_reason: str) -> None:
-        """Append this run's trace as one JSONL line.
+    def write(self, path: Path, *, task: str, stopped_reason: str, run_id: str = "") -> str:
+        """Append this run's trace as one JSONL line. Returns the id it was written under.
 
         One line per run rather than per step: a run is the unit anyone reads back, and a partial
         run interleaved with others is worse than no trace at all.
+
+        **`run_id` and `ts` are what make the line joinable.** The record used to be keyed by a
+        truncated task plus a stop reason, which collides exactly where it matters: a bench runs the
+        same task dozens of times, and one run with three attempts writes three lines that are
+        indistinguishable. Nothing downstream — a success×context curve, a cron replay, failure
+        attribution — can be built on a key that cannot tell two runs apart.
+
+        The body is **redacted** and the file is **capped**, in the same place, because both are
+        properties of writing a trace to disk rather than of producing one. On the 24/7 path this
+        text came from a broker and a payment processor; see :mod:`chimera.core.redact` for exactly
+        what that promises and what it does not.
         """
-        record = {"task": clip(task, _ARG_CHARS), "stopped_reason": stopped_reason, **self.as_dict()}
+        run_id = run_id or uuid.uuid4().hex
+        record = {
+            "run_id": run_id,
+            "ts": datetime.now(UTC).isoformat(),
+            "task": clip(task, _ARG_CHARS),
+            "stopped_reason": stopped_reason,
+            **self.as_dict(),
+        }
+        line = redact(json.dumps(record, ensure_ascii=False))
         path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_if_large(path)
         with path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            fh.write(line + "\n")
+        return run_id
 
 
 def tool_record(name: str, arguments: dict[str, Any], observation: str) -> ToolRecord:

--- a/tests/test_trace_identity.py
+++ b/tests/test_trace_identity.py
@@ -1,0 +1,154 @@
+"""What a trace line has to carry to be worth writing, and what it must never carry.
+
+The trace was keyed by a truncated task plus a stop reason. That collides exactly where the file is
+used: a bench runs the same task dozens of times, one run with three attempts writes three
+indistinguishable lines, and every downstream question — how did success vary with context size,
+what did this cron job actually do at 3 a.m., which attempt produced the bad diff — needs to tell two
+runs apart before it can be asked at all.
+
+The other half is that this file now gets written on the 24/7 path, where the tool text came from a
+broker, a database and a payment processor. Redaction and the size cap are here rather than in a
+later commit because they are properties of putting a trace on disk, not of producing one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from chimera.core.redact import MASK, redact
+from chimera.core.steplog import MAX_TRACE_BYTES, StepLog, StepRecord
+
+
+def _log_with_step(observation: str = "fine", arguments: str = "{}") -> StepLog:
+    from chimera.core.steplog import ToolRecord
+
+    log = StepLog()
+    log.add(
+        StepRecord(
+            index=1,
+            prompt_tokens=100,
+            completion_tokens=10,
+            model="m",
+            tools=[ToolRecord(name="t", arguments=arguments, observation=observation, ok=True)],
+        )
+    )
+    return log
+
+
+def _lines(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+# --- identity ----------------------------------------------------------------------------------
+
+
+def test_two_runs_of_the_same_task_are_distinguishable(tmp_path: Path) -> None:
+    """The collision the old key produced. A bench repeats one task; without an id the lines are the
+    same line twice, and nothing can be attributed to either run."""
+    path = tmp_path / "traces.jsonl"
+
+    first = _log_with_step().write(path, task="fix the bug", stopped_reason="final")
+    second = _log_with_step().write(path, task="fix the bug", stopped_reason="final")
+
+    ids = [row["run_id"] for row in _lines(path)]
+    assert first != second
+    assert ids == [first, second]
+    assert len(set(ids)) == 2
+
+
+def test_every_line_is_timestamped(tmp_path: Path) -> None:
+    # Ordering inside a file is not a time: an appended log survives restarts and copies, and "when"
+    # is the first question asked of any 24/7 trace.
+    path = tmp_path / "traces.jsonl"
+
+    _log_with_step().write(path, task="t", stopped_reason="final")
+
+    assert _lines(path)[0]["ts"].startswith("20")
+
+
+def test_a_caller_can_supply_the_id_it_already_has(tmp_path: Path) -> None:
+    # So a receipt, a usage row and a trace line can share one key rather than three.
+    path = tmp_path / "traces.jsonl"
+
+    returned = _log_with_step().write(path, task="t", stopped_reason="final", run_id="abc123")
+
+    assert returned == "abc123"
+    assert _lines(path)[0]["run_id"] == "abc123"
+
+
+# --- redaction ---------------------------------------------------------------------------------
+
+
+def test_a_configured_secret_never_reaches_the_file(tmp_path: Path, monkeypatch: Any) -> None:
+    """The guarantee this can actually give: a secret THIS process knows about is replaced verbatim.
+
+    On the cron path the observation is whatever a broker or a payment API returned, and the file
+    outlives the incident by weeks.
+    """
+    monkeypatch.setenv("SOME_PROVIDER_API_KEY", "super-secret-value-1234")
+    path = tmp_path / "traces.jsonl"
+
+    _log_with_step(observation="auth ok with super-secret-value-1234").write(
+        path, task="t", stopped_reason="final"
+    )
+
+    body = path.read_text(encoding="utf-8")
+    assert "super-secret-value-1234" not in body
+    assert MASK in body
+
+
+def test_the_task_itself_is_redacted_too(tmp_path: Path, monkeypatch: Any) -> None:
+    # A job's action is written by a person and is exactly where a token gets pasted "just once".
+    monkeypatch.setenv("X_TOKEN", "paste-me-nowhere-9999")
+    path = tmp_path / "traces.jsonl"
+
+    _log_with_step().write(path, task="call the API with paste-me-nowhere-9999", stopped_reason="final")
+
+    assert "paste-me-nowhere-9999" not in path.read_text(encoding="utf-8")
+
+
+def test_a_short_env_value_does_not_mask_the_whole_file(monkeypatch: Any) -> None:
+    """`CI=1` is an env var whose name ends in nothing suspicious, but plenty of credential-named
+    vars hold short placeholders. Redacting an 8-character floor keeps a `1` from erasing every
+    digit in the trace — which would make the file useless and the redaction look thorough."""
+    monkeypatch.setenv("SHORT_TOKEN", "1")
+
+    assert redact("step 1 of 3") == "step 1 of 3"
+
+
+def test_credential_shapes_are_caught_without_being_configured() -> None:
+    # The second net, for secrets this process never held. Narrow on purpose.
+    assert "ghp_" not in redact("token ghp_abcdefghijklmnopqrstuvwxyz0123")
+    assert redact("a normal sentence about a key") == "a normal sentence about a key"
+
+
+def test_redaction_prefers_the_longest_secret(monkeypatch: Any) -> None:
+    """A base token and the same token plus a suffix: masking the short one first leaves the tail
+    behind, which reads as redacted and is not."""
+    monkeypatch.setenv("A_TOKEN", "abcdefgh")
+    monkeypatch.setenv("B_TOKEN", "abcdefgh-with-suffix")
+
+    assert "with-suffix" not in redact("value abcdefgh-with-suffix here")
+
+
+# --- the size cap ------------------------------------------------------------------------------
+
+
+def test_the_trace_rotates_instead_of_growing_forever(tmp_path: Path, monkeypatch: Any) -> None:
+    """A daemon runs for weeks. An uncapped trace stops being a diagnostic and becomes the reason
+    the disk is full — and the first symptom is a daemon that can no longer write anything."""
+    monkeypatch.setattr("chimera.core.steplog.MAX_TRACE_BYTES", 200)
+    path = tmp_path / "traces.jsonl"
+
+    for _ in range(6):
+        _log_with_step().write(path, task="t" * 50, stopped_reason="final")
+
+    assert path.with_suffix(".jsonl.1").exists(), "nothing was rotated aside"
+    assert path.stat().st_size < 200 * 4, "the live file kept growing past the cap"
+
+
+def test_the_cap_is_a_real_number() -> None:
+    # Guards against a future edit that sets it to something a single run could exceed.
+    assert MAX_TRACE_BYTES >= 1024 * 1024


### PR DESCRIPTION
Item 3 do plano — o que a crítica adversarial chamou de "o único habilitador": sem ele não existe
curva sucesso×contexto, replay de cron, atribuição de falha, nem qualquer bench de confiabilidade do
24/7. Todos leem este arquivo.

## O que estava quebrado

A linha do trace era chaveada por **tarefa truncada + razão de parada** — e isso colide exatamente
onde o arquivo é usado: um bench roda a mesma tarefa dezenas de vezes, e uma run com três tentativas
escreve três linhas indistinguíveis. Qualquer pergunta que alguém queira fazer a este arquivo precisa
distinguir duas runs **antes** de poder ser feita.

Agora toda linha carrega `run_id` e timestamp, o `write()` devolve o id, e o `AgentResult` o carrega
— então recibo, linha de uso e linha de trace compartilham uma chave só.

E o caminho que mais roda não tinha registro nenhum: `trace_path` estava setado em 3 de ~15 sítios de
construção, e nenhum era o cron. Passa a estar, com o registro de uso ao lado carregando o mesmo id.

## Redação e teto no mesmo commit

Porque são propriedades de **pôr um trace em disco**, não de produzi-lo — e este arquivo passa a
juntar, numa máquina em que ninguém loga, texto que voltou de uma corretora, de um banco de dados e
de um processador de pagamento.

O `chimera/core/redact.py` diz exatamente o que promete: todo segredo que **este processo** conhece é
substituído literalmente — garantia completa sobre o conjunto que o agente poderia ecoar — mais uma
rede estreita de formatos de credencial para os que ele nunca teve. **Não** promete achar um token
emitido em runtime por uma API remota, e declara isso.

Dois detalhes que separam redação de aparência de redação: os segredos são substituídos **do mais
longo para o mais curto** (mascarar o token base antes do mesmo token com sufixo deixa a cauda no
arquivo), e há um **piso de 8 caracteres** — sem ele, uma variável com nome de credencial contendo
`1` apagaria todo dígito do trace, o que parece minucioso e é inútil.

A rotação **renomeia** em vez de aparar: reescrever para descartar linhas antigas exige ler o arquivo
inteiro, e uma queda no meio perde toda a história em vez da parte mais velha dela.

## Verificação

`ruff` e `mypy --strict` limpos em 298 arquivos · **2861 testes** (10 novos) · OpenAPI regerado.

Quatro mutações: id constante, sem redação, sem piso de tamanho, sem rotação. Cada uma reprova o
teste que a nomeia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)