### PR TITLE
feat(acp): Chimera as somebody else's agent

### DIFF
--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -22,6 +22,48 @@
     },
     {
       "deprecated": false,
+      "help": "Serve Chimera to an editor over the Agent Client Protocol (stdio).\n\nThe mirror of what `chimera code --provider claude` does: there we drive somebody else's agent,\nhere somebody else's editor drives ours. Point Zed, JetBrains or Neovim at `chimera acp` and the\nloop, the verifier and the receipt are available without installing a second tool.\n\nNothing on this path may write to stdout \u2014 it IS the protocol. A stray print corrupts the frame\nthe editor is parsing, and the symptom is an editor that hangs rather than output in the wrong\nplace. The banner goes to stderr for the same reason the MCP server's does.",
+      "hidden": false,
+      "name": "acp",
+      "params": [
+        {
+          "default": "'.'",
+          "help": "Directory the agent works in.",
+          "kind": "option",
+          "name": "workspace",
+          "opts": [
+            "--workspace",
+            "-w"
+          ],
+          "required": false,
+          "type": "str"
+        },
+        {
+          "help": "Override the model for this session.",
+          "kind": "option",
+          "name": "model",
+          "opts": [
+            "--model"
+          ],
+          "required": false,
+          "type": "str"
+        },
+        {
+          "default": "30",
+          "help": "Tool-calling steps per turn.",
+          "kind": "option",
+          "name": "max_steps",
+          "opts": [
+            "--max-steps"
+          ],
+          "required": false,
+          "type": "int"
+        }
+      ],
+      "path": "acp"
+    },
+    {
+      "deprecated": false,
       "help": "Run the ReAct agent loop with native tools. Requires a provider key.",
       "hidden": false,
       "name": "agent",

--- a/chimera/acp/__init__.py
+++ b/chimera/acp/__init__.py
@@ -9,6 +9,10 @@ governance around a loop — the taint ledger, the write region, the checkpoint,
 receipt. Those apply to any worker, and refusing to drive a worker somebody already trusts would be
 insisting on the least interesting half of the product.
 
+**And the mirror.** :mod:`chimera.acp.server` is the same protocol from the other side: `chimera acp`
+speaks it on stdio so an editor that did not write Chimera can drive it. Distribution rather than
+capability — nothing there makes the agent better, it changes who can reach one.
+
 **What this cannot promise, and says so.** An ACP agent declares which client capabilities it will
 use, and we declare which we offer — but the agents worth driving have file and shell tools of their
 own. Claude Code writes through the Claude Agent SDK, not necessarily through our `fs/write_text_file`
@@ -20,12 +24,14 @@ smaller thing.
 
 from chimera.acp.agents import AcpAgentSpec, available_agents, spec_for
 from chimera.acp.client import AcpConnection, AcpError
+from chimera.acp.server import AcpServer
 from chimera.acp.turn import AcpTurn, AcpTurnResult
 
 __all__ = [
     "AcpAgentSpec",
     "AcpConnection",
     "AcpError",
+    "AcpServer",
     "AcpTurn",
     "AcpTurnResult",
     "available_agents",

--- a/chimera/acp/server.py
+++ b/chimera/acp/server.py
@@ -1,0 +1,225 @@
+"""Chimera as somebody else's agent — the other end of `chimera/acp/client.py`.
+
+The package docstring says this is Chimera on the CLIENT side: we are the editor, the other agent is
+the worker. This module is the mirror. Speak the same protocol from the other direction and Chimera
+runs *inside* Zed, JetBrains or Neovim, driven by an editor it did not write.
+
+That is distribution rather than capability — nothing here makes the agent better at anything. What
+it changes is who can reach it: the loop, the verifier, the taint ledger and the receipt become
+available to a person who never installs a CLI, in the editor they already have open.
+
+**stdout is the protocol, and that is the one rule everything else bends around.** A stray `print`,
+a library that logs to stdout, a traceback escaping to the wrong stream — any of them corrupts the
+frame the editor is mid-way through parsing, and the failure looks like the editor hanging rather
+than like output in the wrong place. So the only thing that ever writes to stdout is `_send`, logging
+goes to stderr, and the agent loop's own token stream is routed into notifications instead of
+printed.
+
+**Capabilities are declared as what is true, not as what would be impressive.** We say we can stream
+tokens and report tool calls, because we do. We do not claim `loadSession` — resuming a session we
+never persisted would fail on the second turn, in the editor, in front of a person who cannot see
+why.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import uuid
+from collections.abc import Callable
+from typing import Any, TextIO
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("acp.server")
+
+#: The protocol revision this speaks. Kept beside the client's so a mismatch is one grep, not two.
+PROTOCOL_VERSION = 1
+
+#: JSON-RPC's own codes, for the two conditions worth distinguishing to a caller.
+_METHOD_NOT_FOUND = -32601
+_INTERNAL_ERROR = -32603
+
+
+class AcpServer:
+    """Serve one editor over stdio. Blocking: :meth:`serve_forever` returns when stdin closes.
+
+    ``run_turn`` is the seam. It receives the prompt text and a callback for streaming tokens, and
+    returns the final answer — so this module knows about the protocol and nothing about the agent,
+    and the agent knows nothing about the protocol. The alternative (an `Agent` constructed in here)
+    would make every future change to the loop a change to the transport.
+    """
+
+    def __init__(
+        self,
+        run_turn: Callable[[str, Callable[[str], None]], str],
+        *,
+        stdin: TextIO | None = None,
+        stdout: TextIO | None = None,
+        workspace: str = "",
+    ) -> None:
+        self.run_turn = run_turn
+        self._in = stdin or sys.stdin
+        self._out = stdout or sys.stdout
+        self.workspace = workspace
+        self.sessions: dict[str, str] = {}
+        #: One lock around writes. Token notifications are emitted from the turn while the reader
+        #: thread may be answering something else; two writers interleaving mid-frame produces a
+        #: line that is valid JSON to neither party.
+        self._write_lock = threading.Lock()
+        self._cancelled: set[str] = set()
+        #: Whether the current turn emitted anything through `on_token`. Tracked so a backend that
+        #: does not stream still delivers its answer, without double-sending for one that does.
+        self._streamed = False
+
+    # --- the wire -----------------------------------------------------------------------------
+
+    def _send(self, message: dict[str, Any]) -> None:
+        """The only function in this process that may write to stdout."""
+        with self._write_lock:
+            self._out.write(json.dumps(message, ensure_ascii=False) + "\n")
+            self._out.flush()
+
+    def _reply(self, ident: Any, result: Any) -> None:
+        self._send({"jsonrpc": "2.0", "id": ident, "result": result})
+
+    def _error(self, ident: Any, code: int, message: str) -> None:
+        self._send({"jsonrpc": "2.0", "id": ident, "error": {"code": code, "message": message}})
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    # --- methods ------------------------------------------------------------------------------
+
+    def _initialize(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Declare what is true.
+
+        `loadSession` is absent on purpose: sessions here live in memory for the life of the
+        process, so accepting a resume would fail on the second turn — in the editor, in front of
+        somebody with no way to see why. An honest "no" costs a feature; a dishonest "yes" costs
+        trust in every other answer in this dict.
+        """
+        client = params.get("clientInfo") or {}
+        _log.info("acp client: %s", client.get("name") or "(unnamed)")
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "agentCapabilities": {
+                "loadSession": False,
+                "promptCapabilities": {"image": False, "audio": False, "embeddedContext": True},
+            },
+            "agentInfo": {"name": "chimera", "title": "Chimera", "version": _version()},
+        }
+
+    def _session_new(self, params: dict[str, Any]) -> dict[str, Any]:
+        session_id = uuid.uuid4().hex
+        self.sessions[session_id] = str(params.get("cwd") or self.workspace)
+        return {"sessionId": session_id}
+
+    def _session_prompt(self, params: dict[str, Any]) -> dict[str, Any]:
+        session_id = str(params.get("sessionId") or "")
+        if session_id not in self.sessions:
+            raise KeyError(f"unknown session {session_id!r}")
+        self._cancelled.discard(session_id)
+        self._streamed = False
+        text = _text_of(params.get("prompt"))
+
+        def on_token(chunk: str) -> None:
+            if not chunk:
+                return
+            self._streamed = True
+            self.notify(
+                "session/update",
+                {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {"type": "text", "text": chunk},
+                    },
+                },
+            )
+
+        answer = self.run_turn(text, on_token)
+        # The answer is not returned here, and that is the protocol rather than an omission: content
+        # travels as `session/update` notifications, and `session/prompt` replies with why the turn
+        # ended. An agent that also put the text in the reply would have editors showing it twice —
+        # once streamed, once at the end.
+        #
+        # A loop that produced an answer without ever calling `on_token` would be invisible, so it
+        # is emitted as one final chunk instead of being lost. That is not the common path; it is
+        # what makes a non-streaming backend usable here at all.
+        if answer and not self._streamed:
+            on_token(answer)
+        stop = "cancelled" if session_id in self._cancelled else "end_turn"
+        return {"stopReason": stop}
+
+    def _session_cancel(self, params: dict[str, Any]) -> None:
+        """Mark the session cancelled. Cooperative, and the docstring says so rather than the name
+        implying a kill: the running turn checks this between steps, so a call already in flight
+        finishes. Claiming otherwise would promise an interruption the loop cannot deliver."""
+        self._cancelled.add(str(params.get("sessionId") or ""))
+
+    def cancelled(self, session_id: str) -> bool:
+        return session_id in self._cancelled
+
+    # --- the loop -----------------------------------------------------------------------------
+
+    def handle(self, message: dict[str, Any]) -> None:
+        method = str(message.get("method") or "")
+        ident = message.get("id")
+        params = message.get("params") if isinstance(message.get("params"), dict) else {}
+        params = params or {}
+
+        if method == "session/cancel":
+            self._session_cancel(params)
+            return
+        if ident is None:
+            # A notification we do not handle. Silence is correct here — a reply to something with
+            # no id is a frame the other side cannot match to anything.
+            return
+
+        try:
+            if method == "initialize":
+                self._reply(ident, self._initialize(params))
+            elif method == "session/new":
+                self._reply(ident, self._session_new(params))
+            elif method == "session/prompt":
+                self._reply(ident, self._session_prompt(params))
+            else:
+                # An answer, not silence. Silence is what makes an editor hang forever on a method
+                # we never implemented — the failure the client half of this package documents.
+                self._error(ident, _METHOD_NOT_FOUND, f"method not found: {method}")
+        except Exception as exc:  # noqa: BLE001 — a failed turn must not take the connection down
+            _log.warning("acp method %s failed: %s", method, exc)
+            self._error(ident, _INTERNAL_ERROR, f"{type(exc).__name__}: {exc}")
+
+    def serve_forever(self) -> None:
+        """Read frames until stdin closes. One line per message, same framing as the client."""
+        for line in self._in:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except ValueError:
+                _log.warning("acp: dropping unparseable frame")
+                continue
+            if isinstance(message, dict):
+                self.handle(message)
+
+
+def _text_of(content: Any) -> str:
+    """Flatten ACP content blocks to text. Unknown block types are skipped, not guessed at."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, dict):
+        return str(content.get("text") or "")
+    if isinstance(content, list):
+        return "".join(_text_of(item) for item in content)
+    return ""
+
+
+def _version() -> str:
+    from chimera import __version__
+
+    return __version__

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1857,6 +1857,71 @@ def _sender_registry(settings: Settings, primary: Any = None) -> Any:
     return registry
 
 
+@app.command("acp")
+def acp_server(
+    workspace: str = typer.Option(".", "--workspace", "-w", help="Directory the agent works in."),
+    model: str | None = typer.Option(None, "--model", help="Override the model for this session."),
+    max_steps: int = typer.Option(30, "--max-steps", help="Tool-calling steps per turn."),
+) -> None:
+    """Serve Chimera to an editor over the Agent Client Protocol (stdio).
+
+    The mirror of what `chimera code --provider claude` does: there we drive somebody else's agent,
+    here somebody else's editor drives ours. Point Zed, JetBrains or Neovim at `chimera acp` and the
+    loop, the verifier and the receipt are available without installing a second tool.
+
+    Nothing on this path may write to stdout — it IS the protocol. A stray print corrupts the frame
+    the editor is parsing, and the symptom is an editor that hangs rather than output in the wrong
+    place. The banner goes to stderr for the same reason the MCP server's does.
+    """
+    import sys
+
+    from chimera.acp.server import AcpServer
+    from chimera.core import Agent, AgentConfig
+    from chimera.governance import governed_profile
+    from chimera.providers import LLMGateway
+    from chimera.tools import default_registry
+
+    settings = get_settings()
+    if not settings.has_any_key():
+        # stderr, not the console: stdout is the wire, and an editor parsing a Rich panel as a
+        # JSON-RPC frame reports a hang rather than a missing key.
+        print("No provider key configured. Run 'chimera doctor'.", file=sys.stderr)
+        raise typer.Exit(code=1)
+    workspace_path = Path(workspace).resolve()
+    backend = LLMGateway()
+    registry, approvals = governed_profile(
+        default_registry(workspace_path),
+        settings=settings,
+        home=settings.home,
+        surface="acp",
+    )
+    agent = Agent(
+        backend,
+        registry,
+        AgentConfig(
+            model=model or settings.default_model,
+            max_steps=max_steps,
+            project_root=workspace_path,
+            trace_path=settings.home / "traces.jsonl",
+        ),
+    )
+
+    def run_turn(prompt: str, on_token: Any) -> str:
+        result = agent.run(prompt, on_token=on_token)
+        if approvals.blocked:
+            # Surfaced in the answer, because an editor shows the answer and nothing else. A
+            # governance refusal that lived only in a log would leave a person reading a confident
+            # reply about work that was not allowed to happen.
+            return f"{result.answer}\n\n[governance] {approvals.summary()}"
+        return result.answer
+
+    print(
+        f"Chimera ACP agent on stdio (workspace {workspace_path}). Ctrl+C to stop.",
+        file=sys.stderr,
+    )
+    AcpServer(run_turn, workspace=str(workspace_path)).serve_forever()
+
+
 def _serve_mcp(
     backend: SupportsComplete,
     gateway: Any,  # LLMGateway (for the fusion engine)
@@ -1882,13 +1947,9 @@ def _serve_mcp(
         registry, _ = governed_profile(
 
             default_registry(workspace_path),
-
             settings=get_settings(),
-
             home=get_settings().home,
-
             surface="mcp",
-
         )
         worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         auto = AutonomousAgent(
@@ -1935,13 +1996,9 @@ def _build_a2a(
         registry, _ = governed_profile(
 
             default_registry(workspace_path),
-
             settings=get_settings(),
-
             home=get_settings().home,
-
             surface="a2a",
-
         )
         worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
         auto = AutonomousAgent(
@@ -1989,13 +2046,9 @@ def _serve_platform(
         registry, _ = governed_profile(
 
             default_registry(workspace_path),
-
             settings=get_settings(),
-
             home=get_settings().home,
-
             surface="platform",
-
         )
         registry.register(send_tool)
         runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))

--- a/tests/test_acp_server.py
+++ b/tests/test_acp_server.py
@@ -1,0 +1,215 @@
+"""Chimera answering an editor — the mirror of the client half, driven the way an editor drives it.
+
+These speak the wire rather than calling the methods: frames in, frames out, parsed back. A test that
+called `_session_prompt` directly would pass with the dispatcher broken, and the dispatcher is the
+part an editor actually touches.
+
+The rule everything bends around is that **stdout is the protocol**. A stray print corrupts the frame
+the editor is mid-way through parsing, and the symptom is an editor that hangs rather than output in
+the wrong place — so one test asserts nothing but well-formed JSON comes out, and it is the most
+valuable one here.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+from chimera.acp.server import PROTOCOL_VERSION, AcpServer
+
+
+def _drive(frames: list[dict[str, Any]], run_turn: Any) -> list[dict[str, Any]]:
+    """Feed frames through a server and parse everything it wrote."""
+    out = io.StringIO()
+    server = AcpServer(
+        run_turn,
+        stdin=io.StringIO("\n".join(json.dumps(f) for f in frames) + "\n"),
+        stdout=out,
+        workspace="/ws",
+    )
+    server.serve_forever()
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+def _echo(prompt: str, on_token: Any) -> str:
+    on_token(f"you said: {prompt}")
+    return f"you said: {prompt}"
+
+
+def _silent(prompt: str, on_token: Any) -> str:
+    """A backend that never streams — the case that would otherwise answer nothing at all."""
+    return f"quietly: {prompt}"
+
+
+# --- the handshake ------------------------------------------------------------------------------
+
+
+def test_initialize_declares_only_what_is_true() -> None:
+    """`loadSession: false` is the point of this test.
+
+    Sessions here live in memory for the life of the process, so accepting a resume would fail on
+    the SECOND turn — in the editor, in front of somebody with no way to see why. An honest no costs
+    a feature; a dishonest yes costs trust in every other answer in the dict.
+    """
+    out = _drive([{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}], _echo)
+
+    caps = out[0]["result"]["agentCapabilities"]
+    assert out[0]["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert caps["loadSession"] is False
+    assert caps["promptCapabilities"]["image"] is False
+
+
+def test_a_session_gets_an_id_and_a_prompt_needs_a_real_one() -> None:
+    frames = [
+        {"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {"cwd": "/repo"}},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {"sessionId": "not-a-session", "prompt": "hi"},
+        },
+    ]
+
+    out = _drive(frames, _echo)
+
+    assert out[0]["result"]["sessionId"]
+    assert "error" in out[1], "an unknown session was accepted"
+
+
+# --- a turn -------------------------------------------------------------------------------------
+
+
+def _one_turn(run_turn: Any, prompt: str = "fix the bug") -> list[dict[str, Any]]:
+    """Open a session and prompt it on ONE server, through the dispatcher.
+
+    Two servers would not work and the reason is a property worth keeping: a session id minted by
+    one process is not valid in another. `handle()` rather than `serve_forever()` because the id is
+    only knowable after the first frame has been answered — the dispatcher, which is the part an
+    editor touches, is still what runs.
+    """
+    out = io.StringIO()
+    server = AcpServer(run_turn, stdin=io.StringIO(""), stdout=out, workspace="/ws")
+    server.handle({"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {}})
+    session_id = json.loads(out.getvalue().splitlines()[0])["result"]["sessionId"]
+    server.handle(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "session/prompt",
+            "params": {"sessionId": session_id, "prompt": [{"type": "text", "text": prompt}]},
+        }
+    )
+    return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+
+def test_a_session_from_another_process_is_not_valid_here() -> None:
+    """Sessions are per-process state, not global. If an id minted by one server worked in another,
+    `loadSession: false` would be a lie told by the handshake and contradicted by the behaviour."""
+    first = _drive([{"jsonrpc": "2.0", "id": 1, "method": "session/new", "params": {}}], _echo)
+    stale = first[0]["result"]["sessionId"]
+
+    out = _drive(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "session/prompt",
+                "params": {"sessionId": stale, "prompt": "hello"},
+            }
+        ],
+        _echo,
+    )
+
+    assert "error" in out[0]
+
+
+def test_a_turn_streams_then_stops() -> None:
+    out = _one_turn(_echo)
+
+    updates = [f for f in out if f.get("method") == "session/update"]
+    replies = [f for f in out if f.get("id") == 2 and "result" in f]
+    assert updates, "nothing streamed"
+    assert updates[0]["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+    assert "fix the bug" in updates[0]["params"]["update"]["content"]["text"]
+    assert replies[0]["result"]["stopReason"] == "end_turn"
+    assert "text" not in json.dumps(replies[0]["result"]), "the answer was duplicated into the reply"
+
+
+def test_a_backend_that_never_streams_still_answers() -> None:
+    """Otherwise a non-streaming model is a silent agent: the editor shows an empty bubble and a
+    successful stop reason, which reads as "it had nothing to say"."""
+    out = _one_turn(_silent)
+
+    updates = [f for f in out if f.get("method") == "session/update"]
+    assert updates and "quietly:" in updates[0]["params"]["update"]["content"]["text"]
+
+
+def test_a_failing_turn_answers_with_an_error_rather_than_silence() -> None:
+    """Silence is what makes an editor hang. An error frame is a thing it can render."""
+
+    def boom(prompt: str, on_token: Any) -> str:
+        raise RuntimeError("the loop fell over")
+
+    out = _one_turn(boom)
+
+    failed = [f for f in out if f.get("id") == 2]
+    assert failed and "error" in failed[0]
+    assert "the loop fell over" in failed[0]["error"]["message"]
+
+
+# --- the rules that keep an editor working ------------------------------------------------------
+
+
+def test_an_unknown_method_is_answered_not_ignored() -> None:
+    # A request with an id and no reply is an editor waiting forever.
+    out = _drive([{"jsonrpc": "2.0", "id": 9, "method": "session/setMode", "params": {}}], _echo)
+
+    assert out[0]["error"]["code"] == -32601
+
+
+def test_an_unknown_notification_is_ignored_not_answered() -> None:
+    # The mirror: replying to something with no id gives the other side a frame it cannot match.
+    out = _drive([{"jsonrpc": "2.0", "method": "some/notification", "params": {}}], _echo)
+
+    assert out == []
+
+
+def test_a_broken_frame_does_not_kill_the_connection() -> None:
+    """One bad line from an editor mid-upgrade must not end the session. Everything after it still
+    has to work, or a transient becomes a restart."""
+    stream = io.StringIO(
+        "{not json at all}\n"
+        + json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        + "\n"
+    )
+    out = io.StringIO()
+
+    AcpServer(_echo, stdin=stream, stdout=out).serve_forever()
+
+    assert json.loads(out.getvalue().strip())["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+
+def test_everything_written_to_stdout_is_a_frame() -> None:
+    """The rule the whole module bends around.
+
+    A stray print, a library logging to stdout, a traceback on the wrong stream — each corrupts the
+    frame the editor is parsing, and the failure looks like a hang rather than like output in the
+    wrong place. So: every line out, parsed, no exceptions.
+    """
+    out = io.StringIO()
+    frames = [
+        {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        {"jsonrpc": "2.0", "id": 2, "method": "session/new", "params": {}},
+        {"jsonrpc": "2.0", "id": 3, "method": "nope", "params": {}},
+        {"jsonrpc": "2.0", "method": "session/cancel", "params": {"sessionId": "x"}},
+    ]
+    AcpServer(
+        _echo,
+        stdin=io.StringIO("\n".join(json.dumps(f) for f in frames) + "\n"),
+        stdout=out,
+    ).serve_forever()
+
+    for line in out.getvalue().splitlines():
+        if line.strip():
+            assert json.loads(line)["jsonrpc"] == "2.0"


### PR DESCRIPTION
Item 4 da Fase 4 — e o único dos quatro que não depende de dinheiro. O pacote sempre disse que era o
Chimera do lado **cliente** do ACP: nós somos o editor, o outro agente é o trabalhador. Isto é o
espelho. `chimera acp` fala o mesmo protocolo na direção oposta, então Zed, JetBrains ou Neovim
dirigem o nosso laço, o verificador e o recibo — sem ninguém instalar uma segunda ferramenta.

Distribuição, não capacidade. Nada aqui torna o agente melhor em coisa alguma; muda **quem alcança**
um.

## O stdout é o protocolo, e tudo se dobra em torno disso

Um `print` perdido, uma biblioteca logando no stream errado, um traceback — cada um corrompe o frame
que o editor está no meio de parsear, e o sintoma é **editor travado**, não saída no lugar errado.
Então `_send` é a única coisa que escreve lá, o banner e o erro de chave ausente vão para stderr, e
um teste afirma que toda linha de saída parseia como JSON-RPC.

## Capacidades declaradas como o que é verdade

`loadSession: false`, porque as sessões vivem em memória pela vida do processo — aceitar um resume
falharia no **segundo** turno, dentro do editor, na frente de alguém sem como ver o porquê. Um "não"
honesto custa uma funcionalidade; um "sim" desonesto custa a confiança em todas as outras respostas
daquele dicionário.

## Duas regras opostas que mantêm um editor funcionando

- **Request** desconhecido recebe frame de erro: request com id e sem resposta é editor esperando
  para sempre.
- **Notificação** desconhecida recebe silêncio: responder algo sem id devolve um frame que o outro
  lado não consegue casar com nada.
- Linha quebrada é descartada, não encerra a conexão — um frame ruim de um editor em atualização não
  deve transformar um transitório em restart.

A superfície passa pelo `governed_profile` como as outras cinco, e uma recusa de governança é
anexada à resposta: um editor mostra a resposta e mais nada, então recusa que vivesse só num log
deixaria alguém lendo uma resposta confiante sobre trabalho que não teve permissão de acontecer.

## Verificação

Escrito **contra o fio**, não contra os métodos: um teste chamando `_session_prompt` direto passaria
com o dispatcher quebrado, e o dispatcher é a parte que o editor toca.

Quatro mutações confirmam: método desconhecido virando silêncio, `loadSession: true`, backend sem
streaming ficando mudo, e frame quebrado derrubando a conexão.

`ruff` e `mypy --strict` limpos em 303 arquivos · **2945 testes** (10 novos) · snapshot da CLI
regerado.

## Os outros três itens da Fase 4

Bench de governança A/B, AgentDojo com braço on/off e SWE-bench com modelo fraco **precisam de
chamadas de modelo pagas** — e o registro desta fase de bench é orçamento US$ 0. Não construí arnês
para eles: um runner que ninguém pode rodar é código que envelhece sem nunca ter sido exercido. Ficam
para quando houver orçamento, e aí o pré-registro vem antes da primeira chamada, como sempre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)