### PR TITLE
fix(config): one env var meant two things, so all six of its values were broken

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,21 @@ CHIMERA_SERVER_TOKEN=
 CHIMERA_TOOL_ALLOWLIST=
 CHIMERA_TOOL_DENYLIST=
 
+# The two approval settings, and they are TWO because they answer different questions. They shared
+# one env var until it was noticed that no single value satisfied both vocabularies — so each of the
+# six documented settings below was broken in one direction or the other. Neither was written down
+# anywhere, which is most of how that survived; hence these lines.
+#
+# WHEN a run should stop and ask you: always | suspicious | never (empty = state nothing).
+# Read by the desktop app's Settings screen, which writes this variable.
+CHIMERA_APPROVAL=
+
+# WHAT happens when governance escalates an action to review: ask | deny | allow (default ask).
+# Read by `solve` and by every unattended surface. `ask` degrades to `deny` when no terminal is
+# attached — which is what cron has — because degrading the other way would make an unattended
+# deployment the most permissive configuration in the product.
+CHIMERA_APPROVAL_MODE=
+
 # Cache identical tool-free completions (HORIZON prompt caching): on | off (default off).
 # Saves cost/latency for repeated reasoning turns (fusion, planner, benchmarks).
 CHIMERA_CACHE=off

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,9 @@ npm --prefix apps/desktop run gen:api
 > rename an i18n key, never weaken a test to make it pass, numbers in `bench/` are pre-registered.
 > Every one of those is a rule someone learned the expensive way.
 
-- **Type-safe**: `mypy --strict` clean; avoid `Any`.
+- **Type-safe**: `uv run mypy chimera` clean; avoid `Any`. Strictness lives in `pyproject.toml`, so
+  run it without `--strict` — passing that flag on the command line overrides the project's own
+  `warn_unused_ignores = false` and reports ~15 phantom errors in files you never touched.
 - **Small units**: functions ≤ 40 lines, files ≤ 300 lines where practical.
 - **Tests**: new logic ships with tests; aim for ≥ 80% coverage on new code.
 - **Imports**: absolute imports within the package (`from chimera.x import y`).

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -7,6 +7,7 @@ the providers it actually calls (see :mod:`chimera.providers.gateway`).
 
 from __future__ import annotations
 
+import logging
 import os
 from functools import lru_cache
 from pathlib import Path
@@ -14,6 +15,16 @@ from typing import TYPE_CHECKING, Annotated
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
+
+# stdlib logging rather than `chimera.telemetry.get_logger`: telemetry reads settings, so importing
+# it here is a cycle. Same logger tree either way — this lands under `chimera.config` like the rest.
+_log = logging.getLogger("chimera.config")
+
+#: The two vocabularies that shared one env var until they were split. Named here rather than
+#: inline so each validator can recognise the OTHER side and say which variable the value belongs
+#: to — a message that only says "invalid" sends someone to the wrong file.
+_POSTURE_WORDS = frozenset({"always", "suspicious", "never"})  # CHIMERA_APPROVAL
+_GOVERNANCE_WORDS = frozenset({"ask", "allow", "deny"})  # CHIMERA_APPROVAL_MODE
 
 if TYPE_CHECKING:
     from chimera.providers.catalog import TierLadder
@@ -455,7 +466,22 @@ class Settings(BaseSettings):
     # the other way would make an unattended deployment the most permissive configuration in the
     # product, which is backwards. `allow` exists for a workspace whose contents the owner already
     # trusts, and every grant is recorded so the choice does not become invisible.
-    approval_mode: str = Field(default="ask", validation_alias="CHIMERA_APPROVAL")
+    #
+    # ⚠ This read `CHIMERA_APPROVAL` — the SAME env var as `approval` above — from the day it was
+    # written. Pydantic populated both fields from one variable, and the two vocabularies do not
+    # overlap in a single value, so every documented setting was broken in one direction or the
+    # other. Measured across all six: `ask`, `allow` and `deny` raised `ValidationError` out of
+    # `deployment_posture` (so `ask`, the documented default HERE, killed every coding turn), while
+    # `always`, `suspicious` and `never` arrived here unrecognised, fell through to the `ask` branch
+    # and — headless, which is what cron is — refused everything. An owner writing "never stop and
+    # ask" got the exact opposite, as a refusal string the agent reads past.
+    #
+    # They are not the same axis and never were. `approval` answers "when should a run pause for
+    # me?" — a posture question, owned by the desktop Settings screen, which writes that variable.
+    # This one answers "what happens when the approver is consulted?" — a policy question, read by
+    # `solve` and by every unattended surface. So this one moves, because nothing writes it and
+    # nothing documented it, while renaming the other would silently break saved app settings.
+    approval_mode: str = Field(default="ask", validation_alias="CHIMERA_APPROVAL_MODE")
 
     # Governance on the unattended surfaces (`serve`, cron, MCP, A2A, messaging): `off` | `observe`
     # | `enforce`. Off by default, because turning it on changes what a running deployment is
