### PR TITLE
fix(evolution): the skill a run learned, erased by the run that learned it

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -512,8 +512,23 @@ class Settings(BaseSettings):
     #
     # Where a request carries its own allowlist the two INTERSECT — this list is a ceiling, and a
     # caller must not be able to raise it.
-    tool_allowlist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST")
-    tool_denylist: list[str] = Field(default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST")
+    # `NoDecode` is not decoration. Without it, pydantic-settings' EnvSettingsSource runs
+    # `json.loads` on the raw string BEFORE the comma-splitting validator below ever sees it, so
+    # `CHIMERA_TOOL_DENYLIST=run_shell` raises `SettingsError` at import of `get_settings()` — and
+    # since every entry point builds settings first, the whole CLI stops opening. `chimera --help`
+    # exits 1 on a machine whose only sin was fencing its agent the way `.env.example` says to.
+    #
+    # Ten list fields in this class carry the annotation and these two were the only ones without
+    # it, which is why nothing looked odd. The tests missed it for a sharper reason: they build
+    # `Settings(CHIMERA_TOOL_DENYLIST="...")` by keyword, and a keyword goes through
+    # InitSettingsSource, which does no JSON decoding at all. Thirty-eight green tests exercised a
+    # path no deployment uses.
+    tool_allowlist: Annotated[list[str], NoDecode] = Field(
+        default_factory=list, validation_alias="CHIMERA_TOOL_ALLOWLIST"
+    )
+    tool_denylist: Annotated[list[str], NoDecode] = Field(
+        default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST"
+    )
 
     @field_validator("approval", mode="before")
     @classmethod
@@ -584,10 +599,29 @@ class Settings(BaseSettings):
     )
     @classmethod
     def _split_panel(cls, value: object) -> object:
-        """Accept a comma-separated string from the environment."""
-        if isinstance(value, str):
-            return [item.strip() for item in value.split(",") if item.strip()]
-        return value
+        """Accept a comma-separated string from the environment — or a JSON array.
+
+        Comma-separated is the documented form and what `.env.example` shows. JSON is accepted
+        because these fields carry ``NoDecode``, which turns pydantic-settings' own decoding off, and
+        without this branch a value someone wrote as ``["a", "b"]`` would be split on the comma into
+        ``['["a"', '"b"]']`` — a *silent* wrong answer where the previous behaviour was a loud crash.
+        For a tool denylist that trade is the wrong way round: a fence made of nonsense names denies
+        nothing and says so nowhere.
+        """
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        if text.startswith("[") and text.endswith("]"):
+            import json
+
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                pass  # not valid JSON after all — fall through to the comma split
+            else:
+                if isinstance(parsed, list):
+                    return [str(item).strip() for item in parsed if str(item).strip()]
+        return [item.strip() for item in text.split(",") if item.strip()]
 
     def tier_ladder(self) -> TierLadder:
         """The resolved weak/mid/top model ladder (explicit override > cost_mode)."""

--- a/chimera/evolution/skill_store.py
+++ b/chimera/evolution/skill_store.py
@@ -1,10 +1,34 @@
-"""Persistence for self-authored (learned) skills."""
+"""Persistence for self-authored (learned) skills.
+
+This store got the atomic write and not the re-read, and the two halves are not interchangeable.
+Atomicity means a crash cannot truncate `skills.json`; it says nothing about a second holder of the
+same file writing a snapshot taken before your change. That second holder is not hypothetical here —
+`evolution/context.py` builds **two** instances over this exact path, one for the evolver (:128) and
+one for the card retriever (:158) — so a single ordinary run does this:
+
+    autonomous.py:1018   evolver copy    -> add(new skill)        skills.json = [old, NEW]
+    autonomous.py:1095   retriever copy  -> record_use(old)       skills.json = [old]
+
+The skill the run just learned is erased by the telemetry write that credits the cards it used, in
+the same process, milliseconds later, atomically, with no error anywhere. Reproduced.
+
+That configuration — evolution on **and** cards on — is exactly what `bench/learning_lift` has
+measured since run 3, which added `--skill-cards` to the learning arm. It is a mechanism that
+produces the null those runs found; whether it *explains* the null is a separate question, and the
+suites' 84-92% ceiling is a documented rival explanation.
+
+So mutations re-read under an advisory lock and apply on top, the same shape `chimera/memory/store.py`
+uses and for the same reason.
+"""
 
 from __future__ import annotations
 
 import json
