### PR TITLE
fix(config): the fence nobody could switch on without killing the CLI

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -512,8 +512,23 @@ class Settings(BaseSettings):
     #
     # Where a request carries its own allowlist the two INTERSECT — this list is a ceiling, and a
     # caller must not be able to raise it.
-    tool_allowlist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST")
-    tool_denylist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST")
+    # `NoDecode` is not decoration. Without it, pydantic-settings' EnvSettingsSource runs
+    # `json.loads` on the raw string BEFORE the comma-splitting validator below ever sees it, so
+    # `CHIMERA_TOOL_DENYLIST=run_shell` raises `SettingsError` at import of `get_settings()` — and
+    # since every entry point builds settings first, the whole CLI stops opening. `chimera --help`
+    # exits 1 on a machine whose only sin was fencing its agent the way `.env.example` says to.
+    #
+    # Ten list fields in this class carry the annotation and these two were the only ones without
+    # it, which is why nothing looked odd. The tests missed it for a sharper reason: they build
+    # `Settings(CHIMERA_TOOL_DENYLIST="...")` by keyword, and a keyword goes through
+    # InitSettingsSource, which does no JSON decoding at all. Thirty-eight green tests exercised a
+    # path no deployment uses.
+    tool_allowlist: Annotated[list[str], NoDecode] = Field(
+        default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST"
+    )
+    tool_denylist: Annotated[list[str], NoDecode] = Field(
+        default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST"
+    )
 
     @field_validator("approval", mode="before")
     @classmethod
@@ -584,10 +599,29 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _split_panel(cls, value: object) -> object:
-        """Accept a comma-separated string from the environment."""
-        if isinstance(value, str):
-            return [item.strip() for item in value.split(",") if item.strip()]
-        return value
+        """Accept a comma-separated string from the environment — or a JSON array.
+
+        Comma-separated is the documented form and what `.env.example` shows. JSON is accepted
+        because these fields carry ``NoDecode``, which turns pydantic-settings' own decoding off, and
+        without this branch a value someone wrote as ``["a", "b"]`` would be split on the comma into
+        ``['["a"', '"b"]']`` — a *silent* wrong answer where the previous behaviour was a loud crash.
+        For a tool denylist that trade is the wrong way round: a fence made of nonsense names denies
+        nothing and says so nowhere.
+        """
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        if text.startswith("[") and text.endswith("]"):
+            import json
+
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                pass  # not valid JSON after all — fall through to the comma split
+            else:
+                if isinstance(parsed, list):
+                    return [str(item).strip() for item in parsed if str(item).strip()]
+        return [item.strip() for item in text.split(",") if item.strip()]
 
     def tier_ladder(self) -> TierLadder:
         """The resolved weak/mid/top model ladder (explicit override > cost_mode)."""

