### PR TITLE
feat(skills): thirteen official chimera-* cards, and one deleted for being generic

### DIFF
--- a/skills/chimera-budget-the-context/SKILL.md
+++ b/skills/chimera-budget-the-context/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: chimera-budget-the-context
+description: Spend against a budget below the real window, and count the tool schemas you re-send on every step — they are the floor compaction cannot reach.
+version: 0.1.0
+kind: pattern
+triggers:
+- the run died on context overflow
+- raising max-steps
+- the agent forgot what it was doing
+- adding another MCP server
+- deciding what to drop from the prompt
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are running a loop that appends to a message list every step — a ReAct agent, a coding turn, a
+tool-calling assistant — and the list only ever grows. Symptoms: the provider raises on context
+length, or the run survives but starts working on the wrong file after a long stretch.
+
+It does not apply to a single-shot call whose prompt you assembled yourself and can measure once.
+There is no eviction policy to design when nothing accumulates.
+
+## Do
+
+1. Write down two numbers before touching the loop: the model's advertised window, and the fraction
+   of it you will spend on the prompt. Chimera spends 0.6 (`DEFAULT_BUDGET_FRACTION` in
+   `chimera/core/context_budget.py`). The rest pays for the completion and for the gap between your
+   token estimate and the provider's real count.
+2. Fire compaction on a share of the *budget*, not of the window — Chimera triggers at 0.8 of the
+   budget. Compaction needs room to compact into; a trigger set at the window fires when there is
+   none left.
+3. Measure the fixed floor separately from the growing part. The system message plus the `tools=`
+   payload are re-sent on **every** step and no amount of message compaction touches them. Run
+   `chimera schema-bench` (or count the JSON yourself) before you assume the history is what is
+   expensive. A verbose MCP or OpenAPI import can put tens of thousands of tokens under every single
+   step of the run.
+4. If the floor is a problem, shrink the floor: strip annotation-only schema keys (`examples`,
+   `title`, `default`, `$comment`) and trim parameter prose to the first sentence, keeping `type`,
+   `properties`, `required` and `enum` intact so tool selection and argument validity are unchanged.
+   That is what `chimera/tools/schema_compact.py` does. Advertise fewer tools if it is still too big.
+5. Fix the eviction order explicitly: system message never, recent turns verbatim (Chimera keeps 6),
+   the older span replaced by a summary or a factual note. Never rewrite the system message — it is
+   the stable prefix the prompt cache is keyed on, and editing it invalidates every cached turn
+   behind it.
+6. After compacting, re-inject what the run needs to still be itself: the task **verbatim**, the
+   plan, the task list with status, and the file currently being edited. Re-read the file from disk
+   rather than restoring a remembered copy.
+7. When you estimate token size yourself, count the `tool_calls` payload as well as `content`. Tool
+   arguments ride on the assistant message and are not in `content`; a size estimate that reads only
+   `content` under-reports exactly the messages that grew.
+
+## Avoid
+
+Raising `--max-steps` because a task did not finish. It is the obvious move and it is the one that
+kills the run: more steps means a longer message list against the same window.
+
+Dropping the task statement. It arrives as a user message at the front, so it is the first thing a
+naive compactor evicts and the last thing the agent can work without. The result is an agent
+executing a plan whose purpose was deleted — still confident, still producing edits, no error
+anywhere. A file it can re-read; an instruction it cannot.
+
+Leaving a `tool` message at the head of the kept tail:
+
+```python
+older, recent = body[:-keep_recent], body[-keep_recent:]   # can orphan a tool result
+```
+
+versus
+
+```python
+older, recent = body[:-keep_recent], body[-keep_recent:]
+while recent and recent[0].get("role") == "tool":
+    older.append(recent.pop(0))                            # tail starts on a legal turn
+```
+
+Most providers reject a `tool` message whose matching assistant `tool_call` is gone, so the
+compaction that was supposed to save the run is what ends it.
+
+Also avoid tuning for maximum compression first. Calibrate recall-first: keeping too much costs
+tokens, which is a bill; removing too much loses context that was needed later, and those messages
+are gone. One is a cost, the other is unrecoverable.
+
+## Check
+
+Set the window low on purpose — point the budget at a 4K fake window, or run a task you know is
+long — and confirm three things: compaction fired, the run continued past it, and the message that
+followed contained the original task string. Grep the composed prompt for a distinctive phrase from
+the task after compaction. If it is not there, restoration is not working, whatever the logs say.
+
+Then check the floor with a binary question: does one step's prompt, with an empty history, already
+sit above your threshold? If yes, compaction can never help — `compact()` returns
+`changed=False` on a list it cannot shrink, and the honest reading of a no-op is "this did not
+help", not "retry into the same wall".
+
+## Risk
+
+A budget set too low compacts runs that never needed it, and every compaction rewrites the prompt
+suffix and throws away the cache hits behind it. On a long coding session that is a real bill, paid
+to avoid an overflow that would not have happened.
+
+Schema compaction has its own edge: trimming a parameter description to one sentence is safe for
+argument validity but can remove the sentence that told the model *when* to use the tool. It changes
+selection behaviour without changing any schema the validator checks, so it fails as slightly worse
+tool choice rather than as an error. Measure it as an A/B, do not enable it because it saves tokens.
+
+And the whole pattern buys nothing if the task is genuinely too large for the model. Budgeting turns
+a hard ceiling into a soft one; it does not create room that is not there.