+import threading
+from collections.abc import Callable
 from pathlib import Path
 
+from chimera.core.filelock import atomic_write_text, locked, read_text
 from chimera.evolution.learned_skill import LearnedSkill
 from chimera.providers.gateway import SupportsComplete
 
@@ -14,12 +38,19 @@ def _as_int(value: object) -> int:
     return value if isinstance(value, int) else 0
 
 
+def _set_status(dicts: dict[str, dict[str, object]], name: str, status: str) -> None:
+    entry = dicts.get(name)
+    if entry is not None:
+        entry["status"] = status
+
+
 class SkillStore:
     """A JSON-file store of learned skills (deduped by name)."""
 
     def __init__(self, path: Path) -> None:
         self.path = Path(path)
         self._dicts: dict[str, dict[str, object]] = {}
+        self._lock = threading.RLock()
         self.load()
 
     def load(self) -> None:
@@ -27,7 +58,7 @@ class SkillStore:
         if not self.path.exists():
             return
         try:
-            raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
+            raw = json.loads(read_text(self.path) or "[]")
         except json.JSONDecodeError:  # a truncated/corrupt file -> empty store, not a crash on init
             return
         if not isinstance(raw, list):
@@ -38,34 +69,75 @@ class SkillStore:
             if isinstance(item, dict) and "name" in item:
                 self._dicts[str(item["name"])] = item
 
