### PR TITLE
fix(workflow,sandbox): the guard that covered four callers of five

### DIFF
--- a/chimera/proc/stdio.py
+++ b/chimera/proc/stdio.py
@@ -114,6 +114,16 @@ def kill_tree(proc: subprocess.Popen[Any]) -> None:
     workers — so killing the one we hold leaves the ones doing the work, and the workspace stays
     locked by a process nobody can see. This is the difference between stopping an agent and
     orphaning it.
+
+    ⚠️ **PRECONDITION: spawn the child with :func:`_spawn_flags` (or `start_new_session=True`).**
+    On POSIX this sends `SIGKILL` to the child's whole process *group*, and a child that was not
+    given its own group is still in **yours** — so this kills the caller. That is not theoretical:
+    it took down a test runner during this function's own test, and the only symptom was an exit
+    code with no output, which is about as hard to read as a failure gets.
+
+    Every caller in this package already isolates (`exec_stream`, `sandbox/local`, `lsp/transport`
+    all pass the flags). The requirement is written here because nothing enforces it, and the cost
+    of forgetting is paid by the wrong process.
     """
     if proc.poll() is not None:
         return

--- a/chimera/sandbox/local.py
+++ b/chimera/sandbox/local.py
@@ -7,11 +7,11 @@ the governance kernel gates what reaches it, and DockerSandbox provides real iso
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
 from contextlib import suppress
 from pathlib import Path
 
+from chimera.proc.stdio import kill_tree
 from chimera.sandbox.base import SandboxResult
 
 # Env-var name fragments that mark a secret — scrubbed from the child env so an injected/rogue command
@@ -69,13 +69,13 @@ class LocalSandbox:
         try:
             out, err = proc.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:
-            if posix:
-                try:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)  # type: ignore[attr-defined]
-                except (ProcessLookupError, PermissionError):
-                    proc.kill()
-            else:
-                proc.kill()
+            # `kill_tree` rather than a second copy of the same logic. This branch reimplemented the
+            # POSIX half and stopped there: on Windows it was a bare `proc.kill()`, which kills the
+            # shell and leaves whatever the shell started — `npm test` dies, the node workers holding
+            # the workspace do not. A timeout that orphans the processes it was meant to stop is the
+            # failure it exists to prevent, and it only ever happened on Windows, which is where this
+            # project is developed.
+            kill_tree(proc)
             with suppress(subprocess.TimeoutExpired):
                 proc.communicate(timeout=5)
             return SandboxResult(

--- a/chimera/workflow/executors.py
+++ b/chimera/workflow/executors.py
@@ -30,9 +30,25 @@ def build_executors(*, workspace: Path, model: str | None = None) -> dict[str, S
         return StepResult(True, gateway.quick(prompt, model=model))
 
     def shell_step(step: WorkflowStep) -> StepResult:
-        from chimera.sandbox import get_sandbox
+        """A `shell:` step, gated by `CHIMERA_HOST_EXEC` like every other host-exec path.
 
