### PR TITLE
feat(skills): nine languages, and a hub grouped by stage

### DIFF
--- a/chimera/skills/skill_md.py
+++ b/chimera/skills/skill_md.py
@@ -31,6 +31,30 @@ if TYPE_CHECKING:
 
 _CARD_SECTIONS = ("Trigger", "Do", "Avoid", "Check", "Risk")
 
+#: Where in a piece of work the card applies. Ordered, because the order is the reading order on
+#: the hub — a browsing human walks the work, not the alphabet.
+STAGES = ("define", "build", "verify", "review", "ship")
+
+#: What the card is about. These names are the ecosystem's, not ours, and that is deliberate:
+#: somebody arriving from a skills aggregator should recognise the vocabulary. The list is longer
+#: than what the library currently fills, and the hub renders only the groups that have members —
+#: declaring a taxonomy is cheap, and thirty empty drawers on a page advertise absence rather than
+#: breadth. As contributions arrive the extra names light up on their own, with nobody remembering
+#: to enable them.
+TOPICS = (
+    "software-dev",
+    "ai-agents",
+    "research",
+    "devops",
+    "security",
+    "data-science",
+    "productivity",
+    "mlops",
+    "networking",
+    "vision-ai",
+    "translation",
+)
+
 
 class Disclosure(IntEnum):
     """Progressive disclosure level — load the cheapest that answers the question."""
@@ -53,6 +77,12 @@ class SkillManifest:
     triggers: list[str] = field(default_factory=list)
     license: str | None = None
     allowed_tools: list[str] = field(default_factory=list)  # CrewAI/Anthropic pre-approval field
+    # Browsing metadata: where in the work the card applies, and what it is about. Empty is a legal
+    # parse — an imported third-party card will not carry these, and refusing to read it over a
+    # display field would be the wrong trade. The library's own cards are held to both by a test,
+    # which is where "required" belongs: on what we publish, not on what we can read.
+    stage: str = ""
+    topic: str = ""
 
 
 @dataclass
@@ -76,10 +106,29 @@ class SkillMd:
         return "\n\n".join(parts)
 
 
+def _vocab(value: object, allowed: tuple[str, ...]) -> str:
+    """A frontmatter value normalised into a known vocabulary, or ``""`` when it is not one.
+
+    Silently dropping an unknown value is right HERE and wrong for the library. A card imported
+    from somewhere else may carry a taxonomy that is not ours, and that must not make the card
+    unreadable — a display field is no reason to refuse a payload. The library's own cards are held
+    to the vocabulary by a test that fails the build, so a typo in `skills/` is caught where someone
+    can fix it instead of being rendered into an "Other" bucket nobody browses.
+    """
+    if not isinstance(value, str):
+        return ""
+    word = value.strip().lower().replace("_", "-").replace(" ", "-")
+    return word if word in allowed else ""
+
+
 def render_skill_md(skill: SkillMd) -> str:
     """Render a SkillMd as SKILL.md text (YAML frontmatter + markdown body)."""
     m = skill.manifest
     front: dict[str, object] = {"name": m.name, "description": m.description, "version": m.version, "kind": m.kind}
+    if m.stage:
+        front["stage"] = m.stage
+    if m.topic:
+        front["topic"] = m.topic
     if m.triggers:
         front["triggers"] = m.triggers
     front["provenance"] = m.provenance
@@ -121,6 +170,8 @@ def parse_skill_md(text: str) -> SkillMd:
         triggers=[str(t) for t in triggers] if isinstance(triggers, list) else [],
         license=str(front["license"]) if front.get("license") else None,
         allowed_tools=[str(t) for t in allowed] if isinstance(allowed, list) else [],
+        stage=_vocab(front.get("stage"), STAGES),
+        topic=_vocab(front.get("topic"), TOPICS),
     )
     return SkillMd(manifest=manifest, instructions=body.strip())
 

--- a/skills/assert-what-the-generator-found/SKILL.md
+++ b/skills/assert-what-the-generator-found/SKILL.md
@@ -3,6 +3,8 @@ name: assert-what-the-generator-found
 description: A generator that crashes tells you it failed; one that emits plausible output tells you nothing. Test what it found, never that it ran.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - wrote a code generator
 - testing a schema dump

--- a/skills/build-the-gate-before-the-content/SKILL.md
+++ b/skills/build-the-gate-before-the-content/SKILL.md
@@ -3,6 +3,8 @@ name: build-the-gate-before-the-content
 description: A check added after the thing it guards is a check somebody switches off to ship. Wire it shut while there is nothing to block.
 version: 0.1.0
 kind: pattern
+stage: ship
+topic: devops
 triggers:
 - planning a migration
 - starting a new surface

--- a/skills/chimera-budget-the-context/SKILL.md
+++ b/skills/chimera-budget-the-context/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-budget-the-context
 description: Spend against a budget below the real window, and count the tool schemas you re-send on every step — they are the floor compaction cannot reach.
 version: 0.1.0
 kind: pattern
+stage: build
+topic: ai-agents
 triggers:
 - the run died on context overflow
 - raising max-steps

--- a/skills/chimera-carry-the-failure-forward/SKILL.md
+++ b/skills/chimera-carry-the-failure-forward/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-carry-the-failure-forward
 description: A retry loop that overwrites its feedback variable shows attempt 3 only the failure of attempt 2 — so it re-derives the patch attempt 1 already tried.
 version: 0.1.0
 kind: pattern
+stage: build
+topic: ai-agents
 triggers:
 - writing a retry loop
 - the agent keeps trying the same fix

--- a/skills/chimera-give-the-denominator/SKILL.md
+++ b/skills/chimera-give-the-denominator/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-give-the-denominator
 description: A rate without its denominator and its composition misleads while every digit stays true — say n, and say how much of the numerator is already-known noise.
 version: 0.1.0
 kind: pattern
+stage: review
+topic: research
 triggers:
 - reporting a failure rate
 - a percentage in a summary

--- a/skills/chimera-ground-it-in-the-source/SKILL.md
+++ b/skills/chimera-ground-it-in-the-source/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-ground-it-in-the-source
 description: Take the signature from the installed version, not from memory — a plausible API is indistinguishable from a real one until it runs.
 version: 0.1.0
 kind: pattern