-    def save(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        # Atomic write: save() runs on every record_use (the flywheel's highest-frequency write), so a
+    def _write(self) -> None:
+        """Serialise to disk atomically. Assumes the caller holds the locks."""
+        # Atomic write: this runs on every record_use (the flywheel's highest-frequency write), so a
         # crash mid-write must not truncate skills.json and make the whole library unloadable.
-        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        tmp.write_text(json.dumps(list(self._dicts.values()), indent=2), encoding="utf-8")
-        tmp.replace(self.path)
+        atomic_write_text(self.path, json.dumps(list(self._dicts.values()), indent=2))
+
+    def save(self) -> None:
+        """Write the in-memory skills out, replacing whatever is on disk.
+
+        The blunt form, kept for callers that hold the whole picture. It does **not** merge a
+        concurrent writer — use the mutating methods, which do.
+        """
+        with self._lock, locked(self.path):
+            self._write()
+
+    def _mutate(self, apply: Callable[[dict[str, dict[str, object]]], None]) -> None:
+        """Re-read, apply one change on top, write back — all under the lock.
+
+        The re-read is the part that was missing. Without it every write publishes the dict this
+        object loaded at construction, so the sibling instance's just-added skill disappears.
+        """
+        with self._lock, locked(self.path):
+            self.load()
+            apply(self._dicts)
+            self._write()
+
+    def _mutate_if_present(
+        self, name: str, apply: Callable[[dict[str, dict[str, object]]], None]
+    ) -> bool:
+        """Re-read, change one named skill, write back. False when the name is unknown.
+
+        The presence check has to happen AFTER the re-read: asking the stale snapshot whether a
+        skill exists is how `skills-approve` reports "unknown" for something another process minted
+        a second ago.
+        """
+        found = False
+        with self._lock, locked(self.path):
+            self.load()
+            if name in self._dicts:
+                found = True
+                apply(self._dicts)
+                self._write()
+        return found
 
     def add(self, skill: LearnedSkill) -> None:
-        entry = skill.to_dict()
-        # Usage counters are store-level state (not part of the skill definition):
-        # re-adding/refining a skill must not wipe its measured track record.
-        previous = self._dicts.get(skill.name)
-        if previous is not None:
-            entry["uses"] = previous.get("uses", 0)
-            entry["successes"] = previous.get("successes", 0)
-        self._dicts[skill.name] = entry
-        self.save()
+        def put(dicts: dict[str, dict[str, object]]) -> None:
+            entry = skill.to_dict()
+            # Usage counters are store-level state (not part of the skill definition):
+            # re-adding/refining a skill must not wipe its measured track record.
+            previous = dicts.get(skill.name)
+            if previous is not None:
+                entry["uses"] = previous.get("uses", 0)
+                entry["successes"] = previous.get("successes", 0)
+            dicts[skill.name] = entry
+
+        self._mutate(put)
 
     def record_use(self, name: str, *, success: bool) -> None:
         """Count one retrieval-into-a-run for a skill and whether that run succeeded."""
-        entry = self._dicts.get(name)
-        if entry is None:
-            return
-        entry["uses"] = _as_int(entry.get("uses")) + 1
-        if success:
-            entry["successes"] = _as_int(entry.get("successes")) + 1
-        self.save()
+
+        def credit(dicts: dict[str, dict[str, object]]) -> None:
+            entry = dicts.get(name)
+            if entry is None:
+                return
+            entry["uses"] = _as_int(entry.get("uses")) + 1
+            if success:
+                entry["successes"] = _as_int(entry.get("successes")) + 1
+
+        self._mutate(credit)
 
     def stats(self) -> list[dict[str, object]]:
         """Per-skill usage stats: name, status, provenance, uses, successes, rate."""
@@ -152,18 +224,20 @@ class SkillStore:
 
     def promote(self, name: str) -> bool:
         """Promote a provisional skill to ``active`` (it passed measured probation). False if unknown."""
-        entry = self._dicts.get(name)
-        if entry is None:
-            return False
-        entry["status"] = "active"
-        # Reset the probation counters so the demote rule measures POST-promotion behavior, not the
-        # lifetime ratio. Otherwise a skill promoted at a high rate would need many more failures to
-        # cross the demote threshold — the heavier its winning history, the slower it can be retired
-        # on a real regression, contradicting the "auto-demote on measured regression" contract.
-        entry["uses"] = 0
-        entry["successes"] = 0
-        self.save()
-        return True
+        def apply(dicts: dict[str, dict[str, object]]) -> None:
+            entry = dicts.get(name)
+            if entry is None:
+                return
+            entry["status"] = "active"
+            # Reset the probation counters so the demote rule measures POST-promotion behavior, not
+            # the lifetime ratio. Otherwise a skill promoted at a high rate would need many more
+            # failures to cross the demote threshold — the heavier its winning history, the slower
+            # it can be retired on a real regression, contradicting the "auto-demote on measured
+            # regression" contract.
+            entry["uses"] = 0
+            entry["successes"] = 0
+
+        return self._mutate_if_present(name, apply)
 
     def approve(self, name: str) -> bool:
         """Activate a pending or retired skill after human review. Returns False if unknown.
@@ -171,12 +245,7 @@ class SkillStore:
         The single "back to active" transition — used both to accept a skill held for review
         (tainted-run provenance) and to un-retire one that was proposed for retirement.
         """
-        entry = self._dicts.get(name)
-        if entry is None:
-            return False
-        entry["status"] = "active"
-        self.save()
-        return True
+        return self._mutate_if_present(name, lambda dicts: _set_status(dicts, name, "active"))
 
     def retired(self) -> list[LearnedSkill]:
         """Skills proposed for retirement (kept for review, never deleted)."""
@@ -189,9 +258,4 @@ class SkillStore:
         as a card (retrieval takes only ``active``) yet stays inspectable and can be reactivated
         with :meth:`approve`. Returns False if the skill is unknown.
         """
-        entry = self._dicts.get(name)
-        if entry is None:
-            return False
-        entry["status"] = "retired"
-        self.save()
-        return True
+        return self._mutate_if_present(name, lambda dicts: _set_status(dicts, name, "retired"))

--- a/tests/test_settings_from_the_environment.py
+++ b/tests/test_settings_from_the_environment.py
@@ -1,0 +1,123 @@
+"""Settings read the way a deployment sets them: from the environment.
+
+Thirty-eight tests covered the tool fence and every one of them was green while
+`CHIMERA_TOOL_DENYLIST=run_shell` made `chimera --help` exit 1. They all built
+`Settings(CHIMERA_TOOL_DENYLIST="...")` by keyword, and a keyword goes through pydantic-settings'
+InitSettingsSource, which does no JSON decoding. The env goes through EnvSettingsSource, which runs
+`json.loads` on the raw string unless the field is annotated `NoDecode` — and those two fields were
+the only two list fields in the class without it.
+
+So the bug was not in the fence. It was in the seam between the fence and the only way anybody
+turns it on, and the suite could not see the seam because it never crossed it.
+
+Everything here goes through `monkeypatch.setenv`. That is the point of the file, not an
+implementation detail: a test that passes a keyword is testing a code path no deployment uses.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from chimera.config import Settings
+
+
+def _from_env(monkeypatch: pytest.MonkeyPatch, **env: str) -> Settings:
+    """Build Settings the way a process started from a shell or a `.env` file does."""
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return Settings()
+
+
+# --- the fence, set the documented way ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("run_shell", ["run_shell"]),
+        ("run_shell,write_file", ["run_shell", "write_file"]),
+        (" run_shell , write_file ", ["run_shell", "write_file"]),
+        ("", []),
+    ],
+)
+def test_the_denylist_accepts_what_the_example_file_shows(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: list[str]
+) -> None:
+    """`.env.example:80` shows `CHIMERA_TOOL_DENYLIST=`, so a comma-separated list is THE form.
+
+    Pre-fix every non-empty value here raised `SettingsError` out of `get_settings()`.
+    """
+    assert _from_env(monkeypatch, CHIMERA_TOOL_DENYLIST=raw).tool_denylist == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("read_file", ["read_file"]), ("read_file,write_file", ["read_file", "write_file"]), ("", [])],
+)
+def test_the_allowlist_accepts_the_same_form(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: list[str]
+) -> None:
+    assert _from_env(monkeypatch, CHIMERA_TOOL_ALLOWLIST=raw).tool_allowlist == expected
+
+
+def test_a_json_array_still_works_for_anyone_who_wrote_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The splitting validator handles a bracketed string too, so nobody who guessed JSON is broken
+    by the fix. Worth pinning: `NoDecode` means WE parse it, and we must parse both shapes."""
+    settings = _from_env(monkeypatch, CHIMERA_TOOL_DENYLIST='["run_shell", "write_file"]')
+
+    assert "run_shell" in settings.tool_denylist
+
+
+# --- the property that actually failed ------------------------------------------------------------
+
+
+_LIST_FIELDS_SET_FROM_ENV = [
+    ("CHIMERA_TOOL_ALLOWLIST", "tool_allowlist"),
+    ("CHIMERA_TOOL_DENYLIST", "tool_denylist"),
+    ("CHIMERA_OPENROUTER_KEYS", "openrouter_keys"),
+    ("CHIMERA_OPENAI_KEYS", "openai_keys"),
+    ("CHIMERA_FUSION_PANEL", "fusion_panel"),
+    ("CHIMERA_FALLBACK_MODELS", "fallback_models"),
+]
+
+
+@pytest.mark.parametrize(("env_name", "field"), _LIST_FIELDS_SET_FROM_ENV)
+def test_no_list_field_explodes_on_a_bare_comma_separated_value(
+    monkeypatch: pytest.MonkeyPatch, env_name: str, field: str
+) -> None:
+    """The general rule, so the next list field added does not repeat this.
+
+    Ten of the twelve list fields carried `NoDecode` and two did not, which is exactly why nothing
+    looked wrong: the odd ones out were in the minority and nobody sets them in a unit test.
+    """
+    settings = _from_env(monkeypatch, **{env_name: "alpha,beta"})
+
+    assert getattr(settings, field) == ["alpha", "beta"], f"{env_name} did not split"
+
+
+def test_the_cli_opens_with_a_fence_configured(tmp_path: Any) -> None:
+    """The end of the chain, and the only assertion that would have caught this.
+
+    Every entry point builds settings before it does anything, so a `SettingsError` there is not a
+    degraded feature — it is a product that does not start. A subprocess because that is the only
+    way to prove the import-time path; in-process the module is already loaded.
+    """
+    done = subprocess.run(
+        [sys.executable, "-c", "from chimera.config import get_settings; get_settings(); print('ok')"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env={
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "SYSTEMROOT": __import__("os").environ.get("SYSTEMROOT", ""),
+            "CHIMERA_TOOL_DENYLIST": "run_shell,write_file",
+            "CHIMERA_TOOL_ALLOWLIST": "read_file",
+        },
+    )
+
+    assert done.returncode == 0, f"settings refused to load with a fence set:\n{done.stderr[-800:]}"
+    assert "ok" in done.stdout

--- a/tests/test_skill_store_lost_update.py
+++ b/tests/test_skill_store_lost_update.py
@@ -1,0 +1,177 @@
+"""The skill a run just learned, erased by the run that learned it.
+
+`SkillStore` had the atomic write and not the re-read, and those cover different failures.
+Atomicity means a crash cannot truncate `skills.json`. It says nothing about a second holder of the
+same file publishing a snapshot taken before your change — and there is always a second holder:
+`evolution/context.py` builds one instance for the evolver (:128) and one for the card retriever
+(:158), over the same path, in the same process.
+
+    autonomous.py:1018   evolver copy    -> add(new skill)        skills.json = [old, NEW]
+    autonomous.py:1095   retriever copy  -> record_use(old)       skills.json = [old]
+
+No exception, no log line, no truncated file. The library is intact and the newest thing in it is
+gone.
+
+Why this matters beyond correctness: that configuration — evolution on AND cards on — is what
+`bench/learning_lift` has measured since run 3, the one that added `--skill-cards` to the learning
+arm. So it is a mechanism that produces the null those runs found. It is **not** proof that it
+explains the null: the suites' 84-92% ceiling is a documented rival explanation and a ceiling alone
+produces a null. What these tests establish is that the mechanism is real, not that the mystery is
+solved.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from chimera.evolution.learned_skill import LearnedSkill
+from chimera.evolution.skill_store import SkillStore
+
+
+def _skill(name: str) -> LearnedSkill:
+    return LearnedSkill(name=name, description=f"what {name} knows")
+
+
+def _names(path: Path) -> set[str]:
+    return {s.name for s in SkillStore(path).skills()}
+
+
+# --- the bug, in the shape the product actually has it --------------------------------------------
+
+
+def test_crediting_a_card_does_not_erase_the_skill_just_learned(tmp_path: Path) -> None:
+    """The whole defect in six lines, with the two instances `context.py` really builds."""
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("older"))
+
+    evolver_copy = SkillStore(path)  # context.py:128
+    retriever_copy = SkillStore(path)  # context.py:158
+
+    evolver_copy.add(_skill("just_learned"))  # autonomous.py:1018
+    retriever_copy.record_use("older", success=True)  # autonomous.py:1095
+
+    assert _names(path) == {"older", "just_learned"}, "the run erased what it learned"
+
+
+def test_the_telemetry_it_was_writing_still_lands(tmp_path: Path) -> None:
+    """The fix must not trade one silent loss for another: the use count is the input to retirement,
+    so dropping it would make `retirement_candidates` judge on a record that never accumulated."""
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("older"))
+    evolver_copy, retriever_copy = SkillStore(path), SkillStore(path)
+
+    evolver_copy.add(_skill("just_learned"))
+    retriever_copy.record_use("older", success=True)
+
+    stats = {row["name"]: row for row in SkillStore(path).stats()}
+    assert stats["older"]["uses"] == 1
+    assert stats["older"]["successes"] == 1
+
+
+def test_a_refine_does_not_lose_a_sibling_skill(tmp_path: Path) -> None:
+    """`add` on an existing name is how a skill is refined. Two holders refining different skills
+    must both survive — the counters-preserving branch in `add` reads the dict it was handed, so it
+    has to be handed a fresh one."""
+    path = tmp_path / "skills.json"
+    seed = SkillStore(path)
+    seed.add(_skill("alpha"))
+    seed.add(_skill("beta"))
+
+    first, second = SkillStore(path), SkillStore(path)
+    first.record_use("alpha", success=True)
+    second.add(_skill("beta"))  # refine beta from a snapshot taken before alpha's use
+
+    stats = {row["name"]: row for row in SkillStore(path).stats()}
+    assert set(stats) == {"alpha", "beta"}
+    assert stats["alpha"]["uses"] == 1, "the refine rolled back alpha's telemetry"
+
+
+# --- the lifecycle commands, which are the cross-process case -------------------------------------
+
+
+def test_approving_a_skill_does_not_roll_back_the_library(tmp_path: Path) -> None:
+    """`skills-approve` is a separate process from `serve`. Pre-fix it republished whatever the
+    library held when the command started."""
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("pending_one"))
+
+    reviewer = SkillStore(path)  # the CLI command, snapshot taken at startup
+    SkillStore(path).add(_skill("minted_meanwhile"))  # the daemon, mid-review
+
+    assert reviewer.approve("pending_one") is True
+
+    assert _names(path) == {"pending_one", "minted_meanwhile"}
+
+
+def test_retiring_and_promoting_are_the_same_shape(tmp_path: Path) -> None:
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("a"))
+    SkillStore(path).add(_skill("b"))
+
+    retirer, promoter = SkillStore(path), SkillStore(path)
+    SkillStore(path).add(_skill("c"))  # a third party mints while both hold snapshots
+    retirer.retire("a")
+    promoter.promote("b")
+
+    assert _names(path) == {"a", "b", "c"}
+
+
+def test_an_unknown_name_is_still_reported_as_unknown(tmp_path: Path) -> None:
+    """The re-read must not turn "not found" into a silent success — the CLI prints that verdict."""
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("real"))
+
+    store = SkillStore(path)
+
+    assert store.approve("does_not_exist") is False
+    assert store.retire("does_not_exist") is False
+    assert store.promote("does_not_exist") is False
+
+
+def test_a_name_minted_after_this_object_was_built_is_found(tmp_path: Path) -> None:
+    """The mirror, and the reason the presence check moved inside the lock: asking the snapshot
+    whether a skill exists is how `skills-approve` calls something unknown a second after another
+    process minted it."""
+    path = tmp_path / "skills.json"
+    SkillStore(path).add(_skill("first"))
+    reviewer = SkillStore(path)
+
+    SkillStore(path).add(_skill("minted_after"))
+
+    assert reviewer.approve("minted_after") is True, "the stale snapshot decided it did not exist"
+
+
+# --- two real processes ---------------------------------------------------------------------------
+
+
+_WRITER = """
+import sys
+from pathlib import Path
+from chimera.evolution.learned_skill import LearnedSkill
+from chimera.evolution.skill_store import SkillStore
+
+path, tag = Path(sys.argv[1]), sys.argv[2]
+store = SkillStore(path)
+for i in range(25):
+    store.add(LearnedSkill(name=f"{tag}{i}", description="x"))
+"""
+
+
+def test_two_processes_learning_at_once_keep_every_skill(tmp_path: Path) -> None:
+    """`serve` mints skills while an operator runs `chimera` over SSH. The in-process tests prove
+    the re-read; only this proves the file lock."""
+    path = tmp_path / "skills.json"
+    script = tmp_path / "writer.py"
+    script.write_text(textwrap.dedent(_WRITER), encoding="utf-8")
+
+    procs = [
+        subprocess.Popen([sys.executable, str(script), str(path), tag], cwd=str(Path.cwd()))
+        for tag in ("A", "B")
+    ]
+    for proc in procs:
+        assert proc.wait(timeout=180) == 0
+
+    assert len(_names(path)) == 50


