### PR TITLE
fix(api): the gateway must boot without the desktop extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.45.1] - 2026-08-14
+
+### Fixed
+
+- **The published Docker image crash-looped.** `Dockerfile` installs `.[full]`, which does not
+  include `desktop`, so the container that runs the 24/7 gateway has no FastAPI — and v0.45.0 put
+  `from chimera.api.usage import ...` on the cron path. Importing a leaf executes the package
+  `__init__`, which eagerly re-exported `build_api_app`, so a JSONL reader dragged in the whole web
+  stack: `ModuleNotFoundError: No module named 'fastapi'`, on boot, in a restart loop.
+  - Found by a deployment, not by us. The dev environment has FastAPI, so the import succeeds and
+    the bug is invisible to every test that was running.
+  - Fixed at the cause rather than the symptom. Adding `desktop` to the image would have worked,
+    made it heavier, contradicted the extra's own documented reason for existing — and left the trap
+    for the next leaf import. `chimera/api/__init__.py` now resolves its re-exports lazily, so
+    `chimera.api.usage`, `.roles`, `.sessions`, `.posture` and `.config_api` cost what they should.
+    `chimera app` still needs the extra and still fails loudly without it.
+  - The regression test runs in a subprocess with `fastapi` made unimportable, and starts by
+    asserting the block works — without that, every assertion after it would pass in an environment
+    that has FastAPI installed, which is exactly how this shipped.
+
 ## [0.45.0] - 2026-08-14
 
 The release after the editor, and it is about the other half of the product: the agent that runs

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.45.0"
+version = "0.45.1"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.45.0",
+  "generated_for": "0.45.1",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5064,7 +5064,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.45.0",
+  "generated_for": "0.45.1",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.45.0",
+  "generated_for": "0.45.1",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/chimera/api/__init__.py
+++ b/chimera/api/__init__.py
@@ -1,12 +1,51 @@
 """Desktop app backend: the FastAPI HTTP+SSE API the React frontend (``apps/desktop``) consumes.
 
-Opt-in (``pip install chimera-agent[desktop]``). Importing this package pulls FastAPI; the core CLI
-never imports it unless the user runs ``chimera app``.
+Opt-in (``pip install chimera-agent[desktop]``). This docstring used to say "the core CLI never
+imports it unless the user runs ``chimera app``" — and that stopped being true without anyone
+noticing, because **importing any leaf of this package executes this file**. `chimera.api.usage`,
+`chimera.api.roles`, `chimera.api.sessions`, `chimera.api.posture` and `chimera.api.config_api` hold
+nothing FastAPI-shaped, and the CLI reaches for all five; each one was silently dragging in the whole
+web stack.
+
+That shipped as a broken Docker image in v0.45.0. The Dockerfile installs `.[full]`, which does not
+include `desktop`, so the published gateway crash-looped on `ModuleNotFoundError: No module named
+'fastapi'` the moment the cron path imported the usage ledger. The obvious patch — adding `desktop`
+to the image — treats the symptom, makes the image heavier, and leaves the next leaf import to
+rediscover the same trap.
+
+So the eager re-exports are gone and `build_api_app` resolves on first attribute access. Importing
+`chimera.api.usage` now costs what reading a JSONL file should cost.
 """
 
 from __future__ import annotations
 
-from chimera.api.app import build_api_app
-from chimera.api.sessions import SessionManager, SessionMeta, SessionStore
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from chimera.api.app import build_api_app
+    from chimera.api.sessions import SessionManager, SessionMeta, SessionStore
+
+#: name -> (submodule, attribute). Resolved on demand by ``__getattr__``, so the cost of an import
+#: is the module you asked for and nothing else. Same shape as ``chimera.governance``.
+_LAZY: dict[str, tuple[str, str]] = {
+    "build_api_app": ("app", "build_api_app"),
+    "SessionManager": ("sessions", "SessionManager"),
+    "SessionMeta": ("sessions", "SessionMeta"),
+    "SessionStore": ("sessions", "SessionStore"),
+}
 
 __all__ = ["build_api_app", "SessionManager", "SessionMeta", "SessionStore"]
+
+
+def __getattr__(name: str) -> Any:
+    target = _LAZY.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    module_name, attribute = target
+    from importlib import import_module
+
+    return getattr(import_module(f"{__name__}.{module_name}"), attribute)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.45.0"
+version = "0.45.1"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a