--- a/tests/test_settings_from_the_environment.py
+++ b/tests/test_settings_from_the_environment.py
@@ -1,0 +1,123 @@
+"""Settings read the way a deployment sets them: from the environment.
+
+Thirty-eight tests covered the tool fence and every one of them was green while
+`CHIMERA_TOOL_DENYLIST=run_shell` made `chimera --help` exit 1. They all built
+`Settings(CHIMERA_TOOL_DENYLIST="...")` by keyword, and a keyword goes through pydantic-settings'
+InitSettingsSource, which does no JSON decoding. The env goes through EnvSettingsSource, which runs
+`json.loads` on the raw string unless the field is annotated `NoDecode` — and those two fields were
+the only two list fields in the class without it.
+
+So the bug was not in the fence. It was in the seam between the fence and the only way anybody
+turns it on, and the suite could not see the seam because it never crossed it.
+
+Everything here goes through `monkeypatch.setenv`. That is the point of the file, not an
+implementation detail: a test that passes a keyword is testing a code path no deployment uses.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from chimera.config import Settings
+
+
+def _from_env(monkeypatch: pytest.MonkeyPatch, **env: str) -> Settings:
+    """Build Settings the way a process started from a shell or a `.env` file does."""
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return Settings()
+
+
+# --- the fence, set the documented way ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("run_shell", ["run_shell"]),
+        ("run_shell,write_file", ["run_shell", "write_file"]),
+        (" run_shell , write_file ", ["run_shell", "write_file"]),
+        ("", []),
+    ],
+)
+def test_the_denylist_accepts_what_the_example_file_shows(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: list[str]
+) -> None:
+    """`.env.example:80` shows `CHIMERA_TOOL_DENYLIST=`, so a comma-separated list is THE form.
+
+    Pre-fix every non-empty value here raised `SettingsError` out of `get_settings()`.
+    """
+    assert _from_env(monkeypatch, CHIMERA_TOOL_DENYLIST=raw).tool_denylist == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("read_file", ["read_file"]), ("read_file,write_file", ["read_file", "write_file"]), ("", [])],
+)
+def test_the_allowlist_accepts_the_same_form(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: list[str]
+) -> None:
+    assert _from_env(monkeypatch, CHIMERA_TOOL_ALLOWLIST=raw).tool_allowlist == expected
+
+
+def test_a_json_array_still_works_for_anyone_who_wrote_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The splitting validator handles a bracketed string too, so nobody who guessed JSON is broken
+    by the fix. Worth pinning: `NoDecode` means WE parse it, and we must parse both shapes."""
+    settings = _from_env(monkeypatch, CHIMERA_TOOL_DENYLIST='["run_shell", "write_file"]')
+
+    assert "run_shell" in settings.tool_denylist
+
+
+# --- the property that actually failed ------------------------------------------------------------
+
+
+_LIST_FIELDS_SET_FROM_ENV = [
+    ("CHIMERA_TOOL_ALLOWLIST", "tool_allowlist"),
+    ("CHIMERA_TOOL_DENYLIST", "tool_denylist"),
+    ("CHIMERA_OPENROUTER_KEYS", "openrouter_keys"),
+    ("CHIMERA_OPENAI_KEYS", "openai_keys"),
+    ("CHIMERA_FUSION_PANEL", "fusion_panel"),
+    ("CHIMERA_FALLBACK_MODELS", "fallback_models"),
+]
+
+
+@pytest.mark.parametrize(("env_name", "field"), _LIST_FIELDS_SET_FROM_ENV)
+def test_no_list_field_explodes_on_a_bare_comma_separated_value(
+    monkeypatch: pytest.MonkeyPatch, env_name: str, field: str
+) -> None:
+    """The general rule, so the next list field added does not repeat this.
+
+    Ten of the twelve list fields carried `NoDecode` and two did not, which is exactly why nothing
+    looked wrong: the odd ones out were in the minority and nobody sets them in a unit test.
+    """
+    settings = _from_env(monkeypatch, **{env_name: "alpha,beta"})
+
+    assert getattr(settings, field) == ["alpha", "beta"], f"{env_name} did not split"
+
+
+def test_the_cli_opens_with_a_fence_configured(tmp_path: Any) -> None:
+    """The end of the chain, and the only assertion that would have caught this.
+
+    Every entry point builds settings before it does anything, so a `SettingsError` there is not a
+    degraded feature — it is a product that does not start. A subprocess because that is the only
+    way to prove the import-time path; in-process the module is already loaded.
+    """
+    done = subprocess.run(
+        [sys.executable, "-c", "from chimera.config import get_settings; get_settings(); print('ok')"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "SYSTEMROOT": __import__("os").environ.get("SYSTEMROOT", ""),
+            "CHIMERA_TOOL_DENYLIST": "run_shell,write_file",
+            "CHIMERA_TOOL_ALLOWLIST": "read_file",
+        },
+    )
+
+    assert done.returncode == 0, f"settings refused to load with a fence set:\n{done.stderr[-800:]}"
+    assert "ok" in done.stdout


### PR DESCRIPTION
`CHIMERA_TOOL_DENYLIST=run_shell` — the form `.env.example:80` documents — raised `SettingsError` out of `get_settings()`.

Every entry point builds settings before it does anything, so this is not a degraded feature:

```
$ CHIMERA_TOOL_DENYLIST=run_shell chimera --help
$ echo $?
1
```

**`chimera --help` exited 1 on a machine whose only sin was fencing its agent the way the docs say to.**

## The asymmetry

Twelve list fields in `Settings`. **Ten carry `Annotated[..., NoDecode]`; these two were the only ones without it.** Without the annotation, pydantic-settings' `EnvSettingsSource` runs `json.loads` on the raw string before the comma-splitting validator ever sees it.

## Why 38 green tests never saw it

Not "no coverage" — something sharper. Every one of them builds:

```python
Settings(CHIMERA_TOOL_DENYLIST="run_shell")   # keyword
```

A keyword goes through `InitSettingsSource`, which does **no JSON decoding at all**. The environment goes through `EnvSettingsSource`, which does. The suite exercised a path no deployment uses.

So the new tests read from the environment via `monkeypatch.setenv`, and one starts a **subprocess** — an import-time failure cannot be proved in a process where the module is already loaded.

## The consequence lands on this week's own work

#83 made the tool fence apply regardless of `CHIMERA_GOVERNANCE`, on the grounds that an explicit instruction needs no rollout. It was **unreachable through the documented path** the whole time. The tests for that PR used keywords too.

## One thing found while fixing it, worth more than the fix

With `NoDecode` on, a value someone wrote as `["run_shell", "write_file"]` would be split on the comma into `['["run_shell"', '"write_file"]']` — **a fence made of nonsense names, denying nothing, saying so nowhere.**

That trades a loud crash for a silent wrong answer, which is the wrong direction for this project and especially for a denylist. The splitter now accepts both shapes; JSON is parsed as JSON, everything else splits on commas.

---

**Verification.** 15 new tests, **10 of which fail** against the pre-fix code. `ruff check .`, `mypy chimera` (305 files) clean; **3006 passed**. The 18 failures are pre-existing environment breakage in this WSL venv, byte-identical to a run on unmodified `main`.

Found by the second audit round, which covered the ~150 files the first one never opened — `evolution/`, `tools/`, `governance/`, `memory/`, `skills/`, `scheduler/` and the rest. Five more confirmed P0s from that round are still queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)