### PR TITLE
fix(governance): the app's Discord bot ran unfenced, and the gate could not see it

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -472,11 +472,22 @@ class Settings(BaseSettings):
     # Deployment-level tool allowlist/denylist (names). Empty allowlist = no restriction (all
     # tools); a non-empty allowlist grants only those. Denylist removes even if allowed.
     #
-    # These apply on every surface: `run`/`solve` in a terminal, the coding turn, the autonomous
-    # run, the parallel batch, and the chat the messaging bots and /v1/chat/completions ride on.
-    # They used to reach only the first two, which meant an owner could write a fence in `.env` and
-    # have the app ignore it without saying so. Where a request carries its own allowlist the two
-    # INTERSECT — this list is a ceiling, and a caller must not be able to raise it.
+    # Where they apply, stated exactly, because the previous wording here ("on every surface") was
+    # not true and reading it as true is how an owner ends up with an unfenced bot:
+    #
+    #   ALWAYS — `run`/`solve` in a terminal, the coding turn, the autonomous run, the parallel
+    #   batch, and the desktop app's own chat (which applies them itself, unconditionally).
+    #
+    #   ONLY WITH `CHIMERA_GOVERNANCE=observe|enforce` — the unattended surfaces: `serve`, the cron
+    #   dispatch, MCP, A2A, and the messaging bots started either way. Those go through
+    #   `governed_profile`, and that function returns the registry untouched in `off` mode, which is
+    #   the default. So on a stock deployment a denylist in `.env` does NOT fence the Discord bot.
+    #   That asymmetry is a real gap, not a design: it is written down here rather than papered over,
+    #   and closing it means changing what a default deployment does, which is a decision with a
+    #   migration attached rather than a comment fix.
+    #
+    # Where a request carries its own allowlist the two INTERSECT — this list is a ceiling, and a
+    # caller must not be able to raise it.
     tool_allowlist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST")
     tool_denylist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST")
 

