### PR TITLE
fix(cli,memory,evolution): the last three from the scope audit

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1029,7 +1029,15 @@ def chat(
         backend = RoutedBackend(gateway, FusionEngine(gateway))
     agent = Agent(
         backend,
-        default_registry(Path(workspace)),
+        # The deployment fence, exactly as `run` and the desktop app apply it. An explicit
+        # allowlist is an INSTRUCTION, not an inference: `governed_profile`'s kernel and taint
+        # ledger are staged behind CHIMERA_GOVERNANCE because they can refuse legitimate work,
+        # but removing a named tool cannot, so it needs no rollout and no attendance argument.
+        # These three were the only agent surfaces left without it — and the comment below was
+        # added to these very lines a day earlier, for the sibling field, without noticing.
+        _apply_tool_allowlist(
+            default_registry(Path(workspace)), allow=None, deny=None, settings=get_settings()
+        ),
         # Same workspace, both arguments: the one that roots the tools also carries the
         # project's conventions. Splitting them is how `AGENTS.md` came to be read on
         # four surfaces out of twenty-seven.
@@ -1158,7 +1166,15 @@ def assist(
     backend: SupportsComplete = gateway if no_cascade else _cascade_backend(gateway, settings)
     agent = Agent(
         backend,
-        default_registry(Path(workspace)),
+        # The deployment fence, exactly as `run` and the desktop app apply it. An explicit
+        # allowlist is an INSTRUCTION, not an inference: `governed_profile`'s kernel and taint
+        # ledger are staged behind CHIMERA_GOVERNANCE because they can refuse legitimate work,
+        # but removing a named tool cannot, so it needs no rollout and no attendance argument.
+        # These three were the only agent surfaces left without it — and the comment below was
+        # added to these very lines a day earlier, for the sibling field, without noticing.
+        _apply_tool_allowlist(
+            default_registry(Path(workspace)), allow=None, deny=None, settings=get_settings()
+        ),
         # Same workspace, both arguments: the one that roots the tools also carries the
         # project's conventions. Splitting them is how `AGENTS.md` came to be read on
         # four surfaces out of twenty-seven.
@@ -1314,7 +1330,15 @@ def tui(
         backend = RoutedBackend(gateway, FusionEngine(gateway))
     agent = Agent(
         backend,
-        default_registry(Path(workspace)),
+        # The deployment fence, exactly as `run` and the desktop app apply it. An explicit
+        # allowlist is an INSTRUCTION, not an inference: `governed_profile`'s kernel and taint
+        # ledger are staged behind CHIMERA_GOVERNANCE because they can refuse legitimate work,
+        # but removing a named tool cannot, so it needs no rollout and no attendance argument.
+        # These three were the only agent surfaces left without it — and the comment below was
+        # added to these very lines a day earlier, for the sibling field, without noticing.
+        _apply_tool_allowlist(
+            default_registry(Path(workspace)), allow=None, deny=None, settings=get_settings()
+        ),
         # Same workspace, both arguments: the one that roots the tools also carries the
         # project's conventions. Splitting them is how `AGENTS.md` came to be read on
         # four surfaces out of twenty-seven.

--- a/chimera/evolution/wiring.py
+++ b/chimera/evolution/wiring.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from chimera.core.filelock import atomic_write_text, locked, read_text
+from chimera.telemetry import get_logger
+
+_log = get_logger("evolution.wiring")
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -44,17 +49,41 @@ def playbook_path(settings: Settings) -> Path:
 
 
 def load_playbook(settings: Settings) -> Playbook:
-    """Load the persisted ACE playbook for this home (empty when none exists yet)."""
+    """Load the persisted ACE playbook for this home (empty when none exists yet).
+
+    A corrupt file degrades to an empty playbook rather than raising. `build_evolution_context`
+    loads this before any work starts, so an unreadable file did not cost the playbook — it stopped
+    the next run from starting at all, which is a strictly worse trade for advisory content.
+    """
     from chimera.evolution.playbook import Playbook
 
     path = playbook_path(settings)
-    if not path.exists():
+    raw = read_text(path)
+    if not raw.strip():
         return Playbook()
-    return Playbook.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _log.warning("playbook at %s is not readable JSON: %s", path, exc)
+        return Playbook()
+    if not isinstance(data, dict):
+        _log.warning("playbook at %s is not an object; ignoring", path)
+        return Playbook()
+    try:
+        return Playbook.from_dict(data)
+    except (KeyError, TypeError, ValueError) as exc:
+        _log.warning("playbook at %s has an unreadable shape: %s", path, exc)
+        return Playbook()
 
 
 def save_playbook(settings: Settings, playbook: Playbook) -> None:
-    """Persist the ACE playbook for this home."""
+    """Persist the ACE playbook for this home, atomically and under a lock.
+
+    This runs after EVERY `solve`, and the whole playbook is one JSON array — so a bare
+    `write_text` that died mid-write did not cost the last bullet, it cost all of them. Two
+    processes doing it at once cost one of the two sets, silently. Same shape and same reasoning
+    as the memory, experience, trajectory and skill stores.
+    """
     path = playbook_path(settings)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(playbook.to_dict(), indent=2), encoding="utf-8")
+    with locked(path):
+        atomic_write_text(path, json.dumps(playbook.to_dict(), indent=2))

--- a/chimera/memory/store.py
+++ b/chimera/memory/store.py
@@ -56,7 +56,21 @@ class MemoryStore:
         self._items = {}
         if not self.path.exists():
             return
-        raw = json.loads(read_text(self.path) or "[]")
+        # The per-record guard below exists so "one bad entry must not lose every other memory".
+        # It could not deliver that, because a file truncated mid-write is not a list of records
+        # with one bad entry — it is not JSON, and this line raised before the loop was reached.
+        # Every command builds a memory manager at boot (chat, solve, serve, app, each API
+        # request), so a single truncated file stopped the product rather than one memory.
+        #
+        # The sibling `MemoryGraph.load` already degrades exactly this way, five files over.
+        try:
+            raw = json.loads(read_text(self.path) or "[]")
+        except json.JSONDecodeError as exc:
+            _log.warning("memory store at %s is not readable JSON: %s", self.path, exc)
+            return
+        if not isinstance(raw, list):
+            _log.warning("memory store at %s is not a list; ignoring", self.path)
+            return
         for item in raw:
             # Skip a single malformed record (hand-edit, schema drift, truncated last object) instead
             # of aborting the whole load — one bad entry must not lose every other memory.

--- a/tests/test_three_remaining_p0.py
+++ b/tests/test_three_remaining_p0.py
@@ -1,0 +1,194 @@
+"""The last three from the scope audit: a fence three commands never got, and two files that
+stopped the product instead of losing one record.
+
+Each is the shape the whole week has been: a rule written down in one place, and a neighbour that
+never received it.
+
+1. `chat`, `assist` and `tui` built their tool registry raw. `run` applies the deployment fence one
+   line after building the same registry; the desktop app applies it too. These three were the only
+   agent surfaces without it — and the `project_root` comment sitting in those exact lines was added
+   a day earlier, for the sibling field, without anyone noticing the missing fence beside it.
+
+2. `MemoryStore.load` had a per-record guard whose comment says "one bad entry must not lose every
+   other memory" — and the `json.loads` above it was outside that guard. A file truncated mid-write
+   is not a list with one bad entry; it is not JSON. Every command builds a memory manager at boot,
+   so one truncated file stopped the product rather than one memory.
+
+3. `save_playbook` was a bare `write_text` running after EVERY `solve`, and the playbook is one JSON
+   array — so a death mid-write cost every bullet, not the last one. `load_playbook` then raised on
+   the result, and it is called before any work starts.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from chimera.config import Settings
+from chimera.memory.models import MemoryItem
+from chimera.memory.store import MemoryStore
+
+MAIN = pathlib.Path(__file__).resolve().parents[1] / "chimera" / "cli" / "main.py"
+
+#: Agent surfaces that must apply the deployment fence. Not "everything that builds a registry":
+#: `tools` prints a table and the benches assemble their own — naming them keeps the check honest
+#: about what it is asserting.
+FENCED_COMMANDS = ("chat", "assist", "tui", "agent")
+
+
+def _fence_reaches(command: str) -> bool:
+    """True when ``command`` passes its registry through `_apply_tool_allowlist`.
+
+    An AST walk rather than a grep: a grep cannot tell the call from the word appearing in the
+    comment that explains it, and this file exists because of a comment nobody read closely.
+    """
+    tree = ast.parse(MAIN.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == command:
+            return any(
+                isinstance(inner, ast.Call)
+                and getattr(inner.func, "id", "") == "_apply_tool_allowlist"
+                for inner in ast.walk(node)
+            )
+    raise AssertionError(f"no command named {command!r} — retarget this test")
+
+
+@pytest.mark.parametrize("command", FENCED_COMMANDS)
+def test_every_agent_surface_applies_the_deployment_fence(command: str) -> None:
+    """`run` did this from the start. The other three did not, and nothing said so.
+
+    The fence is deliberately NOT `governed_profile` here: these are attended surfaces, and the
+    kernel and taint ledger are the inferential half that can refuse legitimate work. An allowlist
+    is an instruction — it removes a named tool and cannot be wrong about intent — so it needs no
+    rollout and no attendance argument. That distinction is the one #83 settled.
+    """
+    assert _fence_reaches(command), (
+        f"`{command}` builds its tools without _apply_tool_allowlist — an owner who fenced their "
+        "agent in .env gets no fence on this surface"
+    )
+
+
+def test_the_check_can_still_see_a_missing_fence() -> None:
+    """Proof it is not vacuous: the same walk over a command that does not apply it."""
+    tree = ast.parse("def demo():\n    registry = default_registry(ws)\n")
+    node = next(n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef))
+
+    assert not any(
+        isinstance(inner, ast.Call) and getattr(inner.func, "id", "") == "_apply_tool_allowlist"
+        for inner in ast.walk(node)
+    )
+
+
+# --- a truncated file loses one record, not the product -------------------------------------------
+
+
+def test_a_truncated_memory_file_does_not_stop_every_command(tmp_path: pathlib.Path) -> None:
+    """The guard below the parse says one bad entry must not lose every other memory. The parse
+    itself was above it, so a half-written file raised out of the constructor — and chat, solve,
+    serve, the app and every API request build one at boot."""
+    path = tmp_path / "memory.json"
+    path.write_text('[{"id": "a", "content": "kept"}, {"id": "b", "cont', encoding="utf-8")
+
+    store = MemoryStore(path)  # must not raise
+
+    assert store.all() == []
+
+
+def test_a_readable_file_still_loads_every_record(tmp_path: pathlib.Path) -> None:
+    """The direction that matters more: degrading on corruption must not degrade on health."""
+    path = tmp_path / "memory.json"
+    seed = MemoryStore(path)
+    seed.add(MemoryItem(id="a", content="one"))
+    seed.add(MemoryItem(id="b", content="two"))
+
+    assert {item.id for item in MemoryStore(path).all()} == {"a", "b"}
+
+
+def test_a_memory_file_holding_the_wrong_shape_is_ignored(tmp_path: pathlib.Path) -> None:
+    """Valid JSON, wrong type — a hand edit that wrapped the array in an object. Iterating a dict
+    would silently walk its KEYS and validate strings as memories."""
+    path = tmp_path / "memory.json"
+    path.write_text('{"items": []}', encoding="utf-8")
+
+    assert MemoryStore(path).all() == []
+
+
+def test_the_store_recovers_on_the_next_write(tmp_path: pathlib.Path) -> None:
+    """Degrading to empty is only acceptable if the next write repairs the file — otherwise the
+    agent quietly runs memoryless forever."""
+    path = tmp_path / "memory.json"
+    path.write_text("{ truncated", encoding="utf-8")
+
+    store = MemoryStore(path)
+    store.add(MemoryItem(id="new", content="after the corruption"))
+
+    assert {item.id for item in MemoryStore(path).all()} == {"new"}
+
+
+# --- the playbook, written after every solve ------------------------------------------------------
+
+
+def _settings(tmp_path: pathlib.Path) -> Settings:
+    return Settings(CHIMERA_HOME=str(tmp_path))
+
+
+def test_a_corrupt_playbook_does_not_stop_the_next_run(tmp_path: pathlib.Path) -> None:
+    """`build_evolution_context` loads this before any work starts, so raising here does not lose
+    the playbook — it stops the run. For advisory content that is the wrong trade."""
+    from chimera.evolution.wiring import load_playbook, playbook_path
+
+    playbook_path(_settings(tmp_path)).write_text('{"bullets": [{"id": "x"', encoding="utf-8")
+
+    assert load_playbook(_settings(tmp_path)).to_dict() is not None  # must not raise
+
+
+def test_the_playbook_file_is_never_opened_for_truncation(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mid-write crash cannot be injected portably, but the property that makes it impossible can:
+    the live file is only ever renamed onto, never opened in a mode that empties it first.
+
+    Both `io.open` and `builtins.open` are watched — pathlib reaches `io.open` by its own reference,
+    and a version of this test that watched only the second passed against the code it exists to
+    catch.
+    """
+    import io
+
+    from chimera.evolution.playbook import Playbook
+    from chimera.evolution.wiring import playbook_path, save_playbook
+
+    settings = _settings(tmp_path)
+    save_playbook(settings, Playbook())
+    target = playbook_path(settings)
+    opened: list[tuple[str, str]] = []
+    real_open = io.open
+
+    def watch(file: object, mode: str = "r", *args: object, **kwargs: object) -> object:
+        opened.append((str(file), mode))
+        return real_open(file, mode, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(io, "open", watch)
+    monkeypatch.setattr("builtins.open", watch)
+    save_playbook(settings, Playbook())
+    monkeypatch.undo()
+
+    truncating = [
+        (name, mode)
+        for name, mode in opened
+        if pathlib.Path(name) == target and ("w" in mode or "+" in mode)
+    ]
+    assert not truncating, f"the live playbook was opened in a truncating mode: {truncating}"
+
+
+def test_a_playbook_round_trips(tmp_path: pathlib.Path) -> None:
+    """The fix must not trade a crash for silent data loss — the whole point is that it still saves."""
+    from chimera.evolution.playbook import Playbook
+    from chimera.evolution.wiring import load_playbook, save_playbook
+
+    settings = _settings(tmp_path)
+    original = Playbook()
+    save_playbook(settings, original)
+
+    assert load_playbook(settings).to_dict() == original.to_dict()


### PR DESCRIPTION
Same shape as the eight before them: **a rule written down in one place, and a neighbour that never received it.**

## 1. The fence three commands never got

`chat`, `assist` and `tui` built their tool registry raw. `run` applies the deployment fence one line after building the same registry; the desktop app applies it too. These were the only agent surfaces without it.

The `project_root` comment sitting in those exact lines was added a day earlier, for the sibling field, **by me** — without noticing the missing fence beside it.

`_apply_tool_allowlist` and deliberately **not** `governed_profile`:

| | what it is | can it refuse legitimate work? | needs a rollout? |
|---|---|---|---|
| allowlist / denylist | an **instruction** — removes a named tool | no | no |
| trust kernel + taint ledger | an **inference** — is this action dangerous? | yes, and silently | yes |

These are attended surfaces, so the inferential half stays out. The instruction does not need an attendance argument — that is the distinction #83 settled.

## 2. The parse above its own guard

`MemoryStore.load` carried a per-record `try/except` whose comment reads *"one bad entry must not lose every other memory"* — and the `json.loads` was **outside** it.

A file truncated mid-write is not a list with one bad entry; it is not JSON. Every command builds a memory manager at boot — chat, solve, serve, app, each API request — so one truncated file **stopped the product** rather than losing one memory. `MemoryGraph.load` already degrades exactly this way, five files over.

## 3. The playbook, written after every solve

`save_playbook` was a bare `write_text`, and the playbook is one JSON array — dying mid-write cost **every** bullet, not the last one. `load_playbook` then raised on the result, and it runs before any work starts, so an unreadable file did not cost the playbook: it stopped the next run.

Now atomic under a lock, with a load that degrades to empty and repairs on the next write (there is a test for the repair, because degrading without recovering means the agent quietly runs memoryless forever).

## The count is the finding

That makes **five stores of this family in one week**: memory, experience, trajectory, skills, playbook. Five is not a coincidence of code — the whole-file read-modify-write was copied across the repository without the two primitives that make it safe.

What does **not** yet exist is a gate that fails the build on the sixth, the way governance (#80), `project_root` (#82) and file-writing (#88) now have one. Worth doing; not done here, and not claimed.

---

**Verification.** 12 tests, **7 of which fail** against the pre-fix code. `ruff check .`, `mypy chimera` (305 files) clean; **3037 passed**, with the same 18 pre-existing environment failures this WSL venv always shows.

Closes the scope audit's P0 list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)