### PR TITLE
fix(memory): the three stores that lost data without saying so

### DIFF
--- a/chimera/core/filelock.py
+++ b/chimera/core/filelock.py
@@ -1,0 +1,162 @@
+"""The two primitives the small JSON files Chimera keeps beside itself have to share.
+
+Several stores here follow the same shape: read the whole file into memory, mutate the structure,
+write it all back. Done naively that has two failure modes, and this module holds one answer for
+each so they cannot be solved in one store and forgotten in the next — which is exactly what had
+happened. :func:`atomic_write_text` covers the torn write; :func:`locked` covers the lost update.
+
+**The torn write.** ``path.write_text(...)`` truncates first and fills after. A kill or a full disk
+in between leaves a file that is neither the old contents nor the new, and for a whole-file JSON
+store that means every record is gone, not the last one. Writing to a fresh temp file in the same
+directory and renaming it over the target makes the switch a single atomic step.
+
+**The lost update.** Two writers each read the file, each mutate their own copy, each write it all
+back; the second one publishes a snapshot taken before the first one's change. Nothing raises,
+nothing logs, and the missing record looks like it was never added.
+
+Two writers is the normal case, not an exotic one. ``chimera serve`` runs the cron daemon in a
+background thread of the gateway process, and any ``chimera memory add`` typed over SSH while that
+is up is a second process against the same file.
+
+**Advisory, and only that.** It coordinates writers that both take the lock. A process that ignores
+it is not stopped, and nothing here protects a reader from seeing an older version — that job
+belongs to the atomic replace the stores already do.
+
+The lock lives in a **sibling** ``.lock`` file rather than the data file itself, because the data
+file gets replaced out from under any descriptor held on it. Locking the thing you are about to
+rename is locking a file nobody will be looking at a moment later.
+
+Degrading: if the lock cannot be created or taken, the body runs **unlocked** with a warning. A
+memory that fails to save is a worse outcome than a rare lost update, and with the atomic replace
+the failure mode without a lock is a lost record rather than a corrupt file.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Any, TypeVar
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("core.filelock")
+_T = TypeVar("_T")
+
+#: How long to keep retrying a rename or read that lost a race with another process, and the pause
+#: between attempts. Both are tiny because the window being retried is a single syscall — this is
+#: absorbing a collision, not waiting for anything.
+RETRY_ATTEMPTS = 20
+RETRY_PAUSE = 0.01
+
+
+def retrying(action: Callable[[], _T]) -> _T:
+    """Run ``action``, retrying briefly while the OS says the file is busy.
+
+    POSIX renames a file over an open one without complaint; Windows refuses while any handle is
+    open, so a reader that happens to be mid-read makes an unrelated writer's ``os.replace`` raise
+    ``PermissionError``. Readers in these stores deliberately take no lock, which leaves exactly
+    that window — small, and reached only under two processes, but reached, and observed.
+
+    Retrying is the right shape rather than locking the readers: recall waiting on a writer would
+    be a real cost for a collision measured in microseconds. After the last attempt the error is
+    raised unchanged, because a permission problem that outlives the window is not a race.
+    """
+    for _ in range(RETRY_ATTEMPTS - 1):
+        try:
+            return action()
+        except PermissionError:  # pragma: no cover - Windows-only timing
+            time.sleep(RETRY_PAUSE)
+    return action()
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Replace ``path``'s contents in one step, or leave the previous contents untouched.
+
+    The temp file is unique per call rather than a fixed ``<name>.tmp``. A shared name means two
+    writers that both got past the lock — the degraded path, or a process that never took it —
+    interleave inside the *same* temp file, and the rename then publishes a mixture of two
+    serialisations rather than either one of them. Same directory, because ``os.replace`` is only
+    atomic within a filesystem.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        retrying(lambda: os.replace(tmp_name, path))
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+def read_text(path: Path) -> str:
+    """Read a file that another process may be replacing under us. Empty string when absent."""
+    if not path.exists():
+        return ""
+    return retrying(lambda: path.read_text(encoding="utf-8"))
+
+if sys.platform == "win32":  # pragma: no cover - platform split, both halves ship
+    import msvcrt
+
+    def _acquire(handle: IO[Any]) -> None:
+        # Locks one byte at offset 0. LK_LOCK retries for ~10s and then raises, which is the right
+        # direction: a writer that cannot get in should say so rather than hang a 24/7 process.
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+
+    def _release(handle: IO[Any]) -> None:
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:  # the handle is about to close anyway
+            _log.debug("unlock failed for %s", handle)
+
+else:  # pragma: no cover - platform split, both halves ship
+    import fcntl
+
+    def _acquire(handle: IO[Any]) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+    def _release(handle: IO[Any]) -> None:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def locked(path: Path) -> Iterator[bool]:
+    """Hold an exclusive advisory lock for ``path`` while the body runs.
+
+    Yields whether a real lock was taken, so a caller that wants to record degraded operation can.
+    Both flavours release on process death, so a writer killed mid-update does not wedge the file
+    for everyone else — which is why this uses OS locks rather than an exclusive-create lockfile.
+    """
+    lock_path = Path(str(path) + ".lock")
+    handle: IO[Any]
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "a+b")  # noqa: SIM115 - closed in the finally below
+    except OSError as exc:
+        # Read-only directory, exhausted descriptors, a path that is not writable. None of these
+        # should stop the write itself.
+        _log.warning("could not open lock for %s (%s); writing unlocked", path.name, exc)
+        yield False
+        return
+
+    try:
+        try:
+            handle.write(b"\0")  # msvcrt needs a byte at offset 0 to lock
+            handle.flush()
+            os.lseek(handle.fileno(), 0, os.SEEK_SET)
+            _acquire(handle)
+        except OSError as exc:
+            _log.warning("could not lock %s (%s); writing unlocked", path.name, exc)
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            _release(handle)
+    finally:
+        handle.close()

--- a/chimera/ecosystem/trajectory.py
+++ b/chimera/ecosystem/trajectory.py
@@ -4,6 +4,16 @@ Records (prompt, response, outcome) trajectories from agent runs and exports the
 SFT or DPO datasets. Actual fine-tuning (LoRA/SFT/DPO) is intentionally **opt-in and
 external** — Chimera collects the data and gets out of the way; nothing here trains a
 model or changes weights automatically.
+
+Two things this file used to get wrong, both of the family where **data disappears and nothing
+complains**. ``load()`` validated every line with no guard, so one truncated or schema-drifted
+record — a kill mid-append, a field added in a later version — raised out of the constructor and
+took every ``chimera evolve`` command with it, including the ones whose whole job is to tell you
+what the history holds. And the log grew without a ceiling in either direction: unbounded on disk,
+and fully resident in memory on open.
+
+``chimera/memory/store.py`` had already learned the first half and written the reason down. The
+lesson had simply never crossed to the file next door.
 """
 
 from __future__ import annotations