--- a/skills/chimera-carry-the-failure-forward/SKILL.md
+++ b/skills/chimera-carry-the-failure-forward/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: chimera-carry-the-failure-forward
+description: A retry loop that overwrites its feedback variable shows attempt 3 only the failure of attempt 2 — so it re-derives the patch attempt 1 already tried.
+version: 0.1.0
+kind: pattern
+triggers:
+- writing a retry loop
+- the agent keeps trying the same fix
+- feeding verifier output back to the model
+- attempts keep failing the same way
+- reverting the workspace between attempts
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You have a loop that runs an attempt, judges it, and runs another one with feedback: an agent with a
+verifier, a code fixer against a test suite, a generate-and-check pipeline. The budget is more than
+two attempts, and the workspace is reverted between them so each attempt starts clean.
+
+It does not apply to an idempotent retry over a flaky transport — a network call that failed for
+reasons unrelated to what you sent. There is nothing to learn from attempt 1 there, and carrying it
+forward is just payload.
+
+## Do
+
+1. Store attempts in a list, not in a variable you reassign. One record per attempt: the verifier
+   output, the patch the attempt actually wrote, and which tool step errored first.
+2. Take the patch from the workspace snapshot, before the revert — the real diff, not the model's
+   description of what it changed. The revert is what makes this necessary: once the tree is rolled
+   back, nothing on disk records the wrong path either, so the next attempt has no obstacle to
+   re-deriving the same one.
+3. Compose the retry prompt from every record, oldest first, each labelled with its attempt number
+   and its verdict, under a heading that says these were already tried and reverted.
+4. Bound each record. Chimera caps a fed-back diff at 2000 characters and truncates with a marker;
+   an unbounded three-attempt history will dominate the prompt.
+5. Deduplicate by failure signature. If two attempts failed the same way, keep one and record that
+   it recurred — the repetition is the signal, the second copy is not new information.
+6. When the signature repeats, stop appending and change something structural: re-plan with the
+   accumulated causes as planner context (`TaskLedger.context()` renders them under "Why earlier
+   attempts failed (do NOT repeat these):"), or escalate to a stronger model. More feedback about the
+   same dead end does not leave the dead end.
+7. Emit a countable event each time you inject history, so a benchmark arm can prove the injection
+   fired at all.
+
+## Avoid
+
+The overwrite. In `chimera/core/autonomous.py` the loop's feedback is rebuilt each round:
+
+```python
+feedback = "\n\n".join(p for p in (fb, _verify_fb) if p) or "The attempt did not pass verification."
+```
+
+so attempt 3 is composed with attempt 2's failure and nothing from attempt 1. Carrying it forward
+means appending to a structure instead — sketched, not quoted, because the accumulating version is
+what this card argues for rather than what the file currently does:
+
+```python
+records.append(record_for(index, verdict, patch))   # one entry per attempt
+feedback = render(records)                          # every attempt, oldest first
+```
+
+Be precise about which half is already there when you read this in Chimera: the *content* of the
+feedback is well covered — `--diff-feedback` shows the retry the patch it actually wrote
+(`chimera/core/autonomous.py`, capped at `_DIFF_FEEDBACK_MAX_CHARS = 2000`), and `TaskLedger`
+accumulates causes for the planner. What is not covered is the *accumulation across attempts* in the
+line above. A card that presented all of it as missing would be arguing against work already done.
+
+Also avoid telling the retry *that* it failed without showing *what* it wrote. "The attempt did not
+pass verification" plus a failing test is enough to make a model try again and not enough to make it
+try something different — the wrong patch is invisible to it and the workspace no longer contains
+it, so re-deriving it is the path of least resistance.
+
+And avoid carrying only the manager's prose while dropping the verifier's output. The failing assert
+is the most actionable line in the whole loop; a reviewer's paragraph about it is a paraphrase of
+strictly less information.
+
+## Check
+
+Instrument the composer, run a task you know fails three times, and grep the attempt-3 prompt for a
+string that exists only in attempt 1 — a filename it touched, an identifier from its diff. Present
+or absent; there is no partial credit.
+
+Second check, equally binary: count the injections. A run where the history was never assembled
+because the guard was wrong, or because the diff list was empty, measured nothing at all — and a
+benchmark arm built on that measures the plumbing, not the idea. If the counter reads zero, the
+result is void regardless of what the success rate says.
+
+## Risk
+
+Anchoring is the registered counter-hypothesis, not a hypothetical: showing a model the wrong patch
+can fix its attention on that patch and produce variations of a dead approach instead of a different
+one. This is why the behaviour is opt-in and measured in Chimera (`--diff-feedback`) rather than
+turned on by default. Treat it as a claim to test on your own tasks, not a settled improvement.
+
+The second cost is the context budget. Three diffs, three verifier dumps and a manager review can
+push the prompt past its compaction threshold — and then a compactor with no restoration will drop
+exactly the accumulated history you paid to build. Bound the records and know your budget before
+enabling this, or the two mechanisms will fight and the visible symptom will be neither of them.

--- a/skills/chimera-give-the-denominator/SKILL.md
+++ b/skills/chimera-give-the-denominator/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: chimera-give-the-denominator
+description: A rate without its denominator and its composition misleads while every digit stays true — say n, and say how much of the numerator is already-known noise.
+version: 0.1.0
+kind: pattern
+triggers:
+- reporting a failure rate
+- a percentage in a summary
+- the number looks alarming
+- comparing before and after a change
+- writing a benchmark result
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are about to put a rate, a percentage, or a count into a report, a commit message, a
+benchmark table, or a message to someone who will act on it. "34% of runs failed." "Errors up
+3x." "Coverage dropped."
+
+It does not apply to a number the reader can already decompose: a single measured latency, a
+version string, a count of files in a diff they can see. The risk is specific to an aggregate —
+a quantity computed by dividing one set you chose by another set you chose, where both choices
+are invisible in the sentence.
+
+## Do
+
+1. Write the raw counts next to the rate, always: `34% (17/50 runs)`. If you cannot state the
+   denominator, you do not yet know what you measured.
+2. Say which denominator. Attempted runs and completed runs are different sets, and dividing by
+   completed silently deletes the crashes — the exact population that made you look.
+3. Split the numerator by cause before publishing it. Of those 17 failures, how many are an
+   already-open issue, a known flaky provider timeout, a fixture that fails on this machine?
+   Report the split: `17 failed — 14 are the known connect timeout, 3 unexplained`.
+4. Run the same measurement against an unchanged baseline and subtract. The number that matters
+   is the part that does not survive on `main`.
+5. When n is small enough that one more sample would move the headline figure by several points,
+   put that sentence in the report instead of the percentage.
+
+## Avoid
+
+`"failure rate 34%"` — true, and it invites the reader to spend a day on a timeout they already
+filed last week. Write `"17/50 failed; 14 are the ollama connect timeout (issue open), 3 are new"`
+and the day gets spent on the 3.
+
+Avoid the survivorship denominator. `rate = failures / completed` is the classic: the runs that
+died before producing a row are absent from both sides, so the metric improves as the system gets
+worse.
+
+Avoid percentages over a denominator under about twenty without n attached. `50% → 67%` is a real
+improvement or it is one run out of three flipping, and the two are indistinguishable on the page.
+
+Chimera has published a retraction of exactly this shape, and it is the reason this card exists.
+`bench/learning_lift/RESULTS.md` reported a significant within-family transfer gap of **+6.7%**, and
+run 7 — the same measurement at adequate power — did not hold it. The number was real, the
+arithmetic was right, and it was still best explained as a small-sample fluctuation. What made the
+retraction possible was that the run count had been published beside the percentage from the start.
+Had the page carried only "+6.7%", there would have been nothing to re-examine, and the finding
+would have quietly become a fact.
+
+## Check
+
+Hand the sentence to someone who cannot see your data and ask them to reconstruct the raw
+counts. If they cannot, the sentence is incomplete — this is a binary test and it takes ten
+seconds.
+
+Second check, when the number is driving a decision: re-run the measurement on an unmodified
+baseline. Whatever fraction of the numerator reproduces there is not about your change, and any
+claim built on it is about the harness.
+
+## Risk
+
+Applied to everything, this turns readable prose into a parenthesis swamp, and readers start
+skipping the parentheses — which is worse than the original problem, because now the denominators
+are on the page and unread. Reserve the full decomposition for numbers someone will act on.
+
+The sharper risk runs the other way: cause-splitting is also the tool for making a real problem
+look small. Labelling fourteen failures "known noise" is honest only if the label was assigned
+before you saw which way it helped. If you find yourself widening the "known" bucket while
+writing the summary, the number was the conclusion, not the evidence.
+
+A stated denominator also does not rescue a bad one. `2/3 (n=3)` is still three runs; the
+denominator makes the weakness visible rather than fixing it.

--- a/skills/chimera-ground-it-in-the-source/SKILL.md
+++ b/skills/chimera-ground-it-in-the-source/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: chimera-ground-it-in-the-source
+description: Take the signature from the installed version, not from memory — a plausible API is indistinguishable from a real one until it runs.
+version: 0.1.0
+kind: pattern
+triggers:
+- calling a library I did not write
+- what is the parameter called
+- the API changed between versions
+- writing against a framework from memory
+- AttributeError on a method that should exist
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are about to write a call into someone else's library, framework or CLI: a method name, a
+keyword argument, a config key, the shape of a return value, a flag. This applies most sharply when
+recall feels *confident*, because confidence is produced the same way whether or not the API exists.
+
+It does not apply to the language's own builtins you exercise constantly, and it is not an
+instruction to fetch documentation before writing `dict.get`. The line is whether being wrong would
+be caught immediately by the next thing you run.
+
+## Do
+
+1. Get the version that is actually installed, not the one you remember reading about:
+   `uv pip show <pkg>`, or `python -c "import pkg; print(pkg.__version__)"`.
+2. Read the installed thing. `python -c "import inspect, pkg; print(inspect.signature(pkg.fn))"`,
+   or open the file under `site-packages`, or run `--help` on the binary that is on PATH. This is
+   the authority, because it is the code that will execute.
+3. When you use a blog post, a README on the web, or your own recall, treat it as a hypothesis and
+   confirm it against step 2. Docs sites describe the latest release; your lockfile may not pin it.
+4. Exercise the call once in a throwaway snippet and print the *actual* return value before writing
+   code that indexes into your assumption of it. Nested shapes — `["choices"][0]["message"]` — are
+   where memory is least reliable and least likely to fail loudly.
+5. Leave the evidence next to the code: the version, and the signature or help output you read.
+   A comment or the PR body is enough, and it tells the next reader what the code was written
+   against.
+
+## Avoid
+
+Writing API-shaped text. The failure is not a typo — a typo raises immediately and gets fixed in
+seconds. It is a name that obeys every one of the library's naming conventions and does not exist:
+
+A real one from this repository, and the shape is the point — the guess was not absurd, it was
+*reasonable*:
+
+```python
+# Plausible: snapshots live in checkpoint.py, so the diff of two snapshots should too.
+from chimera.core.checkpoint import WorkspaceGuard, diff_snapshots   # ImportError
+
+# Where it actually is. One grep, before writing the line, would have found it.
+from chimera.core.checkpoint import WorkspaceGuard
+from chimera.evolution.diff_gate import diff_snapshots
+```
+
+The cost was not the exception — an `ImportError` is loud and cheap. It is that the same confident
+guess about a *behaviour* fails silently, and you only find out when the number it produced turns
+out to be wrong.
+
+Also avoid grounding at the wrong version. Reading the current docs for a package pinned two majors
+back produces code that is correct about a library you are not running — and the error message,
+when it comes, points at your call rather than at the mismatch.
+
+And avoid accepting a passing type checker as grounding when the package ships no stubs. Against an
+untyped dependency, `Any` swallows every attribute you invent; the check reports success because it
+had nothing to check.
+
+## Check
+
+For each non-obvious call in the diff, can you point at where you saw it — a signature you printed,
+a line in `site-packages`, a `--help` you ran? If the honest answer for any of them is "it seemed
+right", that call is unverified, and saying so costs one sentence.
+
+The stronger check is executable: run the snippet from step 4 against the installed version and
+paste its output. An import that resolves and a call that returns the shape you expected are two
+different facts; the second is the one you are relying on.
+
+## Risk
+
+Applied to everything, this turns routine code into research and slows work down for no gain. Spend
+it on the unfamiliar call, the version-sensitive one, and the nested return shape — not on the
+hundred lines around them.
+
+The subtler risk is grounding *too* literally. The installed source will happily show you
+`_internal_helper`, which exists, works today, and is nobody's promise. Source tells you what is
+there; docs tell you what is supported. When they disagree, prefer the documented surface, and if
+you knowingly reach past it, say so in the comment rather than letting the next reader assume it
+was sanctioned.

--- a/skills/chimera-list-exemptions-not-obligations/SKILL.md
+++ b/skills/chimera-list-exemptions-not-obligations/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: chimera-list-exemptions-not-obligations
+description: A gate that lists what to check fails open — the site nobody remembered to add is the one that breaks. List the exemptions instead, each with a written reason, and the default becomes fail.
+version: 0.1.0
+kind: pattern
+triggers:
+- writing a build gate
+- enforcing a rule across the whole package
+- a hand-maintained list of files to check
+- a surface lost its guarantee
+- adding a new entry point
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are enforcing a property that has to hold at every site of a certain kind: every unattended
+surface goes through the governance profile, every writer passes the gate, every API route
+regenerates its schema. The rule is one sentence, but the sites are written at different times by
+different hands, and none of them calls the thing the others call.
+
+It does **not** apply when the population is closed by construction — a rule about the three entries
+of a dispatch table is already enumerated by the table. This pattern earns its cost only when a new
+site can appear in a file that does not exist yet.
+
+## Do
+
+1. Enumerate the population mechanically. Walk every `*.py` under the package
+   (`PACKAGE.rglob("*.py")`), not a hand-written list of the files you happen to know about.
+2. Detect the site structurally. Parse and walk the AST for the call you care about; a `grep` cannot
+   tell an assembled registry from the same words inside a docstring, and that docstring *will* exist,
+   because someone will write a comment about the fix.
+3. Walk nested scopes and key by the enclosing chain — `chimera/cli/main.py:solve._run_solve`. The
+   one surface Chimera lost had its registry built inside a `factory()` closure
+   (`chimera/server/manager.py:_gateway_on_message.factory`), invisible to a walk that only looked
+   at top-level functions.
+4. Make the default FAIL. Keep one `EXEMPT: dict[str, str]` from site key to written reason, and have
+   the assertion list every site found that is not a key in it.
+5. Write the reason as a sentence about that specific site, and separate the kinds of reason.
+   "attended: interactive REPL" (a person can hit Ctrl-C) is a much stronger claim than "assembles an
+   equivalent stack from its own flags" — the second marks a duplicate implementation to consolidate,
+   not a settled answer.
+6. Add a second test asserting every `EXEMPT` key still names a live site, so the list cannot outlive
+   the code it excuses and rot into a formality.
+
+## Avoid
+
+The obligations list:
+
+```python
+SURFACES = ["serve", "cron", "mcp", "a2a", "platform"]   # fails OPEN
+for name in SURFACES:
+    assert_governed(name)
+```
+
+versus the exemptions list:
+
+```python
+EXEMPT = {"chimera/cli/main.py:chat": "attended: interactive REPL"}   # fails CLOSED
+assert not [s for s in every_site_in_the_package() if s not in EXEMPT]
+```
+
+The first version of Chimera's governance gate was the top one: it parsed a single file and named
+five surfaces. `chimera/server/manager.py` — the Discord bot the desktop app's Messaging toggle
+starts, the same bot `serve --discord` runs — built its registry ungoverned for three weeks *after*
+the sweep that was supposed to have covered it. It was never failing the gate. It was never looked
+at.
+
+Also avoid an exemption with no reason. A bare `EXEMPT: set[str]` is a list of checks to skip that
+nobody can review a year later; the one sentence is the whole cost of the entry and the whole value
+of it.
+
+## Check
+
+Feed the gate a source that violates the rule and assert it is caught, including from inside a
+nested function — otherwise an AST bug makes the gate pass forever and the guarantee quietly stops
+existing:
+
+```python
+src = "def serve():\n    def factory():\n        r = default_registry(ws)\n"
+assert _bare_registry_calls(ast.parse(src), "m.py") == [("m.py:serve.factory", 3)]
+```
+
+Then the other half: a call already wrapped in the compliant shape must **not** be flagged, or every
+conforming site would need an exemption and the list would stop meaning anything.
+
+The binary question: delete one entry from `EXEMPT` and re-run. Does the suite go red naming exactly
+that site? If not, the gate is not reading the list you think it is.
+
+## Risk
+
+Inverting the list moves the cost onto whoever adds a legitimate new site: an unrelated PR goes red
+with an error about governance they were not thinking about. That is the intended trade, but only if
+the failure message says both ways to comply — route it through the profile, *or* add the exemption
+with a reason. A gate that fires on work it was not built to defend gets argued down until it fires
+on nothing.
+
+The structural detection is also narrower than it feels. It catches the one shape it knows; a surface
+that assembles tools through a different call, or imports a pre-built registry from elsewhere, is
+outside the walk and the green build says nothing about it. Pin the coverage of the file that
+regressed by name in its own test, so a walk that silently stops covering that file fails instead of
+passing.

--- a/skills/chimera-prove-the-test-discriminates/SKILL.md
+++ b/skills/chimera-prove-the-test-discriminates/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: chimera-prove-the-test-discriminates
+description: A regression test you never saw fail is a guess. Re-break the code and watch it go red before you commit it.
+version: 0.1.0
+kind: pattern
+triggers:
+- wrote a regression test
+- fixed a bug and added a test
+- the test passes, ship it
+- adding a test after the fix
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You fixed a bug and wrote a test so it cannot come back. The test passes. That is the whole
+evidence you have, and it is the same evidence you would have if the test asserted nothing about
+the bug at all.
+
+It applies hardest when the test was written *after* the fix, because then the only code the test
+has ever run against is code where the bug is already gone. It applies less to a test written
+first, red, in a TDD loop — you already watched that one fail, which is the entire point of the
+loop.
+
+It does **not** apply to a test for genuinely new behaviour, where there is no "before" to revert
+to. There, the discriminating check is different: delete the new implementation and confirm the
+test fails on the absence, not on the bug.
+
+## Do
+
+1. Identify the exact edit that constitutes the fix — the hunk, not the commit. If the fix is one
+   changed comparison, that comparison is what you are going to undo.
+2. Undo it. `git stash` the fix, or invert the one line back to its broken form by hand.
+3. Run only the new test: `pytest tests/test_thing.py::test_the_regression -x`.
+4. Read the failure. It must be **your assertion** failing, with a message about the behaviour —
+   not a `SyntaxError`, not a collection error, not an `ImportError` from a half-reverted file.
+   Those are red for the wrong reason and prove nothing about the test.
+5. Restore the fix (`git stash pop`) and confirm the same test now passes.
+6. Put the fact in the test's docstring: what was reverted, and what the failure looked like. The
+   next person to touch this test needs to know it was ever exercised against the bug.
+
+## Avoid
+
+Asserting on something true in both worlds. The classic shape:
+
+```python
+# WRONG — passes against the buggy code too
+result = parse_config(raw)
+assert result is not None
+assert "timeout" in result
+```
+
+The bug was that `timeout` came back as the string `"30"` instead of the int `30`. Both assertions
+hold either way. What discriminates is the thing that changed:
+
+```python
+# RIGHT — fails against the buggy code
+assert parse_config(raw)["timeout"] == 30
+assert isinstance(parse_config(raw)["timeout"], int)
+```
+
+Also avoid reverting by commenting out a whole function or deleting an import to "make it fail
+fast". That produces a red run that would have happened for any test in the file, so it tells you
+nothing about *this* one. The revert has to be the fix and only the fix.
+
+And avoid the near-miss where the test reaches the fixed code through a path production never uses
+— that is a different failure, and the card for it is `chimera-test-the-wiring-not-the-class`.
+
+## Check
+
+One binary question: **did you personally see this test print a failure caused by its own
+assertion, against the unfixed code?**
+
+If yes, you are done. If the answer is "it would have failed", you have not checked anything —
+that sentence is a prediction produced by the same reasoning that wrote the test.
+
+Mechanically:
+
+```bash
+git stash                 # remove the fix
+pytest tests/test_x.py::test_regression   # MUST be red, on your assertion
+git stash pop             # restore
+pytest tests/test_x.py::test_regression   # MUST be green
+```
+
+Red-then-green, both observed, or the test is unproven.
+
+## Risk
+
+Some fixes cannot be cheaply reverted: a dependency upgrade, a schema migration, a deleted file, a
+change in a vendored library. Forcing a revert there can cost more than the test is worth. The
+honest fallback is to reconstruct the *input* that used to break it and assert the specific value,
+then say plainly in the docstring that the red run was not observed — an unproven test that admits
+it is unproven is far better than one that implies it was checked.
+
+The real hazard of this card is the revert you forget to undo. Doing this dance in a dirty working
+tree is how a re-broken line gets committed alongside its own regression test, with the suite
+green because you restored the fix in the wrong file. Run `git diff` before committing, every
+time.
+
+And a discriminating test is still only as good as the bug you understood. It proves the test
+catches *this* reversion. It does not prove you fixed the root cause rather than the symptom, and
+treating a red-then-green run as proof of that is a bigger claim than the evidence supports.

--- a/skills/chimera-reproduce-before-diagnosing/SKILL.md
+++ b/skills/chimera-reproduce-before-diagnosing/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: chimera-reproduce-before-diagnosing
+description: A diagnosis is a claim about a machine you have not run. Reproduce the failure in one short command first — especially when the diagnosis arrived from someone else.
+version: 0.1.0
+kind: pattern
+triggers:
+- a bug report arrived
+- another agent explained the cause
+- the traceback points at a file
+- about to fix something you have not seen fail
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are about to change code because of a failure you have not personally watched happen: a red CI
+job, a log excerpt in an issue, a user's description, or — the case this card is really about — a
+confident diagnosis handed to you by a reviewer, a sub-agent, or a static analysis tool, complete
+with a file and a line number.
+
+It does not apply when the failure already *is* one command. A test that fails locally when you run
+it is a reproduction; do not build a second one. It also does not apply to work that has no failure
+in it — a new feature, a refactor, a design question. Those have nothing to reproduce.
+
+## Do
+
+1. Write the shortest thing that fails and can be run by itself: one script, one pytest node id, one
+   CLI invocation. "Run the suite and look at the third error" is not it — you will read past the
+   error every time.
+2. Run it. Copy the real output into your notes: the exception type, the wrong value next to the
+   expected one, the exit code. Not your summary of it.
+3. Now state the diagnosis, and immediately try to kill it. Put a `raise RuntimeError("here")` at the
+   top of the function the diagnosis blames and rerun the reproduction. If the original failure still
+   appears unchanged, that function is not on the failing path and the diagnosis is wrong regardless
+   of how well argued it was.
+4. Fix, rerun the same command, and keep the reproduction as a test in the same change. A repro that
+   is deleted after the fix cannot tell you when the fix is reverted.
+
+## Avoid
+
+Editing the frame of the traceback you recognise. The frame you recognise is the one you have read
+before, not the one that is wrong, and a plausible edit there will often make the symptom move
+somewhere else — which then reads as progress.
+
+Avoid inheriting a diagnosis as a fact. A handed-over explanation is text, and the process that
+produces a fluent wrong explanation is the same process that produces a fluent right one, so the
+fluency carries no information about which you got. Treat it as a hypothesis with a name attached:
+useful for ordering what to try, worthless as evidence.
+
+```python
+# no — the theory is now load-bearing and untested
+# reviewer says the cache key is missing the tenant id
+key = f"{tenant.id}:{user.id}"
+
+# yes — first make the failure appear on demand
+# repro.py: two tenants, same user id, assert the second read misses
+```
+
+And avoid the rerun-until-green reflex on an intermittent failure. Rerunning does not diagnose a
+race, it hides one, and it converts a reproducible-once bug into a bug nobody can reproduce at all.
+
+## Check
+
+Before you write the fix, answer yes or no: *can I make this failure happen again, right now, with
+one command?* If no, you are not debugging, you are speculating with an editor open.
+
+After the fix: does the same command now pass, and did you see it fail beforehand with your own
+eyes? A fix validated only by the suite going green proves the suite is green — which it may have
+been for the wrong reason, if the failing case was never in the suite.
+
+## Risk
+
+Some failures are genuinely expensive to reproduce: a race that appears once a day, a state that
+exists only in production, a crash six hours into a long job. Insisting on a cheap reproduction there
+burns more than the bug costs. Time-box it, and if the box expires, say plainly that the fix is
+unverified rather than describing it as confirmed.
+
+The subtler trap is over-minimisation. A stripped-down script can start failing for a *different*
+reason than the original, and then you fix the toy. Guard against it by applying the fix to the
+original failing path too, and confirming the original symptom disappears there — the minimised case
+is a tool for finding the cause, never the proof that it was the cause.

--- a/skills/chimera-run-the-projects-own-gate-command/SKILL.md
+++ b/skills/chimera-run-the-projects-own-gate-command/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: chimera-run-the-projects-own-gate-command
+description: Run the project's verification command literally — same scope, same flags. The near-identical variant you improvise lies in both directions.
+version: 0.1.0
+kind: pattern
+triggers:
+- about to run lint or type checks
+- verifying before a commit or PR
+- CI failed but it passed locally
+- adding a scope argument or a strictness flag
+- reporting the gate as green
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are about to run the project's quality gate — lint, type check, tests — and report the result as
+evidence that a change is safe. The temptation is to narrow it ("I only touched `chimera/`") or to
+tighten it ("`--strict` is surely better").
+
+It does **not** apply to exploration. Running `pytest tests/test_governed_surfaces.py -x` while
+iterating on one file is the right thing to do; the rule is about what you may then *call the gate*.
+A narrowed run is a debugging aid, never the verification.
+
+## Do
+
+1. Find where the command is written down, and name ONE source as canonical. In Chimera that is the
+   `check` target in the `Makefile` — `make check` — because a target is executable and a prose line
+   is a copy of one. The three checks it runs are `ruff check .`, `mypy chimera` and `pytest -q`.
+2. Run the canonical form byte-for-byte. No added path argument, no added flag, no substituted
+   runner. Beware that a prose copy may differ in ways that look cosmetic and are not: `Makefile:21`
+   wraps it as `uv run --no-sync`, `CONTRIBUTING.md:105` as `uv run --extra dev --extra desktop`.
+   Same tool, different environments — which is exactly why one of them has to be the source.
+3. If two sources disagree, treat the CI workflow as authoritative, run that, and fix the stale doc in
+   the same PR — `CONTRIBUTING.md` carried a wrong `mypy --strict` line for a while, and a stale
+   instruction propagates to everyone who reads it.
+4. If the canonical command cannot run in your environment, say the gate did not run. On Windows the
+   local `.venv` is broken (litellm wants Rust/MSVC), so the gate runs in WSL — moving the *shell* is
+   allowed, editing the *command* is not.
+5. Report the command and its output verbatim, not a summary of how it went.
+
+## Avoid
+
+Two near-misses, both real, both in one session, and note they fail in **opposite** directions:
+
+```bash
+mypy --strict chimera      # WRONG — lies toward failure
+mypy chimera               # right
+```
+The explicit flag overrides the project's own `warn_unused_ignores = false` in `pyproject.toml` and
+reports roughly fifteen `unused-ignore` errors in files nobody touched. That nearly became a bug
+report filed against clean code.
+
+```bash
+ruff check chimera tests   # WRONG — lies toward success
+ruff check .               # right
+```
+The narrowed scope does not report a B023 (a closure capturing a loop variable) that `ruff check .`
+does, because scope changes which files — and therefore which per-directory rule settings — are in
+play. CI failed on a PR whose local "gate" was green.
+
+The shared mechanism: **the flag decides which config wins, and the scope decides which rules fire.**
+Neither is a cosmetic difference, and both variants look close enough to the real command that the
+output reads as authoritative.
+
+## Check
+
+Point at the file and the line where your command is written. `Makefile:21`, `CONTRIBUTING.md:105`.
+If you cannot, you improvised it.
+
+The binary question: could the string you typed be pasted into the `check` recipe with zero edits? If
+your command has an argument or a flag the recipe does not have, the answer is no, and what you ran
+was a different check that happens to share a name.
+
+## Risk
+
+The canonical command is usually the slowest one, and a rule that forbids the fast variant nudges
+toward running nothing at all. That is a worse outcome than a narrowed run honestly labelled.
+
+Measure the cost before deciding the rule is cheap, and re-measure as the suite grows. The first
+draft of this card said Chimera's full suite was "about fifteen seconds" — a number that was true
+once and had drifted to roughly **100 seconds** across four measured runs by the time the card was
+written. A card about not improvising commands is a poor place to publish a figure that does not
+survive running the command.
+
+And the recipe itself can be wrong. Following it verbatim means inheriting its blind spots: `make
+check` will not tell you that a test reads a gitignored `bench/local_lift/results/paired.json` that a
+fresh clone does not have. The fix for a bad gate is to change the recipe in a PR, not to quietly run
+a better private one — a private improvement protects exactly one person and leaves CI, and everybody
+else, on the old command.

--- a/skills/chimera-state-what-you-did-not-check/SKILL.md
+++ b/skills/chimera-state-what-you-did-not-check/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: chimera-state-what-you-did-not-check
+description: A ranking built from part of the system reads as a ranking of the system — write the scope and the exclusions next to the findings, not after them.
+version: 0.1.0
+kind: pattern
+triggers:
+- writing a review or audit
+- listing the top risks
+- reporting findings
+- ranking issues by severity
+- someone asks if it is safe
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are delivering something that reads as a survey: a code review, a security pass, "the three
+biggest problems", a prioritised backlog, a comparison of options. Anything where you looked at
+some of a space and produced an ordering.
+
+It does not apply to answering a bounded question — "does this function handle an empty list?" —
+where the scope is already the whole of what was asked. The risk here is specific to output whose
+*form* is a list of the worst things, because that form carries an implied "of everything" the
+reader will supply for free.
+
+## Do
+
+1. Open with the scope, before the findings. Name what you actually read: paths or globs, the
+   commit or branch, and whether you ran anything or only read. `Reviewed: src/api/*.py at
+   4f2a1c9, static read only, no tests executed.`
+2. List the exclusions with their reason, and keep the reasons concrete: no access to the
+   migrations, the integration suite needs credentials I do not have, the frontend was out of
+   budget for this pass.
+3. Scope every superlative to what you read. Not "the worst issue is the missing auth check" but
+   "the worst of the six handlers I read". The two sentences cost the same and mean different
+   things.
+4. Separate "checked and clean" from "not checked". A reader treats silence as a clean bill;
+   only one of those two states earns it.
+5. Name the unchecked thing most likely to outrank your current number one, so the reader knows
+   what the next pass should buy. If nothing plausible could, say that too — it is a real
+   finding.
+
+## Avoid
+
+Reporting "no SQL injection found" after a pass that never opened the database layer. The
+sentence is literally true and functions as a clearance. Write "did not review `db/` — no access
+to the migration files" and the same pass now says what it knows.
+
+Avoid putting the scope in a closing paragraph under a heading like *Limitations*. Readers act on
+the top of the document; a caveat below the ranking arrives after the decision it was supposed to
+qualify.
+
+Avoid the ordering that spans checked and unchecked work. Ranking three reviewed modules against
+one you skimmed produces a list whose positions mean different things at different rows, and
+nothing in the layout tells the reader which is which.
+
+## Check
+
+Ask one binary question of the finished document: can a reader who was not present name the files
+you read and the ones you did not, without asking you? If not, the scope is missing regardless of
+how careful the findings are.
+
+Second, reread every superlative — *worst*, *main*, *top*, *only*, *no* — and confirm each one
+carries its qualifier in the same sentence. These words are where the partial quietly becomes
+global.
+
+## Risk
+
+Exclusion lists can grow into blanket immunity: a document that disclaims everything asserts
+nothing, and reviewers who write them stop being accountable for the part they did cover. Keep
+the list to exclusions a reader would otherwise assume were included.
+
+Stating scope also invites "then go check the rest", which is sometimes the wrong call — a
+deliberately partial pass on the highest-risk surface can be the correct use of the time. If so,
+say why that surface was chosen, or the honest disclosure gets read as an unfinished job.
+
+And scope is not a substitute for depth. "I read these six files" does not mean the six were read
+well, and a precise boundary around shallow work still makes shallow findings.

--- a/skills/chimera-test-the-wiring-not-the-class/SKILL.md
+++ b/skills/chimera-test-the-wiring-not-the-class/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: chimera-test-the-wiring-not-the-class
+description: A class assembled by hand in a test proves the class works, not that anything reaches it — cover the path production actually takes.
+version: 0.1.0
+kind: pattern
+triggers:
+- feature works in tests but not in the app
+- added a component behind a factory or registry
+- the flag defaults to off
+- green suite, broken behaviour
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You built a component that production reaches indirectly: through a factory, a registry, a plugin
+loader, a config flag, a router, a CLI entrypoint, a dependency-injection container. Your tests
+construct it directly and call its methods.
+
+Every one of those tests can pass while the component is unreachable in the running system —
+because nothing in them exercises the registration, the default value of the flag, or the branch
+in the assembler that decides whether to include it at all.
+
+It does **not** apply to a pure function that callers import and call directly. There, the import
+*is* the wiring, and a unit test covers it. It also does not apply when you are deliberately
+testing an algorithm in isolation — those tests are correct and should stay; this card says they
+are not sufficient on their own.
+
+## Do
+
+1. Name the entrypoint a user actually hits: the CLI subcommand, the HTTP route, the agent's run
+   loop, the scheduled job. Write it down before writing the test.
+2. Write at least one test that starts *there* and passes no constructor arguments for your
+   component. If the test has to name your class to make the feature happen, it is not testing the
+   wiring.
+3. Build the object the way production builds it — call the real factory or config loader:
+
+   ```python
+   # WRONG — proves the class, not the wiring: the component is handed to the thing under test,
+   # so the test passes whether or not anything in production ever hands it over.
+   assert "reminder" in render(feature=Feature(text="reminder"))
+
+   # RIGHT — build it the way the entry point builds it, then look for the same observable
+   assert "reminder" in build_the_real_way(config).render()
+   ```
+
+   Chimera's own case is worth naming because the class was never broken. Skill cards had a
+   working retriever, a working store and a working injector — and `chimera/config.py:244` reads
+   `skill_cards: bool = Field(default=False, ...)`, so on a stock deployment nothing was ever
+   injected. Every unit test passed. The measurement that eventually caught it counted skills
+   minted against skills injected and found 39 against zero.
+
+4. Assert on an observable that can only appear if the component was reached: text in the rendered
+   prompt, a row written, a log line, an exit code.
+5. Assert the **default**. If the feature ships behind a flag, add a separate test that reads the
+   default value with no overrides and asserts what it is. A suite that only ever runs with the
+   flag forced on cannot tell you what users get.
+
+## Avoid
+
+Hand-assembling the collaborators that production wires up. The failure shape is a handler class
+with full unit coverage that the router never registers, or a capability whose config key defaults
+to off — the class is correct, the tests are correct, and the feature does nothing in the product.
+Nothing is red, so nothing gets investigated, and the gap survives until a human tries the feature
+by hand.
+
+Also avoid faking the seam you are trying to cover. Patching the factory, or stubbing the config
+loader to return an object containing your component, deletes exactly the code the test existed to
+exercise:
+
+```python
+# WRONG — the patch is the wiring; the test now asserts its own setup
+monkeypatch.setattr(mod, "load_plugins", lambda: [MyPlugin()])
+```
+
+Fake at the *outermost* boundary instead — the network client, the clock, the LLM call — and let
+everything between the entrypoint and your component be real.
+
+## Check
+
+Delete the wiring and run the suite. Comment out the registration line: the `@register` decorator,
+the entry in the dispatch dict, the `include_router(...)` call, the default in the config schema.
+
+Then the binary question: **did a test go red, and was it a test that never mentions your class by
+name?**
+
+If the suite stays green, your coverage is class-level only and the wiring is untested. If the only
+red test is the one that constructs the class directly, same answer. Restore the line afterwards
+and confirm green — and `git diff` before committing, so the deleted registration does not ship.
+
+## Risk
+
+Entrypoint tests are slower, harder to debug, and give worse localisation: when one fails you know
+the feature is broken but not which of ten components broke it. That is a real cost, and the wrong
+response to this card is deleting your unit tests in favour of end-to-end ones. Keep both — the
+wiring test tells you *that* it broke, the unit test tells you *what*.
+
+Going through the real entrypoint can also touch things you do not want touched in CI: a paid API,
+a live database, a filesystem outside the sandbox. If the only way to reach the entrypoint is to
+spend money or mutate production, do not force it; cover the assembler function directly instead
+and accept that you are one step short of the true path.
+
+And this card catches reachability, not correctness. A feature can be perfectly wired to the
+entrypoint and still produce the wrong answer, so a green wiring test is not licence to skip
+asserting what the output actually says.

--- a/skills/chimera-thin-vertical-slice/SKILL.md
+++ b/skills/chimera-thin-vertical-slice/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: chimera-thin-vertical-slice
+description: Build one narrow path that crosses every layer and runs, before building any layer in full — an integration that has never executed is a guess.
+version: 0.1.0
+kind: pattern
+triggers:
+- starting a new feature
+- this needs a CLI, a service and storage
+- building the abstraction first
+- nothing runs yet
+- scaffolding a subsystem
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are starting work that spans layers — a command that reaches an orchestrator that calls a
+provider that writes to a store — and you are deciding what to build first. The temptation is to
+build the bottom layer completely, then the next, then wire it up at the end.
+
+It does not apply to work that is genuinely one layer deep: a parser, a formatter, a pure function.
+There is no vertical there, and inventing one is ceremony. It also does not apply to a change inside
+a system that already runs end to end; that path exists, and the slice has already been paid for.
+
+## Do
+
+1. Name the observable the slice will produce, as a command someone else could type and a single
+   concrete output. Not "the pipeline works" — `chimera run "hi"` prints one line that came back
+   from a real provider.
+2. Write that invocation first, as a script or a test, and watch it fail for the right reason.
+3. Implement the shortest path through *every* layer, degenerate at each one: one provider, no
+   retry, no config file, no cache, no concurrency. Where a policy will eventually live, put a
+   constant.
+4. Keep the layer that carries the actual unknown real. If you do not yet know what the provider
+   returns, the provider is the one thing in slice one that must not be a stub.
+5. Commit at the moment it runs, before generalising. That commit is the evidence that the layers
+   fit together.
+6. Widen one axis at a time — second provider, then configuration, then caching — and keep the
+   command from step 1 working after each. If it breaks, that widening is the suspect.
+
+## Avoid
+
+Designing an interface against zero callers. The horizontal order produces a base class, six
+adapters, a registry and a retry policy on day one, and discovers at wiring time that the shape is
+wrong — because nothing had yet asked it a real question.
+
+```python
+# Day 1, horizontal: none of this has ever run.
+class BaseProvider(ABC): ...
+class ProviderRegistry: ...
+class RetryPolicy: ...
+
+# Day 1, vertical: ugly, hardcoded, and it answers the question.
+def complete(prompt: str) -> str:
+    return _post(URL, {"model": MODEL, "prompt": prompt})["choices"][0]["text"]
+```
+
+Also avoid the slice that is thin in the wrong dimension: mocking the external call and calling the
+rest end to end. That proves your own layers agree with each other, which was never the doubtful
+part. The integration you did not exercise is the integration that will be wrong.
+
+## Check
+
+Ask a binary question: can someone who did not write it, on a clean checkout, run one command and
+watch the feature do its job all the way through? If the answer needs "well, once you also stub
+X" or "after you paste a token into that constant" — note the second one honestly as setup, and
+treat any *code* caveat as proof it is not yet a slice.
+
+Then check `git log`: is there a commit where the command worked and the abstractions did not exist
+yet? If the first working commit is also the commit that introduced the registry, the slice was
+skipped.
+
+## Risk
+
+A slice hardcodes choices, and hardcodes survive. The usual failure is that steps 5 and 6 never
+happen because the first slice "works", leaving a system whose single provider is welded in and
+whose seams ended up in whatever place was convenient at hour two. Schedule the widening as work in
+the same batch, not as a follow-up nobody funds.
+
+The other cost is real: driving slice one through a live external dependency makes that first test
+slow, paid for, and occasionally flaky. Record and replay it *after* it exists — recording a call
+you have never made is not possible, which is the whole reason the order matters.

--- a/skills/chimera-when-two-results-contradict-suspect-the-apparatus/SKILL.md
+++ b/skills/chimera-when-two-results-contradict-suspect-the-apparatus/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: chimera-when-two-results-contradict-suspect-the-apparatus
+description: When two of your own measurements disagree by a margin no mechanism could produce, the defect is in the instrument. Audit the harness before building theory on top of it.
+version: 0.1.0
+kind: pattern
+triggers:
+- two runs disagree wildly
+- the smaller run scored better
+- a metric moved in an impossible direction
+- explaining a surprising benchmark result
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+Two measurements you produced yourself disagree by an amount you cannot account for: the run with a
+fraction of the data scores better than the big one; a component reads 0% on a task an adjacent
+measurement shows it doing routinely; a change moves a number in the direction it makes impossible.
+
+The trigger is the *size* of the gap, not its existence. Two runs differing within their noise band
+is a sampling question, and this card has nothing to say about it. It also does not apply to your
+number versus somebody else's published number — different data, prompts, seeds and versions explain
+those all day, and treating that as an apparatus alarm will have you auditing a harness that is fine.
+The case here is: both sides of the contradiction are yours, and both cannot be true.
+
+## Do
+
+1. Write the contradiction down first, as two lines: the two numbers, and the exact commands and
+   commits that produced them. Stop theorising until that is on the page — an unwritten contradiction
+   gets softened into a puzzle within about a paragraph.
+2. Diff the two runs before reasoning about them: config, commit, code path, input file hash, the
+   version of the scorer. Prefer a diff you can read over an explanation you can construct.
+3. Push known answers through the measurement itself. Run the reference/gold solutions through your
+   grader *before* trusting any model score. If a known-correct answer is graded as a failure, the
+   defect is in the grader and every number it has produced is void, including the one you liked.
+4. Only once the apparatus survives step 3 do you spend effort explaining the phenomenon.
+5. If the apparatus was at fault, retract the numbers rather than reinterpreting them. A score from a
+   broken scorer is not a noisy estimate of the truth; it is unrelated to it.
+
+## Avoid
+
+Building several careful hypotheses to explain both numbers and then testing them rigorously. That
+is the expensive version of this mistake: the rigour is real, the effort is real, and all of it is
+measured on an artefact. Method quality downstream of a broken instrument only gets you to the wrong
+answer with better error bars.
+
+Avoid reconciling by arithmetic — averaging the two, or quietly keeping the one that matches what you
+expected. Avoid a closed-world grader, which is the specific bug that produces this shape most often:
+
+```python
+# no — an answer that is correct but unlisted is scored as a failure,
+# and the score then reads as "the model cannot do this at all"
+CITIES = {"lisbon", "porto"}
+ok = answer.lower() in CITIES
+
+# yes — grade against a rule that the real world can satisfy
+ok = geocode(answer) == geocode(expected)
+```
+
+And avoid the phrase "it must be a fluke" as a stopping point. It is a hypothesis about the
+apparatus, so it is testable — test it or drop it.
+
+## Check
+
+One sentence, out loud, with a magnitude in it: *"X produces a difference this large because …"*. If
+you cannot finish it — "ten times less data producing a better score because …" — the instrument is
+the suspect and step 3 is where you go next.
+
+Then the binary one: did the gold answers pass the grader? Any gold item the grader marks wrong is a
+ceiling on what the measurement could ever have meant, and the fraction of them that fail is the
+first number to report.
+
+## Risk
+
+Sometimes the contradiction is real and the surprising result is the finding. A reflex of blaming the
+harness discards those, and — worse — it is exactly the move available to anyone who wants an
+inconvenient measurement to go away. So bound it: the apparatus check is a fixed, short list
+(diff the runs, gold through the grader, confirm the input hashes). If that list comes back clean,
+believe the contradiction and go investigate the phenomenon. This card orders the work; it does not
+pick the answer.
+
+The second cost is recursive. New code written to check the old code is one more thing that can be
+wrong, and a buggy audit script has now produced a third number. Prefer checks that use artefacts you
+already have and inputs whose answers are known, over a fresh harness written under the pressure of
+an anomaly.

--- a/skills/chimera-write-the-check-before-the-code/SKILL.md
+++ b/skills/chimera-write-the-check-before-the-code/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: chimera-write-the-check-before-the-code
+description: A criterion written after the implementation describes the implementation. Write the failing check first, watch it fail, then build.
+version: 0.1.0
+kind: pattern
+triggers:
+- about to implement a feature
+- defining what done means
+- writing the test after the code
+- no acceptance criteria on the task
+provenance: clean
+status: active
+license: Apache-2.0
+---
+
+## Trigger
+
+You are about to implement something whose "done" is not yet observable — a feature, a bug fix, a
+refactor that claims to preserve behaviour. It bites hardest when the author and the only reviewer
+are the same process: an agent working alone, or a solo commit nobody else will read.
+
+It does not apply to a spike. Exploration whose purpose is to find out what is even possible has no
+acceptance criterion yet, and inventing one upfront just anchors you to the first idea. Write the
+check when the spike ends and the real work begins.
+
+This card is about the check that does not exist yet. Its sibling, `chimera-prove-the-test-
+discriminates`, is about a check that already exists and may be empty — you reach for that one after
+a fix, to show the test fails without it. Same instinct, opposite ends of the work.
+
+## Do
+
+1. Before touching the implementation, write the criterion as something that can fail: a test, an
+   assertion, a command whose exit code flips, a query with an expected row. Prose is not a check —
+   "the endpoint should be faster" is not; "p95 under 200 ms on the fixture set, measured by the
+   existing bench command" is.
+2. Say where the observation comes from. The machine, not your reading of the diff.
+3. Run the check now, against unmodified code. It must fail. If it passes, either the behaviour
+   already exists — in which case stop, there is nothing to build — or the check does not test what
+   you think.
+4. Read the failure message. It must fail for the intended reason, not on an import error, a missing
+   fixture, or a typo in the test name. A red that comes from the wrong cause is a green in disguise.
+5. Land the check before the implementation, in its own commit. Once the implementation exists, the
+   check becomes editable to match it, and it will be.
+6. Implement. Done is when the check passes — not when the code looks finished.
+
+## Avoid
+
+Writing the assertion afterwards, from the output:
+
+```python
+# implementation already written; you run it once to see what it does
+normalize("  Foo ")        # -> "foo"
+
+# test transcribed from that observation
+assert normalize("  Foo ") == "foo"
+```
+
+That assertion cannot fail against the code it was copied from. It records behaviour instead of
+requirement, so it stays green through every bug the implementation is internally consistent about.
+If the requirement was NFKC normalisation and you shipped `strip().lower()`, this test agrees with
+you forever.
+
+Avoid also the criterion that is a restatement of the change — "done when the function is added",
+"done when the migration runs". Both are satisfied by an empty body.
+
+## Check
+
+Two binary questions, both answerable from the repository:
+
+- Did you watch the check fail before the implementation existed? If there is no moment where it was
+  red, you have no evidence it can go red.
+- Would the check still be correct if the feature had been built a completely different way? A check
+  that names internals — a private call, a log line, an exact SQL string — is pinned to your solution
+  rather than to the requirement, and will block the next refactor while catching nothing.
+
+Concretely: `git log` shows the check landing at or before the implementation, and reverting only the
+implementation commit turns the suite red.
+
+## Risk
+
+A requirement you do not yet understand cannot be pinned by a check written first. You will write a
+precise assertion about the wrong thing and then implement to it — worse than having no check,
+because it launders a misunderstanding into a green suite that a reviewer will trust. When the
+criterion is genuinely unknown, that is a signal to go ask, one question at a time, not to guess in
+test form.
+
+There is also plain cost. For a typo fix or a docs edit, writing the check first is ceremony with no
+payer. The card earns its keep when the behaviour is load-bearing enough that someone gets hurt by
+"done" being wrong.


### PR DESCRIPTION
The library had ten cards, all narrow lessons from this project's own incidents. These thirteen cover the ground a user actually walks — requirements, building, context, debugging, testing, gates, honesty.

## What a Chimera card can and cannot be

A card is **data**: frontmatter plus `Trigger/Do/Avoid/Check/Risk`, read into the prompt at retrieval time. It executes nothing.

So half the competitive landscape — "connect to Gmail", "drive the browser", integration skills — is **not something this format can offer**, and promising it would be lying about what a card is. What it can offer is judgment. The four cards nobody else has are judgment this project paid for:

- `chimera-list-exemptions-not-obligations`
- `chimera-run-the-projects-own-gate-command`
- `chimera-give-the-denominator`
- `chimera-state-what-you-did-not-check`

## The critique changed the result more than the drafting did

An adversarial pass ran against the drafts. Its findings:

| defect | what it was |
|---|---|
| **A false measurement, in the card about not improvising commands** | claimed the suite runs "about fifteen seconds". Measured the same day across four runs: **98.8, 106.3, 101.5, 101.9 s**. The figure came from a stale note of mine — true when written, false by then. |
| **A plural that invented a pattern** | the gate card said "both times Chimera lost a surface". It was **once** (`manager.py`, inside a `factory()` closure). The other five were the *reason* the gate existed, not casualties of it. |
| **Three invented APIs** | the wiring card illustrated with `agent_from_config`, `build_prompt`, `SkillCard` — zero occurrences in the package. |
| **An invented example in the card about reading real source** | replaced with a real `ImportError` from this session. |
| **A quote of `ledger.py:64` that did not match `ledger.py:64`** | fixed to the exact string. |

The timing card now carries its own correction as the example, which is the only honest place for it.

## One card deleted rather than shipped

`chimera-one-question-at-a-time`. It was the only one that could have been written by someone who had never seen a bug, and it carried an empirical claim with no source. **A library whose stated preference is the specific over the complete should not carry the generic card as its fourteenth.** Thirteen good ones beat fourteen.

## Two deliberate non-changes

**The ten existing cards keep their unprefixed names.** Renaming breaks `chimera skill import skills/<dir>` for anyone using them and invalidates the SHA-256 the site publishes for each card's bytes.

**English only.** The site translates the *description* through a sidecar that leaves `SKILL.md` byte-identical — precisely so the published hash keeps attesting to what the agent actually reads. Nine-language descriptions are a follow-up, not part of this.

---

**Verification.** `tests/test_skill_library.py`: **139 passed** (13 cards × 6 structural checks, plus the library-level ones). Full suite: **3115 passed**, `ruff` clean, same 18 pre-existing environment failures. The site reads `skills/` directly from this repo, so merging publishes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)