@@ -479,6 +505,59 @@ class Settings(BaseSettings):
     # INTERSECT — this list is a ceiling, and a caller must not be able to raise it.
     tool_allowlist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST")
     tool_denylist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST")
+
+    @field_validator("approval", mode="before")
+    @classmethod
+    def _approval_is_a_posture_word(cls, value: object) -> object:
+        """Keep the posture vocabulary out of the governance one, and say so when they are mixed.
+
+        The two fields shared an env var, so a value from the wrong side used to fail deep and late:
+        `CHIMERA_APPROVAL=ask` raised `ValidationError: 1 validation error for Posture` on every
+        coding turn, which names neither the setting nor the fix. Warning at construction and
+        falling back to "state nothing" is the same shape `governed_profile` already uses for an
+        unknown mode — a typo must not silently enable or silently disable something stricter than
+        intended, and "" is the value that changes nothing.
+        """
+        if not isinstance(value, str):
+            return value
+        word = value.strip().lower()
+        if word in _GOVERNANCE_WORDS:
+            _log.warning(
+                "CHIMERA_APPROVAL=%r is the governance vocabulary; that setting is now "
+                "CHIMERA_APPROVAL_MODE. Ignoring it here (no posture floor is stated).",
+                word,
+            )
+            return ""
+        if word and word not in _POSTURE_WORDS:
+            _log.warning(
+                "CHIMERA_APPROVAL=%r is not one of %s; ignoring it (no posture floor is stated).",
+                word, ", ".join(sorted(_POSTURE_WORDS)),
+            )
+            return ""
+        return word
+
+    @field_validator("approval_mode", mode="before")
+    @classmethod
+    def _approval_mode_is_a_policy_word(cls, value: object) -> object:
+        """The mirror. Unknown falls back to `ask`, which degrades to deny with no terminal —
+        the fail-closed end, so a typo cannot widen what an unattended deployment may do."""
+        if not isinstance(value, str):
+            return value
+        word = value.strip().lower()
+        if not word:
+            return "ask"
+        if word in _POSTURE_WORDS:
+            _log.warning(
+                "CHIMERA_APPROVAL_MODE=%r is the posture vocabulary; that setting is "
+                "CHIMERA_APPROVAL. Falling back to 'ask'.",
+                word,
+            )
+            return "ask"
+        if word not in _GOVERNANCE_WORDS:
+            _log.warning("CHIMERA_APPROVAL_MODE=%r is not one of %s; falling back to 'ask'.",
+                         word, ", ".join(sorted(_GOVERNANCE_WORDS)))
+            return "ask"
+        return word
 
     @field_validator(
         "fusion_panel",

--- a/tests/test_approval_vocabularies.py
+++ b/tests/test_approval_vocabularies.py
@@ -1,0 +1,156 @@
+"""One env var, two settings, and six documented values that were all broken.
+
+``CHIMERA_APPROVAL`` was declared as the ``validation_alias`` of **two** fields. Pydantic populated
+both, and the two vocabularies share no value, so every documented setting failed in one direction
+or the other. Measured across all six before the split:
+
+| value | field it was written for | what actually happened |
+|---|---|---|
+| ``ask`` / ``allow`` / ``deny`` | ``approval_mode`` | ``ValidationError`` out of `deployment_posture` — and ``ask`` is that field's own documented default, so it killed every coding turn |
+| ``always`` / ``suspicious`` / ``never`` | ``approval`` | arrived at ``approval_mode`` unrecognised, fell through to the ``ask`` branch, and headless — which is what cron is — **refused everything** |
+
+The second row is the worse one. An owner writing "never stop and ask" got the exact opposite, and
+got it as a refusal string the agent reads past, so the job reports success having done nothing.
+
+They are not the same axis and never were. ``approval`` answers *when should a run pause for me* —
+posture, owned by the desktop Settings screen, which writes that variable. ``approval_mode`` answers
+*what happens when the approver is consulted* — policy, read by `solve` and every unattended
+surface. The second one moved, because nothing writes it and nothing documented it, while renaming
+the first would silently break settings already saved by the app.
+
+Every test here fails against the pre-split code.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.posture import deployment_posture
+from chimera.config import Settings
+from chimera.governance.approval import ApprovalLedger, approver_for
+from chimera.governance.ledger import Decision, SequenceAssessment
+
+
+def _settings(tmp_path: Path, **env: str) -> Settings:
+    return Settings(CHIMERA_HOME=str(tmp_path), **env)  # type: ignore[arg-type]
+
+
+def _assessment() -> SequenceAssessment:
+    return SequenceAssessment(True, Decision.REVIEW, "writes after reading untrusted content")
+
+
+# --- the two variables are now independent --------------------------------------------------------
+
+
+def test_the_two_settings_no_longer_share_one_variable(tmp_path: Path) -> None:
+    """The bug in one assertion: setting one must not move the other."""
+    posture = _settings(tmp_path, CHIMERA_APPROVAL="always")
+    policy = _settings(tmp_path, CHIMERA_APPROVAL_MODE="allow")
+
+    assert (posture.approval, posture.approval_mode) == ("always", "ask")
+    assert (policy.approval, policy.approval_mode) == ("", "allow")
+
+
+@pytest.mark.parametrize("value", ["always", "suspicious", "never"])
+def test_every_documented_posture_value_survives_to_the_posture(tmp_path: Path, value: str) -> None:
+    """These used to reach `approval_mode`, land in the `ask` branch and deny everything headless."""
+    settings = _settings(tmp_path, CHIMERA_APPROVAL=value)
+
+    resolved = deployment_posture(settings)  # used to raise for the other three
+
+    assert settings.approval == value
+    assert resolved.pause_always is (value == "always")
+    assert resolved.pause_on_taint is (value == "suspicious")
+
+
+@pytest.mark.parametrize(("value", "approves"), [("allow", True), ("deny", False), ("ask", False)])
+def test_every_documented_policy_value_reaches_the_approver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, value: str, approves: bool
+) -> None:
+    """`ask` is False here because there is no terminal, which is what cron has — the fail-closed
+    end, and the reason `ask` degrades to deny rather than to allow."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO())  # headless
+    settings = _settings(tmp_path, CHIMERA_APPROVAL_MODE=value)
+    book = ApprovalLedger()
+
+    assert approver_for(settings.approval_mode, book)(_assessment()) is approves
+
+
+def test_the_posture_no_longer_dies_on_the_other_vocabulary(tmp_path: Path) -> None:
+    """`CHIMERA_APPROVAL=ask` used to raise `ValidationError: 1 validation error for Posture` on
+    every coding turn — an error naming neither the setting nor the fix, at request time rather
+    than at startup."""
+    for value in ("ask", "allow", "deny"):
+        deployment_posture(_settings(tmp_path, CHIMERA_APPROVAL=value))  # must not raise
+
+
+# --- a value from the wrong side is named, not guessed at ------------------------------------------
+
+
+def test_a_governance_word_in_the_posture_variable_says_where_it_belongs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Falling back to "" is the same shape `governed_profile` uses for an unknown mode: a typo must
+    not silently enable or silently disable something stricter than intended, and "" states nothing.
+
+    The message has to name the OTHER variable. "invalid value" sends someone to the wrong file.
+    """
+    with caplog.at_level(logging.WARNING, logger="chimera.config"):
+        settings = _settings(tmp_path, CHIMERA_APPROVAL="deny")
+
+    assert settings.approval == ""
+    assert "CHIMERA_APPROVAL_MODE" in caplog.text
+
+
+def test_a_posture_word_in_the_governance_variable_says_where_it_belongs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="chimera.config"):
+        settings = _settings(tmp_path, CHIMERA_APPROVAL_MODE="always")
+
+    assert settings.approval_mode == "ask", "fell back to something other than the closed end"
+    assert "CHIMERA_APPROVAL" in caplog.text
+
+
+@pytest.mark.parametrize("field", ["CHIMERA_APPROVAL", "CHIMERA_APPROVAL_MODE"])
+def test_a_typo_falls_back_rather_than_raising(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, field: str
+) -> None:
+    """A misspelled env var must not stop the product from starting — but it must be audible.
+    Silence here is how a fence someone believes they configured turns out not to exist."""
+    with caplog.at_level(logging.WARNING, logger="chimera.config"):
+        settings = _settings(tmp_path, **{field: "susipcious"})
+
+    assert (settings.approval, settings.approval_mode) == ("", "ask")
+    assert "susipcious" in caplog.text
+
+
+def test_the_fallback_for_the_policy_is_the_closed_end(tmp_path: Path, monkeypatch: Any) -> None:
+    """Direction matters more than the fallback existing. Falling back to `allow` would make a typo
+    the most permissive configuration in the product."""
+    monkeypatch.setattr(sys, "stdin", io.StringIO())
+    settings = _settings(tmp_path, CHIMERA_APPROVAL_MODE="alow")  # a plausible typo for `allow`
+    book = ApprovalLedger()
+
+    assert approver_for(settings.approval_mode, book)(_assessment()) is False
+    assert book.blocked
+
+
+# --- defaults are unchanged ------------------------------------------------------------------------
+
+
+def test_a_deployment_that_sets_neither_behaves_exactly_as_before(tmp_path: Path) -> None:
+    """The split must be invisible to everyone who never set the variable — which, since it was
+    undocumented, is nearly everyone."""
+    settings = _settings(tmp_path)
+
+    assert settings.approval == ""
+    assert settings.approval_mode == "ask"
+    resolved = deployment_posture(settings)
+    assert (resolved.pause_always, resolved.pause_on_taint) == (False, False)


### PR DESCRIPTION
`CHIMERA_APPROVAL` was declared as the `validation_alias` of **two** fields. Pydantic populated both, the two vocabularies share no value, and so **every documented setting was broken** — in one direction or the other.

Measured across all six:

| value | written for | what actually happened |
|---|---|---|
| `ask` · `allow` · `deny` | `approval_mode` | `ValidationError` out of `deployment_posture`. `ask` is that field's own documented default, so it killed **every coding turn**. |
| `always` · `suspicious` · `never` | `approval` | arrived at `approval_mode` unrecognised, fell through to the `ask` branch and — headless, which is what cron is — **refused everything**. |

The second row is the worse one. An owner writing *"never stop and ask"* got the exact opposite, delivered as a refusal string the agent reads past, so the job reports success having done nothing.

## Why a merged vocabulary was never going to work

They are not the same axis:

- **`approval`** answers *when should a run pause for me* — posture. Owned by the desktop Settings screen, which writes that variable.
- **`approval_mode`** answers *what happens when the approver is consulted* — policy. Read by `solve` and by every unattended surface.

## Which side moved, and why that is not a coin-flip

`approval_mode` → `CHIMERA_APPROVAL_MODE`. It has **no writer** anywhere and was **documented nowhere**, while renaming the other would silently break settings already saved by the app. The frontend needed no change at all, which is the check on that reasoning.

Anyone who had set the governance vocabulary by hand was already crashing on every coding turn, so no working deployment depends on the old behaviour.

## A wrong-side value is now named, not guessed at

A warning that points at **the other variable**, then a fallback: `""` for the posture (states nothing) and `ask` for the policy — the closed end, because falling back to `allow` would make a typo the most permissive configuration in the product. Same shape `governed_profile` already uses for an unknown mode, and audible instead of a `ValidationError` at request time naming neither the setting nor the fix.

Both variables are now in `.env.example`. Neither ever was, which is most of how this survived.

## Also

One line in `CONTRIBUTING.md` said to run `mypy --strict`. That flag **overrides the project's own `warn_unused_ignores = false`** and reports ~15 phantom errors in files you never touched. CI, `RELEASING.md` and the README all run `mypy chimera`; only that line disagreed — and it sent me down exactly that road while writing this PR.

---

**Verification.** 14 new tests, **7 of which fail against the pre-split code**. Full suite in WSL: ruff clean, `mypy chimera` clean across 303 files in both Windows and Linux, 2929 passed. The 18 failures are pre-existing environment breakage in that WSL venv (sandbox/exec/subprocess-shaped) — byte-identical list to a run on unmodified `main`.

Second finding from the multi-agent audit for the class "an option is accepted and has no effect". First was #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)