### PR TITLE
fix(governance): an explicit fence needs no rollout

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -498,19 +498,17 @@ class Settings(BaseSettings):
     # Deployment-level tool allowlist/denylist (names). Empty allowlist = no restriction (all
     # tools); a non-empty allowlist grants only those. Denylist removes even if allowed.
     #
-    # Where they apply, stated exactly, because the previous wording here ("on every surface") was
-    # not true and reading it as true is how an owner ends up with an unfenced bot:
+    # These apply on every surface, and that sentence was false for three weeks before it was true:
+    # `run`/`solve` in a terminal, the coding turn, the autonomous run, the parallel batch, the
+    # desktop app's chat, and the unattended surfaces — `serve`, the cron dispatch, MCP, A2A, and the
+    # messaging bots started either way.
     #
-    #   ALWAYS — `run`/`solve` in a terminal, the coding turn, the autonomous run, the parallel
-    #   batch, and the desktop app's own chat (which applies them itself, unconditionally).
-    #
-    #   ONLY WITH `CHIMERA_GOVERNANCE=observe|enforce` — the unattended surfaces: `serve`, the cron
-    #   dispatch, MCP, A2A, and the messaging bots started either way. Those go through
-    #   `governed_profile`, and that function returns the registry untouched in `off` mode, which is
-    #   the default. So on a stock deployment a denylist in `.env` does NOT fence the Discord bot.
-    #   That asymmetry is a real gap, not a design: it is written down here rather than papered over,
-    #   and closing it means changing what a default deployment does, which is a decision with a
-    #   migration attached rather than a comment fix.
+    # The last group used to be conditional on `CHIMERA_GOVERNANCE=observe|enforce`, which defaults
+    # to `off`, so on a stock deployment a denylist written here fenced NEITHER Discord bot. That was
+    # a filing error rather than a decision: these lists are an instruction (the tool is in the
+    # registry or it is not), while the trust kernel and taint ledger are an inference that can
+    # refuse legitimate work — only the second needs a rollout to be priced first, and only the
+    # second is still staged behind that variable.
     #
     # Where a request carries its own allowlist the two INTERSECT — this list is a ceiling, and a
     # caller must not be able to raise it.

--- a/chimera/governance/profile.py
+++ b/chimera/governance/profile.py
@@ -17,6 +17,14 @@ agent reads it, carries on, and the run reports success having done nothing. On 
 that is real money unwatched behind a green tick. So `observe` runs the whole stack, records every
 action that WOULD have been refused, and refuses none of them. Turning it to `enforce` is a decision
 someone makes with that count in front of them.