--- a/chimera/server/manager.py
+++ b/chimera/server/manager.py
@@ -112,8 +112,21 @@ class MessagingManager:
 
     def _gateway_on_message(self, adapter: Any) -> Callable[[Any], str]:
         """A MessageGateway.on_message wired to the real agent stack, with send_message registered
-        so the agent can reply and reach out. Mirrors the CLI's `_serve_platform` factory."""
+        so the agent can reply and reach out. Mirrors the CLI's `_serve_platform` factory.
+
+        "Mirrors" was a claim this docstring made and the code did not keep. `_serve_platform` runs
+        its registry through :func:`~chimera.governance.profile.governed_profile`; this built one
+        raw, so the identical Discord bot was fenced when started as `chimera serve --discord` and
+        unfenced when started from the app's Messaging toggle. An owner with
+        ``CHIMERA_TOOL_DENYLIST=shell,write_file`` in `.env` got no denylist here, and anyone who
+        could message the bot reached every builtin.
+
+        Nothing chose that. The build gate written to make this structural
+        (``tests/test_governed_surfaces.py``) parsed only ``chimera/cli/main.py``, so this file was
+        invisible to it — which is why that gate now walks the whole package.
+        """
         from chimera.core import Agent, AgentConfig
+        from chimera.governance.profile import governed_profile
         from chimera.integrations import SenderRegistry, SendMessageTool
         from chimera.interface import ChatSession
         from chimera.server import MessageGateway
@@ -124,7 +137,17 @@ class MessagingManager:
         send_tool = SendMessageTool(senders)
 
         def factory() -> ChatSession:
-            registry = default_registry(self._workspace)
+            # A distinct surface name from the CLI's "platform": the audit log has to be able to say
+            # WHICH way the bot was started, because only one of the two paths was ever governed and
+            # a rollout reading those counts needs to tell them apart.
+            registry, _ = governed_profile(
+                default_registry(self._workspace),
+                settings=self._settings,
+                home=self._settings.home,
+                surface="app-messaging",
+            )
+            # After the profile, exactly as `_serve_platform` does: send_message is this surface's
+            # reason to exist, and a denylist aimed at shell must not take the bot's own voice away.
             registry.register(send_tool)
             runner = Agent(
                 self._backend, registry, AgentConfig(model=self._model, max_steps=self._max_steps)

--- a/tests/test_governed_surfaces.py
+++ b/tests/test_governed_surfaces.py
@@ -5,9 +5,21 @@ endpoint and the messaging adapters each built `default_registry(workspace)` raw
 decision anyone made; it is what happens when the guarantee lives in a convention and the convention
 lives in whoever last edited the file.
 
-So the last test here parses `chimera/cli/main.py` and **fails the build** if any surface constructs
-a bare registry again. A grep would be the obvious way and the wrong one: it cannot tell an
-assembled registry from the string appearing in a docstring or a comment about the fix.
+So the last test here **fails the build** if a surface constructs a bare registry again. A grep would
+be the obvious way and the wrong one: it cannot tell an assembled registry from the string appearing
+in a docstring or a comment about the fix.
+
+**That gate had a blind spot, and it was found the expensive way — by an audit, not by the build.**
+It parsed one file and listed the five surface names inside it, so a sixth unattended surface written
+somewhere else was not "failing"; it was invisible. `chimera/server/manager.py` — the Discord bot
+started from the desktop app's Messaging toggle, the same bot `serve --discord` runs — built its
+registry raw for three weeks after the sweep that was supposed to have covered it.
+
+The shape of the fix matters more than the fix. A list of surfaces to CHECK fails open: forget to add
+one and it is silently unguarded. So it is inverted here — the walk covers every module in the
+package, and what is listed is the set of sites allowed to build a registry ungoverned, each with a
+written reason. A new surface anywhere now fails the build until someone either governs it or says
+in one line why it does not need to be.
 
 The rest is the middle state. `observe` exists because going straight to enforcement on a schedule
 that watches real money is how a silent failure gets discovered in production rather than in a
@@ -30,7 +42,7 @@ from chimera.governance.profile import governed_profile
 from chimera.tools.base import Tool
 from chimera.tools.registry import ToolRegistry
 
-MAIN = pathlib.Path(__file__).resolve().parents[1] / "chimera" / "cli" / "main.py"
+PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "chimera"
 
 
 class _Writer(Tool):
@@ -116,66 +128,155 @@ def test_enforce_actually_wraps(tmp_path: pathlib.Path) -> None:
 # --- the build gate -----------------------------------------------------------------------------
 
 
-#: The entry points that run with nobody watching. Named explicitly rather than "everything",
-#: because the distinction is the point: `run`, `chat` and `solve` are attended — a person is at the
-#: terminal, sees the tool calls, and can stop them — and `solve` additionally assembles its own
-#: stack with options this profile does not model (its own guard/taint flags, the late-bound
-#: subagent). Governing those by fiat here would be a refactor pretending to be a safety gate.
-UNATTENDED = ("serve", "_start_cron_daemon", "_serve_mcp", "_build_a2a", "_serve_platform")
+#: Sites allowed to build a registry WITHOUT the profile, each with the reason.
+#:
+#: Keyed by ``"<module path>:<qualified function>"``. Listing the exemptions rather than the
+#: obligations is the whole design: the previous version listed five surfaces to check, so the sixth
+#: — written in another file three weeks later — was not caught, it was never looked at. Here the
+#: default for a new site is FAIL, and the cost of an exemption is one sentence.
+#:
+#: Two kinds of reason are acceptable and they are not the same. "A person is watching" means the
+#: tool calls scroll past someone who can hit Ctrl-C. "It assembles its own" means the surface builds
+#: an equivalent stack with options this profile does not model — a weaker claim, and every entry
+#: making it is a candidate for consolidation rather than a settled answer.
+EXEMPT: dict[str, str] = {
+    # --- a person is at the terminal, watching the tool calls go by ---
+    "chimera/cli/main.py:agent": "attended: one-shot at the terminal",
+    "chimera/cli/main.py:chat": "attended: interactive REPL",
+    "chimera/cli/main.py:assist": "attended: interactive",
+    "chimera/cli/main.py:tui": "attended: interactive terminal UI",
+    # --- assembles an equivalent stack from its own flags ---
+    "chimera/cli/main.py:solve._run_solve": "own guard/taint/write-region flags + late-bound subagent",
+    "chimera/cli/main.py:solve_batch.make_runner.run": "per-worker ledgers + shared cross-agent monitor",
+    "chimera/cli/main.py:crew_isolated.make_factory.factory": "per-worker ledgers, shared taint view",
+    "chimera/cli/main.py:desktop_app.factory": (
+        "applies _apply_tool_allowlist and the optional chat guard itself. A SECOND implementation "
+        "of what this profile does, kept because it also carries MCP connectors the profile does "
+        "not model — consolidating the two is open work, not a settled answer"
+    ),
+    "chimera/api/code_api.py:assemble_registry": "resolves its own posture floor + taint narrowing",
+    "chimera/kanban/lanes.py:run": "restrict_registry from the card's own role (fail-closed)",
+    # --- not an agent surface at all ---
+    "chimera/api/app.py:build_api_app.tools_endpoint": "lists tool schemas; nothing is invoked",
+    "chimera/cli/main.py:tools": "prints the tool table",
+    "chimera/cli/main.py:schema_bench": "benchmark harness, no deployment",
+    "chimera/cli/main.py:sandbox_bench.factory": "benchmark harness, no deployment",
+    "chimera/cli/main.py:evolve_tune": "offline tuning over recorded trajectories",
+    "chimera/cli/main.py:meta": "designs an agent blueprint; does not run one",
+    "chimera/core/agent.py:_default_skill_registry": "internal default, wrapped by whoever built it",
+    "chimera/orchestration/lifecycle.py:lifecycle_crew": "library constructor; the caller governs",
+    "chimera/workflow/executors.py:build_executors.solve_step": "delegates to solve, governed there",
+}
 
 
-def _bare_registry_calls(tree: ast.Module, *, within: tuple[str, ...] = UNATTENDED) -> list[int]:
-    """Line numbers where an UNATTENDED surface builds `default_registry(...)` outside the profile.
+def _qualname(chain: list[str]) -> str:
+    return ".".join(chain) or "(module)"
+
+
+def _bare_registry_calls(tree: ast.Module, module: str) -> list[tuple[str, int]]:
+    """``(key, lineno)`` for every `default_registry(...)` this module builds outside the profile.
 
     An AST walk rather than a grep, because a grep cannot tell an assembled registry from the same
     words inside a docstring — and this test exists precisely to survive the next person who writes
-    a comment about it. Nested functions count: `serve` builds its registry inside a `factory()`
-    closure, which is exactly where it went missing.
+    a comment about it. Nested functions are walked with their enclosing chain, because that is where
+    it went missing both times: `serve` builds its registry inside a `factory()` closure, and so did
+    the messaging manager.
 
     A call is legitimate when it is an argument to `governed_profile`.
     """
