### PR TITLE
fix(agents-md): the workspace rooted the tools and not the conventions

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -905,7 +905,10 @@ def agent(
 
             kernel = TrustKernel(audit=AuditLog(get_settings().home / "audit.jsonl"))
             registry = govern_registry(registry, kernel)
-        runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        runner = Agent(
+            backend, registry,
+            AgentConfig(model=model, max_steps=max_steps, project_root=Path(workspace)),
+        )
         result = runner.run(task)
     except MissingCredentialsError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -1014,7 +1017,14 @@ def chat(
         from chimera.fusion import FusionEngine, RoutedBackend
 
         backend = RoutedBackend(gateway, FusionEngine(gateway))
-    agent = Agent(backend, default_registry(Path(workspace)), AgentConfig(model=model, max_steps=max_steps))
+    agent = Agent(
+        backend,
+        default_registry(Path(workspace)),
+        # Same workspace, both arguments: the one that roots the tools also carries the
+        # project's conventions. Splitting them is how `AGENTS.md` came to be read on
+        # four surfaces out of twenty-seven.
+        AgentConfig(model=model, max_steps=max_steps, project_root=Path(workspace)),
+    )
     mem = None if no_memory else _memory_manager()
 
     # The conversation outlives the terminal.
@@ -1136,7 +1146,14 @@ def assist(
     routes_path = Path(settings.home) / "routes.jsonl"
     gateway = LLMGateway()
     backend: SupportsComplete = gateway if no_cascade else _cascade_backend(gateway, settings)
-    agent = Agent(backend, default_registry(Path(workspace)), AgentConfig(model=model, max_steps=max_steps))
+    agent = Agent(
+        backend,
+        default_registry(Path(workspace)),
+        # Same workspace, both arguments: the one that roots the tools also carries the
+        # project's conventions. Splitting them is how `AGENTS.md` came to be read on
+        # four surfaces out of twenty-seven.
+        AgentConfig(model=model, max_steps=max_steps, project_root=Path(workspace)),
+    )
     # Second-brain defaults: memory + graph + profile preamble always on (unless opted out).
     mem = None if no_memory else _memory_manager()
     session = ChatSession(
@@ -1285,7 +1302,14 @@ def tui(
         from chimera.fusion import FusionEngine, RoutedBackend
 
         backend = RoutedBackend(gateway, FusionEngine(gateway))
-    agent = Agent(backend, default_registry(Path(workspace)), AgentConfig(model=model, max_steps=max_steps))
+    agent = Agent(
+        backend,
+        default_registry(Path(workspace)),
+        # Same workspace, both arguments: the one that roots the tools also carries the
+        # project's conventions. Splitting them is how `AGENTS.md` came to be read on
+        # four surfaces out of twenty-seven.
+        AgentConfig(model=model, max_steps=max_steps, project_root=Path(workspace)),
+    )
     mem = None if no_memory else _memory_manager()
     session = ChatSession(
         agent, memory=mem, graph=_recall_graph(mem), profile=_session_profile(mem)
@@ -1380,7 +1404,15 @@ def serve(
         )
         if http_send_tool is not None:
             registry.register(http_send_tool)
-        runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        runner = Agent(
+            backend,
+            registry,
+            # The same workspace that roots the tools. It was good enough to grant file
+            # capability here and not good enough to convey the project's conventions, which is
+            # incoherent: `serve --workspace X` is the headless deployment from the README, and
+            # its AGENTS.md was never read.
+            AgentConfig(model=model, max_steps=max_steps, project_root=workspace_path),
+        )
         return ChatSession(
             runner,
             memory=shared_memory,
@@ -1635,6 +1667,9 @@ def desktop_app(
                 # The same identity the coding turn applies. Without it a Discord bot and the app
                 # would answer as two different agents from one configuration.
                 instructions=render_identity(load_identity(live.home)),
+                # …and the same workspace that roots the tools below, so the project's own
+                # conventions reach the app's chat the way they reach `solve`.
+                project_root=workspace_path,
             ),
         )
         return ChatSession(
@@ -1741,6 +1776,10 @@ def _start_cron_daemon(
                 model=model,
                 max_steps=max_steps,
                 max_usd=job.max_usd,
+                # The same workspace the job's tools are rooted in. A scheduled job is the surface
+                # LEAST able to be told the conventions any other way — nobody is at a terminal to
+                # restate them — and it was the one reading none.
+                project_root=workspace,
                 # The path that runs the most was the one with no step-level record at all. Without
                 # it there is no success-versus-context curve, no replay of a job that went wrong,
                 # and no reliability bench for the 24/7 loop — every one of those reads this file.
@@ -1784,7 +1823,10 @@ def _start_cron_daemon(
             home=settings.home,
             surface="cron:task",
         )
-        agent = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        agent = Agent(
+            backend, registry,
+            AgentConfig(model=model, max_steps=max_steps, project_root=workspace),
+        )
         return agent.run(task).answer
 
     results_path = get_settings().home / "scheduler" / "cron_results.jsonl"
@@ -1951,7 +1993,10 @@ def _serve_mcp(
             home=get_settings().home,
             surface="mcp",
         )
-        worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        worker = Agent(
+            backend, registry,
+            AgentConfig(model=model, max_steps=max_steps, project_root=workspace_path),
+        )
         auto = AutonomousAgent(
             worker,
             memory=_memory_manager() if recall else None,
@@ -2000,7 +2045,10 @@ def _build_a2a(
             home=get_settings().home,
             surface="a2a",
         )
-        worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        worker = Agent(
+            backend, registry,
+            AgentConfig(model=model, max_steps=max_steps, project_root=workspace_path),
+        )
         auto = AutonomousAgent(
             worker, config=AutonomousConfig(max_attempts=2, use_planner=False, use_manager=False)
         )
@@ -2051,7 +2099,10 @@ def _serve_platform(
             surface="platform",
         )
         registry.register(send_tool)
-        runner = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+        runner = Agent(
+            backend, registry,
+            AgentConfig(model=model, max_steps=max_steps, project_root=workspace_path),
+        )
         return ChatSession(runner, memory=memory, graph=graph)
 
     gateway = MessageGateway(factory)
@@ -3458,7 +3509,14 @@ def solve_batch(
             ledger = TaintLedger()
             ledgers[name] = ledger
             registry = ledger_registry(default_registry(ws), ledger, narrow_on_taint=taint)
-            worker = Agent(backend, registry, AgentConfig(model=model, max_steps=max_steps))
+            worker = Agent(
+                backend,
+                registry,
+                # `ws` is this task's isolated worktree — a checkout of the repo, so its AGENTS.md is
+                # the same one. Single-task `solve` has always passed it; the batch did not, which is
+                # the same shape as a batch being quietly weaker than one run done alone.
+                AgentConfig(model=model, max_steps=max_steps, project_root=ws),
+            )
             auto = AutonomousAgent(
                 worker,
                 planner=Planner(gateway, model),

--- a/chimera/kanban/lanes.py
+++ b/chimera/kanban/lanes.py
@@ -65,7 +65,14 @@ class SolveLane:
 
         gateway = LLMGateway()
         settings = get_settings()
-        worker = Agent(gateway, default_registry(self.workspace), AgentConfig(model=self.model))
+        worker = Agent(
+            gateway,
+            default_registry(self.workspace),
+            # The card's workspace, in both arguments: it roots the tools and it carries the
+            # project's conventions. A lane is an autonomous path, so nobody is there to
+            # restate them.
+            AgentConfig(model=self.model, project_root=self.workspace),
+        )
         # M19-A4: a lane is an autonomous path too — turn the flywheel on (experience, skills,
         # memory, playbook) so working a card learns exactly as `chimera solve` does.
         evo = build_evolution_context(
@@ -164,6 +171,7 @@ class AgentLane:
                 # untrusted-data fence by being given a personality is not a worker anyone should
                 # be able to define from a text field.
                 instructions=role.system_prompt,
+                project_root=self.workspace,
             ),
         )
         # Same flywheel as every other autonomous path: working a card learns exactly as

--- a/chimera/server/manager.py
+++ b/chimera/server/manager.py
@@ -127,7 +127,14 @@ class MessagingManager:
             registry = default_registry(self._workspace)
             registry.register(send_tool)
             runner = Agent(
-                self._backend, registry, AgentConfig(model=self._model, max_steps=self._max_steps)
+                self._backend,
+                registry,
+                # The same workspace that roots the tools two lines up.
+                AgentConfig(
+                    model=self._model,
+                    max_steps=self._max_steps,
+                    project_root=self._workspace,
+                ),
             )
             return ChatSession(
                 runner,

--- a/tests/test_project_root_reaches_every_surface.py
+++ b/tests/test_project_root_reaches_every_surface.py
@@ -1,0 +1,205 @@
+"""`AGENTS.md` reached four surfaces out of twenty-seven, and not the one in the README.
+
+`serve --workspace X` accepts the flag, roots every tool at X, and then built its agent with
+`project_root=None` — so `chimera/core/agent.py` returned "" at the gate and the project's own
+conventions were never read. That is the headless Docker deployment the README documents: the
+gateway, the Discord bot and the cron dispatch, all running with nobody at a terminal to restate
+what the flag was supposed to have said.
+
+The incoherence is the argument. The same workspace was good enough to grant **file capability** and
+not good enough to convey **file conventions**. Nothing chose that; `project_root` was added later
+and wired at whichever call sites the author was looking at — four of them, and `instructions` at a
+different four, so the two halves of a project's identity were each remembered somewhere the other
+was not.
+
+Two kinds of test here, and they answer different questions — worth stating, because one of them
+does NOT catch this bug and pretending otherwise would be the same kind of overclaim.
+
+The **AST gate** encodes the rule — *a surface that roots its tools in a workspace passes that
+workspace as `project_root`* — and is what fails the build on a new site. Against the shipped code
+it names all fifteen.
+
+The **canary** is the reporter's own repro turned into a test: an `AGENTS.md` in the workspace, and
+its text asserted into the prompt. It passes against the broken code too, because the mechanism was
+never broken — only the wiring was. Its job is to keep the mechanism honest and to document, in one
+readable place, exactly what `project_root` buys.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import pytest
+
+from chimera.core import Agent, AgentConfig
+from chimera.tools.registry import ToolRegistry
+
+PACKAGE = pathlib.Path(__file__).resolve().parents[1] / "chimera"
+
+#: Sites that root a registry in a workspace and legitimately pass no `project_root`, with why.
+#: Listed as exemptions rather than obligations, for the reason the governance gate learned the hard
+#: way: a list of things to CHECK fails open, and the site nobody added is the one that breaks.
+EXEMPT: dict[str, str] = {
+    "chimera/workflow/executors.py:build_executors.solve_step": "delegates to solve, which sets it",
+    "chimera/orchestration/lifecycle.py:lifecycle_crew": "library constructor; the caller owns the root",
+    "chimera/cli/main.py:sandbox_bench.factory": "benchmark harness, not a user's repository",
+    "chimera/cli/main.py:evolve_tune.__init__": "offline tuning over recorded trajectories",
+}
+
+
+def _sites_without_project_root() -> list[tuple[str, int]]:
+    """Every `AgentConfig` that lacks a project root inside a scope rooted in a workspace.
+
+    Each call is attributed to its **innermost** enclosing function, and a scope counts as rooted
+    when that function or any function enclosing it builds a `default_registry`. Attributing to an
+    ancestor instead would name `serve` where the code lives in `serve.factory` — and it is inside
+    the factory, every time, that this goes missing.
+    """
+    found: list[tuple[str, int]] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        source = path.read_text(encoding="utf-8")
+        if "default_registry(" not in source or "AgentConfig(" not in source:
+            continue
+        module = path.relative_to(PACKAGE.parent).as_posix()
+        rooted: set[tuple[str, ...]] = set()
+        configs: list[tuple[tuple[str, ...], int, bool]] = []
+
+        def walk(node: ast.AST, chain: tuple[str, ...]) -> None:
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                chain = (*chain, node.name)
+            if isinstance(node, ast.Call):
+                name = getattr(node.func, "id", "")
+                if name == "default_registry":
+                    rooted.add(chain)
+                elif name == "AgentConfig":
+                    has_root = "project_root" in {kw.arg for kw in node.keywords}
+                    configs.append((chain, node.lineno, has_root))
+            for child in ast.iter_child_nodes(node):
+                walk(child, chain)
+
+        walk(ast.parse(source), ())
+        for chain, lineno, has_root in configs:
+            if has_root:
+                continue
+            # Rooted here, or anywhere up the chain: `serve` opens the workspace and `serve.factory`
+            # is where the agent is built.
+            if any(chain[:n] in rooted for n in range(1, len(chain) + 1)):
+                found.append((f"{module}:{'.'.join(chain)}", lineno))
+    return found
+
+
+# --- the gate -------------------------------------------------------------------------------------
+
+
+def test_a_workspace_that_roots_the_tools_also_carries_the_conventions() -> None:
+    """The rule, over the whole package.
+
+    Deliberately phrased as an equivalence rather than a list of surfaces: if a workspace is trusted
+    enough to decide which files the agent may touch, it is the workspace whose conventions apply.
+    A surface that disagrees says so in EXEMPT, in one line.
+    """
+    ungoverned = [(key, line) for key, line in _sites_without_project_root() if key not in EXEMPT]
+
+    assert not ungoverned, (
+        "these surfaces root their tools in a workspace and then run without its conventions: "
+        + ", ".join(f"{key} (line {line})" for key, line in ungoverned)
+        + " — pass `project_root=<the same workspace>`, or add it to EXEMPT with the reason."
+    )
+
+
+def test_the_gate_catches_the_shape_it_was_written_for() -> None:
+    """Proof the walk is not vacuous, on the exact code that shipped: a factory that roots a
+    registry and builds a config without the root."""
+    source = """
+def serve(workspace):
+    def factory():
+        registry = default_registry(workspace)
+        return Agent(backend, registry, AgentConfig(model=m, max_steps=8))
+"""
+    tree = ast.parse(source)
+    offenders = [
+        call.lineno
+        for call in ast.walk(tree)
+        if isinstance(call, ast.Call)
+        and getattr(call.func, "id", "") == "AgentConfig"
+        and "project_root" not in {kw.arg for kw in call.keywords}
+    ]
+
+    assert offenders == [5]
+
+
+def test_every_exemption_still_points_at_real_code() -> None:
+    """An exemption that outlives its call site is a line claiming something was considered, sitting
+    next to sites that still are."""
+    live = {key for key, _ in _sites_without_project_root()}
+
+    assert not sorted(set(EXEMPT) - live), f"stale EXEMPT entries: {sorted(set(EXEMPT) - live)}"
+
+
+# --- the canary -----------------------------------------------------------------------------------
+
+
+class _Capture:
+    """A backend that records the prompt it was handed and answers nothing useful."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict[str, Any]] = []
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> Any:
+        from chimera.providers import CompletionResult
+
+        self.messages = list(messages)
+        return CompletionResult(content="ok", model="fake")
+
+
+def _prompt_text(backend: _Capture) -> str:
+    return "\n".join(str(m.get("content", "")) for m in backend.messages)
+
+
+def test_agents_md_reaches_the_prompt_when_the_root_is_set(tmp_path: pathlib.Path) -> None:
+    """The reporter's canary, as a test: with an `AGENTS.md` in the workspace naming a command, the
+    agent that was told about the workspace sees it."""
+    (tmp_path / "AGENTS.md").write_text(
+        "# Conventions\n\nAlways run the suite with `just verify`, never with `pytest` directly.\n",
+        encoding="utf-8",
+    )
+    backend = _Capture()
+
+    Agent(backend, ToolRegistry(), AgentConfig(model="m", project_root=tmp_path)).run("how do I test?")
+
+    assert "just verify" in _prompt_text(backend)
+
+
+def test_without_the_root_the_same_file_is_invisible(tmp_path: pathlib.Path) -> None:
+    """The other half, and the reason the bug was silent: nothing errors, nothing warns. The agent
+    simply answers from general knowledge and looks like it is working."""
+    (tmp_path / "AGENTS.md").write_text("Always run `just verify`.\n", encoding="utf-8")
+    backend = _Capture()
+
+    Agent(backend, ToolRegistry(), AgentConfig(model="m")).run("how do I test?")
+
+    assert "just verify" not in _prompt_text(backend)
+
+
+@pytest.mark.parametrize("command", ["serve", "chat", "assist", "tui"])
+def test_the_named_surfaces_pass_the_workspace_they_were_given(command: str) -> None:
+    """Named explicitly, because these are the ones a user hands a `--workspace` to and then expects
+    the flag to mean something. `serve` is the one in the README's Docker deployment."""
+    source = (PACKAGE / "cli" / "main.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    scope = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == command
+    )
+
+    configs = [
+        call
+        for call in ast.walk(scope)
+        if isinstance(call, ast.Call) and getattr(call.func, "id", "") == "AgentConfig"
+    ]
+
+    assert configs, f"`{command}` no longer builds an AgentConfig — retarget this test"
+    assert all("project_root" in {kw.arg for kw in call.keywords} for call in configs)

--- a/tests/test_project_root_reaches_every_surface.py
+++ b/tests/test_project_root_reaches_every_surface.py
@@ -63,23 +63,7 @@ def _sites_without_project_root() -> list[tuple[str, int]]:
         if "default_registry(" not in source or "AgentConfig(" not in source:
             continue
         module = path.relative_to(PACKAGE.parent).as_posix()
-        rooted: set[tuple[str, ...]] = set()
-        configs: list[tuple[tuple[str, ...], int, bool]] = []
-
-        def walk(node: ast.AST, chain: tuple[str, ...]) -> None:
-            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-                chain = (*chain, node.name)
-            if isinstance(node, ast.Call):
-                name = getattr(node.func, "id", "")
-                if name == "default_registry":
-                    rooted.add(chain)
-                elif name == "AgentConfig":
-                    has_root = "project_root" in {kw.arg for kw in node.keywords}
-                    configs.append((chain, node.lineno, has_root))
-            for child in ast.iter_child_nodes(node):
-                walk(child, chain)
-
-        walk(ast.parse(source), ())
+        rooted, configs = _scan(ast.parse(source))
         for chain, lineno, has_root in configs:
             if has_root:
                 continue
@@ -88,6 +72,35 @@ def _sites_without_project_root() -> list[tuple[str, int]]:
             if any(chain[:n] in rooted for n in range(1, len(chain) + 1)):
                 found.append((f"{module}:{'.'.join(chain)}", lineno))
     return found
+
+
+def _scan(
+    tree: ast.Module,
+) -> tuple[set[tuple[str, ...]], list[tuple[tuple[str, ...], int, bool]]]:
+    """One pass: which scopes root a registry, and every `AgentConfig` with its scope chain.
+
+    A module-level function rather than a closure inside the loop above — a nested one would capture
+    the accumulators from an enclosing `for`, which is a real footgun and which ruff's B023 catches.
+    """
+    rooted: set[tuple[str, ...]] = set()
+    configs: list[tuple[tuple[str, ...], int, bool]] = []
+
+    def walk(node: ast.AST, chain: tuple[str, ...]) -> None:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            chain = (*chain, node.name)
+        if isinstance(node, ast.Call):
+            name = getattr(node.func, "id", "")
+            if name == "default_registry":
+                rooted.add(chain)
+            elif name == "AgentConfig":
+                configs.append(
+                    (chain, node.lineno, "project_root" in {kw.arg for kw in node.keywords})
+                )
+        for child in ast.iter_child_nodes(node):
+            walk(child, chain)
+
+    walk(tree, ())
+    return rooted, configs
 
 
 # --- the gate -------------------------------------------------------------------------------------


### PR DESCRIPTION
`serve --workspace X` accepts the flag, roots every tool at X, and then built its agent with `project_root=None` — so the gate at `chimera/core/agent.py:256` returned `""` and the project's own `AGENTS.md` was **never read**.

That is the headless Docker deployment the README documents: the gateway, the Discord bot and the cron dispatch — none of them with anyone at a terminal to restate what the flag was supposed to have said.

Reported from a live 24/7 deployment, with a canary: with `AGENTS.md` present in the workspace, the agent answered an **invented** command instead of the documented one.

## The argument is the code's own

The **same workspace** was good enough to grant file **capability** and not good enough to convey file **conventions**. Nothing chose that — `project_root` was added later and wired at whichever call sites the author happened to be looking at.

Measured across the package:

| field | sites carrying it | of |
|---|---|---|
| `project_root` | **4** | 27 |
| `instructions` | **4** | 27 |

…and they are **not the same 4**. `acp_server` had the root and not the instructions; the desktop chat had the instructions and not the root. Both halves of a project's identity, each remembered somewhere the other was not.

## The rule, not a list

Stated as an equivalence: *if a workspace is trusted enough to decide which files the agent may touch, it is the workspace whose conventions apply.*

13 sites now pass it — `serve`, cron (both dispatch paths), MCP, A2A, the CLI messaging gateway, the in-app bot, the desktop chat, `agent`/`chat`/`assist`/`tui`, both kanban lanes, and `solve_batch`.

`solve_batch` is worth naming: single-task `solve` had always passed it, so the batch was quietly weaker than the same task run alone — the same shape as a batch that never mints a pause thread.

The gate lists **exemptions, not obligations**, which is the lesson the governance gate learned the expensive way in #80: a list of things to CHECK fails open, and the site nobody remembered to add is exactly the one that breaks. Four remain, each with its reason.

## Two honesty notes, written into the test file

**The canary does not catch this bug.** It passes against the broken code too, because the mechanism was never broken — only the wiring was. Its job is to keep the mechanism honest and to show, in one readable place, what `project_root` buys. The **AST gate** is what catches the wiring: against the shipped code it names all fifteen sites with line numbers.

**`instructions` is deliberately untouched.** It has the identical 4-of-27 hole, but it changes the system prompt on surfaces that do not carry it today — a behaviour change for running deployments. `project_root` is additive: with no `AGENTS.md`, nothing moves. That one gets its own PR and its own decision.

---

**Verification.** 9 new tests. Against the pre-fix code the gate fails naming every site, and the four `serve`/`chat`/`assist`/`tui` assertions fail. Full suite in WSL: ruff clean, `mypy chimera` clean across 303 files, 2924 passed. The 18 failures are pre-existing environment breakage in that WSL venv (sandbox/exec/subprocess-shaped) — byte-identical list to a run on unmodified `main`.

Third finding from the multi-agent audit for the class "an option is accepted and has no effect" (#80, #81). This one was the original report that started the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)