### PR TITLE
fix(server): refuse to serve an unauthenticated agent to the internet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ CHIMERA_TAINT_NARROW=1
 # reverse proxy in front). When set, requests need `Authorization: Bearer <token>`; the desktop UI
 # is handed the token automatically only for loopback clients, so a remotely-exposed instance stays
 # behind your own auth.
+# Bearer token for the HTTP gateway. EMPTY MEANS NO AUTHENTICATION — and `chimera serve` now
+# refuses to bind a reachable address without one, so this is the line that decides whether the
+# server can be published at all. Any long random string works.
 CHIMERA_SERVER_TOKEN=
 
 # Per-session tool allowlist/denylist (comma-separated tool names). An allowlist grants

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -3663,6 +3663,16 @@
           "type": "int"
         },
         {
+          "help": "Serve on a reachable address with no token. Only behind a network you already trust.",
+          "kind": "option",
+          "name": "allow_insecure_bind",
+          "opts": [
+            "--allow-insecure-bind"
+          ],
+          "required": false,
+          "type": "boolean"
+        },
+        {
           "help": "Override the model slug.",
           "kind": "option",
           "name": "model",

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1298,6 +1298,12 @@ def tui(
 def serve(
     host: str = typer.Option("127.0.0.1", "--host", help="Bind host."),
     port: int = typer.Option(8765, "--port", help="Bind port."),
+    allow_insecure_bind: bool = typer.Option(
+        False,
+        "--allow-insecure-bind",
+        envvar="CHIMERA_ALLOW_INSECURE_BIND",
+        help="Serve on a reachable address with no token. Only behind a network you already trust.",
+    ),
     model: str = typer.Option(None, "--model", "-m", help="Override the model slug."),
     max_steps: int = typer.Option(6, "--max-steps", help="Max tool-calling steps per message."),
     workspace: str = typer.Option(".", "--workspace", "-w", help="Workspace root for tools."),
@@ -1376,6 +1382,16 @@ def serve(
             profile=shared_profile,
             remember_from_chat=settings.remember_from_chat,
         )
+
+    # Before anything binds. A gateway that starts and then 401s has already told the internet
+    # there is a Chimera here, and still depends on every future transport remembering to ask.
+    from chimera.server import InsecureBindError, check_bind
+
+    try:
+        check_bind(host, token=settings.server_token, allow_insecure=allow_insecure_bind)
+    except InsecureBindError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
     message_gateway = MessageGateway(factory)
     a2a_pair = _build_a2a(backend, model, max_steps, workspace_path, host, port) if a2a else None

--- a/chimera/server/__init__.py
+++ b/chimera/server/__init__.py
@@ -4,6 +4,7 @@ The gateway routes per-chat messages into ChatSessions; adapters (local + Discor
 are its transports.
 """
 
+from chimera.server.bind import InsecureBindError, check_bind, is_loopback
 from chimera.server.discord_adapter import DiscordAdapter
 from chimera.server.gateway import (
     Adapter,
@@ -22,6 +23,9 @@ from chimera.server.telegram_adapter import TelegramAdapter
 from chimera.server.whatsapp import WhatsAppSender, WhatsAppWebhook
 
 __all__ = [
+    "InsecureBindError",
+    "check_bind",
+    "is_loopback",
     "InboundMessage",
     "MessageGateway",
     "MessagingManager",

--- a/chimera/server/bind.py
+++ b/chimera/server/bind.py
@@ -1,0 +1,62 @@
+"""Refuse to serve an unauthenticated agent to the internet.
+
+The shipped `docker-compose.yml` published `8765:8765` on every interface, `.env.example` left
+`CHIMERA_SERVER_TOKEN=` empty, and auth is opt-in — no token configured means no check. Follow the
+README's one-command deployment and the result is an agent gateway, with tools, answering anyone who
+finds the port. Nothing in that chain is a bug on its own; together they are the default.
+
+The check is on the BIND, not on the request, and that distinction is the design. Refusing per
+request would mean the port is open, the service is up, and every probe gets a polite 401 — which
+still tells an attacker there is a Chimera here and still depends on every future transport
+remembering to ask. Refusing to start means the failure happens once, on the operator's terminal,
+with the fix in the message.
+
+`0.0.0.0` behind an authenticating proxy is a legitimate deployment, so there is an explicit escape.
+Without one this correction would be a regression for everyone already running that way — and a
+guard people are forced to work around is a guard they learn to disable everywhere.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+#: Hosts that cannot receive a connection from another machine. `localhost` is resolved by name
+#: rather than assumed: it is the spelling almost everyone types, and on a normal machine it is
+#: exactly as private as the two addresses beside it.
+_LOOPBACK_NAMES = {"localhost", "localhost.localdomain", ""}
+
+
+class InsecureBindError(RuntimeError):
+    """Raised when a non-loopback bind is requested with no token and no explicit escape."""
+
+
+def is_loopback(host: str) -> bool:
+    """True when nothing outside this machine can reach a socket bound to ``host``."""
+    name = (host or "").strip().lower()
+    if name in _LOOPBACK_NAMES:
+        return True
+    try:
+        return ipaddress.ip_address(name).is_loopback
+    except ValueError:
+        # A hostname we cannot classify. Treated as reachable — the conservative direction, because
+        # the cost of being wrong here is an unauthenticated agent on a public interface, and the
+        # cost of being wrong the other way is one flag on the command line.
+        return False
+
+
+def check_bind(host: str, *, token: str | None, allow_insecure: bool = False) -> None:
+    """Raise :class:`InsecureBindError` for a reachable bind with no token.
+
+    Order matters: the escape is checked last so the message a person sees first is the problem
+    rather than the way around it.
+    """
+    if is_loopback(host) or (token or "").strip() or allow_insecure:
+        return
+    raise InsecureBindError(
+        f"refusing to serve on {host} with no CHIMERA_SERVER_TOKEN set.\n"
+        "  Anyone who can reach that address would get an agent with tools, unauthenticated.\n"
+        "  Fix it one of three ways:\n"
+        "    · set CHIMERA_SERVER_TOKEN (any long random string) and pass it as a bearer token\n"
+        "    · bind to 127.0.0.1 and reach it through a proxy that authenticates\n"
+        "    · pass --allow-insecure-bind if the network in front of this is already trusted"
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,11 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "8765:8765"          # HTTP gateway: POST /chat, POST /webhook/<hook>, GET /health
+      # LOOPBACK by default. `8765:8765` publishes on every interface, and with an empty
+      # CHIMERA_SERVER_TOKEN the gateway authenticates nobody — one `docker compose up` and an
+      # agent with tools is answering the internet. Put a proxy that authenticates in front, or
+      # set a token and change this line deliberately.
+      - "127.0.0.1:8765:8765" # HTTP gateway: POST /chat, POST /webhook/<hook>, GET /health
     volumes:
       - chimera-data:/data   # CHIMERA_HOME — agent state survives restarts
     # Default command runs the HTTP gateway + cron daemon. To also serve a chat platform,

--- a/tests/test_bind_guard.py
+++ b/tests/test_bind_guard.py
@@ -1,0 +1,73 @@
+"""The shipped default that put an unauthenticated agent on the public internet.
+
+Three things, each defensible alone: the compose published `8765:8765` on every interface,
+`.env.example` left the token empty, and auth is opt-in — no token configured means no check. Follow
+the README's one-command deployment and you get an agent with tools answering anyone who finds the
+port. Nobody chose that; it is what the three defaults compose into.
+
+The check is on the BIND rather than on the request, and that is the design. A gateway that starts
+and then 401s has already announced itself, and still depends on every future transport branch
+remembering to ask — which is exactly how the A2A streaming path once served an unauthenticated
+agent by short-circuiting ahead of the auth call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.server.bind import InsecureBindError, check_bind, is_loopback
+
+# --- what counts as reachable -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "127.0.0.53", ""])
+def test_loopback_is_recognised_by_name_and_by_number(host: str) -> None:
+    # `localhost` is the spelling almost everyone types, and on a normal machine it is exactly as
+    # private as the two addresses beside it. Missing it would make the guard fire on the safe case.
+    assert is_loopback(host) is True
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.10", "2.24.95.82", "chimera.example"])
+def test_anything_reachable_is_treated_as_reachable(host: str) -> None:
+    assert is_loopback(host) is False
+
+
+def test_an_unclassifiable_hostname_is_assumed_reachable() -> None:
+    """The conservative direction. Being wrong here costs one flag on a command line; being wrong
+    the other way costs an unauthenticated agent on a public interface."""
+    assert is_loopback("some-host-we-cannot-resolve") is False
+
+
+# --- the refusal --------------------------------------------------------------------------------
+
+
+def test_it_refuses_a_public_bind_with_no_token() -> None:
+    with pytest.raises(InsecureBindError) as caught:
+        check_bind("0.0.0.0", token="")
+
+    message = str(caught.value)
+    assert "CHIMERA_SERVER_TOKEN" in message
+    assert "--allow-insecure-bind" in message, "a refusal with no way forward is a wall, not a guard"
+
+
+def test_loopback_needs_no_token() -> None:
+    # The default, and it has to stay frictionless: a guard that fires on `chimera serve` with no
+    # arguments would be worked around by everyone within a week.
+    check_bind("127.0.0.1", token="")
+
+
+def test_a_token_is_what_makes_a_public_bind_legitimate() -> None:
+    check_bind("0.0.0.0", token="a-long-random-string")
+
+
+def test_whitespace_is_not_a_token() -> None:
+    # `CHIMERA_SERVER_TOKEN=" "` in an .env is a typo, not a decision.
+    with pytest.raises(InsecureBindError):
+        check_bind("0.0.0.0", token="   ")
+
+
+def test_the_escape_exists_because_a_trusted_proxy_is_a_real_deployment() -> None:
+    """Without it this correction is a regression for everyone already serving behind an
+    authenticating proxy — and a guard people must work around is one they learn to disable
+    everywhere."""
+    check_bind("0.0.0.0", token="", allow_insecure=True)


### PR DESCRIPTION
Item 1.4 do plano — e a investigação mudou de quem é o problema.

## O problema não é a sua VPS. É de quem baixa.

Antes de escrever qualquer linha, conferi a VPS de produção: o compose de lá **não tem seção
`ports:`**, o container só faz `EXPOSE 8765`, nenhum label de Traefik roteia para ele, e de fora só
**22 e 443** respondem. A regra de firewall que o plano pedia não tinha o que fechar.

O que está exposto é o **padrão distribuído**. Três defaults, cada um defensável sozinho:

- `docker-compose.yml` publicava `8765:8765` em **todas** as interfaces
- `.env.example` deixava `CHIMERA_SERVER_TOKEN=` vazio
- a autenticação é opt-in — sem token, sem checagem (`server/http.py:57`)

Quem segue o "one-command deployment" do README fica com um gateway de agente, **com ferramentas**,
respondendo a quem achar a porta. Ninguém escolheu isso; é no que os três defaults se somam.

## A checagem é no bind, não no request

Um gateway que sobe e depois devolve 401 já anunciou que existe um Chimera ali, e continua dependendo
de toda futura ramificação de transporte lembrar de perguntar — que é exatamente como o caminho de
streaming do A2A já serviu um agente sem autenticação, curto-circuitando antes da chamada de auth.
Recusar a subir põe a falha no terminal do operador **uma vez**, com o conserto na mensagem.

O `--allow-insecure-bind` existe porque `0.0.0.0` atrás de proxy autenticado é deploy legítimo. Sem
o escape isto seria regressão para quem já roda assim — e guarda que as pessoas são obrigadas a
contornar é guarda que elas aprendem a desligar em todo lugar.

O compose distribuído passa a publicar em `127.0.0.1` e diz por quê no próprio arquivo.

## O teste que não provou nada da primeira vez

`chimera serve --host 0.0.0.0` saiu no portão de credencial **antes** de chegar ao bind — a rodada
"passou" sem exercer a fiação. Com chave configurada, os três caminhos reais: recusa com exit 1 e as
três saídas; sobe com token; sobe com o escape.

`ruff` e `mypy --strict` limpos em 301 arquivos · **2923 testes** (16 novos) · snapshot da CLI
regerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)