@@ -12,9 +22,24 @@ import json
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
+
+from chimera.core.filelock import read_text
+from chimera.telemetry import get_logger
+
+_log = get_logger("ecosystem.trajectory")
 
 Outcome = Literal["success", "failure", "unknown"]
+
+#: Rotate the log once it passes this, keeping exactly one previous generation. Same policy and
+#: same reasoning as the step trace: rename rather than trim, because rewriting to drop old lines
+#: has to read all of it and a crash mid-rewrite loses the whole history instead of its oldest part.
+MAX_TRAJECTORY_BYTES = 64 * 1024 * 1024
+
+#: How many trajectories stay resident. Curation and export read the tail — the recent runs are the
+#: ones that describe the agent as it is now — so an older prefix on disk is not lost, just not
+#: carried in memory. Both numbers are here rather than inline so a deployment can say what it wants.
+MAX_RESIDENT = 50_000
 
 
 class Trajectory(BaseModel):
@@ -38,21 +63,72 @@ class Trajectory(BaseModel):
         return step_following_score(self.events)
 
 
+def _rotate_if_large(path: Path) -> None:
+    """Move the log aside once it passes the cap, keeping exactly one previous generation.
+
+    Rename rather than trim, for the reason the step trace gives: rewriting the file to drop old
+    lines has to read all of it, and a crash mid-rewrite loses the whole history instead of the
+    oldest part of it. A rotation that fails must not take the run down — the trajectory is evidence
+    about the work, not the work.
+    """
+    try:
+        if path.exists() and path.stat().st_size >= MAX_TRAJECTORY_BYTES:
+            path.replace(path.with_suffix(path.suffix + ".1"))
+    except OSError as exc:  # pragma: no cover - disk-shaped failure
+        _log.warning("could not rotate %s: %s", path.name, exc)
+
+
 class TrajectoryCollector:
     """A JSONL-backed append-only log of trajectories, exportable for training."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, max_resident: int = MAX_RESIDENT) -> None:
         self.path = Path(path)
+        self.max_resident = max_resident
         self._items: list[Trajectory] = []
+        #: Next sequence number to hand out. Tracked separately from ``len(self._items)`` because
+        #: the resident window can be smaller than the history: numbering from the length would
+        #: restart mid-file and hand two different runs the same seq.
+        self._next_seq = 0
+        self.skipped = 0
         self.load()
 
     def load(self) -> None:
+        """Read the log, skipping any line that will not parse.
+
+        A malformed record is a thing that happens — a process killed between the write and the
+        newline, a field that changed shape across versions, a hand edit. Letting one of those abort
+        the load makes the entire history unreadable, which is a strictly worse outcome than losing
+        the one line, and it fails in the commands you would reach for to diagnose it.
+
+        The count of skips is kept on ``self.skipped`` rather than only logged, so a caller can say
+        "997 of 1000" instead of quietly reporting 997 as if that were all there ever was.
+        """
         self._items = []
+        self.skipped = 0
+        highest = -1
         if not self.path.exists():
+            self._next_seq = 0
             return
-        for line in self.path.read_text(encoding="utf-8").splitlines():
-            if line.strip():
-                self._items.append(Trajectory.model_validate_json(line))
+        for number, line in enumerate(read_text(self.path).splitlines(), start=1):
+            if not line.strip():
+                continue
+            try:
+                item = Trajectory.model_validate_json(line)
+            except ValidationError as exc:
+                self.skipped += 1
+                _log.warning("skipping malformed trajectory at line %d: %s", number, exc)
+                continue
+            highest = max(highest, item.seq)
+            self._items.append(item)
+        # Keep only the tail in memory. The prefix stays on disk and is still there for anything
+        # that wants to read the file directly; what it is not is resident in a long-lived process.
+        if len(self._items) > self.max_resident:
+            _log.info(
+                "trajectory log holds %d records; keeping the most recent %d in memory",
+                len(self._items), self.max_resident,
+            )
+            self._items = self._items[-self.max_resident :]
+        self._next_seq = highest + 1
 
     def record(
         self,
@@ -67,7 +143,7 @@ class TrajectoryCollector:
         diff_summary: str | None = None,
     ) -> Trajectory:
         item = Trajectory(
-            seq=len(self._items),
+            seq=self._next_seq,
             prompt=prompt,
             response=response,
             outcome=outcome,
@@ -77,8 +153,12 @@ class TrajectoryCollector:
             diff_productive=diff_productive,
             diff_summary=diff_summary,
         )
+        self._next_seq += 1
         self._items.append(item)
+        if len(self._items) > self.max_resident:
+            del self._items[0]
         self.path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_if_large(self.path)
         with self.path.open("a", encoding="utf-8") as handle:
             handle.write(item.model_dump_json() + "\n")
         return item

--- a/chimera/evolution/experience.py
+++ b/chimera/evolution/experience.py
@@ -3,20 +3,44 @@
 Records each autonomous attempt and its outcome. Failures become negative examples
 and successes become positive ones (per HORIZON), so future runs can learn from past
 attempts. v1 is a simple JSON-backed log; the evolution engine (M4) builds on it.
+
+This one is written from ``AutonomousLoop`` after every attempt, which puts it on the 24/7 path,
+and its ``save()`` used to be a bare ``write_text``. That truncates before it fills, so a kill or a
+full disk during the write leaves a file that is neither the old contents nor the new — and because
+the whole buffer is one JSON array, the loss is **every** lesson ever recorded, not the last one.
+An unattended agent restarted at the wrong moment would come back with no history and no error to
+explain where it went.
+
+Three of the four fixes here are the same ones :mod:`chimera.memory.store` already carried, which
+is the actual lesson: whole-file JSON stores share a failure family, so the primitives now live in
+one place (:mod:`chimera.core.filelock`) instead of being rediscovered per store. The fourth is
+this file's own — ``load()`` parsed the array in one call, so one bad record made the whole buffer
+unreadable, and the ``all()`` in ``chimera evolve`` is where you would find out.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import threading
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+
+from chimera.core.filelock import atomic_write_text, locked, read_text
+from chimera.telemetry import get_logger
+
+_log = get_logger("evolution.experience")
 
 Outcome = Literal["success", "failure"]
 
 _WORD = re.compile(r"[a-z0-9]+")
+
+#: How many attempts stay in the buffer. ``relevant()`` scores every entry on every planning step,
+#: so this is a latency ceiling as much as a memory one, and the oldest attempts are the least
+#: likely to describe the agent as it is now. Dropping the head is deliberate and logged.
+MAX_EXPERIENCES = 20_000
 
 
 def _tokens(text: str) -> set[str]:
@@ -35,27 +59,89 @@ class Experience(BaseModel):
 class ExperienceBuffer:
     """A JSON-backed, append-only log of attempts."""
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path, *, max_items: int = MAX_EXPERIENCES) -> None:
         self.path = Path(path)
+        self.max_items = max_items
         self._items: list[Experience] = []
+        #: Next sequence number. Tracked rather than derived from ``len(self._items)`` because the
+        #: buffer is capped: numbering from the length would restart once the head is dropped and
+        #: hand two different attempts the same seq, which ``relevant()`` uses as its tiebreak.
+        self._next_seq = 0
+        self._lock = threading.RLock()
+        self.skipped = 0
         self.load()
 
     def load(self) -> None:
+        """Read the buffer, skipping any record that will not validate.
+
+        Per record, not per file. Validating the array in one call means a single entry with a
+        field from another version makes every other lesson unreadable — and the commands you would
+        reach for to look at the history are the ones that fail.
+
+        A file that is not JSON at all is a different case and is reported as an empty buffer with a
+        warning rather than an exception, because the alternative is an autonomous loop that will
+        not start.
+        """
         self._items = []
-        if not self.path.exists():
+        self.skipped = 0
+        raw_text = read_text(self.path)
+        if not raw_text.strip():
+            self._next_seq = 0
             return
-        raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
-        self._items = [Experience.model_validate(item) for item in raw]
+        try:
+            raw: Any = json.loads(raw_text)
+        except ValueError as exc:
+            _log.warning("experience buffer at %s is not readable JSON: %s", self.path, exc)
+            self._next_seq = 0
+            return
+        if not isinstance(raw, list):
+            _log.warning("experience buffer at %s is not a list; ignoring", self.path)
+            self._next_seq = 0
+            return
+        for entry in raw:
+            try:
+                self._items.append(Experience.model_validate(entry))
+            except ValidationError as exc:
+                self.skipped += 1
+                _log.warning("skipping malformed experience record: %s", exc)
+        if self.skipped:
+            _log.warning("%d experience record(s) skipped as malformed", self.skipped)
+        self._next_seq = max((item.seq for item in self._items), default=-1) + 1
+        self._trim()
+
+    def _trim(self) -> None:
+        if len(self._items) > self.max_items:
+            dropped = len(self._items) - self.max_items
+            _log.info("experience buffer over %d; dropping %d oldest", self.max_items, dropped)
+            del self._items[:dropped]
+
+    def _write(self) -> None:
+        """Serialise to disk atomically. Assumes the caller holds the locks."""
+        atomic_write_text(self.path, json.dumps([i.model_dump() for i in self._items], indent=2))
 
     def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        data = [item.model_dump() for item in self._items]
-        self.path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        """Write the buffer out atomically, under the lock.
+
+        The blunt form, kept for callers holding the whole picture: it does **not** merge concurrent
+        writes. :meth:`record` does.
+        """
+        with self._lock, locked(self.path):
+            self._write()
 
     def record(self, task: str, outcome: Outcome, detail: str = "") -> Experience:
-        exp = Experience(seq=len(self._items), task=task, outcome=outcome, detail=detail)
-        self._items.append(exp)
-        self.save()
+        """Append one attempt, re-reading first so a second writer's lessons are not erased.
+
+        The reload matters here for the same reason it does in the memory store: ``chimera serve``
+        runs the autonomous work in one process and an operator can run ``chimera`` in another, and
+        without it whichever writes second republishes a snapshot from before the other started.
+        """
+        with self._lock, locked(self.path):
+            self.load()
+            exp = Experience(seq=self._next_seq, task=task, outcome=outcome, detail=detail)
+            self._next_seq += 1
+            self._items.append(exp)
+            self._trim()
+            self._write()
         return exp
 
     def all(self) -> list[Experience]:

--- a/chimera/memory/store.py
+++ b/chimera/memory/store.py
@@ -1,11 +1,28 @@
-"""Persistence for memory items (a JSON-file store)."""
+"""Persistence for memory items (a JSON-file store).
+
+The write was atomic long before the *update* was. ``save()`` has always written through a temp file
+and replaced, so a crash mid-write cannot truncate the store — but ``add()`` is a read-modify-write
+over a snapshot taken in ``__init__``, and two writers each doing that lose one of the two records
+with nothing raised and nothing logged.
+
+That is the ordinary configuration, not a corner: ``chimera serve`` runs the cron daemon in a thread
+of the gateway process, so any ``chimera memory add`` typed over SSH while the daemon is up is a
+second process holding a stale snapshot of the same file.
+
+So every mutation now happens under an advisory lock and **re-reads the file first**, applying its
+own change on top of whatever else landed. Reads stay lock-free: the atomic replace means a reader
+sees a complete old version or a complete new one, never a torn one.
+"""
 
 from __future__ import annotations
 
 import json
+import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Protocol
 
+from chimera.core.filelock import atomic_write_text, locked, read_text
 from chimera.memory.models import MemoryItem, MemoryKind
 from chimera.telemetry import get_logger
 
@@ -29,13 +46,17 @@ class MemoryStore:
     def __init__(self, path: Path) -> None:
         self.path = Path(path)
         self._items: dict[str, MemoryItem] = {}
+        # Serialises threads sharing this instance. Two *instances* in one process (and two
+        # processes) are serialised by the file lock instead — always taken second, so the ordering
+        # is consistent and there is no cycle to deadlock on.
+        self._lock = threading.RLock()
         self.load()
 
     def load(self) -> None:
         self._items = {}
         if not self.path.exists():
             return
-        raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
+        raw = json.loads(read_text(self.path) or "[]")
         for item in raw:
             # Skip a single malformed record (hand-edit, schema drift, truncated last object) instead
             # of aborting the whole load — one bad entry must not lose every other memory.
@@ -46,25 +67,46 @@ class MemoryStore:
                 continue
             self._items[obj.id] = obj
 
-    def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+    def _write(self) -> None:
+        """Serialise the current items to disk atomically. Assumes the caller holds the locks."""
         data = [item.model_dump() for item in self._items.values()]
-        # Atomic write (temp + replace): a crash or ENOSPC mid-write must not truncate the store and
-        # make every memory unreadable on next load. os.replace is atomic on the same filesystem.
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        tmp.replace(self.path)
+        atomic_write_text(self.path, json.dumps(data, indent=2))
+
+    def save(self) -> None:
+        """Write the in-memory items out, replacing whatever is on disk.
+
+        This is the blunt form and it is kept for callers that hold the whole picture. It does
+        **not** merge concurrent writes — use :meth:`add` / :meth:`remove`, which do.
+        """
+        with self._lock, locked(self.path):
+            self._write()
+
+    def _mutate(self, apply: Callable[[dict[str, MemoryItem]], None]) -> None:
+        """Re-read, apply one change on top, write back — all under the lock.
+
+        The reload is the part that matters. Without it every mutation writes a dict built from
+        whatever the file held when this object was constructed, so a second writer's records
+        vanish on the next save with nothing to show it happened.
+        """
+        with self._lock, locked(self.path):
+            self.load()
+            apply(self._items)
+            self._write()
 
     def add(self, item: MemoryItem) -> None:
-        self._items[item.id] = item
-        self.save()
+        def put(items: dict[str, MemoryItem]) -> None:
+            items[item.id] = item
+
+        self._mutate(put)
 
     def get(self, item_id: str) -> MemoryItem:
         return self._items[item_id]
 
     def remove(self, item_id: str) -> None:
-        self._items.pop(item_id, None)
-        self.save()
+        def drop(items: dict[str, MemoryItem]) -> None:
+            items.pop(item_id, None)
+
+        self._mutate(drop)
 
     def all(self) -> list[MemoryItem]:
         return list(self._items.values())

--- a/tests/test_learning_logs_durability.py
+++ b/tests/test_learning_logs_durability.py
@@ -1,0 +1,243 @@
+"""The two logs the agent learns from, and the ways they used to lose everything at once.
+
+``experience.json`` and ``trajectories.jsonl`` are the only places an autonomous run's history
+outlives the process. Both were written the direct way, and both shared a failure family the
+memory store next door had already been fixed for: **data disappears and nothing complains**.
+
+Three shapes, in descending order of how much they cost:
+
+1. ``ExperienceBuffer.save`` was a bare ``write_text``, which truncates before it fills. It runs
+   from ``AutonomousLoop`` after every attempt, so a kill at the wrong moment leaves a file that is
+   neither the old contents nor the new — and because the buffer is one JSON array, that is *every*
+   lesson, not the last one.
+2. Both loaders validated without a guard. One record with a field from another version made the
+   whole history unreadable, and the failure surfaced in the ``chimera evolve`` commands you would
+   reach for to look at it.
+3. Neither had a ceiling, on disk or in memory, and ``relevant()`` scores every entry on every
+   planning step.
+
+Each test below fails against the pre-fix implementation. The ordering here follows the cost, not
+the effort.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from chimera.ecosystem.trajectory import TrajectoryCollector
+from chimera.evolution.experience import ExperienceBuffer
+
+# --- the whole file, gone -------------------------------------------------------------------------
+
+
+def test_a_crash_mid_save_does_not_erase_every_lesson(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one that costs the most. A non-atomic write that dies halfway leaves a truncated JSON
+    array — unparseable — where forty attempts' worth of history used to be."""
+    import chimera.core.filelock as filelock
+
+    path = tmp_path / "experience.json"
+    buffer = ExperienceBuffer(path)
+    for i in range(40):
+        buffer.record(f"task {i}", "success" if i % 2 else "failure")
+    before = path.read_text(encoding="utf-8")
+
+    def die(src: object, dst: object) -> None:
+        raise OSError("killed mid-write")
+
+    monkeypatch.setattr(filelock.os, "replace", die)
+    with pytest.raises(OSError):
+        buffer.record("the attempt that crashes", "failure")
+    monkeypatch.undo()
+
+    assert path.read_text(encoding="utf-8") == before, "the buffer was damaged by a failed write"
+    assert len(ExperienceBuffer(path)) == 40
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_the_buffer_file_is_never_opened_for_truncation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The structural guarantee behind the test above, asserted directly.
+
+    A mid-write crash cannot be injected portably — the corruption happens inside a syscall. But the
+    property that makes it impossible can be: the live file is only ever *renamed onto*, never
+    opened in a mode that truncates it. ``write_text`` opens it ``"w"``, which empties it before a
+    single byte of the new contents exists, and that is the whole bug in one flag.
+
+    Both ``io.open`` and ``builtins.open`` are watched, and the first draft of this test watched
+    only the second — so it passed against the very implementation it exists to catch, because
+    ``pathlib`` reaches ``io.open`` by its own reference.
+    """
+    import io
+
+    path = tmp_path / "experience.json"
+    ExperienceBuffer(path).record("first", "success")
+    opened: list[tuple[str, str]] = []
+    real_open = io.open
+
+    def watch(file: object, mode: str = "r", *args: object, **kwargs: object) -> object:
+        opened.append((str(file), mode))
+        return real_open(file, mode, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(io, "open", watch)
+    monkeypatch.setattr("builtins.open", watch)
+    ExperienceBuffer(path).record("second", "success")
+    monkeypatch.undo()
+
+    truncating = [
+        (name, mode)
+        for name, mode in opened
+        if Path(name) == path and ("w" in mode or "+" in mode)
+    ]
+    assert not truncating, f"the live buffer was opened in a truncating mode: {truncating}"
+    assert len(ExperienceBuffer(path)) == 2
+
+
+def test_a_second_writer_does_not_erase_the_first_buffer(tmp_path: Path) -> None:
+    """``chimera serve`` runs the autonomous work in one process; an operator can run ``chimera`` in
+    another. Whichever wrote second used to republish a snapshot from before the other started."""
+    path = tmp_path / "experience.json"
+    first = ExperienceBuffer(path)
+    second = ExperienceBuffer(path)
+
+    first.record("built the thing", "success")
+    second.record("broke the other thing", "failure")
+
+    assert {e.task for e in ExperienceBuffer(path).all()} == {
+        "built the thing",
+        "broke the other thing",
+    }
+
+
+# --- one bad record ---------------------------------------------------------------------------
+
+
+def test_one_malformed_experience_does_not_hide_the_rest(tmp_path: Path) -> None:
+    """Skip the record, keep the history, and *count* the skip — reporting 2 as though that were
+    all there ever was is how a silent loss becomes a wrong conclusion."""
+    path = tmp_path / "experience.json"
+    path.write_text(
+        json.dumps(
+            [
+                {"seq": 0, "task": "good one", "outcome": "success"},
+                {"seq": 1, "task": "from a later version", "outcome": "maybe", "extra": 1},
+                {"seq": 2, "task": "another good one", "outcome": "failure"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    buffer = ExperienceBuffer(path)
+
+    assert [e.task for e in buffer.all()] == ["good one", "another good one"]
+    assert buffer.skipped == 1
+
+
+def test_a_file_that_is_not_json_reports_empty_rather_than_refusing_to_start(tmp_path: Path) -> None:
+    """The alternative is an autonomous loop that will not boot because of a file it only reads."""
+    path = tmp_path / "experience.json"
+    path.write_text("{ this was hand-edited and left brok", encoding="utf-8")
+
+    buffer = ExperienceBuffer(path)
+
+    assert buffer.all() == []
+    buffer.record("carry on", "success")
+    assert len(ExperienceBuffer(path)) == 1
+
+
+def test_one_malformed_trajectory_does_not_take_the_history_with_it(tmp_path: Path) -> None:
+    """Same shape, other file. A process killed between the write and the newline leaves exactly
+    this, and every ``chimera evolve`` command used to raise on it."""
+    path = tmp_path / "traj.jsonl"
+    good = '{"seq": 0, "prompt": "p", "response": "r", "outcome": "success"}'
+    truncated = '{"seq": 1, "prompt": "p2", "resp'
+    later = '{"seq": 2, "prompt": "p3", "response": "r3", "outcome": "failure"}'
+    path.write_text("\n".join([good, truncated, later]) + "\n", encoding="utf-8")
+
+    collector = TrajectoryCollector(path)
+
+    assert [t.prompt for t in collector.all()] == ["p", "p3"]
+    assert collector.skipped == 1
+
+
+def test_a_blank_line_is_not_counted_as_damage(tmp_path: Path) -> None:
+    """A trailing newline is normal. Reporting it as a skipped record would make every healthy file
+    look slightly corrupt, and a warning nobody can act on is one nobody reads."""
+    path = tmp_path / "traj.jsonl"
+    path.write_text(
+        '{"seq": 0, "prompt": "p", "response": "r"}\n\n\n', encoding="utf-8"
+    )
+
+    collector = TrajectoryCollector(path)
+
+    assert len(collector) == 1
+    assert collector.skipped == 0
+
+
+# --- the ceilings -------------------------------------------------------------------------------
+
+
+def test_the_experience_buffer_stops_growing(tmp_path: Path) -> None:
+    """``relevant()`` scores every entry on every planning step, so this is a latency ceiling as
+    much as a memory one."""
+    path = tmp_path / "experience.json"
+    buffer = ExperienceBuffer(path, max_items=10)
+    for i in range(25):
+        buffer.record(f"task {i}", "success")
+
+    assert len(buffer) == 10
+    assert [e.task for e in buffer.all()][0] == "task 15", "the wrong end was dropped"
+    assert len(json.loads(path.read_text(encoding="utf-8"))) == 10
+
+
+def test_dropping_the_head_does_not_reissue_a_sequence_number(tmp_path: Path) -> None:
+    """``relevant()`` breaks ties on ``seq`` to prefer newer attempts. Numbering from the list
+    length restarts once the head is dropped, so an old attempt starts winning that tiebreak."""
+    path = tmp_path / "experience.json"
+    buffer = ExperienceBuffer(path, max_items=5)
+    for i in range(12):
+        buffer.record(f"task {i}", "success")
+
+    seqs = [e.seq for e in buffer.all()]
+
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs), f"seq reused: {seqs}"
+    assert seqs[-1] == 11
+    assert ExperienceBuffer(path, max_items=5).record("next", "success").seq == 12
+
+
+def test_the_trajectory_log_keeps_only_the_tail_in_memory(tmp_path: Path) -> None:
+    """The prefix stays on disk — this is about what a long-lived process carries, not about
+    deleting history."""
+    path = tmp_path / "traj.jsonl"
+    collector = TrajectoryCollector(path, max_resident=8)
+    for i in range(30):
+        collector.record(f"p{i}", "r")
+
+    assert len(collector) == 8
+    assert collector.all()[-1].prompt == "p29"
+    on_disk = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(on_disk) == 30, "the log itself was truncated; only memory should be capped"
+
+    assert TrajectoryCollector(path, max_resident=8).record("next", "r").seq == 30
+
+
+def test_the_trajectory_log_rotates_instead_of_growing_without_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rename, not trim: rewriting the file to drop old lines has to read all of it, and a crash
+    mid-rewrite loses the whole history instead of its oldest part."""
+    import chimera.ecosystem.trajectory as module
+
+    monkeypatch.setattr(module, "MAX_TRAJECTORY_BYTES", 200)
+    path = tmp_path / "traj.jsonl"
+    collector = TrajectoryCollector(path)
+    for i in range(12):
+        collector.record(f"prompt number {i}", "a response of some length")
+
+    assert (tmp_path / "traj.jsonl.1").exists(), "nothing was rotated"
+    assert path.exists() and path.stat().st_size < 400

--- a/tests/test_memory_concurrency.py
+++ b/tests/test_memory_concurrency.py
@@ -1,0 +1,298 @@
+"""Two writers against one memory file — the update that used to disappear.
+
+``save()`` has been atomic since it was written, and that covers the failure everyone thinks of: a
+crash mid-write leaving an unreadable store. It does nothing for the other one. ``add()`` writes the
+dict this object loaded when it was constructed, so a second writer that started from an older
+snapshot republishes it and the first writer's record is gone — no exception, no log line, nothing
+in the file to say a record was ever there.
+
+Worth being exact about who the two writers are, because "concurrency bug" invites hand-waving.
+``chimera serve`` builds one shared memory and runs the cron daemon in a background thread of the
+same process, so those two share ``_items`` and do not race this way. The second *process* is the
+ordinary one: any ``chimera memory add`` run over SSH while the gateway is up.
+
+Every test here fails on the pre-fix implementation. The one that matters most is
+``test_a_second_writer_does_not_erase_the_first``, which is that bug in six lines.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+import threading
+from pathlib import Path
+
+import pytest
+
+import chimera.core.filelock as filelock
+from chimera.core.filelock import atomic_write_text
+from chimera.memory.models import MemoryItem
+from chimera.memory.store import MemoryStore
+
+
+def _item(ident: str) -> MemoryItem:
+    return MemoryItem(id=ident, content=f"fact {ident}")
+
+
+def _ids(path: Path) -> set[str]:
+    return {row["id"] for row in json.loads(path.read_text(encoding="utf-8"))}
+
+
+# --- the lost update ----------------------------------------------------------------------------
+
+
+def test_a_second_writer_does_not_erase_the_first(tmp_path: Path) -> None:
+    """The whole bug. Two stores open the same file, each adds one fact, both must survive.
+
+    Pre-fix: ``second`` was constructed while the file was empty, so its save writes ``[b]`` over
+    ``[a]``. The assertion below found one id where two were added.
+    """
+    path = tmp_path / "memory.json"
+    first = MemoryStore(path)
+    second = MemoryStore(path)  # a second process, holding the same empty snapshot
+
+    first.add(_item("a"))
+    second.add(_item("b"))
+
+    assert _ids(path) == {"a", "b"}
+
+
+def test_a_removal_does_not_resurrect_what_another_writer_deleted(tmp_path: Path) -> None:
+    """The mirror, and the nastier direction: a stale writer can bring deleted data BACK.
+
+    ``stale`` holds a snapshot from before the deletion. Under the old code its next write
+    republished that snapshot, undoing someone else's ``memory forget``.
+    """
+    path = tmp_path / "memory.json"
+    seed = MemoryStore(path)
+    seed.add(_item("keep"))
+    seed.add(_item("secret"))
+
+    stale = MemoryStore(path)  # snapshot with both
+    MemoryStore(path).remove("secret")  # somebody else forgets it
+    stale.add(_item("new"))
+
+    assert _ids(path) == {"keep", "new"}, "a deleted memory came back"
+
+
+def test_interleaved_writers_keep_every_record(tmp_path: Path) -> None:
+    """Alternating writers, which is what a daemon and a shell session actually look like."""
+    path = tmp_path / "memory.json"
+    left = MemoryStore(path)
+    right = MemoryStore(path)
+
+    for i in range(10):
+        left.add(_item(f"L{i}"))
+        right.add(_item(f"R{i}"))
+
+    assert len(_ids(path)) == 20
+
+
+# --- threads, and real processes ------------------------------------------------------------------
+
+
+def test_threads_sharing_one_store_do_not_lose_records(tmp_path: Path) -> None:
+    """One store, many threads — the `serve` shape. The risk here is not the stale snapshot but
+    ``_write`` iterating the dict while another thread mutates it."""
+    path = tmp_path / "memory.json"
+    store = MemoryStore(path)
+
+    def write(start: int) -> None:
+        for i in range(start, start + 25):
+            store.add(_item(f"t{i}"))
+
+    threads = [threading.Thread(target=write, args=(base,)) for base in (0, 100, 200, 300)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(_ids(path)) == 100
+
+
+_WRITER = """
+import sys
+from pathlib import Path
+from chimera.memory.models import MemoryItem
+from chimera.memory.store import MemoryStore
+
+path, tag = Path(sys.argv[1]), sys.argv[2]
+store = MemoryStore(path)
+for i in range(40):
+    store.add(MemoryItem(id=f"{tag}{i}", content="fact"))
+"""
+
+
+def test_two_real_processes_both_land(tmp_path: Path) -> None:
+    """The configuration the fix is actually for: separate interpreters, separate file descriptors,
+    genuine OS-level interleaving. The in-process tests cannot prove the *file* lock works, only the
+    reload — a threading.Lock alone would pass those and still lose records here.
+    """
+    path = tmp_path / "memory.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    script = tmp_path / "writer.py"
+    script.write_text(textwrap.dedent(_WRITER), encoding="utf-8")
+
+    procs = [
+        subprocess.Popen([sys.executable, str(script), str(path), tag], cwd=str(Path.cwd()))
+        for tag in ("A", "B")
+    ]
+    for proc in procs:
+        assert proc.wait(timeout=180) == 0
+
+    assert len(_ids(path)) == 80
+
+
+# --- the temp file ------------------------------------------------------------------------------
+
+
+def test_a_temp_file_is_never_reused_between_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fixed ``<name>.tmp`` lets two writers that both got past the lock — the degraded path, or
+    anything that never took it — interleave inside the same temp file, so the rename publishes a
+    mixture of two serialisations rather than either one.
+
+    Held still by stubbing out the rename: the temp files then accumulate instead of being consumed,
+    and three writes have to leave three of them. With a shared name they leave one.
+    """
+    path = tmp_path / "memory.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(filelock, "retrying", lambda action: None)  # the rename never happens
+
+    for payload in ("[]", '[{"a": 1}]', '[{"b": 2}]'):
+        atomic_write_text(path, payload)
+
+    leftovers = list(tmp_path.glob("*.tmp"))
+    monkeypatch.undo()
+
+    assert len(leftovers) == 3, f"temp file name was reused: {[p.name for p in leftovers]}"
+    assert all(p.parent == tmp_path for p in leftovers), "os.replace is only atomic within a filesystem"
+
+
+def test_no_temp_file_survives_an_ordinary_write(tmp_path: Path) -> None:
+    path = tmp_path / "memory.json"
+    store = MemoryStore(path)
+    store.add(_item("a"))
+    store.add(_item("b"))
+
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_a_failed_write_leaves_no_temp_file_behind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Otherwise a full disk seeds the directory with debris that the next `ls` reads as corruption
+    — and the previous contents have to still be there, which is what the replace buys."""
+    path = tmp_path / "memory.json"
+    store = MemoryStore(path)
+    store.add(_item("a"))
+
+    def boom(src: object, dst: object) -> None:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(filelock.os, "replace", boom)
+    with pytest.raises(OSError):
+        store.add(_item("b"))
+    monkeypatch.undo()
+
+    assert not list(tmp_path.glob("*.tmp"))
+    assert _ids(path) == {"a"}, "the previous contents did not survive the failed write"
+
+
+# --- what must not have changed -------------------------------------------------------------------
+
+
+def test_the_lock_file_is_a_sibling_not_the_store(tmp_path: Path) -> None:
+    """Locking the data file would be locking a descriptor that ``os.replace`` invalidates a moment
+    later. And the lock must never end up parsed as memory."""
+    path = tmp_path / "memory.json"
+    MemoryStore(path).add(_item("a"))
+
+    assert (tmp_path / "memory.json.lock").exists()
+    assert _ids(path) == {"a"}
+
+
+# --- the collision the lock cannot cover ---------------------------------------------------------
+
+
+def test_a_busy_file_is_retried_and_then_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Readers take no lock, so on Windows a reader mid-``read_text`` makes an unrelated writer's
+    ``os.replace`` raise ``PermissionError``. That is absorbed — but only for as long as a race
+    plausibly lasts. A permission problem that outlives the retries is a real one and must surface,
+    not turn into a hang or a silently skipped write.
+    """
+    monkeypatch.setattr(filelock, "RETRY_PAUSE", 0)
+    calls = {"n": 0}
+
+    def busy_twice() -> str:
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise PermissionError("file in use")
+        return "ok"
+
+    assert filelock.retrying(busy_twice) == "ok"
+    assert calls["n"] == 3
+
+    def always_busy() -> str:
+        raise PermissionError("genuinely not permitted")
+
+    with pytest.raises(PermissionError):
+        filelock.retrying(always_busy)
+
+
+def test_a_reader_and_a_writer_do_not_take_each_other_down(tmp_path: Path) -> None:
+    """The scenario in full: one thread writing while another reads as fast as it can.
+
+    This is the shape the fix's own design creates — lock-free reads beside locked writes — so it
+    is the one that has to hold. On Windows the pre-retry code raised ``PermissionError`` out of
+    ``os.replace`` here; on POSIX it always passed, which is exactly why it needs asserting on both.
+    """
+    path = tmp_path / "memory.json"
+    writer_store = MemoryStore(path)
+    writer_store.add(_item("seed"))
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def write() -> None:
+        try:
+            for i in range(60):
+                writer_store.add(_item(f"w{i}"))
+        except BaseException as exc:  # noqa: BLE001 - the point is to report it, not handle it
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    def read() -> None:
+        try:
+            while not stop.is_set():
+                assert MemoryStore(path).all(), "recall came back empty mid-write"
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=write), threading.Thread(target=read)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=120)
+
+    assert not errors, f"reader/writer collision surfaced: {errors[0]!r}"
+    assert len(_ids(path)) == 61
+
+
+def test_reading_still_works_without_taking_a_lock(tmp_path: Path) -> None:
+    """Reads stay lock-free on purpose: the atomic replace already guarantees a reader sees one
+    complete version or the other. Making recall wait on a writer would be a real cost for a
+    problem that does not exist."""
+    path = tmp_path / "memory.json"
+    store = MemoryStore(path)
+    store.add(_item("a"))
+
+    with open(str(path) + ".lock", "a+b") as held:
+        filelock._acquire(held)
+        try:
+            assert MemoryStore(path).all()[0].id == "a"  # would hang if load() locked
+        finally:
+            filelock._release(held)