+stage: build
+topic: software-dev
 triggers:
 - calling a library I did not write
 - what is the parameter called

--- a/skills/chimera-list-exemptions-not-obligations/SKILL.md
+++ b/skills/chimera-list-exemptions-not-obligations/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-list-exemptions-not-obligations
 description: A gate that lists what to check fails open — the site nobody remembered to add is the one that breaks. List the exemptions instead, each with a written reason, and the default becomes fail.
 version: 0.1.0
 kind: pattern
+stage: ship
+topic: devops
 triggers:
 - writing a build gate
 - enforcing a rule across the whole package

--- a/skills/chimera-prove-the-test-discriminates/SKILL.md
+++ b/skills/chimera-prove-the-test-discriminates/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-prove-the-test-discriminates
 description: A regression test you never saw fail is a guess. Re-break the code and watch it go red before you commit it.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - wrote a regression test
 - fixed a bug and added a test

--- a/skills/chimera-reproduce-before-diagnosing/SKILL.md
+++ b/skills/chimera-reproduce-before-diagnosing/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-reproduce-before-diagnosing
 description: A diagnosis is a claim about a machine you have not run. Reproduce the failure in one short command first — especially when the diagnosis arrived from someone else.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - a bug report arrived
 - another agent explained the cause

--- a/skills/chimera-run-the-projects-own-gate-command/SKILL.md
+++ b/skills/chimera-run-the-projects-own-gate-command/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-run-the-projects-own-gate-command
 description: Run the project's verification command literally — same scope, same flags. The near-identical variant you improvise lies in both directions.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: devops
 triggers:
 - about to run lint or type checks
 - verifying before a commit or PR

--- a/skills/chimera-state-what-you-did-not-check/SKILL.md
+++ b/skills/chimera-state-what-you-did-not-check/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-state-what-you-did-not-check
 description: A ranking built from part of the system reads as a ranking of the system — write the scope and the exclusions next to the findings, not after them.
 version: 0.1.0
 kind: pattern
+stage: review
+topic: research
 triggers:
 - writing a review or audit
 - listing the top risks

--- a/skills/chimera-test-the-wiring-not-the-class/SKILL.md
+++ b/skills/chimera-test-the-wiring-not-the-class/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-test-the-wiring-not-the-class
 description: A class assembled by hand in a test proves the class works, not that anything reaches it — cover the path production actually takes.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - feature works in tests but not in the app
 - added a component behind a factory or registry

--- a/skills/chimera-thin-vertical-slice/SKILL.md
+++ b/skills/chimera-thin-vertical-slice/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-thin-vertical-slice
 description: Build one narrow path that crosses every layer and runs, before building any layer in full — an integration that has never executed is a guess.
 version: 0.1.0
 kind: pattern
+stage: define
+topic: software-dev
 triggers:
 - starting a new feature
 - this needs a CLI, a service and storage

--- a/skills/chimera-when-two-results-contradict-suspect-the-apparatus/SKILL.md
+++ b/skills/chimera-when-two-results-contradict-suspect-the-apparatus/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-when-two-results-contradict-suspect-the-apparatus
 description: When two of your own measurements disagree by a margin no mechanism could produce, the defect is in the instrument. Audit the harness before building theory on top of it.
 version: 0.1.0
 kind: pattern
+stage: review
+topic: research
 triggers:
 - two runs disagree wildly
 - the smaller run scored better

--- a/skills/chimera-write-the-check-before-the-code/SKILL.md
+++ b/skills/chimera-write-the-check-before-the-code/SKILL.md
@@ -3,6 +3,8 @@ name: chimera-write-the-check-before-the-code
 description: A criterion written after the implementation describes the implementation. Write the failing check first, watch it fail, then build.
 version: 0.1.0
 kind: pattern
+stage: define
+topic: software-dev
 triggers:
 - about to implement a feature
 - defining what done means

--- a/skills/declare-when-a-setting-takes-effect/SKILL.md
+++ b/skills/declare-when-a-setting-takes-effect/SKILL.md
@@ -3,6 +3,8 @@ name: declare-when-a-setting-takes-effect
 description: A control that saves successfully and changes nothing until a restart is worse than one that fails. Say when it applies, and derive that from where it is read.
 version: 0.1.0
 kind: pattern
+stage: define
+topic: software-dev
 triggers:
 - adding a settings screen
 - the config is cached

--- a/skills/derive-instead-of-transcribing/SKILL.md
+++ b/skills/derive-instead-of-transcribing/SKILL.md
@@ -3,6 +3,8 @@ name: derive-instead-of-transcribing
 description: Anything copied by hand from another file is correct exactly once. If it can be generated, generate it and fail the build when the copy is stale.
 version: 0.1.0
 kind: pattern
+stage: build
+topic: software-dev
 triggers:
 - documenting a command list
 - copying values between projects

--- a/skills/do-not-ship-an-empty-surface/SKILL.md
+++ b/skills/do-not-ship-an-empty-surface/SKILL.md
@@ -3,6 +3,8 @@ name: do-not-ship-an-empty-surface
 description: An empty screen, tab or category is a promise the product is not keeping. Hide it until it has content, or do not build it yet.
 version: 0.1.0
 kind: anti_pattern
+stage: ship
+topic: software-dev
 triggers:
 - adding a tab with no data
 - the category has no posts

