### PR TITLE
feat(governance): someone on the other side of the gate

### DIFF
--- a/bench/injection/PREREGISTRATION.md
+++ b/bench/injection/PREREGISTRATION.md
@@ -61,6 +61,25 @@ This is the same configuration the roadmap proposes turning on for the 24/7 cron
 why that step is gated behind an observer mode: the refusal is returned as an ordinary observation
 string, so the job would finish "successfully" having done nothing.
 
+## Second measurement (2026-08-14, with an approver wired)
+
+The action the first measurement pointed at was "wire a real approver" — the `approve=` parameter
+existed at both layers and had no production caller. Done, and re-measured:
+
+| configuration | attacks blocked | over-block (all) | over-block (fetch) | gate |
+|---|---|---|---|---|
+| no approver (the shipped state) | 85.7% | 50% | 100% | **FAIL** |
+| approver that approves | **85.7%** | **0%** | **0%** | **pass** |
+
+The attack block rate does not move. That is the point of the change and the reason the approver is
+offered only to the benign arm: handing the same yes to the attack corpus would model a user who
+approves whatever an injected page asks for, which measures nothing about the defense.
+
+What this does **not** show is that approving is the right policy — only that the gate was empty
+rather than strict. `deny` remains the unattended default, and it is now a *recorded* deny: the run
+can say what it was not allowed to do, which is what makes a refusal distinguishable from a job that
+simply had nothing to do.
+
 ## What this does NOT license
 
 The obvious response is to loosen the narrowing until the gate goes green. That would be tuning to

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -2986,6 +2986,13 @@ def solve(
 
     meter = MeteredBackend(gateway, label="overhead")
 
+    # Built OUTSIDE `_run_solve` on purpose: the worktree path calls that function again on retry,
+    # and a ledger created inside it would be discarded along with the evidence of what the run was
+    # not allowed to do — which is the one fact this whole mechanism exists to keep.
+    from chimera.governance import ApprovalLedger, approver_for
+
+    approvals = ApprovalLedger()
+
     def _run_solve(ws: Path) -> AutonomousResult:
         from chimera.tools.write_region import WriteRegion
 
@@ -3020,11 +3027,19 @@ def solve(
             registry.register(
                 SubAgentTool(gateway, lambda: registry, model=model, max_turns=max_steps)
             )
+        # Someone on the other side of the gate. Both layers have accepted an approver since they
+        # were written and neither was ever given one, which measured out as 100% of dangerous-class
+        # calls refused on any run that read something external — the gate was never too strict,
+        # there was nothing behind it. `ask` degrades to `deny` without a terminal, and every
+        # decision is recorded so a refused run can be told apart from an idle one.
+        approve = approver_for(settings.approval_mode, approvals)
         if guard:
             from chimera.governance import TrustKernel, govern_registry
 
             registry = govern_registry(
-                registry, TrustKernel(audit=AuditLog(settings.home / "audit.jsonl"))
+                registry,
+                TrustKernel(audit=AuditLog(settings.home / "audit.jsonl")),
+                approve=approve,
             )
         ledger = None
         if taint:
@@ -3036,7 +3051,7 @@ def solve(
             # narrow_on_taint: once the run consumes untrusted content, dangerous tools
             # (shell/write/exec/email) require approval for the rest of the run (M9b).
             registry = ledger_registry(
-                registry, ledger, audit=allow_audit, narrow_on_taint=True
+                registry, ledger, audit=allow_audit, narrow_on_taint=True, approve=approve
             )
         # insist_on_action: solve is autonomous task completion, so a described-but-unexecuted plan
         # is pushed back to actually run — the fix for the worker narrating instead of acting.
@@ -3191,6 +3206,18 @@ def solve(
     console.print(result.answer)
     status = "[green]success[/green]" if result.success else "[red]failed[/red]"
     console.print(f"[dim]{status} after {len(result.attempts)} attempt(s)[/dim]")
+
+    # The loud half, and the reason the approver exists at all. A refused call comes back as an
+    # ordinary observation string, so the agent reads it like any tool result and carries on — the
+    # run ends in prose and the receipt says success. That is how a guardian reports green having
+    # guarded nothing. Saying it here costs one line and removes the whole failure mode.
+    if approvals.blocked:
+        console.print(f"[yellow]governance: {approvals.summary()}[/yellow]")
+        if result.success:
+            console.print(
+                "[yellow]…and this run was reported successful anyway — check that the work it "
+                "was asked to do actually happened.[/yellow]"
+            )
 
     # Close the ACE loop: reflect on this run's outcome (success or failure) and curate the
     # playbook with incremental deltas, so the next run starts from the improved guidance.

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -444,6 +444,19 @@ class Settings(BaseSettings):
     # position guardian silenced at 2 p.m. until midnight costs more than it saves.
     daily_usd_cap: float | None = Field(default=None, validation_alias="CHIMERA_DAILY_USD_CAP")
 
+    # Who says yes when governance escalates an action to review: `ask` | `deny` | `allow`.
+    #
+    # Both governance layers have taken an approver since they were written and never been given
+    # one, which measured out as 100% of dangerous-class calls refused on any run that read
+    # something external (bench/injection/PREREGISTRATION.md). The gate was never too strict —
+    # there was nothing on the other side of it.
+    #
+    # `ask` degrades to `deny` with no terminal attached, which is what a cron job has. Degrading
+    # the other way would make an unattended deployment the most permissive configuration in the
+    # product, which is backwards. `allow` exists for a workspace whose contents the owner already
+    # trusts, and every grant is recorded so the choice does not become invisible.
+    approval_mode: str = Field(default="ask", validation_alias="CHIMERA_APPROVAL")
+
     # Deployment-level tool allowlist/denylist (names). Empty allowlist = no restriction (all
     # tools); a non-empty allowlist grants only those. Denylist removes even if allowed.
     #

--- a/chimera/eval/injection.py
+++ b/chimera/eval/injection.py
@@ -313,7 +313,9 @@ def run_redteam(
     return report
 
 
-def run_benign(tasks: Iterable[BenignTask], *, defended: bool) -> BenignReport:
+def run_benign(
+    tasks: Iterable[BenignTask], *, defended: bool, approve: Any = None
+) -> BenignReport:
     """Run legitimate work through the SAME stack, and count what the defense destroyed.
 
     Deliberately identical to :func:`run_redteam` except for the corpus. A benign harness with its
@@ -331,7 +333,7 @@ def run_benign(tasks: Iterable[BenignTask], *, defended: bool) -> BenignReport:
         executed = {"hit": False}
         tool: Tool = _HarmfulTool(task.tool, executed)
         if defended:
-            tool = LedgeredTool(tool, ledger, narrow_on_taint=True)
+            tool = LedgeredTool(tool, ledger, narrow_on_taint=True, approve=approve)
         out = tool.run(**task.args)
         report.outcomes.append(
             BenignOutcome(
@@ -342,9 +344,14 @@ def run_benign(tasks: Iterable[BenignTask], *, defended: bool) -> BenignReport:
     return report
 
 
-def run_posture(*, defended: bool = True) -> PostureReport:
-    """Both corpora through the same stack — the only form in which either number is publishable."""
+def run_posture(*, defended: bool = True, approve: Any = None) -> PostureReport:
+    """Both corpora through the same stack — the only form in which either number is publishable.
+
+    ``approve`` is passed to the BENIGN arm only, and that asymmetry is the point: an approver is a
+    person deciding about work they asked for. Handing the same yes to the attack corpus would model
+    a user who approves whatever an injected page asks for, which measures nothing about the defense.
+    """
     return PostureReport(
         attacks=run_redteam(default_attacks(), defended=defended),
-        benign=run_benign(default_benign(), defended=defended),
+        benign=run_benign(default_benign(), defended=defended, approve=approve),
     )

--- a/chimera/governance/__init__.py
+++ b/chimera/governance/__init__.py
@@ -70,6 +70,9 @@ if TYPE_CHECKING:
 
 # Exported name -> (submodule, attribute). No renames here, but the shape matches chimera.eval's.
 _LAZY: dict[str, tuple[str, str]] = {
+    "ApprovalLedger": ("approval", "ApprovalLedger"),
+    "Approver": ("approval", "Approver"),
+    "approver_for": ("approval", "approver_for"),
     "ActorResult": ("actors", "ActorResult"),
     "ChangeProposal": ("actors", "ChangeProposal"),
     "FourActorGovernance": ("actors", "FourActorGovernance"),
@@ -158,6 +161,9 @@ __all__ = [
     "QuarantinedReader",
     "QuarantineResult",
     "fields_schema",
+    "ApprovalLedger",
+    "Approver",
+    "approver_for",
     "SkillValidator",
     "ScheduleValidator",
     "ValidationResult",

--- a/chimera/governance/approval.py
+++ b/chimera/governance/approval.py
@@ -1,0 +1,155 @@
+"""Who says yes — and, when nobody can, how the refusal gets heard.
+
+Both governance layers have taken an ``approve=`` callable since they were written, and neither has
+ever been given one. The consequence is measured rather than argued: with no approver, a run that
+reads anything external has **100%** of its dangerous-class calls refused
+(`bench/injection/PREREGISTRATION.md`). The gate was never too strict — there was simply nothing on
+the other side of it.
+
+**The failure this module is really built against is not the refusal, it is the silence.** A refused
+call returns an ordinary observation string, so the agent reads "[taint: needs review]" like any
+other tool result and carries on. The run finishes, the answer is prose, and the receipt says
+success. On the 24/7 path that means a position guardian reporting green while it guarded nothing —
+and that is indistinguishable, from outside, from a daemon that stopped.
+
+So every refusal is COUNTED, on the run, wherever it happens. An approver that denies loudly is a
+policy decision; an approver that denies invisibly is a bug with a configuration file.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("governance.approval")
+
+
+class _HasReason(Protocol):
+    reason: str
+
+
+@dataclass
+class ApprovalLedger:
+    """Every refusal and grant on one run, so a job can be asked how much it was allowed to do.
+
+    A list rather than a counter: "three writes were refused" is a different sentence from "three
+    writes were refused, all of them to the same file", and the second is the one that tells you
+    whether the run was blocked or merely nudged.
+    """
+
+    refused: list[str] = field(default_factory=list)
+    granted: list[str] = field(default_factory=list)
+
+    def record(self, action: str, approved: bool) -> None:
+        (self.granted if approved else self.refused).append(action[:200])
+
+    @property
+    def blocked(self) -> bool:
+        """True when anything at all was refused. The signal a caller must not be able to miss."""
+        return bool(self.refused)
+
+    def summary(self) -> str:
+        if not self.refused:
+            return ""
+        return f"{len(self.refused)} action(s) refused for review: " + "; ".join(
+            sorted(set(self.refused))[:5]
+        )
+
+
+#: The two layers ask in two shapes: the kernel passes ``(verdict, action)`` and the taint ledger
+#: passes ``(assessment,)``. One adapter takes both rather than two near-identical approvers that
+#: drift apart — the reason a caller can wire the same policy into both.
+Approver = Callable[..., bool]
+
+
+def _describe(*args: Any) -> tuple[str, str]:
+    """(action, reason) out of either call shape."""
+    if len(args) == 2:
+        verdict, action = args
+        return str(action), str(getattr(verdict, "reason", "") or "")
+    assessment = args[0] if args else None
+    return "", str(getattr(assessment, "reason", "") or "")
+
+
+def deny(ledger: ApprovalLedger | None = None) -> Approver:
+    """Refuse everything, and say so — the honest headless default.
+
+    Unattended, there is no one to ask, and inventing consent is the one answer that must never be
+    available. What changes versus having no approver at all is that the refusal is recorded, so the
+    caller can tell "the job did its work" from "the job was not allowed to".
+    """
+
+    def approve(*args: Any) -> bool:
+        action, reason = _describe(*args)
+        if ledger is not None:
+            ledger.record(action or reason, approved=False)
+        _log.warning("refused (no approver available): %s", reason or action)
+        return False
+
+    return approve
+
+
+def allow(ledger: ApprovalLedger | None = None) -> Approver:
+    """Grant everything. Opt-in, never a default, and still recorded.
+
+    For a batch on a workspace whose contents the owner already trusts — where the narrowing costs
+    more than it buys and that trade has been made deliberately. The record is what keeps it from
+    becoming invisible: a run that was allowed 40 dangerous actions should be able to say so.
+    """
+
+    def approve(*args: Any) -> bool:
+        action, reason = _describe(*args)
+        if ledger is not None:
+            ledger.record(action or reason, approved=True)
+        return True
+
+    return approve
+
+
+def ask(ledger: ApprovalLedger | None = None, *, stream: Any = None) -> Approver:
+    """Prompt a person. Anything other than an explicit yes is a no.
+
+    Default-deny on EOF, on a closed pipe, and on an unreadable answer — a prompt that treats
+    silence as consent is worse than no prompt, because it produces a record of an approval nobody
+    gave.
+    """
+
+    def approve(*args: Any) -> bool:
+        action, reason = _describe(*args)
+        out = stream or sys.stderr
+        try:
+            print(f"\n[governance] {reason or 'review required'}", file=out)
+            if action:
+                print(f"  action: {action[:300]}", file=out)
+            print("  allow this once? [y/N] ", end="", file=out, flush=True)
+            answer = input().strip().lower()
+        except (EOFError, OSError, KeyboardInterrupt):
+            answer = ""
+        approved = answer in ("y", "yes")
+        if ledger is not None:
+            ledger.record(action or reason, approved=approved)
+        return approved
+
+    return approve
+
+
+def approver_for(mode: str, ledger: ApprovalLedger | None = None) -> Approver:
+    """Build the approver for a configured mode: ``ask`` | ``deny`` | ``allow``.
+
+    ``ask`` degrades to ``deny`` with no terminal attached, which is what a cron job has. Degrading
+    the other way — falling back to allow because nobody could be asked — would turn an unattended
+    deployment into the most permissive configuration in the product, which is exactly backwards.
+    """
+    mode = (mode or "ask").strip().lower()
+    if mode == "allow":
+        return allow(ledger)
+    if mode == "deny":
+        return deny(ledger)
+    if not sys.stdin or not sys.stdin.isatty():
+        _log.info("approval mode 'ask' with no terminal: denying and recording")
+        return deny(ledger)
+    return ask(ledger)

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,199 @@
+"""The other side of the gate — and the silence it was hiding.
+
+Both governance layers have taken an ``approve=`` callable since they were written and neither was
+ever given one. The consequence is not an opinion: with no approver, `bench/injection` measures
+**100%** of dangerous-class calls refused on any run that read something external. The gate was
+never too strict; there was nothing behind it.
+
+The subtler failure is what a refusal looks like from outside. It comes back as an ordinary
+observation string, so the agent reads it like any tool result and carries on — the run ends in
+prose and the receipt says success. Most of this file is about making that countable.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from chimera.governance.approval import ApprovalLedger, allow, approver_for, ask, deny
+from chimera.governance.ledger import Decision, SequenceAssessment, TaintLedger
+from chimera.governance.ledger_tool import LedgeredTool
+from chimera.tools.base import Tool
+
+
+class _Writer(Tool):
+    name = "write_file"
+    description = "writes"
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, **kwargs: Any) -> str:
+        self.calls += 1
+        return "wrote it"
+
+
+def _assessment() -> SequenceAssessment:
+    return SequenceAssessment(True, Decision.REVIEW, "writes after reading untrusted content")
+
+
+# --- the policies -------------------------------------------------------------------------------
+
+
+def test_deny_refuses_and_records() -> None:
+    """Refusing is fine. Refusing invisibly is the bug — the caller has to be able to tell "the job
+    did its work" from "the job was not allowed to"."""
+    book = ApprovalLedger()
+
+    assert deny(book)(_assessment()) is False
+    assert book.blocked is True
+    assert "1 action(s) refused" in book.summary()
+
+
+def test_allow_grants_and_still_records() -> None:
+    # A run that was allowed forty dangerous actions should be able to say so. An opt-in that
+    # becomes invisible is how a deliberate trade turns into an accident nobody remembers making.
+    book = ApprovalLedger()
+
+    assert allow(book)(_assessment()) is True
+    assert book.granted and book.blocked is False
+
+
+def test_ask_treats_anything_but_yes_as_no(monkeypatch: Any) -> None:
+    """A prompt that reads silence as consent is worse than no prompt: it produces a record of an
+    approval nobody gave."""
+    for answer in ("", "n", "no", "maybe", "Y E S", "sure"):
+        monkeypatch.setattr("builtins.input", lambda a=answer: a)
+        book = ApprovalLedger()
+
+        assert ask(book, stream=io.StringIO())(_assessment()) is False, answer
+        assert book.blocked
+
+
+def test_ask_denies_when_the_input_is_closed(monkeypatch: Any) -> None:
+    # The cron case, reached by accident: stdin exists but hands back EOF.
+    def eof() -> str:
+        raise EOFError
+
+    monkeypatch.setattr("builtins.input", eof)
+    book = ApprovalLedger()
+
+    assert ask(book, stream=io.StringIO())(_assessment()) is False
+    assert book.blocked
+
+
+def test_ask_accepts_an_explicit_yes(monkeypatch: Any) -> None:
+    monkeypatch.setattr("builtins.input", lambda: "y")
+    book = ApprovalLedger()
+
+    assert ask(book, stream=io.StringIO())(_assessment()) is True
+
+
+# --- choosing one ------------------------------------------------------------------------------
+
+
+def test_ask_degrades_to_deny_without_a_terminal(monkeypatch: Any) -> None:
+    """The direction of the fallback is the whole decision. Degrading the other way — allowing
+    because nobody could be asked — would make an unattended deployment the most permissive
+    configuration in the product."""
+    monkeypatch.setattr("sys.stdin", io.StringIO())  # not a tty
+    book = ApprovalLedger()
+
+    assert approver_for("ask", book)(_assessment()) is False
+    assert book.blocked
+
+
+def test_allow_is_never_reached_by_accident(monkeypatch: Any) -> None:
+    # It has to be spelled out. No terminal, no default, no inference gets you here.
+    monkeypatch.setattr("sys.stdin", io.StringIO())
+
+    assert approver_for("", ApprovalLedger())(_assessment()) is False
+    assert approver_for("deny", ApprovalLedger())(_assessment()) is False
+    assert approver_for("allow", ApprovalLedger())(_assessment()) is True
+
+
+def test_both_call_shapes_reach_the_same_policy() -> None:
+    """The kernel asks with ``(verdict, action)`` and the taint ledger with ``(assessment,)``. One
+    adapter, or the same policy drifts into two implementations that disagree under pressure."""
+    book = ApprovalLedger()
+    approve = deny(book)
+
+    approve(_assessment())
+    approve(type("V", (), {"reason": "blocked by kernel"})(), "run_shell {'command': 'rm -rf /'}")
+
+    assert len(book.refused) == 2
+    assert any("rm -rf" in r for r in book.refused)
+
+
+# --- wired into the real tool -------------------------------------------------------------------
+
+
+def test_an_approved_call_actually_runs() -> None:
+    """The measurement this whole module answers: with an approver that says yes, legitimate work
+    after an external read completes instead of being refused."""
+    tainted = TaintLedger()
+    tainted.record_fetch("docs-site", content="the upgrade guide says set timeout to 30")
+    inner = _Writer()
+    tool = LedgeredTool(inner, tainted, narrow_on_taint=True, approve=allow())
+
+    out = tool.run(path="config/app.yml", content="timeout_seconds: 30")
+
+    assert inner.calls == 1
+    assert "needs review" not in out
+
+
+def test_without_an_approver_it_is_still_refused() -> None:
+    # The baseline that made this necessary, asserted so the fix cannot be mistaken for the gate
+    # having been loosened.
+    tainted = TaintLedger()
+    tainted.record_fetch("docs-site", content="the upgrade guide says set timeout to 30")
+    inner = _Writer()
+    tool = LedgeredTool(inner, tainted, narrow_on_taint=True)
+
+    out = tool.run(path="config/app.yml", content="timeout_seconds: 30")
+
+    assert inner.calls == 0
+    assert "needs review" in out
+
+
+def test_a_refusal_through_the_real_tool_is_counted() -> None:
+    """The bridge between the string the agent sees and the fact the caller needs. Without this the
+    refusal exists only inside an observation nobody parses."""
+    tainted = TaintLedger()
+    tainted.record_fetch("page", content="x")
+    book = ApprovalLedger()
+    tool = LedgeredTool(_Writer(), tainted, narrow_on_taint=True, approve=deny(book))
+
+    tool.run(path="a.py", content="x")
+
+    assert book.blocked, "the run was blocked and nothing outside the observation string knew"
+
+
+# --- the measurement that closes the loop -------------------------------------------------------
+
+
+def test_an_approver_recovers_the_honest_work_without_weakening_the_defense() -> None:
+    """The whole argument, in one comparison.
+
+    Without an approver the stack refuses 50% of legitimate work (100% of the runs that read
+    anything external) and the posture gate fails. With one, that goes to zero — and the attack
+    block rate does not move, because the approver is offered only to the benign arm.
+
+    That asymmetry is deliberate and worth stating: handing the same yes to the attack corpus would
+    model a user who approves whatever an injected page asks for, which measures nothing about the
+    defense and everything about the fiction.
+    """
+    from chimera.eval.injection import run_posture
+
+    without = run_posture(defended=True)
+    with_approver = run_posture(defended=True, approve=allow(ApprovalLedger()))
+
+    assert without.gate()[0] is False
+    assert with_approver.gate()[0] is True
+    assert without.benign.summary()["over_block_rate"] == 0.5
+    assert with_approver.benign.summary()["over_block_rate"] == 0.0
+    # Unchanged: the approver bought back the work, not the exposure.
+    assert (
+        with_approver.attacks.summary()["block_rate"] == without.attacks.summary()["block_rate"]
+    )


### PR DESCRIPTION
O portão nunca foi estrito demais — **não havia nada atrás dele**. Os dois níveis de governança
aceitam um `approve=` desde que foram escritos e nenhum jamais recebeu um. O bench de ontem pôs
número nisso: **100%** das chamadas de classe perigosa recusadas em qualquer run que leu algo externo.

## O número que fecha o argumento

| configuração | ataques bloqueados | over-block (total) | over-block (fetch) | portão |
|---|---|---|---|---|
| sem aprovador (estado atual) | 85,7% | 50% | 100% | **REPROVA** |
| com aprovador que aprova | **85,7%** | **0%** | **0%** | **passa** |

O bloqueio de ataques **não se move**. O aprovador é oferecido só ao braço benigno, de propósito:
entregar o mesmo "sim" ao corpus de ataque modelaria um usuário que aprova o que uma página injetada
pedir — o que não mede nada sobre a defesa.

## Três políticas, e a direção do fallback é a decisão inteira

- **`ask`** pergunta e trata qualquer coisa que não seja um "sim" explícito como não. Um prompt que
  lê silêncio como consentimento é pior que nenhum: produz registro de uma aprovação que ninguém deu.
- **Sem terminal** — que é o que um cron tem — `ask` degrada para **`deny`**. Degradar para o outro
  lado faria de um deploy não-supervisionado a configuração mais permissiva do produto.
- **`allow`** existe e precisa ser escrito. Nenhum default, nenhuma inferência e nenhum terminal
  ausente chega lá.

## A metade sutil é o silêncio

Uma chamada recusada volta como string de observação comum — o agente lê como qualquer resultado de
tool e segue. A run termina em prosa e o recibo diz sucesso. É assim que um guardião de posições
reporta verde sem ter guardado nada, e de fora isso é indistinguível de um daemon parado.

Agora toda decisão é registrada na run, e o `solve` diz quando algo foi recusado — mais alto ainda
quando a run foi reportada como bem-sucedida mesmo assim.

O ledger é construído **fora** do `_run_solve` porque o caminho de worktree chama aquela função de
novo no retry, e um ledger criado lá dentro seria descartado junto com a evidência do que a run não
teve permissão de fazer.

`deny` continua sendo o padrão não-supervisionado. O que mudou é que agora é um **deny registrado**.

## Verificação

`ruff` e `mypy --strict` limpos em 300 arquivos · **2907 testes** (12 novos) · snapshot da CLI
regerado · pré-registro do bench atualizado com a segunda medição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)