### PR DESCRIPTION
Every store Chimera keeps beside itself is a whole-file JSON read-modify-write, and each one had rediscovered part of the same failure family on its own. `chimera/memory/store.py` had already been fixed for one half and written down why — the lesson had never crossed to the two files next door. The two primitives now live in `chimera/core/filelock.py` so the next store cannot rediscover it a third time.

## The torn write

`ExperienceBuffer.save` was a bare `write_text`, which truncates before it fills. It runs from `AutonomousLoop` after **every attempt**, so it is on the 24/7 path — and because the buffer is one JSON array, a kill or a full disk mid-write costs *every* lesson, not the last one. An unattended agent restarted at the wrong moment comes back with no history and no error to explain where it went.

Now an atomic rename onto the target. A mid-write crash cannot be injected portably, so the guarantee is asserted structurally instead: the live file is never opened in a mode that truncates it.

> The first draft of that test watched only `builtins.open` and **passed against the very code it exists to catch**, because `pathlib` reaches `io.open` by its own reference. Both are watched now, and the docstring says so.

## The lost update

`MemoryStore.add` wrote the dict loaded at construction, so a second writer republished a snapshot from before the first one's change: no exception, no log, nothing in the file to say a record was ever there. The nastier direction is deletion — a stale writer brings a forgotten memory *back*.