--- a/skills/i18n/de.json
+++ b/skills/i18n/de.json
@@ -9,6 +9,58 @@
       "text": "Eine Prüfung, die nach dem eingeführt wird, was sie schützt, ist eine Prüfung, die jemand zum Ausliefern abschaltet. Schließe sie, solange es nichts zu blockieren gibt.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Rechne gegen ein Budget unterhalb des echten Fensters, und zähle die Tool-Schemas mit, die du bei jedem Schritt erneut mitschickst — sie sind der Boden, den Compaction nicht erreicht.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Eine Retry-Schleife, die ihre Feedback-Variable überschreibt, zeigt Versuch 3 nur den Fehlschlag von Versuch 2 — also leitet sie wieder den Patch her, den Versuch 1 schon probiert hat.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Eine Rate ohne ihren Nenner und ihre Zusammensetzung führt in die Irre, während jede Ziffer stimmt — nenne n, und nenne, wie viel des Zählers bereits bekanntes Rauschen ist.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Nimm die Signatur aus der installierten Version, nicht aus dem Gedächtnis — eine plausible API ist von einer echten nicht zu unterscheiden, bis sie läuft.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Ein Gate, das auflistet, was zu prüfen ist, ist fail-open — die Seite, an die niemand gedacht hat, ist die, die bricht. Liste stattdessen die Ausnahmen auf, jede mit einer schriftlichen Begründung, und der Standard wird Fehlschlag.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Ein Regressionstest, den du nie hast scheitern sehen, ist eine Vermutung. Mach den Code wieder kaputt und sieh zu, wie er rot wird, bevor du ihn committest.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Eine Diagnose ist eine Behauptung über eine Maschine, die du nicht ausgeführt hast. Reproduziere den Fehler erst mit einem kurzen Befehl — besonders dann, wenn die Diagnose von jemand anderem kam.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Führe den Verifikationsbefehl des Projekts wörtlich aus — gleicher Scope, gleiche Flags. Die fast identische Variante, die du improvisierst, lügt in beide Richtungen.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Ein Ranking, das aus einem Teil des Systems entsteht, liest sich als Ranking des Systems — schreibe Umfang und Ausschlüsse neben die Befunde, nicht dahinter.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Eine Klasse, die im Test von Hand zusammengebaut wird, beweist, dass die Klasse funktioniert, nicht dass irgendetwas sie erreicht — decke den Pfad ab, den die Produktion tatsächlich nimmt.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Baue einen schmalen Pfad, der jede Schicht durchquert und läuft, bevor du irgendeine Schicht vollständig baust — eine Integration, die nie ausgeführt wurde, ist eine Vermutung.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Wenn zwei deiner eigenen Messungen um einen Abstand auseinandergehen, den kein Mechanismus erzeugen könnte, liegt der Defekt im Instrument. Prüfe das Harness, bevor du Theorie darauf aufbaust.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Ein Kriterium, das nach der Implementierung geschrieben wird, beschreibt die Implementierung. Schreibe zuerst die fehlschlagende Prüfung, sieh sie scheitern, dann baue.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Eine Einstellung, die erfolgreich speichert und bis zum Neustart nichts ändert, ist schlimmer als eine, die fehlschlägt. Sag, wann sie greift, und leite das davon ab, wo sie gelesen wird.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/es.json
+++ b/skills/i18n/es.json
@@ -9,6 +9,58 @@
       "text": "Una comprobación añadida después de lo que protege es una comprobación que alguien apaga para poder entregar. Déjala cerrada mientras no hay nada que bloquear.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Gasta contra un presupuesto por debajo de la ventana real, y cuenta los esquemas de herramientas que reenvías en cada paso — son el suelo al que la compactación no puede llegar.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Un bucle de reintentos que sobrescribe su variable de feedback le muestra al intento 3 solo el fallo del intento 2 — así que vuelve a derivar el parche que el intento 1 ya probó.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Una tasa sin su denominador y sin su composición induce a error aunque cada dígito sea verdadero — di n, y di cuánto del numerador es ruido ya conocido.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Toma la firma de la versión instalada, no de la memoria — una API plausible es indistinguible de una real hasta que se ejecuta.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Una compuerta que enumera qué comprobar falla en abierto — el sitio que nadie recordó añadir es el que se rompe. Enumera en su lugar las exenciones, cada una con una razón escrita, y el valor por defecto pasa a ser fallar.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Una prueba de regresión que nunca has visto fallar es una suposición. Vuelve a romper el código y obsérvala ponerse en rojo antes de hacerle commit.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Un diagnóstico es una afirmación sobre una máquina que no has ejecutado. Reproduce primero el fallo con un solo comando corto — sobre todo cuando el diagnóstico llegó de otra persona.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Ejecuta literalmente el comando de verificación del proyecto — mismo alcance, mismos flags. La variante casi idéntica que improvisas miente en ambas direcciones.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Un ranking construido a partir de una parte del sistema se lee como un ranking del sistema — escribe el alcance y las exclusiones junto a los hallazgos, no después de ellos.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Una clase ensamblada a mano en una prueba demuestra que la clase funciona, no que algo llegue hasta ella — cubre el camino que producción toma realmente.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Construye un único camino estrecho que atraviese todas las capas y se ejecute, antes de construir ninguna capa por completo — una integración que nunca se ha ejecutado es una suposición.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Cuando dos de tus propias mediciones discrepan por un margen que ningún mecanismo podría producir, el defecto está en el instrumento. Audita el harness antes de construir teoría encima.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Un criterio escrito después de la implementación describe la implementación. Escribe primero la comprobación que falla, obsérvala fallar, y luego construye.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Un control que guarda correctamente y no cambia nada hasta reiniciar es peor que uno que falla. Di cuándo se aplica, y deriva eso de dónde se lee el valor.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/fr.json
+++ b/skills/i18n/fr.json
@@ -9,6 +9,58 @@
       "text": "Un contrôle ajouté après ce qu'il protège est un contrôle que quelqu'un désactive pour livrer. Fermez-le pendant qu'il n'y a rien à bloquer.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Dépensez sur un budget inférieur à la fenêtre réelle, et comptez les schémas d'outils que vous renvoyez à chaque étape — ils sont le plancher que la compaction ne peut pas atteindre.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Une boucle de réessai qui écrase sa variable de feedback ne montre à la tentative 3 que l'échec de la tentative 2 — elle redérive donc le patch que la tentative 1 avait déjà essayé.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Un taux sans son dénominateur ni sa composition induit en erreur alors que chaque chiffre reste vrai — donnez n, et dites quelle part du numérateur est du bruit déjà connu.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Prenez la signature depuis la version installée, pas depuis votre mémoire — une API plausible est indiscernable d'une vraie tant qu'elle n'a pas été exécutée.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Une barrière qui énumère ce qu'il faut vérifier échoue en laissant passer — le site que personne n'a pensé à ajouter est celui qui casse. Énumérez plutôt les exemptions, chacune avec une raison écrite, et le défaut devient l'échec.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Un test de régression que vous n'avez jamais vu échouer est une supposition. Recassez le code et regardez-le passer au rouge avant de le committer.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Un diagnostic est une affirmation sur une machine que vous n'avez pas exécutée. Reproduisez d'abord l'échec en une commande courte — surtout quand le diagnostic vient de quelqu'un d'autre.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Lancez la commande de vérification du projet à la lettre — même périmètre, mêmes flags. La variante presque identique que vous improvisez ment dans les deux sens.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Un classement construit à partir d'une partie du système se lit comme un classement du système — écrivez le périmètre et les exclusions à côté des conclusions, pas après elles.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Une classe assemblée à la main dans un test prouve que la classe fonctionne, pas que quoi que ce soit l'atteint — couvrez le chemin que la production emprunte réellement.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Construisez un seul chemin étroit qui traverse toutes les couches et qui s'exécute, avant de construire une seule couche en entier — une intégration qui ne s'est jamais exécutée est une supposition.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Quand deux de vos propres mesures divergent d'une marge qu'aucun mécanisme ne pourrait produire, le défaut est dans l'instrument. Auditez le harness avant de bâtir une théorie dessus.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Un critère écrit après l'implémentation décrit l'implémentation. Écrivez d'abord la vérification qui échoue, observez son échec, puis construisez.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Un réglage qui s'enregistre correctement et ne change rien jusqu'au redémarrage est pire qu'un réglage qui échoue. Dites quand il s'applique, et déduisez-le de l'endroit où il est lu.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/it.json