-    scopes = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name in within
-    ]
     governed: set[int] = set()
-    for scope in scopes:
-        for node in ast.walk(scope):
-            if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "governed_profile":
-                for arg in node.args:
-                    for inner in ast.walk(arg):
-                        if isinstance(inner, ast.Call):
-                            governed.add(id(inner))
-    bare = []
-    for scope in scopes:
-        for node in ast.walk(scope):
-            if (
-                isinstance(node, ast.Call)
-                and getattr(node.func, "id", "") == "default_registry"
-                and id(node) not in governed
-            ):
-                bare.append(node.lineno)
-    return sorted(bare)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "governed_profile":
+            for arg in node.args:
+                for inner in ast.walk(arg):
+                    if isinstance(inner, ast.Call):
+                        governed.add(id(inner))
+
+    found: list[tuple[str, int]] = []
+
+    def walk(node: ast.AST, chain: list[str]) -> None:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            chain = [*chain, node.name]
+        if (
+            isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") == "default_registry"
+            and id(node) not in governed
+        ):
+            found.append((f"{module}:{_qualname(chain)}", node.lineno))
+        for child in ast.iter_child_nodes(node):
+            walk(child, chain)
+
+    walk(tree, [])
+    return found
 
 
-def test_no_unattended_surface_builds_a_registry_outside_the_profile() -> None:
-    """The test that makes the guarantee structural.
+def _ungoverned_sites() -> list[tuple[str, int]]:
+    """Every site in the package that builds a registry outside the profile and is not exempt."""
+    out: list[tuple[str, int]] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "default_registry(" not in source:
+            continue
+        module = path.relative_to(PACKAGE.parent).as_posix()
+        out.extend(
+            (key, line)
+            for key, line in _bare_registry_calls(ast.parse(source), module)
+            if key not in EXEMPT
+        )
+    return out
 
-    Five surfaces lost their governance not through a decision but through absence: each was written
-    at a different time and none of them called the thing the others called. A convention cannot fix
-    that. A build that fails can.
+
+def test_no_surface_builds_a_registry_outside_the_profile_unless_it_says_why() -> None:
+    """The test that makes the guarantee structural — over the whole package, not one file.
+
+    Surfaces lose their governance through absence rather than decision: each is written at a
+    different time and none calls the thing the others call. A convention cannot fix that. A build
+    that fails can — but only if it looks everywhere, which the first version of this did not.
     """
-    tree = ast.parse(MAIN.read_text(encoding="utf-8"))
+    ungoverned = _ungoverned_sites()
 
-    bare = _bare_registry_calls(tree)
-
-    assert not bare, (
-        "an unattended surface assembles tools without governed_profile, at "
-        f"chimera/cli/main.py:{bare} — every unattended entry point has to go through the same "
-        "profile, or the deployment's allowlist and taint ledger are true only where someone "
-        "remembered"
+    assert not ungoverned, (
+        "a surface assembles tools without governed_profile and is not in EXEMPT: "
+        + ", ".join(f"{key} (line {line})" for key, line in ungoverned)
+        + " — either route it through governed_profile, or add it to EXEMPT with the reason it "
+        "does not need to be. An unlisted surface means the deployment's allowlist and taint "
+        "ledger are true only where someone remembered."
     )
+
+
+def test_the_messaging_manager_is_covered_by_the_walk() -> None:
+    """The specific regression, pinned by name.
+
+    The blind spot was not that `manager.py` was wrong — it was that the gate could not see it. A
+    walk that silently stopped covering this file again would leave the same bot unfenced with a
+    green build, so the coverage itself is asserted rather than assumed.
+    """
+    source = (PACKAGE / "server" / "manager.py").read_text(encoding="utf-8")
+
+    assert "default_registry(" in source, "the file no longer builds a registry — retarget this test"
+    assert "governed_profile(" in source, "the app's messaging bot lost its governance again"
+    assert not [
+        key for key, _ in _bare_registry_calls(ast.parse(source), "chimera/server/manager.py")
+    ], "manager.py builds a registry outside the profile"
+
+
+def test_every_exemption_still_points_at_real_code() -> None:
+    """An exemption list that outlives the code it exempts is how a gate rots into a formality.
+
+    A stale key is not harmless: it is a line saying "this was considered" about a site that no
+    longer exists, next to sites that do.
+    """
+    live = set()
+    for path in sorted(PACKAGE.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "default_registry(" not in source:
+            continue
+        module = path.relative_to(PACKAGE.parent).as_posix()
+        live.update(key for key, _ in _bare_registry_calls(ast.parse(source), module))
+
+    stale = sorted(set(EXEMPT) - live)
+
+    assert not stale, f"EXEMPT names sites that no longer build a bare registry: {stale}"
 
 
 def test_the_gate_would_catch_a_regression() -> None:
@@ -190,26 +291,47 @@ def test_the_gate_would_catch_a_regression() -> None:
         """
     )
 