### PR DESCRIPTION
Reproduced:

```
estado inicial  : ['older']
after learning  : ['just_learned', 'older']
after telemetry : ['older']
```

`SkillStore` got the atomic write and **not** the re-read, and those cover different failures. Atomicity means a crash cannot truncate `skills.json`. It says nothing about a second holder of the same file publishing a snapshot taken before your change.

**There is always a second holder.** `evolution/context.py` builds one instance for the evolver (`:128`) and one for the card retriever (`:158`), over the same path, in the same process:

```
autonomous.py:1018   evolver copy     -> add(new skill)     skills.json = [old, NEW]
autonomous.py:1095   retriever copy   -> record_use(old)    skills.json = [old]
```

No exception, no log line, no truncated file. The library is intact and the newest thing in it is gone.

## Three more methods nobody had named

`promote`, `approve` and `retire` — the CLI commands, i.e. the **cross-process** case. `chimera skills-approve` over SSH republished whatever the library held when the command started.

Writing their test moved the presence check *inside* the lock: asking a stale snapshot whether a skill exists is how the CLI reports "unknown" for something another process minted a second earlier. There is a test for each direction.

## On the learning-lift nulls — precisely

`bench/learning_lift/run_learning.py` records that **run 3 added `--skill-cards` to the learning arm**. Evolution on *and* cards on is exactly where this fires — and it explains why run 2 behaved differently: it "minted 39 skills and injected zero", so nothing ever called `record_use`.

So this is a mechanism that **produces** that null. It is **not** proof that it **explains** it: the suites' documented 84-92% ceiling is a rival explanation, and a ceiling produces a null on its own. What is established here is that the mechanism is real — not that the mystery is solved. Re-running the bench is the next step, and it is the thing that would tell them apart.

## The uncomfortable part

This is the **fourth store of this family** fixed this week. The commit for the first three (`MemoryStore`, `ExperienceBuffer`, `TrajectoryCollector`) said the primitives now live in one place *"instead of being rediscovered per store"*.

`SkillStore` sat one directory away and was not included, because that audit had never opened `evolution/`. **The fix against repetition did not prevent the repetition — the scope gap did.** That is the argument for having closed it.

---

**Verification.** 8 tests, **6 of which fail** against the pre-fix code (the two that pass both ways assert what must not change). `ruff check .`, `mypy chimera` (305 files) clean; **3014 passed**. The 18 failures are pre-existing environment breakage in this WSL venv, byte-identical to a run on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)