+++ b/skills/i18n/it.json
@@ -9,6 +9,58 @@
       "text": "Un controllo aggiunto dopo ciò che protegge è un controllo che qualcuno spegne per consegnare. Chiudilo finché non c'è nulla da bloccare.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Spendi rispetto a un budget inferiore alla finestra reale, e conta gli schemi delle tool che rinvii a ogni passo — sono il pavimento che la compattazione non può raggiungere.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Un ciclo di retry che sovrascrive la propria variabile di feedback mostra al tentativo 3 solo il fallimento del tentativo 2 — così ricava di nuovo la patch che il tentativo 1 aveva già provato.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Un tasso senza il suo denominatore e la sua composizione fuorvia pur restando vero in ogni cifra — dichiara n, e dichiara quanta parte del numeratore è rumore già noto.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Prendi la firma dalla versione installata, non dalla memoria — un'API plausibile è indistinguibile da una reale finché non viene eseguita.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Un gate che elenca cosa controllare fallisce aperto — il sito che nessuno si è ricordato di aggiungere è quello che si rompe. Elenca invece le esenzioni, ognuna con un motivo scritto, e il default diventa il fallimento.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Un test di regressione che non hai mai visto fallire è una supposizione. Rompi di nuovo il codice e guardalo diventare rosso prima di farne commit.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Una diagnosi è un'affermazione su una macchina che non hai eseguito. Riproduci prima il fallimento con un solo comando breve — soprattutto quando la diagnosi è arrivata da qualcun altro.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Esegui alla lettera il comando di verifica del progetto — stesso scope, stessi flag. La variante quasi identica che improvvisi mente in entrambe le direzioni.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Una classifica costruita su una parte del sistema si legge come una classifica del sistema — scrivi lo scope e le esclusioni accanto ai risultati, non dopo di essi.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Una classe assemblata a mano in un test prova che la classe funziona, non che qualcosa la raggiunga — copri il percorso che la produzione prende davvero.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Costruisci un solo percorso stretto che attraversa ogni livello e viene eseguito, prima di costruire per intero qualsiasi livello — un'integrazione che non è mai stata eseguita è una supposizione.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Quando due tue misurazioni divergono di un margine che nessun meccanismo potrebbe produrre, il difetto è nello strumento. Verifica l'harness prima di costruirci sopra una teoria.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Un criterio scritto dopo l'implementazione descrive l'implementazione. Scrivi prima il controllo che fallisce, guardalo fallire, poi costruisci.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Un controllo che salva con successo e non cambia nulla fino al riavvio è peggio di uno che fallisce. Di' quando si applica, e ricavalo da dove viene letto.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/ja.json
+++ b/skills/i18n/ja.json
@@ -9,6 +9,58 @@
       "text": "守る対象より後から追加したチェックは、リリースのために誰かが切るチェックです。まだ止めるものが何もないうちに閉じておいてください。",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "実際のウィンドウより低く設定した予算に対して消費し、毎ステップ再送信するツールスキーマを数に入れてください——それは圧縮では到達できない下限です。",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "フィードバック用の変数を上書きするリトライループは、3回目の試行に2回目の失敗しか見せません——だから1回目がすでに試したパッチを導き直してしまいます。",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "分母とその内訳を欠いた比率は、どの桁も真実のまま誤解を招きます——n を示し、分子のうちどれだけが既知のノイズなのかを述べてください。",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "シグネチャは記憶からではなく、インストール済みのバージョンから取ること——もっともらしい API は、実行するまで本物と見分けがつきません。",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "チェック対象を列挙するゲートはフェイルオープンします——誰も追加し忘れたサイトこそが壊れるのです。代わりに免除対象を、一つずつ理由を書き添えて列挙すれば、デフォルトはフェイルになります。",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "失敗するところを一度も見ていないリグレッションテストは、推測にすぎません。commit する前にコードを壊し直し、赤くなるのを確認してください。",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "診断とは、自分が動かしていないマシンについての主張です。まず短いコマンド一つで失敗を再現してください——とりわけ、その診断が他人から届いたものである場合には。",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "プロジェクトの検証コマンドは、そのまま実行すること——同じ範囲、同じフラグで。その場で組み立てたほぼ同じ変種は、両方向に嘘をつきます。",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "システムの一部から作られたランキングは、システム全体のランキングとして読まれます——調査範囲と除外対象は、結果の後ではなく隣に書いてください。",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "テストの中で手組みしたクラスは、そのクラスが動くことを証明するだけで、そこに何かが到達することは証明しません——本番が実際に通る経路をカバーしてください。",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "どの層も作り込む前に、全層を貫いて動く細い経路を一本作ること——一度も実行されていない統合は推測にすぎません。",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "自分の測定結果ふたつが、どんな仕組みでも生じえない幅で食い違うなら、欠陥は測定器の側にあります。その上に理論を組み立てる前に、ハーネスを監査してください。",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "実装の後に書かれた基準は、その実装を記述しているだけです。まず失敗するチェックを書き、それが失敗するのを確認してから作ってください。",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "保存には成功するのに再起動まで何も変わらない設定は、失敗する設定より悪いものです。いつ効くのかを明示し、それを読み取り箇所から導いてください。",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/pl.json
