### PR TITLE
feat(eval): the context curve, and the answer that there is no data yet

### DIFF
--- a/bench/context_curve/PREREGISTRATION.md
+++ b/bench/context_curve/PREREGISTRATION.md
@@ -1,0 +1,73 @@
+# Pre-registration — does success fall as context grows, on our own runs?
+
+**Registered 2026-08-13, before any data existed.** That is not a formality here: at the time of
+writing, the join this analysis needs returns **zero rows** (see "Starting state" below). The
+criterion is fixed now precisely because nobody can yet see the number it will be applied to.
+
+## The question
+
+The literature calls it *context rot*: a model's reliability degrades as the prompt grows, and the
+degradation begins well before the advertised window is full. It is the stated reason to build
+context compaction into an agent loop — which is a real piece of work, with a real failure mode of
+its own (a compaction that drops a constraint is how an agent forgets the instruction it was given).
+
+Before building it, this project measures whether the effect is present **in its own runs**, with its
+own loop, its own models and its own task mix. A number measured on someone else's harness is not
+evidence about ours.
+
+## Design
+
+- **Unit:** one attempt. One attempt is one agent run, which is one trace line — so a run with three
+  attempts contributes three points, each with the context *that attempt* carried.
+- **Exposure:** `context_peak_tokens` from `traces.jsonl` — the largest prompt that attempt sent.
+  The peak, not the mean: the question is whether a large context hurts, and an attempt that spent
+  one call at 100k tokens was exposed to that.
+- **Outcome:** `success` on the attempt receipt in `runs.jsonl`. The attempt's own flag, never the
+  run's: the run's is the last attempt's, and attributing a late success to an early attempt's
+  context smears exactly the relationship being measured.
+- **Join key:** `run_id`, present on both sides. Unjoinable rows on either side are **counted and
+  reported**, never dropped silently.
+- **Buckets (fixed now):** 0–8k, 8k–32k, 32k–128k, 128k+ prompt tokens.
+- **Interval:** Wilson 95%, which stays inside [0,1] at small n.
+
+## Floors — registered, and enforced in code
+
+| floor | value | why |
+|---|---|---|
+| per bucket | **20 attempts** | below this the rate moves >5pp on one flipped outcome; the interval spans most of the unit interval |
+| total | **60 joined attempts** | fewer cannot populate three buckets |
+| buckets above floor | **3** | with two, "declining" is indistinguishable from "one bucket is unlucky" |
+
+Below any floor the analysis reports **"not enough data"** and makes no claim in either direction.
+That is not the same as a null result, and the code says so in those words: a null result means the
+effect was looked for and not found; this means nobody has looked yet.
+
+## Decision rule — fixed before the data
+
+- **Intervals disjoint, later bucket lower** → the effect is present on our runs. Compaction becomes
+  a funded item, and this file becomes its baseline.
+- **Intervals overlap** → on our data compaction is not the lever. It stays unbuilt, and the finding
+  is published as a reason not to build something.
+- **Intervals disjoint, later bucket HIGHER** → the opposite of the expected effect. No action either
+  way until it is understood; a surprise this size usually means the apparatus, not the phenomenon.
+
+No re-bucketing after seeing the numbers. No dropping the smallest bucket because it is noisy. If the
+buckets turn out to be wrong, that is a finding to publish and a **new** registration, not an edit to
+this one.
+
+## Starting state (measured 2026-08-13)
+
+- `traces.jsonl` — **does not exist** on the development machine, and no `*trace*` file exists in
+  `/opt/data` on the production VPS either. The step log has been written at 3 of ~15 construction
+  sites since it was added, and none of them was a path that runs unattended.
+- `.chimera/runs.jsonl` — 403 runs, 706 attempts, all written before the receipt carried
+  `prompt_tokens`, and none carrying a `run_id`.
+- **Joinable attempts today: 0.**
+
+So this analysis currently returns "not enough data", and that is its honest first output. What
+changes it is time: the cron path started writing traces, and both sides now carry the key. Re-run
+the command below once the logs have accumulated.
+
+```bash
+chimera context-curve
+```

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -687,6 +687,45 @@
     },
     {
       "deprecated": false,
+      "help": "Did runs carrying more context do worse? Measured on THIS machine's own logs.\n\nAnswers with \"not enough data\" until the pre-registered floors are met \u2014 see\n`bench/context_curve/PREREGISTRATION.md`, which fixed those floors before any data existed.",
+      "hidden": false,
+      "name": "context-curve",
+      "params": [
+        {
+          "help": "Path to traces.jsonl (default: CHIMERA_HOME).",
+          "kind": "option",
+          "name": "traces",
+          "opts": [
+            "--traces"
+          ],
+          "required": false,
+          "type": "str"
+        },
+        {
+          "help": "Path to runs.jsonl (default: CHIMERA_HOME).",
+          "kind": "option",
+          "name": "runs",
+          "opts": [
+            "--runs"
+          ],
+          "required": false,
+          "type": "str"
+        },
+        {
+          "help": "Print the raw result instead of a table.",
+          "kind": "option",
+          "name": "json_out",
+          "opts": [
+            "--json"
+          ],
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path": "context-curve"
+    },
+    {
+      "deprecated": false,
       "help": "Run a multi-agent crew on a task (Tier 3). Requires a provider key.",
       "hidden": false,
       "name": "crew",

--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -74,6 +74,11 @@ class AttemptReceipt(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     model: str = ""  # the model that actually answered (the EDITOR's, under role routing)
+    #: The trace line this attempt wrote, by id. The join key between what a run ACHIEVED (here) and
+    #: what it was CARRYING (the step log) — the pair nobody could compute while the trace was keyed
+    #: by a truncated task. Empty for an attempt that ran without tracing, and for every receipt
+    #: written before this field existed.
+    run_id: str = ""
     #: Out-of-checkout side effects this attempt actually performed (send_email, http_post, …).
     #: An empty diff means one thing for a run that only touched files and something else entirely
     #: for a run that already sent mail — the receipt should not force that inference.
@@ -172,6 +177,7 @@ def build_receipt(
             # accepts by design — an older Attempt without these fields reads as "unknown" rather
             # than raising, which is the honest answer for a record that predates them.
             evidence=getattr(a, "evidence", "none") or "none",
+            run_id=getattr(a, "run_id", "") or "",
             diff_productive=getattr(a, "diff_productive", None),
             side_effects=list(getattr(a, "side_effects", None) or []),
             usd=getattr(a, "usd", None),

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -361,6 +361,54 @@ def _doctor_fixes(settings: Any, *, cwd: Path | None = None) -> list[str]:
     return done
 
 
+@app.command("context-curve")
+def context_curve_cmd(
+    traces: str = typer.Option(None, "--traces", help="Path to traces.jsonl (default: CHIMERA_HOME)."),
+    runs: str = typer.Option(None, "--runs", help="Path to runs.jsonl (default: CHIMERA_HOME)."),
+    json_out: bool = typer.Option(False, "--json", help="Print the raw result instead of a table."),
+) -> None:
+    """Did runs carrying more context do worse? Measured on THIS machine's own logs.
+
+    Answers with "not enough data" until the pre-registered floors are met — see
+    `bench/context_curve/PREREGISTRATION.md`, which fixed those floors before any data existed.
+    """
+    import json as _json
+
+    from chimera.eval.context_curve import context_curve
+
+    settings = get_settings()
+    result = context_curve(
+        Path(traces) if traces else settings.home / "traces.jsonl",
+        Path(runs) if runs else settings.home / "runs.jsonl",
+    )
+    if json_out:
+        console.print_json(_json.dumps(result.as_dict()))
+        return
+
+    table = Table(title="Success vs peak context", header_style="bold")
+    for col in ("context (prompt tokens)", "attempts", "success", "rate", "95% CI"):
+        table.add_column(col, justify="right")
+    for bucket in result.as_dict()["buckets"]:
+        rate = bucket["rate"]
+        ci = bucket["ci95"]
+        table.add_row(
+            str(bucket["context_tokens"]),
+            str(bucket["runs"]),
+            str(bucket["successes"]),
+            "—" if rate is None else f"{rate:.1%}",
+            "—" if ci is None else f"[{ci[0]:.1%}, {ci[1]:.1%}]",
+        )
+    console.print(table)
+    console.print(f"[bold]{result.verdict()}[/bold]")
+    if result.unjoinable_attempts or result.unjoinable_traces:
+        # Said out loud rather than swallowed: a silently dropped half of the data is how a real
+        # effect gets measured away.
+        console.print(
+            f"[dim]{result.unjoinable_attempts} attempt(s) and {result.unjoinable_traces} trace(s) "
+            "could not be joined — they predate the run id, or ran without tracing.[/dim]"
+        )
+
+
 @app.command()
 def doctor(
     fix: bool = typer.Option(False, "--fix", help="Auto-repair safe setup issues (state dir, .env scaffold)."),

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -231,6 +231,13 @@ class Attempt:
     completion_tokens: int = 0
     #: The model slug that actually answered this attempt (the EDITOR's model under role routing).
     model: str = ""
+    #: The id this attempt's trace line was written under, or "" when no trace was written.
+    #:
+    #: One attempt IS one agent run, which is one trace line — so this is the exact key that joins a
+    #: verified outcome to the context it was carrying. Without it the two files can only be joined
+    #: on a truncated task, which collides precisely where the join matters: a bench repeats one
+    #: task, and a run with three attempts writes three indistinguishable lines.
+    run_id: str = ""
     #: Names of out-of-checkout side-effect tools this attempt actually called (send_email,
     #: http_post, …), read off the step log. Recorded, never acted on: an empty diff means
     #: something very different once a run has already sent mail, and a reader of the receipt
@@ -721,6 +728,10 @@ class AutonomousAgent:
             attempt.diffs = diffs
             attempt.diff_productive = diff_productive
             attempt.side_effects = _side_effects(steplog)
+            # The key that joins this outcome to the trace line the same run just wrote. Read off
+            # the worker's result, like  above and for the same reason: it is the worker that
+            # knows, and re-deriving it here would be a second place for the two to disagree.
+            attempt.run_id = str(getattr(agent_result, 'run_id', '') or '')
             # What this attempt charged. Read off the worker's own result rather than recomputed:
             # `usd` is None there whenever the model's price is unknown, and that None has to
             # survive all the way to the receipt for the "was it worth it?" view to stay honest.

--- a/chimera/eval/context_curve.py
+++ b/chimera/eval/context_curve.py
@@ -1,0 +1,184 @@
+"""Did runs carrying more context do worse? Measured on our own logs, or not claimed at all.
+
+The literature calls it context rot, and it is the stated reason to build compaction. Building it on
+someone else's benchmark would be building on a number measured with a different loop, a different
+model and a different task mix. This computes it on ours: join what a run ACHIEVED (`runs.jsonl`,
+where the verifier's verdict lives) to what it was CARRYING (`traces.jsonl`, where the per-step
+prompt size lives), bucket by peak context, and report a success rate per bucket with a confidence
+interval.
+
+**It refuses to answer on thin data, and that is the feature.** With a handful of runs per bucket the
+rate swings twenty points on one flipped outcome, and a curve drawn through that noise is an argument
+for whatever the author already believed. The floor is pre-registered in
+``bench/context_curve/PREREGISTRATION.md`` and enforced here, so the decision to act is made before
+the number is seen rather than after.
+
+The join key is ``run_id``, present on both sides since the trace stopped being keyed by a truncated
+task. Rows that cannot be joined are counted and reported — a silently dropped half of the data is
+how a real effect gets measured away.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+#: Pre-registered. Below this many joined runs in a bucket, the bucket reports no rate at all: the
+#: Wilson interval at n=5 spans most of the unit interval, and a point estimate drawn from it is
+#: decoration.
+MIN_PER_BUCKET = 20
+
+#: And below this in total, the whole analysis declines. Three populated buckets are the minimum
+#: shape in which "it declines with context" is distinguishable from "one bucket is unlucky".
+MIN_TOTAL = 60
+
+#: Peak-context buckets, in prompt tokens. Wide and few on purpose: narrow buckets look precise and
+#: put five runs in each.
+BUCKETS: tuple[tuple[int, int], ...] = ((0, 8_000), (8_000, 32_000), (32_000, 128_000), (128_000, 2**31))
+
+
+def wilson(successes: int, total: int, z: float = 1.96) -> tuple[float, float]:
+    """Wilson score interval — the one that stays inside [0,1] at small n, unlike the normal
+    approximation that hands back a negative lower bound and makes a thin bucket look decisive."""
+    if total == 0:
+        return (0.0, 1.0)
+    phat = successes / total
+    denom = 1 + z * z / total
+    centre = (phat + z * z / (2 * total)) / denom
+    margin = z * math.sqrt((phat * (1 - phat) + z * z / (4 * total)) / total) / denom
+    return (max(0.0, centre - margin), min(1.0, centre + margin))
+
+
+@dataclass
+class Bucket:
+    low: int
+    high: int
+    runs: int = 0
+    successes: int = 0
+
+    @property
+    def rate(self) -> float | None:
+        """None below the floor. A rate computed from four runs is a number, not a measurement."""
+        return (self.successes / self.runs) if self.runs >= MIN_PER_BUCKET else None
+
+    def as_dict(self) -> dict[str, Any]:
+        low, high = wilson(self.successes, self.runs) if self.runs else (0.0, 1.0)
+        return {
+            "context_tokens": f"{self.low}–{'∞' if self.high >= 2**31 else self.high}",
+            "runs": self.runs,
+            "successes": self.successes,
+            "rate": self.rate,
+            "ci95": [round(low, 4), round(high, 4)] if self.runs >= MIN_PER_BUCKET else None,
+        }
+
+
+@dataclass
+class CurveResult:
+    buckets: list[Bucket] = field(default_factory=list)
+    joined: int = 0
+    traces_seen: int = 0
+    attempts_seen: int = 0
+    unjoinable_traces: int = 0
+    unjoinable_attempts: int = 0
+
+    @property
+    def enough(self) -> bool:
+        return self.joined >= MIN_TOTAL and sum(1 for b in self.buckets if b.rate is not None) >= 3
+
+    def verdict(self) -> str:
+        """What the numbers license, in one sentence — never more than that.
+
+        Three outcomes, and the first is the one this project keeps having to say out loud: there is
+        not enough data to answer. That is not a null result. A null result means the effect was
+        looked for and not found; this means nobody has looked yet, and reporting the two the same
+        way is how an absence of evidence gets published as evidence of absence.
+        """
+        if not self.enough:
+            return (
+                f"not enough data: {self.joined} joined run(s), "
+                f"{sum(1 for b in self.buckets if b.rate is not None)} bucket(s) above the floor "
+                f"(need {MIN_TOTAL} and 3). No claim either way."
+            )
+        rated = [b for b in self.buckets if b.rate is not None]
+        first, last = rated[0], rated[-1]
+        low_last, high_last = wilson(last.successes, last.runs)
+        low_first, high_first = wilson(first.successes, first.runs)
+        if high_last < low_first:
+            return (
+                f"success falls with context: {first.rate:.1%} in the smallest bucket vs "
+                f"{last.rate:.1%} in the largest, intervals disjoint."
+            )
+        if low_last > high_first:
+            return (
+                f"success RISES with context ({first.rate:.1%} -> {last.rate:.1%}), which is the "
+                "opposite of the expected effect and worth understanding before acting on either."
+            )
+        return (
+            f"no separation: {first.rate:.1%} vs {last.rate:.1%}, intervals overlap. On this data "
+            "compaction is not the lever to pull."
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict(),
+            "enough_data": self.enough,
+            "joined_runs": self.joined,
+            "traces_seen": self.traces_seen,
+            "attempts_seen": self.attempts_seen,
+            "unjoinable_traces": self.unjoinable_traces,
+            "unjoinable_attempts": self.unjoinable_attempts,
+            "min_per_bucket": MIN_PER_BUCKET,
+            "min_total": MIN_TOTAL,
+            "buckets": [b.as_dict() for b in self.buckets],
+        }
+
+
+def _rows(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            out.append(json.loads(line))
+        except ValueError:
+            continue  # a torn last line after a crash must not lose the file
+    return out
+
+
+def context_curve(traces: Path, runs: Path) -> CurveResult:
+    """Join the two logs on ``run_id`` and bucket the joined runs by peak context."""
+    peak_by_id = {
+        str(row.get("run_id") or ""): int(row.get("context_peak_tokens") or 0)
+        for row in _rows(traces)
+        if row.get("run_id")
+    }
+    result = CurveResult(buckets=[Bucket(low, high) for low, high in BUCKETS])
+    result.traces_seen = len(peak_by_id)
+
+    used: set[str] = set()
+    for run in _rows(runs):
+        for attempt in run.get("attempts") or []:
+            result.attempts_seen += 1
+            run_id = str(attempt.get("run_id") or "")
+            if not run_id or run_id not in peak_by_id:
+                result.unjoinable_attempts += 1
+                continue
+            used.add(run_id)
+            peak = peak_by_id[run_id]
+            # `success` on the ATTEMPT, not on the run: the run's flag is the last attempt's, and
+            # attributing a late success to the context of an early attempt would smear the very
+            # relationship being measured.
+            succeeded = bool(attempt.get("success"))
+            for bucket in result.buckets:
+                if bucket.low <= peak < bucket.high:
+                    bucket.runs += 1
+                    bucket.successes += int(succeeded)
+                    result.joined += 1
+                    break
+    result.unjoinable_traces = len(peak_by_id) - len(used)
+    return result

--- a/tests/test_context_curve.py
+++ b/tests/test_context_curve.py
@@ -1,0 +1,176 @@
+"""The curve, and the thing it must refuse to draw.
+
+This analysis exists to decide whether to build context compaction. The failure it is built against
+is not arithmetic — it is drawing a confident line through six data points and calling it a reason to
+spend two weeks. So most of what is tested here is the refusal: below the pre-registered floors it
+reports "not enough data" and makes no claim in either direction.
+
+That refusal is also its first real output. At the time of writing, the join returns zero rows on
+this machine and on the production VPS.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.eval.context_curve import MIN_PER_BUCKET, context_curve, wilson
+
+
+def _write(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _traces(path: Path, entries: list[tuple[str, int]]) -> None:
+    _write(path, [{"run_id": rid, "context_peak_tokens": peak} for rid, peak in entries])
+
+
+def _runs(path: Path, entries: list[tuple[str, bool]]) -> None:
+    _write(path, [{"attempts": [{"run_id": rid, "success": ok}]} for rid, ok in entries])
+
+
+# --- the refusal -------------------------------------------------------------------------------
+
+
+def test_no_data_is_not_a_null_result(tmp_path: Path) -> None:
+    """The distinction the whole file turns on. "The effect was looked for and not found" and
+    "nobody has looked yet" license completely different decisions, and only one of them is true
+    today."""
+    result = context_curve(tmp_path / "traces.jsonl", tmp_path / "runs.jsonl")
+
+    assert result.enough is False
+    assert "not enough data" in result.verdict()
+    assert result.joined == 0
+
+
+def test_a_thin_bucket_reports_no_rate_at_all(tmp_path: Path) -> None:
+    # Not a rate with a wide interval — no rate. A point estimate invites being quoted without it.
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    few = [(f"r{i}", 1_000) for i in range(MIN_PER_BUCKET - 1)]
+    _traces(traces, few)
+    _runs(runs, [(rid, True) for rid, _ in few])
+
+    result = context_curve(traces, runs)
+
+    assert result.buckets[0].runs == MIN_PER_BUCKET - 1
+    assert result.buckets[0].rate is None
+    assert result.enough is False
+
+
+def test_two_populated_buckets_are_still_not_enough(tmp_path: Path) -> None:
+    """With two, "it declines with context" cannot be told apart from "one bucket is unlucky"."""
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    entries = [(f"a{i}", 1_000) for i in range(30)] + [(f"b{i}", 20_000) for i in range(30)]
+    _traces(traces, entries)
+    _runs(runs, [(rid, i % 2 == 0) for i, (rid, _) in enumerate(entries)])
+
+    result = context_curve(traces, runs)
+
+    assert result.joined == 60
+    assert sum(1 for b in result.buckets if b.rate is not None) == 2
+    assert result.enough is False
+
+
+# --- what it says when there IS data -----------------------------------------------------------
+
+
+def _three_buckets(tmp_path: Path, rates: tuple[float, float, float], n: int = 40):
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    peaks = (1_000, 20_000, 60_000)
+    entries, outcomes = [], []
+    for band, (peak, rate) in enumerate(zip(peaks, rates, strict=True)):
+        for i in range(n):
+            rid = f"{band}-{i}"
+            entries.append((rid, peak))
+            outcomes.append((rid, i < round(rate * n)))
+    _traces(traces, entries)
+    _runs(runs, outcomes)
+    return context_curve(traces, runs)
+
+
+def test_a_clear_decline_is_reported_as_one(tmp_path: Path) -> None:
+    result = _three_buckets(tmp_path, (0.95, 0.60, 0.15))
+
+    assert result.enough is True
+    assert "falls with context" in result.verdict()
+
+
+def test_overlapping_intervals_are_reported_as_no_separation(tmp_path: Path) -> None:
+    # The outcome that would SAVE work: it says, in as many words, not to build the thing.
+    result = _three_buckets(tmp_path, (0.60, 0.58, 0.62))
+
+    assert result.enough is True
+    assert "no separation" in result.verdict()
+    assert "not the lever" in result.verdict()
+
+
+def test_the_opposite_effect_is_not_quietly_reported_as_a_decline(tmp_path: Path) -> None:
+    """A curve going the wrong way usually means the apparatus, not the phenomenon — and a report
+    that phrased it as "no decline found" would hide the surprise."""
+    result = _three_buckets(tmp_path, (0.15, 0.55, 0.95))
+
+    assert "RISES" in result.verdict()
+
+
+# --- the join ----------------------------------------------------------------------------------
+
+
+def test_unjoinable_rows_are_counted_not_dropped(tmp_path: Path) -> None:
+    """A silently dropped half of the data is how a real effect gets measured away — and every
+    receipt written before the run id exists is exactly that half."""
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    _traces(traces, [("known", 5_000), ("orphan", 9_000)])
+    _runs(runs, [("known", True), ("", False), ("missing", True)])
+
+    result = context_curve(traces, runs)
+
+    assert result.joined == 1
+    assert result.unjoinable_attempts == 2  # the empty id and the one with no trace
+    assert result.unjoinable_traces == 1  # "orphan" was never claimed by an attempt
+
+
+def test_it_scores_the_attempt_not_the_run(tmp_path: Path) -> None:
+    """A run's success flag is its LAST attempt's. Using it would credit a late success to the
+    context an early, failed attempt was carrying — smearing the very relationship measured."""
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    _traces(traces, [("first", 1_000), ("second", 1_000)])
+    runs.write_text(
+        json.dumps(
+            {
+                "success": True,
+                "attempts": [
+                    {"run_id": "first", "success": False},
+                    {"run_id": "second", "success": True},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = context_curve(traces, runs)
+
+    assert result.buckets[0].runs == 2
+    assert result.buckets[0].successes == 1, "the failed attempt was credited with the run's success"
+
+
+def test_a_torn_last_line_does_not_lose_the_file(tmp_path: Path) -> None:
+    # Append-only logs get truncated by crashes, and this one is written by a daemon.
+    traces, runs = tmp_path / "t.jsonl", tmp_path / "r.jsonl"
+    _traces(traces, [("a", 1_000)])
+    traces.write_text(traces.read_text(encoding="utf-8") + '{"run_id": "b", "cont', encoding="utf-8")
+    _runs(runs, [("a", True)])
+
+    assert context_curve(traces, runs).joined == 1
+
+
+# --- the interval ------------------------------------------------------------------------------
+
+
+def test_wilson_stays_inside_the_unit_interval_at_small_n() -> None:
+    """The normal approximation hands back a negative lower bound at 1/5 and makes a thin bucket
+    look decisive. That is precisely the shape this analysis must not produce."""
+    low, high = wilson(1, 5)
+
+    assert 0.0 <= low <= high <= 1.0
+    assert high - low > 0.4, "an interval this narrow at n=5 would be a fabrication"


### PR DESCRIPTION
Item 8 do plano — medir, no nosso próprio log, se a taxa de sucesso cai conforme o contexto cresce.
É o pré-requisito honesto para decidir se compactação vale o trabalho.

## A premissa do item era falsa, e verificar foi o primeiro trabalho

O plano dizia para rodar "sobre o `traces.jsonl` e o `runs.jsonl` que **já temos**". Não temos:

- `.chimera/traces.jsonl` **não existe** nesta máquina;
- `find /opt/data -name "*trace*"` na **VPS de produção** também não devolve nada;
- os 403 runs / 706 tentativas do `runs.jsonl` local são de antes de o recibo carregar tokens, e
  nenhum tem chave de junção.

O step log era escrito em 3 de ~15 sítios de construção, e nenhum deles era um caminho que roda
sozinho. Então a primeira saída honesta do `chimera context-curve` é **0 juntáveis de 706 reais** —
e a ferramenta diz isso, em vez de traçar uma linha por cima de nada.

## A distinção que ela existe para proteger

**Resultado nulo** significa que o efeito foi procurado e não achado — isso licenciaria deixar a
compactação sem construir. **Ausência de dado** significa que ninguém procurou, e não licencia nada.
O veredito diz isso com essas palavras.

Os pisos que produzem esse veredito — 20 tentativas juntadas por faixa, 60 no total, 3 faixas
povoadas — estão registrados em `bench/context_curve/PREREGISTRATION.md`, escrito **antes** de
qualquer dado existir. Não é cerimônia: com n=5 o intervalo de Wilson cobre quase todo o [0,1], e uma
estimativa pontual tirada dali é argumento para o que o autor já achava.

## Fechar a junção era a outra metade

O #69 deu `run_id` ao trace; o lado do recibo não tinha, então os dois logs continuavam sem se
juntar. `AttemptReceipt.run_id` fecha — lido do resultado do worker, como o `usd` ao lado. Uma
tentativa **é** uma run do agente, que **é** uma linha de trace: exatamente a granularidade da
pergunta.

O sucesso contado é o **da tentativa**, nunca o da run: o da run é o da última tentativa, e creditar
um sucesso tardio ao contexto de uma tentativa anterior borraria justamente a relação medida.

Linhas não-juntáveis dos dois lados são **contadas e impressas**. Todo recibo escrito até hoje é uma
delas, e meia base de dados descartada em silêncio é como um efeito real acaba medido para fora.

## Verificação

`ruff` e `mypy --strict` limpos em 299 arquivos · **2871 testes** (10 novos) · snapshot da CLI e
OpenAPI regerados · saída real conferida contra os 706 registros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)