-        result = get_sandbox().run(str(step.with_.get("command", "")), cwd=workspace)
+        It was the one caller of five that ran ungated. Someone who writes `deny` expects it to hold
+        everywhere — a fence with one documented gap is worse than no fence, because the gap is
+        exactly where a run goes when the fenced routes refuse it. And a workflow is the least
+        supervised of the five: it runs unattended, so nobody is watching to notice.
+
+        The gate is skipped for an isolated sandbox, matching `RunShellTool`: the confirmation asks
+        about running on the HOST, and inside a container that question does not arise.
+        """
+        from chimera.sandbox import get_sandbox
+        from chimera.sandbox.confirm import resolve_host_exec_confirm, sandbox_is_isolated
+
+        command = str(step.with_.get("command", ""))
+        sandbox = get_sandbox()
+        confirm = resolve_host_exec_confirm()
+        if confirm is not None and not sandbox_is_isolated(sandbox) and not confirm(command):
+            return StepResult(False, "host execution declined (CHIMERA_HOST_EXEC). Not run.")
+        result = sandbox.run(command, cwd=workspace)
         return StepResult(result.exit_code == 0, result.output[:_MAX_OUTPUT])
 
     def solve_step(step: WorkflowStep) -> StepResult:

--- a/tests/test_ungated_host_exec.py
+++ b/tests/test_ungated_host_exec.py
@@ -1,0 +1,115 @@
+"""Two host-exec paths that behaved differently from the four beside them.
+
+Both were found by an audit asking the same question of every caller — "does this one do what the
+other four do?" — which is the only reliable way to find a guard that exists and does not cover
+everything. Neither failed a test before this file, because nothing had ever asked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from chimera.sandbox.base import SandboxResult
+from chimera.workflow.executors import build_executors
+from chimera.workflow.models import WorkflowStep
+
+
+class _Recording:
+    """A sandbox that records whether it was asked to run anything."""
+
+    isolated = False
+
+    def __init__(self) -> None:
+        self.ran: list[str] = []
+
+    def run(self, command: str, *, timeout: int = 60, cwd: Any = None) -> SandboxResult:
+        self.ran.append(command)
+        return SandboxResult(exit_code=0, stdout="ok")
+
+
+def _shell_step(monkeypatch: Any, *, host_exec: str, tmp_path: Path) -> tuple[Any, _Recording]:
+    sandbox = _Recording()
+    monkeypatch.setenv("CHIMERA_HOST_EXEC", host_exec)
+    monkeypatch.setattr("chimera.sandbox.get_sandbox", lambda: sandbox)
+    from chimera.config import get_settings
+
+    get_settings.cache_clear()
+    execs = build_executors(workspace=tmp_path, model="x")
+    return execs["shell"], sandbox
+
+
+def test_a_workflow_shell_step_honours_deny(monkeypatch: Any, tmp_path: Path) -> None:
+    """The regression this file exists for.
+
+    `shell:` was the one host-exec caller of five with no gate. A workflow is also the least
+    supervised of the five — it runs unattended — so the gap sat exactly where nobody was watching.
+    """
+    step_fn, sandbox = _shell_step(monkeypatch, host_exec="deny", tmp_path=tmp_path)
+    result = step_fn(WorkflowStep(name="s", uses="shell", with_={"command": "rm -rf /"}))
+    assert result.success is False
+    assert "declined" in result.output
+    assert sandbox.ran == [], "the command reached the sandbox despite CHIMERA_HOST_EXEC=deny"
+
+
+def test_allow_still_runs(monkeypatch: Any, tmp_path: Path) -> None:
+    """A gate that blocks the allowed case is a regression, not a fix."""
+    step_fn, sandbox = _shell_step(monkeypatch, host_exec="allow", tmp_path=tmp_path)
+    result = step_fn(WorkflowStep(name="s", uses="shell", with_={"command": "echo hi"}))
+    assert result.success is True
+    assert sandbox.ran == ["echo hi"]
+
+
+def test_the_local_sandbox_kills_the_whole_tree() -> None:
+    """`LocalSandbox` reimplemented the POSIX half of `kill_tree` and stopped there.
+
+    On Windows the timeout path was a bare `proc.kill()`: the shell dies, everything the shell
+    started keeps running and keeps the workspace locked. This project is developed on Windows, so
+    the broken half was the one that mattered here.
+
+    Asserted structurally rather than by spawning a real process tree: a test that launches
+    grandchildren and hunts for orphans is slow, platform-forked and flaky, and what regressed was
+    which function gets called.
+    """
+    import inspect
+
+    from chimera.sandbox import local
+
+    source = inspect.getsource(local)
+    assert "kill_tree(proc)" in source, "the timeout path no longer delegates to kill_tree"
+    assert "os.killpg" not in source, (
+        "the POSIX-only copy is back — that is the shape of the bug: correct on Linux, silently "
+        "orphaning on Windows"
+    )
+
+
+def test_kill_tree_covers_both_platforms() -> None:
+    """The reason delegating is worth anything: the shared helper handles what the copy did not."""
+    import inspect
+
+    from chimera.proc import stdio
+
+    source = inspect.getsource(stdio.kill_tree)
+    assert "killpg" in source and "taskkill" in source
+
+
+def test_kill_tree_really_kills_a_child() -> None:
+    """One live check, so the structural assertions above are not the only evidence.
+
+    ⚠️ `**_spawn_flags()` is load-bearing, not decoration. The first version of this test spawned a
+    plain child, which on POSIX stays in *pytest's* process group — and `kill_tree` killpg's the
+    group, so the test killed the runner. Exit code 9, no output, no failing test to read. The
+    precondition is now written on `kill_tree` itself; this line is what proves the docstring.
+    """
+    from chimera.proc.stdio import _spawn_flags, kill_tree
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        **_spawn_flags(),
+    )
+    kill_tree(proc)
+    assert proc.wait(timeout=10) is not None
+    assert proc.poll() is not None


### PR DESCRIPTION
Items 7 and 8 of the competitive study's roadmap — the two cheapest, and the two whose absence is paid for by whoever is running the agent.

Both were found by asking every caller the same question: **"does this one do what the other four do?"** That is the only reliable way to find a guard that exists and does not cover everything. Neither failed a test before this commit, because nothing had ever asked.

## A workflow `shell:` step ignored `CHIMERA_HOST_EXEC`

Five paths run a command on the host. Four gate it. `chimera/workflow/executors.py` called `get_sandbox().run(...)` directly.

Someone who writes `deny` expects it to hold **everywhere**, and a fence with one documented gap is worse than no fence — the gap is precisely where a run goes once the fenced routes refuse it. A workflow is also the **least supervised** of the five: it runs unattended, so the hole sat exactly where nobody was watching.

Gated now, and skipped for an isolated sandbox exactly as `RunShellTool` does — the confirmation asks about running on the **host**, and inside a container that question does not arise.

## `LocalSandbox` reimplemented half of `kill_tree`

Its timeout path had the POSIX branch (`killpg`) and, on Windows, a bare `proc.kill()`.

That kills the shell and leaves everything the shell started: `npm test` dies, the node workers holding the workspace do not. The shared helper has handled both platforms all along — `taskkill /F /T` on Windows — and this now calls it instead of carrying a copy that was correct on Linux and silently orphaning on Windows.

**The broken half was the one that mattered here**, since this project is developed on Windows.

## The mistake on the way is worth more than either fix

The live test for `kill_tree` **killed the test runner**.

On POSIX it SIGKILLs the child's process *group*, and a child spawned without `start_new_session` is still in **yours**. Symptom: exit code 9, no output, no failing test to read — about as hard to diagnose as a failure gets.

Every real caller isolates correctly (`exec_stream`, `sandbox/local`, `lsp/transport` all pass `_spawn_flags()`). But **that precondition existed nowhere except in the heads of the people who wrote them**, which is not a precondition — it is luck. It is on `kill_tree` now, together with what happens when it is forgotten.

## Verified

`ruff` clean · `mypy` 305 files · **3230 passed, 12 skipped**.

The gate test proven non-vacuous by deleting the gate and watching **only that test** go red. The sandbox change is asserted structurally plus one live kill — a test that spawns real grandchildren and hunts for orphans is slow, platform-forked and flaky, and what regressed was which function gets called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)