+++ b/skills/i18n/pl.json
@@ -9,6 +9,58 @@
       "text": "Kontrola dodana po tym, co ma strzec, to kontrola, którą ktoś wyłączy, żeby wydać. Zamknij ją, póki nie ma czego blokować.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Wydawaj w ramach budżetu mniejszego niż realne okno i licz schematy narzędzi, które wysyłasz ponownie na każdym kroku — to podłoga, poniżej której kompaktowanie nie zejdzie.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Pętla ponawiania, która nadpisuje swoją zmienną z feedbackiem, pokazuje próbie 3 tylko porażkę próby 2 — więc na nowo wyprowadza łatkę, którą próba 1 już wypróbowała.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Wskaźnik bez mianownika i bez swojego składu wprowadza w błąd, choć każda cyfra pozostaje prawdziwa — podaj n i podaj, jaka część licznika to już znany szum.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Weź sygnaturę z zainstalowanej wersji, nie z pamięci — wiarygodne API jest nie do odróżnienia od prawdziwego, dopóki nie zostanie uruchomione.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Bramka, która wylicza, co sprawdzić, zawodzi otwarciem — psuje się ta strona, o której dodaniu nikt nie pamiętał. Wylicz zamiast tego wyjątki, każdy z zapisanym powodem, a domyślnym wynikiem staje się porażka.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Test regresji, którego nigdy nie widziałeś zawodzącego, to domysł. Zepsuj kod ponownie i patrz, jak robi się czerwony, zanim go zacommitujesz.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Diagnoza to twierdzenie o maszynie, której nie uruchomiłeś. Najpierw odtwórz awarię jednym krótkim poleceniem — zwłaszcza gdy diagnoza przyszła od kogoś innego.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Uruchom polecenie weryfikacyjne projektu dosłownie — ten sam zakres, te same flagi. Niemal identyczny wariant, który improwizujesz, kłamie w obie strony.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Ranking zbudowany z części systemu czyta się jak ranking całego systemu — zapisz zakres i wyłączenia obok ustaleń, nie po nich.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Klasa złożona ręcznie w teście dowodzi, że klasa działa, a nie że cokolwiek do niej dociera — pokryj ścieżkę, którą faktycznie idzie produkcja.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Zbuduj jedną wąską ścieżkę, która przecina każdą warstwę i działa, zanim zbudujesz jakąkolwiek warstwę w całości — integracja, która nigdy się nie wykonała, to domysł.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Gdy dwa twoje własne pomiary rozchodzą się o margines, którego nie wytworzyłby żaden mechanizm, defekt tkwi w przyrządzie. Zaudytuj harness, zanim zbudujesz na nim teorię.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Kryterium napisane po implementacji opisuje implementację. Napisz najpierw zawodzące sprawdzenie, zobacz, jak zawodzi, i dopiero buduj.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Ustawienie, które zapisuje się poprawnie i nic nie zmienia aż do restartu, jest gorsze od takiego, które zawodzi. Powiedz, kiedy zaczyna działać, i wyprowadź to z miejsca, w którym jest odczytywane.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/pt.json
+++ b/skills/i18n/pt.json
@@ -9,6 +9,58 @@
       "text": "Uma checagem acrescentada depois daquilo que ela guarda é uma checagem que alguém desliga para entregar. Feche-a enquanto não há nada para bloquear.",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "Gaste contra um orçamento abaixo da janela real, e conte os schemas de tools que você reenvia a cada passo — eles são o piso que a compactação não alcança.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Um loop de retry que sobrescreve sua variável de feedback mostra à tentativa 3 apenas a falha da tentativa 2 — então ela re-deriva o patch que a tentativa 1 já testou.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Uma taxa sem o denominador e sem sua composição engana com todos os dígitos verdadeiros — diga o n, e diga quanto do numerador é ruído já conhecido.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Pegue a assinatura na versão instalada, não na memória — uma API plausível é indistinguível de uma real até rodar.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Um gate que lista o que checar falha aberto — o site que ninguém lembrou de adicionar é o que quebra. Liste as isenções, cada uma com um motivo escrito, e o padrão passa a ser reprovar.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Um teste de regressão que você nunca viu falhar é um chute. Quebre o código de novo e veja o teste ficar vermelho antes de commitá-lo.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Um diagnóstico é uma afirmação sobre uma máquina que você não rodou. Reproduza a falha em um comando curto primeiro — especialmente quando o diagnóstico veio de outra pessoa.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Rode o comando de verificação do projeto literalmente — mesmo escopo, mesmas flags. A variante quase idêntica que você improvisa mente nas duas direções.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Um ranking feito a partir de uma parte do sistema é lido como um ranking do sistema — escreva o escopo e as exclusões ao lado dos achados, não depois deles.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Uma classe montada à mão num teste prova que a classe funciona, não que algo chega até ela — cubra o caminho que a produção de fato percorre.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Construa um caminho estreito que atravesse todas as camadas e rode, antes de construir qualquer camada por inteiro — uma integração que nunca executou é um chute.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Quando duas medições suas discordam por uma margem que nenhum mecanismo produziria, o defeito está no instrumento. Audite o harness antes de construir teoria em cima dele.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Um critério escrito depois da implementação descreve a implementação. Escreva a checagem que falha primeiro, veja-a falhar, e só então construa.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "Um controle que salva com sucesso e não muda nada até reiniciar é pior que um que falha. Diga quando ele passa a valer, e derive isso de onde o valor é lido.",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/i18n/ru.json