+
+**But an explicit fence is not part of that rollout, and filing it under the same switch was a
+mistake.** `CHIMERA_TOOL_ALLOWLIST` / `CHIMERA_TOOL_DENYLIST` are an instruction, not an inference:
+the named tool is in the registry or it is not, there is no legitimate work they can refuse by
+accident, and there is nothing to price before turning them on. Gating them behind `governance_mode`
+meant the only way to get a fence you had written by hand was to accept a rollout you had not asked
+for — so on a stock deployment they reached neither Discord bot, while `config.py` said they applied
+"on every surface". They now apply whatever the mode; the kernel and the taint ledger still do not.
 """
 
 from __future__ import annotations
@@ -70,24 +78,32 @@ def governed_profile(
         resolved = "off"
 
     approvals = ApprovalLedger()
-    if resolved == "off":
-        return registry, approvals
 
+    from chimera.governance import restrict_registry
     from chimera.governance.audit import AuditLog
 
     audit = AuditLog(home / "audit.jsonl")
-    # In observe mode the approver says yes to everything and writes down that it did. Every call
-    # that reaches an approver is one the policy WOULD have refused, so `approvals.granted` is
-    # exactly the report a rollout needs: what enforcement would have cost, per surface, measured
-    # rather than guessed.
-    approve = (
-        allow_everything(approvals)
-        if resolved == "observe"
-        else approver_for(settings.approval_mode, approvals)
-    )
 
-    from chimera.governance import restrict_registry
-
+    # --- the explicit fence: applied whatever the mode -------------------------------------------
+    #
+    # This sits ABOVE the `off` return, and the distinction it draws is the whole point. An owner who
+    # writes `CHIMERA_TOOL_DENYLIST=run_shell` has stated an instruction with no ambiguity in it:
+    # remove that tool. There is nothing to stage, nothing to measure, no legitimate work it might
+    # refuse by mistake — the tool is either in the registry or it is not.
+    #
+    # The machinery below is different in kind. The kernel and the taint ledger *infer* whether an
+    # action is dangerous, and inference can be wrong in the expensive direction: a job that reads a
+    # feed and then cannot write for the rest of its run, reporting success having done nothing.
+    # That is what `observe` exists to price before anyone turns it on.
+    #
+    # Filing the two under one switch meant the ONLY way to get a fence you had written by hand was
+    # to also accept a rollout you had not asked for — so `config.py` promised the lists "apply on
+    # every surface" and, on a stock deployment, they reached neither Discord bot. The desktop app's
+    # own chat had already gone the other way and applied them unconditionally, which is how a
+    # product ends up with two implementations of one rule that disagree about the default.
+    #
+    # Nothing changes for a deployment that set neither list: both resolve to empty, the call below
+    # is skipped, and `registry` is returned exactly as it arrived.
     allow_names = (
         [x.strip() for x in allow.split(",") if x.strip()]
         if allow is not None
@@ -100,6 +116,22 @@ def governed_profile(
     )
     if allow_names is not None or deny_names:
         registry = restrict_registry(registry, allow=allow_names, deny=deny_names, audit=audit)
+        _log.info("tool fence applied on %s", surface or "(unnamed surface)")
+
+    if resolved == "off":
+        return registry, approvals
+
+    # --- the inferential machinery: still staged behind observe/enforce ---------------------------
+    #
+    # In observe mode the approver says yes to everything and writes down that it did. Every call
+    # that reaches an approver is one the policy WOULD have refused, so `approvals.granted` is
+    # exactly the report a rollout needs: what enforcement would have cost, per surface, measured
+    # rather than guessed.
+    approve = (
+        allow_everything(approvals)
+        if resolved == "observe"
+        else approver_for(settings.approval_mode, approvals)
+    )
 
     registry = govern_registry(registry, TrustKernel(audit=audit), approve=approve)
     registry = ledger_registry(

--- a/tests/test_governed_surfaces.py
+++ b/tests/test_governed_surfaces.py
@@ -335,3 +335,102 @@ def test_each_named_surface_is_declared(surface: str, module: str) -> None:
     body = (PACKAGE / module).read_text(encoding="utf-8")
 
     assert f'surface="{surface}' in body or f'surface=f"{surface}' in body
+
+
+# --- the fence, and what it is NOT filed under ----------------------------------------------------
+
+
+def test_an_explicit_denylist_applies_with_governance_off(tmp_path: pathlib.Path) -> None:
+    """The gap this closes.
+
+    `CHIMERA_GOVERNANCE` defaults to `off`, and `off` used to return the registry untouched — so an
+    owner who wrote `CHIMERA_TOOL_DENYLIST=write_file` in `.env` got no fence on any unattended
+    surface, while `config.py` said the lists apply everywhere. The two are not the same kind of
+    thing: a denylist is an instruction, and there is nothing to stage about removing a named tool.
+    """
+    registry, _ = governed_profile(
+        _registry(),
+        settings=_settings(tmp_path, CHIMERA_TOOL_DENYLIST="write_file"),
+        home=tmp_path,
+    )
+
+    assert "write_file" not in {t.name for t in registry.tools()}, (
+        "the owner's fence did not reach an off-mode surface"
+    )
+
+
+def test_an_explicit_allowlist_applies_with_governance_off(tmp_path: pathlib.Path) -> None:
+    """The other half: a non-empty allowlist grants ONLY those, everything else is dropped."""
+    registry, _ = governed_profile(
+        _registry(),
+        settings=_settings(tmp_path, CHIMERA_TOOL_ALLOWLIST="read_file"),
+        home=tmp_path,
+    )
+
+    # `_Writer` is the only tool in the fixture and it is not `read_file`, so an allowlist that
+    # names something else must leave nothing behind — fail-closed, not fail-open.
+    assert [t.name for t in registry.tools()] == []
+
+
+def test_setting_no_list_still_returns_the_very_same_registry(tmp_path: pathlib.Path) -> None:
+    """The blast radius, asserted rather than claimed.
+
+    Both lists default to empty, both resolve to "no restriction", and the restrict call is skipped
+    — so a deployment that set neither is handed back the identical object. That identity check is
+    what makes this a fix for people who wrote a fence and not a change for everybody else.
+    """
+    raw = _registry()
+
+    wrapped, approvals = governed_profile(raw, settings=_settings(tmp_path), home=tmp_path)
+
+    assert wrapped is raw
+    assert not approvals.granted and not approvals.refused
+
+
+def test_the_inferential_half_is_still_staged(tmp_path: pathlib.Path) -> None:
+    """What must NOT have moved. The kernel and the taint ledger can refuse legitimate work, which
+    is the whole reason `observe` exists — turning those on by default under cover of a fence fix
+    would be exactly the breaking change this avoids."""
+    registry, _ = governed_profile(
+        _registry(),
+        settings=_settings(tmp_path, CHIMERA_TOOL_DENYLIST="nothing_by_this_name"),
+        home=tmp_path,
+    )
+    tool = registry.get("write_file")
+
+    assert tool is not None
+    assert type(tool).__name__ == "_Writer", "off mode wrapped the tool in governance machinery"
+
+
+def test_the_fence_reaches_the_in_app_bot_with_governance_off(tmp_path: pathlib.Path) -> None:
+    """End to end on the surface that started this: the app's Messaging toggle, stock config."""
+    from chimera.config import Settings
+    from chimera.providers import CompletionResult
+    from chimera.server import MessagingManager
+
+    class _Backend:
+        def complete(self, messages: list[Any], **kwargs: Any) -> CompletionResult:
+            return CompletionResult(content="ok", model="fake")
+
+    class _Adapter:
+        platform = "discord"
+
+        def send(self, *a: Any, **k: Any) -> str:
+            return "ok"
+
+    settings = Settings(
+        CHIMERA_HOME=str(tmp_path),
+        CHIMERA_DISCORD_BOT_TOKEN="t",
+        CHIMERA_TOOL_DENYLIST="run_shell",
+        # governance deliberately left at its default `off`
+    )
+    adapter = _Adapter()
+    manager = MessagingManager(
+        settings=settings, backend=_Backend(), model=None, max_steps=4,
+        workspace=tmp_path, adapter_factory=lambda _p: adapter,
+    )
+    on_message = manager._gateway_on_message(adapter)
+    names = {t.name for t in on_message.__self__.session_for("c").agent.tools.tools()}  # type: ignore[attr-defined]
+
+    assert "run_shell" not in names
+    assert "send_message" in names