-    assert _bare_registry_calls(ast.parse(source), within=("serve",)) == [4]
+    assert _bare_registry_calls(ast.parse(source), "m.py") == [("m.py:serve.factory", 4)]
 
 
-def test_the_gate_ignores_the_attended_commands() -> None:
-    # Otherwise it would demand a refactor of `solve` under the banner of a security fix — and a
-    # gate that fires on things it was not built to defend gets weakened until it fires on nothing.
+def test_a_governed_call_is_not_flagged() -> None:
+    # The other half: the walk must recognise the legitimate shape, or every governed surface would
+    # have to be exempted and the list would stop meaning anything.
     source = textwrap.dedent(
         """
-        def run():
-            registry = default_registry(ws)
+        def serve():
+            registry, _ = governed_profile(default_registry(ws), settings=s, home=h)
         """
     )
 
-    assert _bare_registry_calls(ast.parse(source)) == []
+    assert _bare_registry_calls(ast.parse(source), "m.py") == []
 
 
-@pytest.mark.parametrize("surface", ["serve", "cron", "mcp", "a2a", "platform"])
-def test_each_named_surface_is_declared(surface: str) -> None:
+def test_the_gate_does_not_demand_a_refactor_of_the_attended_commands() -> None:
+    # Otherwise it would rewrite `solve` under the banner of a security fix — and a gate that fires
+    # on things it was not built to defend gets weakened until it fires on nothing. The exemption is
+    # what expresses that, so what is asserted is that the exemption is doing the work.
+    assert "chimera/cli/main.py:solve._run_solve" in EXEMPT
+    assert not [key for key, _ in _ungoverned_sites() if key.endswith(":chat")]
+
+
+@pytest.mark.parametrize(
+    ("surface", "module"),
+    [
+        ("serve", "cli/main.py"),
+        ("cron", "cli/main.py"),
+        ("mcp", "cli/main.py"),
+        ("a2a", "cli/main.py"),
+        ("platform", "cli/main.py"),
+        # The app's Messaging toggle gets its OWN label rather than reusing "platform": an audit
+        # reading these counts has to be able to say which of the two ways the bot was started,
+        # because for three weeks only one of them was governed at all.
+        ("app-messaging", "server/manager.py"),
+    ],
+)
+def test_each_named_surface_is_declared(surface: str, module: str) -> None:
     # The `surface=` label is what makes an audit line answerable ("which entry point was that?").
     # Cheap to drop while refactoring, and invisible once dropped.