+++ b/skills/i18n/ru.json
@@ -1,0 +1,97 @@
+{
+  "_why": "Translated card descriptions, and only the descriptions.\n\nThe body of a card is not prose about the product: it is the payload the agent reads at runtime, the bytes the published SHA-256 attests to, and the text the CLI imports by path. Translating it would break all three at once — the page would show a hash that does not match what the reader is reading, and the translation would never reach the agent anyway, because the CLI only ever imports skills/.\n\nSo the description travels here instead, in a sidecar that leaves SKILL.md byte-identical. Each entry declares source_sha256 of the English description it was made from; when the English changes, the site falls back to it rather than showing a translation of a sentence that no longer exists.",
+  "descriptions": {
+    "assert-what-the-generator-found": {
+      "text": "Генератор, который падает, сообщает, что он не справился; генератор, выдающий правдоподобный результат, не сообщает ничего. Проверяйте, что он нашёл, а не то, что он отработал.",
+      "source_sha256": "059b66d7e09a1aa6ce2b31647672f3c724dbafb4d8b75c1b599d79c0762823f2"
+    },
+    "build-the-gate-before-the-content": {
+      "text": "Проверка, добавленная после того, что она охраняет, — это проверка, которую кто-нибудь отключит ради релиза. Замкните её, пока блокировать нечего.",
+      "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
+    },
+    "chimera-budget-the-context": {
+      "text": "Расходуйте по бюджету, который ниже реального окна, и учитывайте схемы инструментов, пересылаемые заново на каждом шаге, — это пол, до которого сжатие не достаёт.",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "Цикл повторов, перезаписывающий переменную с обратной связью, показывает третьей попытке только провал второй — и она заново выводит патч, который уже пробовала первая.",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "Доля без знаменателя и без его состава вводит в заблуждение, хотя каждая цифра остаётся верной: укажите n и укажите, какая часть числителя — уже известный шум.",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "Берите сигнатуру из установленной версии, а не из памяти: правдоподобный API неотличим от настоящего, пока не будет запущен.",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "Проверка, перечисляющая, что проверять, работает как fail-open — ломается именно тот сайт, который никто не вспомнил добавить. Перечисляйте вместо этого исключения, каждое с записанной причиной, и поведением по умолчанию станет отказ.",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "Регрессионный тест, падения которого вы никогда не видели, — это догадка. Сломайте код обратно и убедитесь, что тест краснеет, прежде чем его коммитить.",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "Диагноз — это утверждение о машине, которую вы не запускали. Сначала воспроизведите сбой одной короткой командой — особенно если диагноз пришёл от кого-то другого.",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "Запускайте команду проверки проекта буквально — тот же охват, те же флаги. Почти идентичный вариант, придуманный вами на ходу, врёт в обе стороны.",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "Рейтинг, построенный по части системы, читается как рейтинг всей системы — пишите охват и исключения рядом с выводами, а не после них.",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "Класс, собранный вручную в тесте, доказывает, что класс работает, а не что до него что-то доходит, — покрывайте тот путь, которым система идёт в production.",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "Сначала постройте один узкий путь, который проходит через все слои и работает, и только потом стройте любой слой целиком — интеграция, которая ни разу не выполнялась, это догадка.",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "Когда два ваших собственных измерения расходятся настолько, что ни один механизм такого дать не может, дефект в инструменте. Проверьте harness, прежде чем строить на нём теорию.",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "Критерий, написанный после реализации, описывает реализацию. Сначала напишите падающую проверку, убедитесь, что она падает, и только потом стройте.",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
+    "declare-when-a-setting-takes-effect": {
+      "text": "Настройка, которая успешно сохраняется и ничего не меняет до перезапуска, хуже той, что завершается ошибкой. Укажите, когда она вступает в силу, и выводите это из того места, где её читают.",
+      "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"
+    },
+    "derive-instead-of-transcribing": {
+      "text": "Всё, что скопировано вручную из другого файла, верно ровно один раз. Если это можно сгенерировать — генерируйте, и роняйте build, когда копия устарела.",
+      "source_sha256": "ba0e688ec255689f4e441a5f14e2377b0e044b64c1679e303612f0a4dc4439ee"
+    },
+    "do-not-ship-an-empty-surface": {
+      "text": "Пустой экран, вкладка или категория — это обещание, которого продукт не выполняет. Скройте их, пока в них нет содержимого, или пока не стройте вовсе.",
+      "source_sha256": "4b4defbce9c566af11eab06a9ce9d33b65edd59a556ca4555c0b80de3409dd42"
+    },
+    "keep-the-caveat-with-the-number": {
+      "text": "Число и оговорка к нему должны быть одним артефактом. Два абзаца расходятся; один компонент — не может.",
+      "source_sha256": "9560e76d7c148785f634f7d8b71e7bee1525972db4b530af7ec42d67e9588eb6"
+    },
+    "pin-the-case-that-narrowed-the-rule": {
+      "text": "Когда проверка срабатывает не на той цели, исправление делает её слабее. Зафиксируйте ложное срабатывание тестом в том же commit, иначе правило разрушится незаметно.",
+      "source_sha256": "2ec4320899defc512245ee7d45eab69f3911c207a0f9e576341490f76b836a52"
+    },
+    "publish-the-run-that-did-not-work": {
+      "text": "Публикуйте эксперимент, который не удался, сохраняйте отменённый неизменным и никогда не перезапускайте ради значимости. Смещение — в отборе, а не в числе.",
+      "source_sha256": "9e96faac615281ebefeacbac915cdab98215ecf8da14b68048eba557eb0e8064"
+    },
+    "verify-before-claiming": {
+      "text": "Прежде чем сообщить, что задача выполнена, запустите проверку, которая упала бы, если бы это было не так, — объяснение не является исправлением.",
+      "source_sha256": "1d5f5e274b524ce6980b2d980a5504a3350563858b5160b99303962a0b232120"
+    },
+    "warn-before-the-thing-you-are-warning-about": {
+      "text": "Предупреждение, помещённое после действия, к которому оно относится, приходит, когда читатель уже принял решение. Ставьте его выше и делайте неотклоняемым, когда это важно.",
+      "source_sha256": "e1f0c23a799b631b2081b73d1f2941094c34150f6663ea486c6315b63f141fea"
+    }
+  }
+}

--- a/skills/i18n/zh.json
+++ b/skills/i18n/zh.json
@@ -9,6 +9,58 @@
       "text": "在被守护的东西之后才加的检查，是有人为了发布而关掉的检查。趁还没有东西要拦，就把它接死。",
       "source_sha256": "3458f7683941585bbca67d834bcd4f33f2d5eea3124c194cb08ed6acb9a238b9"
     },
