### PR TITLE
fix(tools): the single gate had three of eight callers

### DIFF
--- a/chimera/tools/browser.py
+++ b/chimera/tools/browser.py
@@ -22,10 +22,13 @@ Two things are non-negotiable here:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol
 
 from chimera.governance.ledger_tool import fence
 from chimera.tools.base import Tool
+from chimera.tools.workspace import resolve_in_workspace
+from chimera.tools.write_region import WriteRegion, refuse_write
 
 _MAX_CHARS = 20_000
 # Playwright is a CORE dependency, so this only shows on a broken install (the package went missing).
@@ -186,11 +189,22 @@ class BrowserTool(Tool):
         "required": ["action"],
     }
 
-    def __init__(self, driver: BrowserDriver | None = None, *, headless: bool = True) -> None:
+    def __init__(
+        self,
+        driver: BrowserDriver | None = None,
+        *,
+        headless: bool = True,
+        workspace: Path | None = None,
+        write_region: WriteRegion | None = None,
+    ) -> None:
         # The driver is built lazily on first use so importing this tool never needs Playwright.
         self._driver = driver
         self._own_driver = driver is None
         self._headless = headless
+        # `screenshot` handed its path straight to the driver, and this tool had no workspace to
+        # resolve against — so an absolute path wrote a PNG anywhere the process could reach.
+        self.workspace = (workspace or Path.cwd()).resolve()
+        self.write_region = write_region
 
     def _ensure_driver(self) -> BrowserDriver | None:
         if self._driver is not None:
@@ -257,9 +271,13 @@ class BrowserTool(Tool):
             if action == "back":
                 return render_elements(driver.back())
             if action == "screenshot":
-                path = str(kwargs.get("path", "")).strip()
-                if not path:
+                raw = str(kwargs.get("path", "")).strip()
+                if not raw:
                     return "error: screenshot needs a path"
+                target = resolve_in_workspace(self.workspace, raw)
+                if err := refuse_write(self.workspace, target, self.write_region):
+                    return err
+                path = str(target)
                 url = str(kwargs.get("url", "")).strip()
                 if url:
                     check_url(url)