Mutations now re-read under an advisory lock and apply on top. Being exact about who the two writers are, because "concurrency bug" invites hand-waving: `serve` runs the cron daemon in a thread of the gateway process and both share one memory object, so the second **process** is the ordinary one — any `chimera` command over SSH while the daemon is up.

Both halves earn their place, checked by removing each:

| removed | result |
|---|---|
| the reload | 4 tests fail; two real processes kept **40 of 80** records |
| the file lock | the two-process test fails **5 runs out of 5** |

## The collision that design creates

Lock-free readers beside locked writers leaves a window, and on Windows it is not theoretical: the **pre-existing** code raised `PermissionError` out of `os.replace` there, 3 runs out of 3 — and Windows is the desktop app's platform. A brief retry absorbs it; a permission error that outlives the window still surfaces unchanged.

## One bad record

Both learning logs validated without a guard, so a truncated line or a field from another version made the whole history unreadable — surfacing in the `chimera evolve` commands you would reach for to look at it. Skipped and **counted** now, so a caller can say "997 of 1000" instead of reporting 997 as if that were all there ever was.

## Ceilings

Neither learning log had one, in memory or on disk, and `relevant()` scores every entry on every planning step. Sequence numbers are tracked rather than derived from list length — deriving them reissues an id once the head is dropped, and `relevant()` breaks ties on it.

---

**Verification.** Full suite in WSL: ruff clean, mypy `--strict` reports nothing in any changed file, 2948 passed. The 18 failures are pre-existing environment breakage in this WSL venv (sandbox/exec/subprocess-shaped); 12 of them were confirmed failing on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)