-    body = MAIN.read_text(encoding="utf-8")
+    body = (PACKAGE / module).read_text(encoding="utf-8")
 
     assert f'surface="{surface}' in body or f'surface=f"{surface}' in body

--- a/tests/test_messaging_manager.py
+++ b/tests/test_messaging_manager.py
@@ -123,3 +123,77 @@ def test_stop_all_closes_every_running_adapter(tmp_path: Path) -> None:
     mgr.stop_all()
     assert adapter.stopped
     assert mgr.is_running("discord") is False
+
+
+# --- the fence, which this surface did not have --------------------------------------------------
+
+
+def _session_registry(mgr: MessagingManager, adapter: _FakeAdapter) -> Any:
+    """Build one chat session the way an incoming message does, and hand back its tool registry.
+
+    Through `_gateway_on_message` rather than by reassembling the stack here: a test that built its
+    own registry would pass with the manager's factory broken, and the factory is the thing that was
+    broken for three weeks.
+    """
+    on_message = mgr._gateway_on_message(adapter)
+    gateway = on_message.__self__  # type: ignore[attr-defined]
+    return gateway.session_for("some-chat").agent.tools
+
+
+def test_the_deployment_denylist_reaches_the_in_app_bot(tmp_path: Path) -> None:
+    """The bug this file is now guarding.
+
+    `chimera serve --discord` and the app's Messaging toggle run the SAME bot. Only the first was
+    fenced: an owner with `CHIMERA_TOOL_DENYLIST=shell,write_file` in `.env` who started Discord
+    from the UI handed every builtin to anyone who could message it.
+    """
+    settings = Settings(
+        CHIMERA_HOME=str(tmp_path),
+        CHIMERA_DISCORD_BOT_TOKEN="t",
+        CHIMERA_GOVERNANCE="enforce",
+        CHIMERA_TOOL_DENYLIST="run_shell,write_file",
+    )
+    adapter = _FakeAdapter()
+    mgr = MessagingManager(
+        settings=settings, backend=_FakeBackend(), model=None, max_steps=4,
+        workspace=tmp_path, adapter_factory=lambda _p: adapter,
+    )
+
+    registry = _session_registry(mgr, adapter)
+    names = {tool.name for tool in registry.tools()}
+
+    assert "run_shell" not in names, "the denylist did not reach the in-app bot"
+    assert "write_file" not in names
+    assert "send_message" in names, "the bot lost the one tool that is its reason to exist"
+
+
+def test_governance_off_still_leaves_the_bot_usable(tmp_path: Path) -> None:
+    """The other direction, and it is not a formality: the profile returns the registry untouched in
+    `off` mode, and `off` is the default. A fix that fenced everyone by default would be a breaking
+    change wearing a security label."""
+    adapter = _FakeAdapter()
+    mgr = _manager(tmp_path, adapter=adapter)
+
+    names = {tool.name for tool in _session_registry(mgr, adapter).tools()}
+
+    assert "run_shell" in names and "send_message" in names
+
+
+def test_the_send_tool_survives_a_denylist_aimed_at_everything_else(tmp_path: Path) -> None:
+    """`send_message` is registered AFTER the profile, deliberately — same order as the CLI. A bot
+    that can read but cannot answer is a bot that looks online and is not."""
+    settings = Settings(
+        CHIMERA_HOME=str(tmp_path),
+        CHIMERA_DISCORD_BOT_TOKEN="t",
+        CHIMERA_GOVERNANCE="enforce",
+        CHIMERA_TOOL_ALLOWLIST="read_file",
+    )
+    adapter = _FakeAdapter()
+    mgr = MessagingManager(
+        settings=settings, backend=_FakeBackend(), model=None, max_steps=4,
+        workspace=tmp_path, adapter_factory=lambda _p: adapter,
+    )
+
+    names = {tool.name for tool in _session_registry(mgr, adapter).tools()}
+
+    assert names == {"read_file", "send_message"}


