### PR TITLE
feat(governance): the five unattended surfaces, and the state that comes before enforcing

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -35,6 +35,7 @@ from rich.table import Table
 
 from chimera import __version__
 from chimera.config import get_settings
+from chimera.governance import governed_profile
 
 if TYPE_CHECKING:
     from chimera.config import Settings
@@ -1371,7 +1372,12 @@ def serve(
     http_send_tool = SendMessageTool(push_senders) if push_senders.platforms() else None
 
     def factory() -> ChatSession:
-        registry = default_registry(workspace_path)
+        registry, _ = governed_profile(
+            default_registry(workspace_path),
+            settings=settings,
+            home=settings.home,
+            surface="serve",
+        )
         if http_send_tool is not None:
             registry.register(http_send_tool)
         runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
@@ -1719,9 +1725,18 @@ def _start_cron_daemon(
             if spent >= cap:
                 raise BudgetExceeded(f"daily cap reached: ${spent:.4f} of ${cap:.4f}")
 
+        # Governance on the path that runs unattended. In `observe` this refuses nothing and
+        # records what enforcement would have cost; the count is reported below, per job, which is
+        # the whole point of having a middle state.
+        job_registry, job_approvals = governed_profile(
+            default_registry(workspace),
+            settings=settings,
+            home=settings.home,
+            surface=f"cron:{job.name}",
+        )
         agent = Agent(
             backend,
-            default_registry(workspace),
+            job_registry,
             AgentConfig(
                 model=model,
                 max_steps=max_steps,
@@ -1746,10 +1761,30 @@ def _start_cron_daemon(
                 usd=result.usd,
             ),
         )
+        # Said out loud, on the job, every time. A governance decision that only exists inside an
+        # observation string is one nobody counts — and on this path "nobody counted" reads as a
+        # green tick over work that never happened.
+        if job_approvals.granted or job_approvals.refused:
+            touched = len(job_approvals.granted) + len(job_approvals.refused)
+            detail = job_approvals.summary() or (
+                f"{len(job_approvals.granted)} would be refused under enforce"
+            )
+            console.print(
+                f"[yellow]cron '{job.name}': governance touched {touched} action(s) — "
+                f"{detail}[/yellow]"
+            )
         return result.answer
 
     def run_task(task: str) -> str:
-        agent = Agent(backend, default_registry(workspace), AgentConfig(model=model, max_steps=max_steps))
+        """The job-less fallback. Governed too — it is reachable, and "reachable but forgotten" is
+        the exact shape of the hole this whole change closes."""
+        registry, _ = governed_profile(
+            default_registry(workspace),
+            settings=settings,
+            home=settings.home,
+            surface="cron:task",
+        )
+        agent = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         return agent.run(task).answer
 
     results_path = get_settings().home / "scheduler" / "cron_results.jsonl"
@@ -1844,7 +1879,17 @@ def _serve_mcp(
     from chimera.tools import default_registry
 
     def _solve(task: str) -> str:
-        registry = default_registry(workspace_path)
+        registry, _ = governed_profile(
+
+            default_registry(workspace_path),
+
+            settings=get_settings(),
+
+            home=get_settings().home,
+
+            surface="mcp",
+
+        )
         worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         auto = AutonomousAgent(
             worker,
@@ -1887,7 +1932,17 @@ def _build_a2a(
     from chimera.tools import default_registry
 
     def _solve(task: str) -> str:
-        registry = default_registry(workspace_path)
+        registry, _ = governed_profile(
+
+            default_registry(workspace_path),
+
+            settings=get_settings(),
+
+            home=get_settings().home,
+
+            surface="a2a",
+
+        )
         worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         auto = AutonomousAgent(
             worker, config=AutonomousConfig(max_attempts=2, use_planner=False, use_manager=False)
@@ -1931,7 +1986,17 @@ def _serve_platform(
     send_tool = SendMessageTool(senders)
 
     def factory() -> ChatSession:
-        registry = default_registry(workspace_path)
+        registry, _ = governed_profile(
+
+            default_registry(workspace_path),
+
+            settings=get_settings(),
+
+            home=get_settings().home,
+
+            surface="platform",
+
+        )
         registry.register(send_tool)
         runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         return ChatSession(runner, memory=memory, graph=graph)

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -457,6 +457,18 @@ class Settings(BaseSettings):
     # trusts, and every grant is recorded so the choice does not become invisible.
     approval_mode: str = Field(default="ask", validation_alias="CHIMERA_APPROVAL")
 
+    # Governance on the unattended surfaces (`serve`, cron, MCP, A2A, messaging): `off` | `observe`
+    # | `enforce`. Off by default, because turning it on changes what a running deployment is
+    # allowed to do and nobody should get that from an upgrade.
+    #
+    # `observe` runs the entire stack and refuses nothing, recording every action enforcement WOULD
+    # have refused. That middle state exists because the failure it guards against is silent: with
+    # narrowing on and no approver, a job that reads a feed cannot write for the rest of its run,
+    # the refusal arrives as an ordinary observation string, and the run reports success having done
+    # nothing. Going straight to `enforce` on a schedule that watches real positions is how that
+    # gets discovered in production instead of in a report.
+    governance_mode: str = Field(default="off", validation_alias="CHIMERA_GOVERNANCE")
+
     # Deployment-level tool allowlist/denylist (names). Empty allowlist = no restriction (all
     # tools); a non-empty allowlist grants only those. Denylist removes even if allowed.
     #

--- a/chimera/governance/__init__.py
+++ b/chimera/governance/__init__.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
 # Exported name -> (submodule, attribute). No renames here, but the shape matches chimera.eval's.
 _LAZY: dict[str, tuple[str, str]] = {
     "ApprovalLedger": ("approval", "ApprovalLedger"),
+    "governed_profile": ("profile", "governed_profile"),
     "Approver": ("approval", "Approver"),
     "approver_for": ("approval", "approver_for"),
     "ActorResult": ("actors", "ActorResult"),
@@ -162,6 +163,7 @@ __all__ = [
     "QuarantineResult",
     "fields_schema",
     "ApprovalLedger",
+    "governed_profile",
     "Approver",
     "approver_for",
     "SkillValidator",

--- a/chimera/governance/profile.py
+++ b/chimera/governance/profile.py
@@ -1,0 +1,109 @@
+"""One place that assembles a governed registry — and the observation mode that comes before it.
+
+Every surface used to build its own stack, and five of them built none at all: `serve`, the cron
+dispatch, the MCP server, the A2A endpoint and the messaging adapters all constructed
+`default_registry(workspace)` raw. `CHIMERA_TOOL_ALLOWLIST` had three call sites and none of them
+were these, which made `config.py`'s claim that the lists "apply on every surface" false for exactly
+the surfaces that run unattended.
+
+The fix is not more calls to remember. It is one function, plus a test that fails the build when a
+surface is assembled without it — because a convention held by discipline decays at the rate people
+join and leave a project, and this one is held by nobody at 3 a.m.
+
+**Observation before enforcement, and that ordering is a safety property rather than caution.** With
+`narrow_on_taint` on and no approver, a job that reads a news feed or a ticket becomes unable to
+write for the rest of its run — and the refusal arrives as an ordinary observation string, so the
+agent reads it, carries on, and the run reports success having done nothing. On a position guardian
+that is real money unwatched behind a green tick. So `observe` runs the whole stack, records every
+action that WOULD have been refused, and refuses none of them. Turning it to `enforce` is a decision
+someone makes with that count in front of them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from chimera.telemetry import get_logger
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pathlib import Path
+
+    from chimera.config import Settings
+
+_log = get_logger("governance.profile")
+
+#: What a surface asked for, so the answer can be audited later. Not a bool: "this surface has no
+#: governance" and "this surface was assembled in observe mode" are different states and the
+#: distinction is what the rollout is about.
+MODES = ("off", "observe", "enforce")
+
+
+def governed_profile(
+    registry: Any,
+    *,
+    settings: Settings,
+    home: Path,
+    mode: str = "",
+    allow: str | None = None,
+    deny: str | None = None,
+    surface: str = "",
+) -> tuple[Any, Any]:
+    """Wrap ``registry`` in the deployment's governance. Returns ``(registry, approvals)``.
+
+    The order is the same one `solve` has always used and it is load-bearing: the allowlist filters
+    first (a tool that is not there cannot be reasoned about), the kernel wraps next, and the taint
+    ledger is outermost so it sees the same calls the kernel does.
+
+    ``approvals`` is the ledger of what was refused or granted. A caller that throws it away is a
+    caller that cannot tell "the job did its work" from "the job was not allowed to" — which is the
+    failure this whole module exists to make impossible.
+    """
+    from chimera.governance import ApprovalLedger, TaintLedger, TrustKernel
+    from chimera.governance.approval import allow as allow_everything
+    from chimera.governance.approval import approver_for
+    from chimera.governance.governed_tool import govern_registry
+    from chimera.governance.ledger_tool import ledger_registry
+
+    resolved = (mode or settings.governance_mode or "off").strip().lower()
+    if resolved not in MODES:
+        _log.warning("unknown governance mode %r on %s: treating as 'off'", resolved, surface)
+        resolved = "off"
+
+    approvals = ApprovalLedger()
+    if resolved == "off":
+        return registry, approvals
+
+    from chimera.governance.audit import AuditLog
+
+    audit = AuditLog(home / "audit.jsonl")
+    # In observe mode the approver says yes to everything and writes down that it did. Every call
+    # that reaches an approver is one the policy WOULD have refused, so `approvals.granted` is
+    # exactly the report a rollout needs: what enforcement would have cost, per surface, measured
+    # rather than guessed.
+    approve = (
+        allow_everything(approvals)
+        if resolved == "observe"
+        else approver_for(settings.approval_mode, approvals)
+    )
+
+    from chimera.governance import restrict_registry
+
+    allow_names = (
+        [x.strip() for x in allow.split(",") if x.strip()]
+        if allow is not None
+        else (settings.tool_allowlist or None)
+    )
+    deny_names = (
+        [x.strip() for x in deny.split(",") if x.strip()]
+        if deny is not None
+        else list(settings.tool_denylist)
+    )
+    if allow_names is not None or deny_names:
+        registry = restrict_registry(registry, allow=allow_names, deny=deny_names, audit=audit)
+
+    registry = govern_registry(registry, TrustKernel(audit=audit), approve=approve)
+    registry = ledger_registry(
+        registry, TaintLedger(), audit=audit, narrow_on_taint=True, approve=approve
+    )
+    _log.info("governance %s on %s", resolved, surface or "(unnamed surface)")
+    return registry, approvals

--- a/tests/test_governed_surfaces.py
+++ b/tests/test_governed_surfaces.py
@@ -1,0 +1,215 @@
+"""Every unattended surface goes through the profile — enforced by the build, not by discipline.
+
+Five surfaces ran with no governance at all: `serve`, the cron dispatch, the MCP server, the A2A
+endpoint and the messaging adapters each built `default_registry(workspace)` raw. That was not a
+decision anyone made; it is what happens when the guarantee lives in a convention and the convention
+lives in whoever last edited the file.
+
+So the last test here parses `chimera/cli/main.py` and **fails the build** if any surface constructs
+a bare registry again. A grep would be the obvious way and the wrong one: it cannot tell an
+assembled registry from the string appearing in a docstring or a comment about the fix.
+
+The rest is the middle state. `observe` exists because going straight to enforcement on a schedule
+that watches real money is how a silent failure gets discovered in production rather than in a
+report — with narrowing on and no approver, a job that reads a feed cannot write for the rest of its
+run, and the refusal arrives as an ordinary observation string the agent reads and moves past.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import textwrap
+from typing import Any
+
+import pytest
+
+from chimera.config import Settings
+from chimera.governance.ledger import TaintLedger
+from chimera.governance.profile import governed_profile
+from chimera.tools.base import Tool
+from chimera.tools.registry import ToolRegistry
+
+MAIN = pathlib.Path(__file__).resolve().parents[1] / "chimera" / "cli" / "main.py"
+
+
+class _Writer(Tool):
+    name = "write_file"
+    description = "writes"
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, **kwargs: Any) -> str:
+        self.calls += 1
+        return "wrote"
+
+
+def _registry() -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(_Writer())
+    return registry
+
+
+def _settings(tmp_path: pathlib.Path, **kw: Any) -> Settings:
+    return Settings(CHIMERA_HOME=str(tmp_path), **kw)  # type: ignore[arg-type]
+
+
+# --- the three modes ----------------------------------------------------------------------------
+
+
+def test_off_is_a_no_op(tmp_path: pathlib.Path) -> None:
+    """The default has to change nothing. Governance arriving through an upgrade would alter what a
+    running deployment is allowed to do, which is not a thing an upgrade may decide."""
+    raw = _registry()
+
+    wrapped, approvals = governed_profile(raw, settings=_settings(tmp_path), home=tmp_path)
+
+    assert wrapped is raw
+    assert not approvals.granted and not approvals.refused
+
+
+def test_observe_refuses_nothing_and_counts_everything(tmp_path: pathlib.Path) -> None:
+    """The whole reason the middle state exists.
+
+    Every call that reaches an approver is one enforcement WOULD have refused. So the count after a
+    window in observe mode is exactly the price of turning it on — measured on the real schedule,
+    rather than guessed from the corpus.
+    """
+    registry, approvals = governed_profile(
+        _registry(), settings=_settings(tmp_path), home=tmp_path, mode="observe"
+    )
+    tool = registry.get("write_file")
+    # Make the run tainted the way a real job does: read something external first.
+    for wrapper in (tool, getattr(tool, "inner", None)):
+        ledger = getattr(wrapper, "ledger", None)
+        if isinstance(ledger, TaintLedger):
+            ledger.record_fetch("news-feed", content="the market moved")
+            break
+
+    out = tool.run(path="report.md", content="today's summary")
+
+    assert "needs review" not in out, "observe mode refused something"
+    assert approvals.granted, "observe mode refused nothing AND counted nothing — it saw nothing"
+
+
+def test_an_unknown_mode_is_off_rather_than_a_guess(tmp_path: pathlib.Path) -> None:
+    # A typo in an env var must not silently enable or silently disable something stricter than
+    # intended. Off is the state that changes nothing.
+    raw = _registry()
+
+    wrapped, _ = governed_profile(raw, settings=_settings(tmp_path), home=tmp_path, mode="enfroce")
+
+    assert wrapped is raw
+
+
+def test_enforce_actually_wraps(tmp_path: pathlib.Path) -> None:
+    registry, _ = governed_profile(
+        _registry(), settings=_settings(tmp_path), home=tmp_path, mode="enforce"
+    )
+
+    assert registry.get("write_file") is not None
+    assert type(registry.get("write_file")).__name__ != "_Writer", "nothing was wrapped"
+
+
+# --- the build gate -----------------------------------------------------------------------------
+
+
+#: The entry points that run with nobody watching. Named explicitly rather than "everything",
+#: because the distinction is the point: `run`, `chat` and `solve` are attended — a person is at the
+#: terminal, sees the tool calls, and can stop them — and `solve` additionally assembles its own
+#: stack with options this profile does not model (its own guard/taint flags, the late-bound
+#: subagent). Governing those by fiat here would be a refactor pretending to be a safety gate.
+UNATTENDED = ("serve", "_start_cron_daemon", "_serve_mcp", "_build_a2a", "_serve_platform")
+
+
+def _bare_registry_calls(tree: ast.Module, *, within: tuple[str, ...] = UNATTENDED) -> list[int]:
+    """Line numbers where an UNATTENDED surface builds `default_registry(...)` outside the profile.
+
+    An AST walk rather than a grep, because a grep cannot tell an assembled registry from the same
+    words inside a docstring — and this test exists precisely to survive the next person who writes
+    a comment about it. Nested functions count: `serve` builds its registry inside a `factory()`
+    closure, which is exactly where it went missing.
+
+    A call is legitimate when it is an argument to `governed_profile`.
+    """
+    scopes = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name in within
+    ]
+    governed: set[int] = set()
+    for scope in scopes:
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "governed_profile":
+                for arg in node.args:
+                    for inner in ast.walk(arg):
+                        if isinstance(inner, ast.Call):
+                            governed.add(id(inner))
+    bare = []
+    for scope in scopes:
+        for node in ast.walk(scope):
+            if (
+                isinstance(node, ast.Call)
+                and getattr(node.func, "id", "") == "default_registry"
+                and id(node) not in governed
+            ):
+                bare.append(node.lineno)
+    return sorted(bare)
+
+
+def test_no_unattended_surface_builds_a_registry_outside_the_profile() -> None:
+    """The test that makes the guarantee structural.
+
+    Five surfaces lost their governance not through a decision but through absence: each was written
+    at a different time and none of them called the thing the others called. A convention cannot fix
+    that. A build that fails can.
+    """
+    tree = ast.parse(MAIN.read_text(encoding="utf-8"))
+
+    bare = _bare_registry_calls(tree)
+
+    assert not bare, (
+        "an unattended surface assembles tools without governed_profile, at "
+        f"chimera/cli/main.py:{bare} — every unattended entry point has to go through the same "
+        "profile, or the deployment's allowlist and taint ledger are true only where someone "
+        "remembered"
+    )
+
+
+def test_the_gate_would_catch_a_regression() -> None:
+    """Proof the check is not vacuous: the same walk over a surface that DOES build one bare must
+    find it, including from inside a nested factory. Without this, an AST bug makes the gate pass
+    forever and the guarantee quietly stops existing."""
+    source = textwrap.dedent(
+        """
+        def serve():
+            def factory():
+                registry = default_registry(ws)
+        """
+    )
+
+    assert _bare_registry_calls(ast.parse(source), within=("serve",)) == [4]
+
+
+def test_the_gate_ignores_the_attended_commands() -> None:
+    # Otherwise it would demand a refactor of `solve` under the banner of a security fix — and a
+    # gate that fires on things it was not built to defend gets weakened until it fires on nothing.
+    source = textwrap.dedent(
+        """
+        def run():
+            registry = default_registry(ws)
+        """
+    )
+
+    assert _bare_registry_calls(ast.parse(source)) == []
+
+
+@pytest.mark.parametrize("surface", ["serve", "cron", "mcp", "a2a", "platform"])
+def test_each_named_surface_is_declared(surface: str) -> None:
+    # The `surface=` label is what makes an audit line answerable ("which entry point was that?").
+    # Cheap to drop while refactoring, and invisible once dropped.
+    body = MAIN.read_text(encoding="utf-8")
+
+    assert f'surface="{surface}' in body or f'surface=f"{surface}' in body


### PR DESCRIPTION
Fase 3 do plano — passos 1 e 2, **mais o modo observador**. O passo 3 (virar bloqueante em job
financeiro) fica como decisão sua, com número na mão, que é exatamente a condição que a crítica
adversarial impôs.

## O buraco

`serve`, o despacho de cron, o servidor MCP, o endpoint A2A e os adaptadores de mensagem montavam
`default_registry(workspace)` **cru**. O `CHIMERA_TOOL_ALLOWLIST` tinha três call sites e nenhum era
esses — então a afirmação do `config.py` de que as listas "apply on every surface" era falsa
justamente nas superfícies que rodam sem ninguém olhando.

Ninguém decidiu isso. É o que acontece quando a garantia mora numa convenção e a convenção mora em
quem editou o arquivo por último.

## O `observe` é o ponto desta mudança, não o `enforce`

Ligar fiscalização num agendamento que vigia posições reais é como uma falha silenciosa é descoberta
em produção: com o estreitamento ligado e sem aprovador, um job que lê um feed **não consegue mais
escrever** pelo resto da run — e a recusa chega como string de observação comum, que o agente lê e
ignora. A run termina em prosa e reporta sucesso.

Então o `observe` roda a pilha inteira, **não recusa nada**, e registra toda ação que a fiscalização
teria recusado. Como o aprovador só é chamado em escalonamento, cada chamada que chega nele é uma que
seria bloqueada — o total depois de uma janela é o **preço medido** de virar a chave. O cron reporta
isso por job.

O padrão é `off`, e tem de ser: governança chegando por upgrade mudaria o que um deploy em execução
pode fazer, e isso não é decisão de upgrade. Modo não reconhecido também é `off` — um typo não pode
ligar algo mais estrito do que se pretendia.

## A garantia é estrutural

Um teste parseia o `main.py` e **reprova o build** se uma superfície não-supervisionada voltar a
montar registry cru. AST e não grep: grep não distingue um registry montado das mesmas palavras num
docstring — e este teste precisa sobreviver à próxima pessoa que escrever um comentário sobre ele.

## Duas coisas que saíram de escrever o portão, não a feature

Ele sinalizou **14** sítios de início, porque exigia que todo comando passasse pelo perfil. `run`,
`chat` e `solve` são supervisionados, e o `solve` monta a própria pilha com opções que este perfil
não modela. Portão que dispara no que não foi feito para defender vai sendo enfraquecido até não
disparar em nada — então ele nomeia as cinco.

Estreitado, achou um **buraco real que eu tinha deixado**: o `run_task` de fallback do daemon de
cron, ainda cru.

## Verificação

`ruff` e `mypy --strict` limpos · **2935 testes** (12 novos) · snapshot da CLI regerado.

Três mutações: o `serve` voltando a montar cru (portão reprova), o `observe` passando a recusar de
verdade, e o `off` passando a envolver. Cada uma reprova o teste que a nomeia.

## Para rodar o observador na VPS

```bash
CHIMERA_GOVERNANCE=observe
```

Nada é recusado. Depois de uma janela, os avisos por job dizem quantas ações a fiscalização teria
barrado — e aí a decisão de virar para `enforce` tem base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)