+    "chimera-budget-the-context": {
+      "text": "按低于真实窗口的预算来花，并把你每一步都重新发送的工具 schema 算进去——它们是压缩触及不到的地板。",
+      "source_sha256": "d2965f2e791ddf5fd6b631b5f2459d7e2944462e1aafc5bd03adeab99b483788"
+    },
+    "chimera-carry-the-failure-forward": {
+      "text": "覆盖掉自己反馈变量的重试循环，只把第 2 次的失败展示给第 3 次——于是它又推导出第 1 次已经试过的那个补丁。",
+      "source_sha256": "0372f2e81fc6c2c1ace4fa675ab102721db8f014966cbfeabe74ed12b8315c36"
+    },
+    "chimera-give-the-denominator": {
+      "text": "不给出分母和构成的比率，每一位数字都是真的，却依然误导人——说出 n，并说清分子里有多少是本来就已知的噪声。",
+      "source_sha256": "d8cb19e4d5dce08511d5dfc2b7fca86383702506c4ac19ceb126ddb9b82114e7"
+    },
+    "chimera-ground-it-in-the-source": {
+      "text": "从已安装的版本里取签名，不要从记忆里取——一个看似合理的 API，在真正跑起来之前和真的没有区别。",
+      "source_sha256": "c1f8f9fa3889007702f4217774c606cc055512521019e456df8be0bc9215e064"
+    },
+    "chimera-list-exemptions-not-obligations": {
+      "text": "列出要检查什么的门禁是失效即放行的——没人记得加进去的那个站点，正是会出问题的那个。改成列出豁免项，每一条都写明理由，默认就变成了失败。",
+      "source_sha256": "349ffc5938703251524530fd1a559c2e1ef55cd4fb83508e9432f69716c6c6b1"
+    },
+    "chimera-prove-the-test-discriminates": {
+      "text": "一个你从没见它失败过的回归测试只是猜测。提交之前，把代码重新弄坏，看着它变红。",
+      "source_sha256": "5486f466781c30e1b7a11d59f92e9d33c97b5d68ba1adaf412315b5d1cc7018b"
+    },
+    "chimera-reproduce-before-diagnosing": {
+      "text": "诊断是对一台你没有跑过的机器下的论断。先用一条简短的命令复现这次失败——尤其是当诊断来自别人的时候。",
+      "source_sha256": "5de6a9fba19b1026f910426061557407718d11f61ff8e94ccd7990f69ff21fdd"
+    },
+    "chimera-run-the-projects-own-gate-command": {
+      "text": "原封不动地运行项目自己的验证命令——同样的范围，同样的参数。你临时改出来的那个几乎一样的变体，会在两个方向上都说谎。",
+      "source_sha256": "480ca99f4b28af2fb27787d43e6a6d29eaf143763ff57237fb6fc98c9311024e"
+    },
+    "chimera-state-what-you-did-not-check": {
+      "text": "只根据系统的一部分做出的排名，读起来就像是对整个系统的排名——把范围和排除项写在结论旁边，而不是写在结论后面。",
+      "source_sha256": "c2a88dc246d5ecac858cda8ade83016a6ae2fb384898b86a3c6d5db57161dd48"
+    },
+    "chimera-test-the-wiring-not-the-class": {
+      "text": "在测试里手工组装出来的类，只能证明这个类能用，证明不了有任何东西能走到它——要覆盖生产环境真正走的那条路径。",
+      "source_sha256": "f3c07e2553a863ee7f43cfa6a7df77378bfc379ed66a0e80bcbf1eac537d5252"
+    },
+    "chimera-thin-vertical-slice": {
+      "text": "在把任何一层建完整之前，先建一条穿过每一层并且能跑起来的窄路径——一次从未执行过的集成只是猜测。",
+      "source_sha256": "7a7426092fcac41032cf4d8bc5a0fb63f2392fb5bdd5acaba71d753416cf0808"
+    },
+    "chimera-when-two-results-contradict-suspect-the-apparatus": {
+      "text": "当你自己的两次测量相差到没有任何机制能产生的幅度时，缺陷在仪器上。在此之上建立理论之前，先审查那套框架（harness）。",
+      "source_sha256": "ef37f01d111710aec1e07536eba0b4b03ddbddbf15ca62f860d200933ff5abd4"
+    },
+    "chimera-write-the-check-before-the-code": {
+      "text": "在实现之后才写下的标准，描述的是那个实现。先写下会失败的检查，看着它失败，然后再开始构建。",
+      "source_sha256": "533a8370bec93659c286086d8238be269d7c0259bb6903e9814d234e180dcd71"
+    },
     "declare-when-a-setting-takes-effect": {
       "text": "保存成功却要重启才生效的设置，比保存失败还糟。说明它何时生效，并从读取它的地方推导出来。",
       "source_sha256": "db548604dbe6cfe82f690d90ddfdcf107ff6a76abcfb7f3b73a60616d343453a"

--- a/skills/keep-the-caveat-with-the-number/SKILL.md
+++ b/skills/keep-the-caveat-with-the-number/SKILL.md
@@ -3,6 +3,8 @@ name: keep-the-caveat-with-the-number
 description: A figure and its qualification must be one artifact. Two paragraphs drift apart; one component cannot.
 version: 0.1.0
 kind: pattern
+stage: review
+topic: research
 triggers:
 - publishing a benchmark result
 - writing a metric into a page

--- a/skills/pin-the-case-that-narrowed-the-rule/SKILL.md
+++ b/skills/pin-the-case-that-narrowed-the-rule/SKILL.md
@@ -3,6 +3,8 @@ name: pin-the-case-that-narrowed-the-rule
 description: When a check fires on the wrong target, the fix makes it weaker. Capture the false positive as a test in the same commit, or the rule erodes silently.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - the linter flagged something legitimate
 - adding an exception

--- a/skills/publish-the-run-that-did-not-work/SKILL.md
+++ b/skills/publish-the-run-that-did-not-work/SKILL.md
@@ -3,6 +3,8 @@ name: publish-the-run-that-did-not-work
 description: Report the experiment that failed, preserve the superseded one unchanged, and never re-roll for significance. Selection is the bias, not the number.
 version: 0.1.0
 kind: pattern
+stage: review
+topic: research
 triggers:
 - the A/B came out negative
 - rerunning the benchmark

--- a/skills/verify-before-claiming/SKILL.md
+++ b/skills/verify-before-claiming/SKILL.md
@@ -3,6 +3,8 @@ name: verify-before-claiming
 description: Before reporting a task as done, run the check that would fail if it were not — an explanation is not a fix.
 version: 0.1.0
 kind: pattern
+stage: verify
+topic: software-dev
 triggers:
 - finished the change
 - about to report success

--- a/skills/warn-before-the-thing-you-are-warning-about/SKILL.md
+++ b/skills/warn-before-the-thing-you-are-warning-about/SKILL.md
@@ -3,6 +3,8 @@ name: warn-before-the-thing-you-are-warning-about
 description: A caution placed after the action it concerns arrives after the reader has already decided. Put it above, and make it undismissable when it matters.
 version: 0.1.0
 kind: pattern
+stage: ship
+topic: software-dev
 triggers:
 - writing a download page
 - adding a destructive action

--- a/tests/test_skill_library.py
+++ b/tests/test_skill_library.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from chimera.skills.skill_md import _CARD_SECTIONS, parse_skill_md
+from chimera.skills.skill_md import _CARD_SECTIONS, STAGES, TOPICS, parse_skill_md
 
 LIBRARY = Path(__file__).resolve().parent.parent / "skills"
 CARDS = sorted(LIBRARY.glob("*/SKILL.md"))
@@ -117,3 +117,46 @@ def test_round_trips_through_the_renderer(card: Path) -> None:
     twice = parse_skill_md(render_skill_md(once))
     assert twice.manifest == once.manifest
     assert twice.instructions == once.instructions
+
+
+# --- browsing metadata: the hub groups by these, so a card without them is invisible ---------------
+
+
+@pytest.mark.parametrize("card", CARDS, ids=_IDS)
+def test_declares_a_stage_and_a_topic(card: Path) -> None:
+    """A card with no stage lands in no group, and the hub renders only non-empty groups — so the
+    failure is not an ugly "Other" bucket, it is a card that silently does not appear.
+
+    The parser deliberately does NOT enforce this: an imported third-party card may carry a
+    taxonomy that is not ours, and refusing to READ it over a display field would be the wrong
+    trade. "Required" belongs on what we publish, which is here.
+    """
+    skill = parse_skill_md(card.read_text(encoding="utf-8"))
+
+    assert skill.manifest.stage in STAGES, (
+        f"{card.parent.name}: stage must be one of {STAGES} — a value outside the vocabulary is "
+        "dropped to '' by the parser, so a typo removes the card from the hub without any error"
+    )
+    assert skill.manifest.topic in TOPICS, (
+        f"{card.parent.name}: topic must be one of {TOPICS}"
+    )
+
+
+def test_every_stage_the_hub_can_show_has_at_least_one_card() -> None:
+    """The taxonomy is longer than the library on purpose — topics light up as contributions
+    arrive. Stages are different: five is the whole shape of a piece of work, and an empty one
+    means the library has a hole in it rather than room to grow.
+    """
+    seen = {parse_skill_md(c.read_text(encoding="utf-8")).manifest.stage for c in CARDS}
+
+    assert set(STAGES) <= seen, f"no card covers: {sorted(set(STAGES) - seen)}"
+
+
+def test_the_vocabulary_check_would_catch_a_typo() -> None:
+    """Proof the check is not vacuous. `_vocab` returning '' for an unknown value is what makes a
+    typo silent, so this asserts the silence exists and that the test above is what breaks it."""
+    from chimera.skills.skill_md import _vocab
+
+    assert _vocab("Verify", STAGES) == "verify"  # case and spacing are normalised
+    assert _vocab("verifyy", STAGES) == ""  # a typo becomes empty, not an error
+    assert _vocab(None, STAGES) == ""


### PR DESCRIPTION
Two commits: the translations the thirteen new cards shipped without, and the categorization for browsing them.

## 1. Nine languages, and Russian at all

207 entries (23 cards × 9 languages), each declaring the `sha256` of the English description it was made from — so the card body stays byte-identical and the published hash keeps attesting to what the agent reads.

Verified mechanically, not by eye: all 207 hashes recomputed from the frontmatter and matched, zero left identical to English, zero empty. **The check was proved non-vacuous** by corrupting one hash and one text and confirming it flagged exactly one card each time.

`ru.json` did not exist. The site serves ten locales and the sidecar had eight, so a Russian reader has been getting English descriptions since the locale was added, with nothing on the page saying so.

**What this does not close, and it is bigger than what it does:** the sidecar also carries `sections` — the five card sections in the reader's language — and those exist for 10 cards in 8 languages. The thirteen new cards have sections in **no** language; `ru.json` has none at all. A German reader opening a new card gets a German description and an English body. That is **127 card-language blocks** of real translation, queued separately.

## 2. A hub grouped by stage

Twenty-three cards in a flat list is hard to scan, and copying a competitor's taxonomy would have made it worse:

| their scheme | what it would give us |
|---|---|
| Built-in / Optional / Community | one bucket with 23, three empty |
| the aggregator's 34 topics | 30 empty drawers — and **82,115 of their 90,698 cards sit in "Other"** |

Half those names (Blockchain, Gaming, Real Estate, Smart Home) only mean something for *integration* skills, which this format cannot be.

So: `stage` (define · build · verify · review · ship) groups the hub; `topic` labels the card and keeps the ecosystem's vocabulary untranslated, so a reader who searched "devops" sees "devops".

**The taxonomy is declared longer than the library fills, and only non-empty groups render.** Today: `software-dev` 13, `research` 5, `devops` 3, `ai-agents` 2, and seven declared names showing nothing until a contribution arrives.

### The gate is the point

A stage outside the vocabulary parses to `""`, and `""` means the card renders in **no group at all** — it vanishes from the hub with no error anywhere. So one test fails the build on it, and another asserts no stage ends up empty: topics may be aspirational, five stages are the shape of a piece of work.

Proved by typo — `buildd` fails and the message says exactly why the failure would otherwise be silent.

The **parser** deliberately does not enforce any of it. An imported third-party card may carry a taxonomy that is not ours, and refusing to *read* a card over a display field is the wrong trade. "Required" belongs on what we publish.

---

**Verification.** `ruff` and `mypy chimera` clean; **3140 passed** with the same 18 pre-existing environment failures. Rendering checked against the running dev server: five stage headings in Portuguese and English, 23 cards distributed 13/5/3/2 across the topics.

Needs the companion site PR to render the groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)