### PR DESCRIPTION
`chimera serve --discord` and the desktop app's Messaging toggle start the **same bot**. Only the first was governed.

`MessagingManager._gateway_on_message` built `default_registry(workspace)` raw — no denylist, no trust kernel, no taint ledger. An owner with `CHIMERA_TOOL_DENYLIST=shell,write_file` in `.env` who started Discord from the UI got no fence at all, and anyone who could message the bot reached every builtin. The file's own docstring claimed it *"Mirrors the CLI's `_serve_platform` factory"*, which is what made it easy to miss.

## The part that matters more than the fix

Nobody decided this. The build gate written to make governance structural (`tests/test_governed_surfaces.py`) parsed **one file** — `chimera/cli/main.py` — and listed five function names inside it. `chimera/server/manager.py` landed three weeks later, in another file, so it was not failing the gate. It was invisible to it.

**A list of surfaces to CHECK fails open.** Forget one and it is silently unguarded. So the gate is inverted:

| before | after |
|---|---|
| parse `cli/main.py`, check 5 named functions | walk every module in the package |
| unlisted surface → not checked | unlisted surface → **build fails** |
| obligations listed | **exemptions** listed, each with a written reason |

A new surface anywhere now fails the build until someone either routes it through `governed_profile` or adds one line saying why it does not need to be.

## Proved, not assumed

- A **fabricated new file** with an ungoverned factory, dropped into `chimera/server/`, breaks the build on its own and names the file, the line and the two ways out. That was the blind spot; it is closed.
- Reverting `manager.py` fails **three** gate tests — including one that pins this file by name, so a walk that silently stopped covering it again would not pass — and **two behavioural** ones.
- The behavioural half matters separately: the AST proves the *shape*, not the *effect*. With `CHIMERA_GOVERNANCE=enforce` and a denylist, `run_shell` was still in the bot's registry.

## What deliberately did not change

`send_message` is registered **after** the profile, the same order the CLI uses — a denylist aimed at shell must not take away the one tool that is this surface's reason to exist. And `off` mode still returns the registry untouched, so a default deployment behaves exactly as before: a fix that fenced everyone by default would be a breaking change wearing a security label.

The surface label is `app-messaging` rather than reusing the CLI's `platform`, because an audit reading those counts has to be able to say which of the two ways the bot was started.

## One thing measured on the way

The comment on `tool_allowlist` promised the lists apply *"on every surface"*. They do not. Measured across all three modes: with `CHIMERA_GOVERNANCE=off` — **the default** — `governed_profile` returns the registry untouched, so on a stock deployment a denylist in `.env` fences neither Discord bot.

The comment now states exactly where they apply and where they do not. The gap itself is left open on purpose: closing it changes what a default deployment does, which is a decision with a migration attached rather than a comment fix.

---

**Verification.** Full suite in WSL: ruff clean, 2922 passed. The 18 failures are pre-existing environment breakage in this WSL venv (sandbox/exec/subprocess-shaped) — byte-identical list to the run on unmodified `main`.

Found by a multi-agent audit for the class "an option is accepted and has no effect", after another session found `serve --workspace` never reaching `AgentConfig.project_root`. More findings from that sweep are pending triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)