--- a/chimera/tools/builtin.py
+++ b/chimera/tools/builtin.py
@@ -98,10 +98,10 @@ def default_registry(
     registry.register(YouTubeTranscriptTool())
     from chimera.tools.download import DownloadMediaTool
 
-    registry.register(DownloadMediaTool(workspace))
+    registry.register(DownloadMediaTool(workspace, write_region=write_region))
     from chimera.tools.chart import RenderChartTool
 
-    registry.register(RenderChartTool(workspace))  # Vega-Lite spec -> HTML (dep-free) / PNG-SVG (viz-vega)
+    registry.register(RenderChartTool(workspace, write_region=write_region))  # Vega-Lite -> HTML/PNG/SVG
 
     # Web scraping + secure structured extraction (fetch->clean markdown; schema->JSON via quarantine)
     # + whole-site discovery (map/crawl, robots-aware).
@@ -122,11 +122,11 @@ def default_registry(
     if settings.key_pool("openai") or importlib.util.find_spec("diffusers") is not None:
         from chimera.tools.media import ImageGenTool
 
-        registry.register(ImageGenTool())  # hosted (OpenAI key) or local (diffusers/imagegen-local)
+        registry.register(ImageGenTool(workspace, write_region=write_region))  # hosted key or local diffusers
     if settings.elevenlabs_api_key:
         from chimera.tools.media import TextToSpeechTool
 
-        registry.register(TextToSpeechTool())
+        registry.register(TextToSpeechTool(workspace, write_region=write_region))
     # Speech-to-text lights up with local faster-whisper (the `stt` extra) OR an OpenAI key.
     import importlib.util
 
@@ -153,5 +153,11 @@ def default_registry(
     if importlib.util.find_spec("playwright") is not None:
         from chimera.tools.browser import BrowserTool
 
-        registry.register(BrowserTool(headless=settings.browser_headless))
+        registry.register(
+            BrowserTool(
+                headless=settings.browser_headless,
+                workspace=workspace,
+                write_region=write_region,
+            )
+        )
     return registry

--- a/chimera/tools/chart.py
+++ b/chimera/tools/chart.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from chimera.tools.base import Tool
 from chimera.tools.workspace import resolve_in_workspace
+from chimera.tools.write_region import WriteRegion, refuse_write
 
 # Pinned CDN majors — the client-side render path, no Python dep. jsDelivr serves the latest of each.
 _VEGA_CDN = (
@@ -116,8 +117,11 @@ class RenderChartTool(Tool):
         "required": ["spec"],
     }
 
-    def __init__(self, workspace: Path | None = None) -> None:
+    def __init__(
+        self, workspace: Path | None = None, *, write_region: WriteRegion | None = None
+    ) -> None:
         self.workspace = (workspace or Path.cwd()).resolve()
+        self.write_region = write_region
 
     def run(self, **kwargs: Any) -> str:
         spec = _parse_spec(kwargs.get("spec"))
@@ -130,6 +134,8 @@ class RenderChartTool(Tool):
         if shape_error:
             return f"error: invalid Vega-Lite spec: {shape_error}"
         out = resolve_in_workspace(self.workspace, str(kwargs.get("out") or f"chart.{fmt}"))
+        if err := refuse_write(self.workspace, out, self.write_region):
+            return err
         out.parent.mkdir(parents=True, exist_ok=True)
         try:
             if fmt == "html":

--- a/chimera/tools/download.py
+++ b/chimera/tools/download.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from chimera.tools.base import Tool
 from chimera.tools.workspace import resolve_in_workspace
+from chimera.tools.write_region import WriteRegion, refuse_write
 
 _INSTALL_HINT = (
     "error: media download needs the 'media-dl' extra — install with: "
@@ -54,13 +55,21 @@ class DownloadMediaTool(Tool):
         "required": ["url"],
     }
 
-    def __init__(self, workspace: Path | None = None) -> None:
+    def __init__(
+        self, workspace: Path | None = None, *, write_region: WriteRegion | None = None
+    ) -> None:
         self.workspace = (workspace or Path.cwd()).resolve()
+        self.write_region = write_region
 
     def run(self, **kwargs: Any) -> str:
         url = str(kwargs.get("url", "")).strip()
         if not url:
             return "error: download_media needs a url"
+        # The write gate runs BEFORE the network does: a download we are not allowed to save is a
+        # fetch nobody wanted, and refusing after it has already happened is the wrong order.
+        out_dir = resolve_in_workspace(self.workspace, str(kwargs.get("out_dir") or "downloads"))
+        if err := refuse_write(self.workspace, out_dir, self.write_region):
+            return err
         # SSRF guard: the URL is model-/content-supplied and yt-dlp will happily fetch an
         # http(s) target — reject non-http(s) schemes and hosts resolving to private IPs before
         # handing it off, the same guard http_get/browser use.
@@ -71,7 +80,6 @@ class DownloadMediaTool(Tool):
         except ValueError as exc:
             return f"error: {exc}"
         audio_only = bool(kwargs.get("audio_only"))
-        out_dir = resolve_in_workspace(self.workspace, str(kwargs.get("out_dir") or "downloads"))
         out_dir.mkdir(parents=True, exist_ok=True)
         before = {p.name for p in out_dir.iterdir()}
         try:

--- a/chimera/tools/media.py
+++ b/chimera/tools/media.py
@@ -14,6 +14,7 @@ from typing import Any
 from chimera.config import get_settings
 from chimera.tools.base import Tool
 from chimera.tools.workspace import resolve_in_workspace
+from chimera.tools.write_region import WriteRegion, refuse_write
 
 _OPENAI_IMAGES = "https://api.openai.com/v1/images/generations"
 _ELEVEN_TTS = "https://api.elevenlabs.io/v1/text-to-speech"
@@ -55,15 +56,27 @@ class ImageGenTool(Tool):
         "required": ["prompt"],
     }
 
-    def __init__(self, *, model: str = "gpt-image-1") -> None:
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        *,
+        model: str = "gpt-image-1",
+        write_region: WriteRegion | None = None,
+    ) -> None:
+        # This tool took no workspace at all, which is why its output path was used verbatim: there
+        # was nothing to resolve against. An absolute `out` wrote wherever it pointed.
+        self.workspace = (workspace or Path.cwd()).resolve()
         self.model = model
+        self.write_region = write_region
 
     def run(self, **kwargs: Any) -> str:
         import httpx  # lazy
 
         settings = get_settings()
         prompt = str(kwargs["prompt"])
-        out = Path(str(kwargs.get("out") or "generated_image.png"))
+        out = resolve_in_workspace(self.workspace, str(kwargs.get("out") or "generated_image.png"))
+        if err := refuse_write(self.workspace, out, self.write_region):
+            return err
         size = str(kwargs.get("size") or "1024x1024")
         keys = settings.key_pool("openai")
 
@@ -122,19 +135,30 @@ class TextToSpeechTool(Tool):
     }
 
     def __init__(
-        self, *, voice_id: str = "21m00Tcm4TlvDq8ikWAM", model_id: str = "eleven_multilingual_v2"
+        self,
+        workspace: Path | None = None,
+        *,
+        voice_id: str = "21m00Tcm4TlvDq8ikWAM",
+        model_id: str = "eleven_multilingual_v2",
+        write_region: WriteRegion | None = None,
     ) -> None:
+        self.workspace = (workspace or Path.cwd()).resolve()
         self.voice_id = voice_id
         self.model_id = model_id
+        self.write_region = write_region
 
     def run(self, **kwargs: Any) -> str:
         import httpx  # lazy
 
+        # Where the audio would land is settled BEFORE the key check and before the request: a
+        # synthesis we are not allowed to save is an API call nobody wanted.
+        out = resolve_in_workspace(self.workspace, str(kwargs.get("out") or "speech.mp3"))
+        if err := refuse_write(self.workspace, out, self.write_region):
+            return err
         key = get_settings().elevenlabs_api_key
         if not key:
             return "error: text_to_speech needs ELEVENLABS_API_KEY (set it in .env)."
         text = str(kwargs["text"])
-        out = Path(str(kwargs.get("out") or "speech.mp3"))
         voice = str(kwargs.get("voice_id") or self.voice_id)
         try:
             response = httpx.post(

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -59,9 +59,17 @@ class _FakeDriver:
         self.calls.append("close")
 
 
-def _tool() -> tuple[BrowserTool, _FakeDriver]:
+def _tool(workspace: object = None) -> tuple[BrowserTool, _FakeDriver]:
+    """The tool under test, rooted at ``workspace`` when a screenshot destination matters.
+
+    `screenshot` used to hand its path straight to the driver, and this tool took no workspace at
+    all — so the tests below passed an absolute path and had it honoured verbatim, which is the
+    escape asserted as correct behaviour. They now write RELATIVE, inside the workspace.
+    """
     driver = _FakeDriver()
-    return BrowserTool(driver=driver), driver
+    import pathlib as _pathlib
+
+    return BrowserTool(driver=driver, workspace=_pathlib.Path(str(workspace)) if workspace else None), driver
 
 
 @pytest.fixture(autouse=True)
@@ -185,9 +193,9 @@ def test_new_actions_are_advertised() -> None:
 def test_screenshot_saves_file_and_confirms(tmp_path: pytest.TempPathFactory) -> None:
     import pathlib
 
-    tool, driver = _tool()
+    tool, driver = _tool(tmp_path)
     dest = pathlib.Path(str(tmp_path)) / "shot.png"
-    out = tool.run(action="screenshot", path=str(dest))
+    out = tool.run(action="screenshot", path="shot.png")
     assert "saved screenshot to" in out and str(dest) in out
     assert dest.is_file() and dest.read_bytes().startswith(b"\x89PNG")  # a real (stub) capture
     assert f"screenshot:{dest}" in driver.calls
@@ -195,11 +203,9 @@ def test_screenshot_saves_file_and_confirms(tmp_path: pytest.TempPathFactory) ->
 
 
 def test_screenshot_with_url_navigates_first(tmp_path: pytest.TempPathFactory) -> None:
-    import pathlib
 
-    tool, driver = _tool()
-    dest = pathlib.Path(str(tmp_path)) / "shot.png"
-    tool.run(action="screenshot", url="https://example.com", path=str(dest))
+    tool, driver = _tool(tmp_path)
+    tool.run(action="screenshot", url="https://example.com", path="shot.png")
     assert driver.calls[0] == "navigate:https://example.com"
     assert any(c.startswith("screenshot:") for c in driver.calls)
 
@@ -212,9 +218,12 @@ def test_screenshot_needs_a_path() -> None:
 def test_screenshot_blocks_ssrf_url(tmp_path: pytest.TempPathFactory) -> None:
     import pathlib
 
-    tool, driver = _tool()
+    # A RELATIVE destination, because the subject here is the SSRF block and an absolute path now
+    # fails earlier for a different reason — a test that stops at the first error stops testing what
+    # it is named after.
+    tool, driver = _tool(tmp_path)
     dest = pathlib.Path(str(tmp_path)) / "shot.png"
-    out = tool.run(action="screenshot", url="http://169.254.169.254/latest/", path=str(dest))
+    out = tool.run(action="screenshot", url="http://169.254.169.254/latest/", path="shot.png")
     assert out.startswith("error:") and "blocked" in out
     assert driver.calls == [] and not dest.exists()  # never navigated, never captured
 

--- a/tests/test_every_writer_passes_the_gate.py
+++ b/tests/test_every_writer_passes_the_gate.py
@@ -1,0 +1,237 @@
+"""`refuse_write` calls itself "the single gate every file-writing tool passes". It had 3 callers of 8.
+
+Its own docstring says why it exists: an earlier denylist lived inside `WriteRegion` and the writers
+read `if region is not None`, so the never-writable set was unreachable in the default configuration
+— "code that looks like a guard and never executes". The fix made the gate mandatory and then five
+writers were added over time that do not call it.
+
+Two different severities, and conflating them would overstate the first or understate the second:
+
+  ESCAPES THE WORKSPACE — `generate_image`, `text_to_speech`, `browser screenshot`. None of these
+  three took a `workspace` at all, so there was nothing to resolve an output path against and an
+  absolute `out` wrote wherever it pointed.
+
+  CONFINED BUT UNGATED — `render_chart`, `download_media`. Both resolve into the workspace, so no
+  escape; both then skip `refuse_write`, so they reach `.git/` and `.chimera/` inside it and ignore
+  any `--write-region` the run declared.
+
+The last test is the one that matters in a year: an AST walk that fails the build when a tool in
+`chimera/tools/` writes to disk without passing the gate.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+import pytest
+
+from chimera.tools.chart import RenderChartTool
+from chimera.tools.download import DownloadMediaTool
+from chimera.tools.media import ImageGenTool, TextToSpeechTool
+from chimera.tools.workspace import PathEscapesWorkspaceError
+from chimera.tools.write_region import WriteRegion
+
+TOOLS_DIR = pathlib.Path(__file__).resolve().parents[1] / "chimera" / "tools"
+
+#: Calls that put bytes on disk. `atomic_write_text` is the project's own helper and lands here too.
+_WRITE_CALLS = {"write_text", "write_bytes", "atomic_write_text", "mkstemp"}
+
+
+# --- the three that escaped the workspace ---------------------------------------------------------
+
+
+def test_image_generation_cannot_write_outside_the_workspace(tmp_path: pathlib.Path) -> None:
+    """An absolute `out` used to be taken verbatim. The tool had no workspace to resolve against."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    escape = tmp_path / "outside" / "escaped.png"
+
+    # Refused by raising, which is the convention `write_file` already sets for an escaping path.
+    with pytest.raises(PathEscapesWorkspaceError):
+        ImageGenTool(workspace).run(prompt="x", out=str(escape))
+
+    assert not escape.exists(), "the tool wrote outside the workspace"
+
+
+def test_text_to_speech_cannot_write_outside_the_workspace(tmp_path: pathlib.Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    escape = tmp_path / "outside" / "escaped.mp3"
+
+    with pytest.raises(PathEscapesWorkspaceError):
+        TextToSpeechTool(workspace).run(text="hello", out=str(escape))
+
+    assert not escape.exists()
+
+
+def test_the_browser_screenshot_is_confined(tmp_path: pathlib.Path) -> None:
+    """`screenshot` handed its path straight to the driver. A fake driver records what it was
+    given, which is the only way to see the confinement without Playwright."""
+    from chimera.tools.browser import BrowserTool
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    taken: list[str] = []
+
+    class _Driver:
+        def screenshot(self, path: str) -> None:
+            taken.append(path)
+
+        def navigate(self, url: str) -> Any:  # pragma: no cover - not reached here
+            return []
+
+    tool = BrowserTool(_Driver(), workspace=workspace)
+
+    # This one reports rather than raises: `run` wraps its dispatch in a broad except, so the
+    # escape surfaces as an ordinary tool error. What matters either way is that the driver never
+    # sees the path.
+    refused = tool.run(action="screenshot", path=str(tmp_path / "outside" / "shot.png"))
+    assert "escapes" in refused
+    assert not taken, "the driver was handed a path outside the workspace"
+
+    tool.run(action="screenshot", path="shots/ok.png")  # a relative one still works
+    assert taken and pathlib.Path(taken[0]).is_relative_to(workspace)
+
+
+# --- the two that were confined but ungated -------------------------------------------------------
+
+
+def test_a_chart_cannot_be_written_into_dot_git(tmp_path: pathlib.Path) -> None:
+    """Inside the workspace is not the same as allowed. `.git/` is never writable, whatever the
+    region — that is the whole reason `refuse_write` exists separately from `WriteRegion`."""
+    workspace = tmp_path / "ws"
+    (workspace / ".git").mkdir(parents=True)
+    spec = {"mark": "bar", "data": {"values": [{"a": 1, "b": 2}]}, "encoding": {}}
+
+    out = RenderChartTool(workspace).run(spec=spec, out=".git/HEAD", format="html")
+
+    assert "refused" in out.lower()
+    assert not (workspace / ".git" / "HEAD").exists()
+
+
+def test_a_chart_respects_a_declared_write_region(tmp_path: pathlib.Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    region = WriteRegion(["docs/*"], workspace)
+    spec = {"mark": "bar", "data": {"values": [{"a": 1, "b": 2}]}, "encoding": {}}
+
+    refused = RenderChartTool(workspace, write_region=region).run(
+        spec=spec, out="src/chart.html", format="html"
+    )
+    allowed = RenderChartTool(workspace, write_region=region).run(
+        spec=spec, out="docs/chart.html", format="html"
+    )
+
+    assert "refused" in refused.lower()
+    assert "refused" not in allowed.lower()
+    assert (workspace / "docs" / "chart.html").exists()
+
+
+def test_download_respects_the_region(tmp_path: pathlib.Path) -> None:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    region = WriteRegion(["media/*"], workspace)
+
+    out = DownloadMediaTool(workspace, write_region=region).run(
+        url="https://example.test/v.mp4", out_dir="elsewhere"
+    )
+
+    assert "refused" in out.lower()
+
+
+# --- the gate that keeps the next writer honest ---------------------------------------------------
+
+#: Write sites that legitimately skip `refuse_write`, each with the reason. Listing the EXEMPTIONS
+#: rather than the obligations is deliberate and is the same shape the governance gate uses: a list
+#: of things to check fails open, and the site nobody remembered to add is exactly the one that
+#: breaks. This list is how a reviewer sees a new escape hatch in a diff.
+EXEMPT: dict[str, str] = {
+    "browser.py:_html_to_markdown": "mkstemp in the system temp dir; never a caller-supplied path",
+    "chart.py:_render_static": "a helper; its only caller (RenderChartTool.run) holds the gate",
+    "code.py:run": "writes the script into the sandbox's own scratch dir, not the workspace",
+    "workspace.py:atomic_write_text": "the primitive itself — the gate calls IT, not the reverse",
+}
+
+
+def _ungated_writers() -> list[str]:
+    """`file.py:function` for every write in `chimera/tools/` with no `refuse_write` beside it."""
+    offenders: list[str] = []
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            names = {
+                getattr(inner.func, "attr", "") or getattr(inner.func, "id", "")
+                for inner in ast.walk(node)
+                if isinstance(inner, ast.Call)
+            }
+            if not (names & _WRITE_CALLS) or "refuse_write" in names:
+                continue
+            key = f"{path.name}:{node.name}"
+            if key not in EXEMPT:
+                offenders.append(key)
+    return offenders
+
+
+def test_no_tool_writes_to_disk_without_passing_the_gate() -> None:
+    """The structural half. `refuse_write` says it is "the single gate every file-writing tool
+    passes" — it had three callers out of eight, and nothing made that visible."""
+    ungated = _ungated_writers()
+
+    assert not ungated, (
+        f"a tool writes to disk without refuse_write: {ungated} — route it through the gate, or "
+        "add it to EXEMPT with the reason it does not need one"
+    )
+
+
+def test_the_gate_check_is_not_vacuous(tmp_path: pathlib.Path) -> None:
+    """Proof the walk can still see an offender: the same analysis over a fabricated tool."""
+    source = ast.parse(
+        "def run(self, **kwargs):\n"
+        "    out = resolve_in_workspace(self.workspace, kwargs['out'])\n"
+        "    out.write_text('data')\n"
+    )
+    node = next(n for n in ast.walk(source) if isinstance(n, ast.FunctionDef))
+    names = {
+        getattr(inner.func, "attr", "") or getattr(inner.func, "id", "")
+        for inner in ast.walk(node)
+        if isinstance(inner, ast.Call)
+    }
+
+    assert names & _WRITE_CALLS
+    assert "refuse_write" not in names
+
+
+def test_every_exemption_still_points_at_real_code() -> None:
+    """A stale exemption is a line saying "this was considered" about a site that no longer exists."""
+    live: set[str] = set()
+    for path in sorted(TOOLS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                names = {
+                    getattr(inner.func, "attr", "") or getattr(inner.func, "id", "")
+                    for inner in ast.walk(node)
+                    if isinstance(inner, ast.Call)
+                }
+                if names & _WRITE_CALLS:
+                    live.add(f"{path.name}:{node.name}")
+
+    assert not sorted(set(EXEMPT) - live), f"EXEMPT names sites that no longer write: {sorted(set(EXEMPT) - live)}"
+
+
+@pytest.mark.parametrize("tool", ["render_chart", "download_media"])
+def test_the_registry_hands_the_region_to_every_writer(tool: str, tmp_path: pathlib.Path) -> None:
+    """The wiring half: a tool that accepts a region and is registered without one is a fence that
+    exists in the class and not in the product."""
+    from chimera.tools import default_registry
+
+    region = WriteRegion(["docs/*"], tmp_path)
+    registry = default_registry(tmp_path, write_region=region)
+
+    instance = next((t for t in registry.tools() if t.name == tool), None)
+    assert instance is not None, f"{tool} is not registered"
+    assert getattr(instance, "write_region", None) is region

--- a/tests/test_integrations_extra.py
+++ b/tests/test_integrations_extra.py
@@ -110,7 +110,7 @@ def test_image_local_backend(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     monkeypatch.setattr(media, "get_settings", lambda: SimpleNamespace(
         image_backend="local", image_model_local="flux", key_pool=lambda p: []))
     target = tmp_path / "img.png"
-    res = media.ImageGenTool().run(prompt="a cat", out=str(target))
+    res = media.ImageGenTool(tmp_path).run(prompt="a cat", out=target.name)
     assert "saved image" in res and "local: flux" in res and target.exists()
 
 
@@ -121,5 +121,5 @@ def test_image_local_missing_extra(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     monkeypatch.setattr(media, "_generate_local", raise_import)
     monkeypatch.setattr(media, "get_settings", lambda: SimpleNamespace(
         image_backend="local", image_model_local="flux", key_pool=lambda p: []))
-    res = media.ImageGenTool().run(prompt="x", out=str(tmp_path / "i.png"))
+    res = media.ImageGenTool(tmp_path).run(prompt="x", out="i.png")
     assert res.startswith("error:") and "imagegen-local" in res

--- a/tests/test_reference_tools.py
+++ b/tests/test_reference_tools.py
@@ -34,7 +34,10 @@ def test_image_gen_writes_decoded_file(monkeypatch: pytest.MonkeyPatch, tmp_path
 
     monkeypatch.setattr(httpx, "post", lambda *a, **k: Resp())
     out = tmp_path / "img.png"
-    result = ImageGenTool().run(prompt="a cat", out=str(out))
+    # The tool is given the tmp workspace it writes into. Before the write gate reached these
+    # tools they took no workspace at all, so this test used to pass an absolute path and have
+    # it honoured verbatim — the escape itself, asserted as correct.
+    result = ImageGenTool(tmp_path).run(prompt="a cat", out="img.png")
     assert out.read_bytes() == b"PNGDATA"
     assert "saved image" in result
 
@@ -58,7 +61,7 @@ def test_tts_writes_audio_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
 
     monkeypatch.setattr(httpx, "post", lambda *a, **k: Resp())
     out = tmp_path / "speech.mp3"
-    result = TextToSpeechTool().run(text="hello", out=str(out))
+    result = TextToSpeechTool(tmp_path).run(text="hello", out="speech.mp3")
     assert out.read_bytes() == b"MP3BYTES"
     assert "saved audio" in result
 


### PR DESCRIPTION
`refuse_write` describes itself as *"the single gate every file-writing tool passes"*. **It had three callers.** Five other tools write to disk and none went through it.

Its own docstring says why it exists: an earlier denylist lived inside `WriteRegion` and the writers read `if region is not None`, so the never-writable set was unreachable in the default configuration — *"code that looks like a guard and never executes"*. The gate was made mandatory, and then five writers were added that do not call it.

## Two severities, kept apart

| | tools | what happened |
|---|---|---|
| **Escaped the workspace** | `generate_image`, `text_to_speech`, `browser screenshot` | none took a `workspace` **at all**, so there was nothing to resolve against and an absolute `out` wrote wherever it pointed |
| **Confined but ungated** | `render_chart`, `download_media` | resolve into the workspace (no escape), then skip `refuse_write` — so they reached `.git/` and `.chimera/` inside it and ignored any declared `--write-region` |

Merging the two would overstate the second or understate the first.

## Writing the tests moved three gates earlier

- `download_media` now checks permission **before the network** — a download we may not save is a fetch nobody wanted.
- `text_to_speech` checks **before the API key**, same argument.
- `browser` turned out to **already block** the escape: the broad `except` converts the raise into an ordinary tool error and the driver never sees the path. My test asserted the wrong surface, not the tool.

## Seven existing tests failed, and what they asserted matters

Each built its tool with **no workspace** and passed an absolute `tmp_path` destination expecting it to be honoured — **they encoded the escape as correct behaviour.** They now pass a workspace and write relative inside it, which is what every other write-tool test has always done.

One is different and worth naming: `test_screenshot_blocks_ssrf_url` broke because the write gate fires *before* the SSRF check, and its subject is SSRF — the absolute path was incidental. A test that stops at the first error stops testing what it is named after.

## The gate that keeps the sixth writer honest

An AST walk fails the build when a tool in `chimera/tools/` writes to disk without passing `refuse_write`. It lists **exemptions with reasons** rather than obligations — the same shape as the governance gate (#80) and the project-root gate (#82), for the same reason: a list of things to check fails open, and the site nobody remembered to add is the one that breaks.

---

**Verification.** 11 new tests, **9 of which fail** against the pre-fix code. `ruff check .`, `mypy chimera` (305 files) clean; **3002 passed**, and the failure count is back to the same 18 pre-existing environment failures this WSL venv always shows — the seven I introduced are gone.

From the second audit round. Three P0s from it remain: `chat`/`assist`/`tui` building an ungoverned registry, the unprotected `json.loads` in `memory.json`, and `playbook.json`'s non-atomic write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)