--- a/tests/test_headless_imports.py
+++ b/tests/test_headless_imports.py
@@ -1,0 +1,130 @@
+"""The gateway must boot without the desktop extra installed.
+
+This is a regression test for a broken published image. The Dockerfile installs `.[full]`, which
+does not include `desktop`, so nothing FastAPI-shaped exists in the container that runs the 24/7
+gateway. v0.45.0 shipped with the cron path importing `chimera.api.usage` — a JSONL reader with no
+web anything in it — and because importing a leaf executes the package `__init__`, which eagerly
+re-exported `build_api_app`, the whole web stack came with it. The container crash-looped on
+`ModuleNotFoundError: No module named 'fastapi'`.
+
+Nothing in the normal suite could catch it: the dev environment has FastAPI, so the import succeeds
+and the bug is invisible. So these run in a **subprocess with `fastapi` made unimportable**, which is
+the cheap way to reproduce a smaller install without building one.
+
+The rule being defended: a module that does not serve HTTP must be importable without an HTTP
+framework. Adding `desktop` to the image would have made the symptom go away and left the trap for
+the next leaf import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+#: Makes `import fastapi` (and the rest of the desktop stack) raise, the way a `.[full]` container
+#: does — without needing one.
+_BLOCK = """
+import sys
+
+class _Blocked:
+    BLOCKED = ("fastapi", "starlette", "sse_starlette", "uvicorn")
+
+    def find_module(self, name, path=None):
+        return self if name.split(".")[0] in self.BLOCKED else None
+
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in self.BLOCKED:
+            raise ModuleNotFoundError(f"No module named {name.split('.')[0]!r}")
+        return None
+
+for _name in list(sys.modules):
+    if _name.split(".")[0] in _Blocked.BLOCKED:
+        del sys.modules[_name]
+sys.meta_path.insert(0, _Blocked())
+"""
+
+
+def _run(body: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", _BLOCK + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_the_block_actually_blocks() -> None:
+    """Without this the rest of the file proves nothing: if the guard silently let FastAPI through,
+    every assertion below would pass in a dev environment that has it installed."""
+    done = _run("import fastapi")
+
+    assert done.returncode != 0
+    assert "No module named 'fastapi'" in done.stderr
+
+
+def test_the_usage_ledger_imports_without_the_web_stack() -> None:
+    """The exact import the cron path makes, and the one that broke the published image."""
+    done = _run(
+        """
+        from chimera.api.usage import UsageRecord, append_usage, spent_today
+        print("ok", UsageRecord(model="m").model, callable(append_usage), callable(spent_today))
+        """
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert "ok m True True" in done.stdout
+
+
+def test_every_leaf_the_cli_reaches_for_imports_clean() -> None:
+    """The other four. Each holds nothing FastAPI-shaped and each was dragging in the whole stack,
+    so listing them here is what keeps the fix from decaying to the one module that hurt."""
+    done = _run(
+        """
+        import chimera.api.roles
+        import chimera.api.sessions
+        import chimera.api.posture
+        import chimera.api.config_api
+        print("ok")
+        """
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert "ok" in done.stdout
+
+
+def test_the_cron_daemon_starts_without_fastapi() -> None:
+    """End to end for the path that actually crash-looped: build the dispatch the cron daemon uses.
+
+    A test that only imported modules would have passed while the daemon still died, because the
+    failure was a transitive import inside a function body.
+    """
+    done = _run(
+        """
+        from chimera.scheduler import make_agent_dispatch
+        from chimera.api.usage import UsageRecord, append_usage, spent_today  # the cron's import
+        dispatch = make_agent_dispatch(lambda task: "ok")
+        print("ok", callable(dispatch))
+        """
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert "ok True" in done.stdout
+
+
+def test_the_desktop_api_still_needs_its_extra_and_says_so() -> None:
+    """The counterpart. `chimera app` genuinely needs FastAPI, and asking for it without the extra
+    must fail loudly — a lazy package that swallowed the error would turn a missing dependency into
+    a mysterious AttributeError at the first request."""
+    done = _run(
+        """
+        import chimera.api
+        try:
+            chimera.api.build_api_app
+        except ModuleNotFoundError as exc:
+            print("raised", "fastapi" in str(exc))
+        """
+    )
+
+    assert done.returncode == 0, done.stderr
+    assert "raised True" in done.stdout


### PR DESCRIPTION
A v0.45.0 embarcou uma **imagem Docker que entra em loop de restart**. Reportado por um deployment
real, não por nós.

## A causa, e não é a que o contorno sugere

O `Dockerfile` instala `.[full]`, que **não** inclui `desktop` — então o container que roda o gateway
24/7 não tem FastAPI. E a release pôs `from chimera.api.usage import ...` no caminho do cron.
Importar uma folha executa o `__init__` do pacote, que reexportava `build_api_app` de forma ansiosa:
um leitor de JSONL arrastava a pilha web inteira. `ModuleNotFoundError: No module named 'fastapi'`,
no boot, em loop.

**Por que 2.945 testes não viram:** o ambiente de desenvolvimento tem FastAPI, então o import
funciona e a falha é invisível.

## Corrigido na causa

Adicionar `desktop` à imagem funcionaria — e deixaria a imagem mais pesada, contradiria a razão de
existir declarada do próprio extra ("o CLI/gateway core nunca precisa disso") e deixaria a armadilha
armada para o próximo import de folha.

O `chimera/api/__init__.py` passa a resolver as reexportações preguiçosamente, no mesmo formato que
`chimera.governance` já usa. `chimera.api.usage`, `.roles`, `.sessions`, `.posture` e `.config_api`
voltam a custar o que deveriam. O `chimera app` continua precisando do extra e continua falhando alto
sem ele — os testes fixam isso.

A afirmação daquele docstring já era falsa havia tempo: cinco módulos-folha sem nada de FastAPI
dentro, todos alcançados pela CLI, cada um arrastando a pilha atrás. O que a v0.45.0 mudou foi pôr
**um deles no caminho de boot não-supervisionado**, onde deixou de ser latente.

## Verificação

O teste de regressão roda num subprocesso com `fastapi` tornado inimportável — a forma barata de
reproduzir uma instalação menor. **A primeira asserção dele é que o bloqueio funciona**: sem isso,
toda checagem seguinte passaria num ambiente que tem FastAPI, que é exatamente como isto foi parar
numa release.

E de ponta a ponta: instalação limpa `.[full]`, sem `desktop`, e `serve --cron` chega em
`gateway on http://127.0.0.1:8765` em vez de um traceback.

`ruff` e `mypy --strict` limpos · **2950 testes** (5 novos) · versão em **0.45.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)