### PR DESCRIPTION
> **Based on #80** — it rewrites a paragraph that PR introduced. Merge #80 first; GitHub will retarget this to `main` automatically.

`CHIMERA_GOVERNANCE` defaults to `off`, and `off` returned the registry untouched — so an owner who wrote `CHIMERA_TOOL_DENYLIST=run_shell` in `.env` got **no fence on any unattended surface**, while `config.py` promised the lists apply *"on every surface"*. On a stock deployment they reached neither Discord bot.

#80 documented that gap rather than closing it, on the grounds that closing it "changes what a default deployment does". **That reasoning was wrong, and this PR measures why.**

## Two different kinds of thing under one switch

| | what it is | can it refuse legitimate work? | needs a staged rollout? |
|---|---|---|---|
| `CHIMERA_TOOL_ALLOWLIST` / `DENYLIST` | an **instruction** — the named tool is in the registry or it is not | no | **no** |
| trust kernel + taint ledger | an **inference** — is this action dangerous? | **yes**, and silently: a job that reads a feed then cannot write, and reports success having done nothing | **yes** — this is what `observe` is for |

Filing them together meant the only way to get a fence you had written by hand was to also accept a rollout you had not asked for. The lists now apply whatever the mode; the kernel and the ledger still do not.

The desktop app's own chat had already gone the other way and applied the lists unconditionally — which is how a product ends up with two implementations of one rule that disagree about the default.

## The blast radius, asserted rather than described

With both lists empty — the state of anyone who never wrote a fence — `allow_names` resolves to `None`, `deny_names` to `[]`, the restrict call is **skipped entirely**, and the caller is handed back the *identical object*:

```python
assert wrapped is raw
```

Object identity, not equivalent behaviour. **This is a fix for people who wrote a fence, not a change for everybody else.**

`restrict_registry` only writes to the audit trail when something is actually excluded, so a deployment with no fence still writes nothing new.

## The guard on the other side

One test asserts what must **not** have moved: with governance `off`, the tool is still not wrapped in machinery. A future change that slides the kernel into `off` mode under cover of "fixing the fence" fails the build.

---

**Verification.** 5 new tests, **3 of which fail** without the change (denylist, allowlist, and the in-app bot end-to-end on stock config); the 2 guard tests pass both ways, which is what a guard should do. Full gate with the project's own commands — `ruff check .`, `mypy chimera`, `pytest -q` — clean across 303 files, 2927 passed. The 18 failures are pre-existing environment breakage in this WSL venv, byte-identical to a run on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)