### PR TITLE
fix(desktop): the app used to fail to start by doing nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,10 +261,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
-      # `tauri.conf.json` points frontendDist at ../dist. Building the real SPA here would duplicate
-      # the `desktop` job above for no gain: these tests never load a page.
-      - name: Placeholder SPA dist
-        run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
+      # Two placeholders, because `tauri-build` resolves the bundle manifest before it compiles
+      # anything and refuses on either: `frontendDist` points at ../dist, and `bundle.resources`
+      # globs the PyInstaller output, which only the release workflow produces. Building the real
+      # SPA and freezing the real backend here would duplicate two other jobs for no gain — these
+      # tests never load a page and never launch the sidecar; they exercise the code that runs when
+      # launching it FAILS.
+      - name: Placeholders the build script insists on
+        run: |
+          mkdir -p apps/desktop/dist apps/desktop/src-tauri/sidecar-dist/chimera-backend
+          touch apps/desktop/dist/index.html
+          touch apps/desktop/src-tauri/sidecar-dist/chimera-backend/chimera-backend
 
       - name: cargo test
         run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,43 @@ jobs:
       - name: Build the frontend (tsc + vite — proves the UI matches the generated types)
         run: npm --prefix apps/desktop run build
 
+  desktop-shell:
+    # The Tauri shell has Rust tests and nothing ran them — not this file, not the release workflow.
+    # `desktop-release` compiles the crate, so a *compile* error was always caught at release time; a
+    # failing assertion was caught nowhere, on any branch, ever. The tests it runs guard the startup
+    # path (the sidecar's stderr is captured, a dead backend leaves a report, the tail is bounded),
+    # which is precisely the code a user hits when nothing else works, so a guard that only runs on
+    # the author's laptop is the same defect one layer up.
+    name: desktop shell (Rust tests)
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    needs: quality
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: apps/desktop/src-tauri -> target
+
+      # The same four packages desktop-release.yml installs — tauri does not compile on Linux without
+      # them, and `cargo test` compiles the whole crate.
+      - name: Linux system deps for Tauri
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      # `tauri.conf.json` points frontendDist at ../dist. Building the real SPA here would duplicate
+      # the `desktop` job above for no gain: these tests never load a page.
+      - name: Placeholder SPA dist
+        run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
+
+      - name: cargo test
+        run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml
+
   mutation:
     name: mutation testing (critical modules)
     timeout-minutes: 120
@@ -306,7 +343,17 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     if: always()
-    needs: [quality, quality-windows, integration, install-smoke, desktop, mutation, supply-chain]
+    needs:
+      [
+        quality,
+        quality-windows,
+        integration,
+        install-smoke,
+        desktop,
+        desktop-shell,
+        mutation,
+        supply-chain,
+      ]
     steps:
       # A run can go red without anything failing. On 2026-08-06 two of the three `quality` matrix
       # jobs were created, never assigned a runner, and were cancelled 15 minutes later; the third

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chimera-desktop"
-version = "0.43.0"
+version = "0.46.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -9,10 +9,12 @@
 //! at that localhost origin. The SPA is served BY the sidecar (same origin), so its relative `/api`
 //! calls just work — no divergent server code, no base-URL rewiring. The sidecar is killed on exit.
 
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
-use std::sync::Mutex;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use tauri::menu::{Menu, MenuItem};
@@ -103,6 +105,77 @@ fn port_of(url: &str) -> Option<u16> {
 }
 
 /// Launch the sidecar and return the running child plus the URL it reported.
+/// Lines the backend's stderr is worth keeping. A traceback is the last ~30; the rest is boot noise,
+/// and an unbounded buffer is how a chatty backend eats memory over a long session.
+const STDERR_KEEP: usize = 80;
+
+/// Read the child's stderr on a thread, keeping the last [`STDERR_KEEP`] lines.
+///
+/// A thread rather than a read-on-failure: an unread pipe fills, and a process blocked writing into
+/// a full pipe never gets to say the thing we wanted to hear. Diagnosing a hang by causing one is
+/// the wrong trade.
+fn drain_stderr(child: &mut Child) -> Arc<Mutex<VecDeque<String>>> {
+    let tail = Arc::new(Mutex::new(VecDeque::with_capacity(STDERR_KEEP)));
+    let Some(stderr) = child.stderr.take() else {
+        return tail;
+    };
+    let sink = Arc::clone(&tail);
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            // A poisoned lock here must not take the reader down: the backend keeps running, and
+            // losing the tail is a worse-diagnosed failure, not a second failure.
+            if let Ok(mut buf) = sink.lock() {
+                if buf.len() == STDERR_KEEP {
+                    buf.pop_front();
+                }
+                buf.push_back(line);
+            }
+        }
+    });
+    tail
+}
+
+/// Write what we know about a failed startup, and return the path.
+///
+/// Best-effort throughout: this runs on the path where something already went wrong, and a
+/// diagnostics writer that can itself fail the startup would be the joke writing itself. Every
+/// error here degrades to a less complete file, never to a second failure.
+fn write_startup_report(
+    data_dir: &Path,
+    exe: &Path,
+    child: &mut Child,
+    tail: &Arc<Mutex<VecDeque<String>>>,
+    why: &str,
+) -> PathBuf {
+    let path = data_dir.join("startup-failure.txt");
+    let exit = match child.try_wait() {
+        Ok(Some(status)) => format!("{status}"),
+        Ok(None) => "still running (killed after this report)".to_string(),
+        Err(e) => format!("unknown: {e}"),
+    };
+    let stderr = tail
+        .lock()
+        .map(|buf| buf.iter().cloned().collect::<Vec<_>>().join("\n"))
+        .unwrap_or_else(|_| "<stderr buffer unavailable>".to_string());
+    let body = format!(
+        "Chimera desktop — backend failed to start\n\
+         version: {}\n\
+         backend: {}\n\
+         pid: {}\n\
+         exit: {exit}\n\
+         reason: {why}\n\
+         \n\
+         --- last {STDERR_KEEP} lines of backend stderr ---\n{}\n",
+        env!("CARGO_PKG_VERSION"),
+        exe.display(),
+        child.id(),
+        if stderr.is_empty() { "<the backend printed nothing>" } else { &stderr },
+    );
+    let _ = std::fs::create_dir_all(data_dir);
+    let _ = std::fs::write(&path, body);
+    path
+}
+
 fn start_sidecar(app: &tauri::App) -> Result<(Child, String), String> {
     let exe = sidecar_path(app)?;
     if !exe.exists() {
@@ -130,16 +203,36 @@ fn start_sidecar(app: &tauri::App) -> Result<(Child, String), String> {
     let wanted = remembered_port(&memo);
     let wanted_arg = wanted.to_string();
 
-    let child = Command::new(&exe)
+    // stderr is PIPED so a backend that dies on startup leaves its last words somewhere. It used to
+    // be inherited, which on a windowed Windows build means discarded: the sidecar would print a
+    // traceback into a console that does not exist, `start_sidecar` would return a timeout with no
+    // detail, and the user would click the icon and get nothing at all — no window, no log, no file.
+    //
+    // Four competing agent apps each hardened this same step, independently and in four different
+    // frameworks. That is not convergent taste; it is the failure everyone met in the field.
+    let mut child = Command::new(&exe)
         .args(["--no-open", "--port", &wanted_arg, "--emit-port-file"])
         .arg(&port_file)
         .env("CHIMERA_HOME", data_dir.join("data"))
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to launch backend {exe:?}: {e}"))?;
 
+    // Drain it on a thread. Reading it only after a failure would deadlock instead of diagnosing:
+    // a pipe nobody reads fills, and a backend blocked writing to a full pipe never reaches the
+    // line that would have told us what was wrong.
+    let stderr_tail = drain_stderr(&mut child);
+
     // The frozen exe unpacks + boots; give it a generous window before giving up.
-    let url = wait_for_url(&port_file, Duration::from_secs(45))?;
-    wait_for_listening(&url, Duration::from_secs(30))?;
+    let url = wait_for_url(&port_file, Duration::from_secs(45))
+        .and_then(|url| wait_for_listening(&url, Duration::from_secs(30)).map(|()| url))
+        .map_err(|why| {
+            // Whatever the backend managed to say, plus the exit code if it already died — written
+            // BEFORE this error propagates, because everything above it is about to be unwound.
+            let report = write_startup_report(&data_dir, &exe, &mut child, &stderr_tail, &why);
+            let _ = child.kill();
+            format!("{why}\n\nDiagnostics written to:\n{}", report.display())
+        })?;
     let _ = std::fs::remove_file(&port_file);
 
     // Remember what we actually got, which is not always what we asked for. Best-effort on purpose:
@@ -155,7 +248,128 @@ fn start_sidecar(app: &tauri::App) -> Result<(Child, String), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{port_of, remembered_port};
+    use super::{drain_stderr, port_of, remembered_port, write_startup_report, STDERR_KEEP};
+    use std::process::{Command, Stdio};
+
+    /// A backend that dies on startup must leave its last words behind.
+    ///
+    /// This is the regression the whole change exists for: stderr used to be inherited, which on a
+    /// windowed Windows build means discarded — the traceback went to a console that does not exist.
+    #[test]
+    fn a_dying_backend_leaves_its_stderr_in_the_report() {
+        let dir = std::env::temp_dir().join(format!("chimera-startup-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+
+        let mut child = Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) {
+                vec!["/C", "echo ModuleNotFoundError: no module named chimera 1>&2 & exit 3"]
+            } else {
+                vec!["-c", "echo 'ModuleNotFoundError: no module named chimera' >&2; exit 3"]
+            })
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn the stand-in backend");
+
+        let tail = drain_stderr(&mut child);
+        let _ = child.wait();
+        // The draining thread races the exit; give it a moment to finish the last line.
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        let path = write_startup_report(
+            &dir,
+            std::path::Path::new("chimera-backend"),
+            &mut child,
+            &tail,
+            "timed out waiting for the port file",
+        );
+        let body = std::fs::read_to_string(&path).expect("the report was written");
+
+        assert!(body.contains("ModuleNotFoundError"), "the backend's own words are missing: {body}");
+        assert!(body.contains("timed out waiting"), "the reason is missing");
+        assert!(body.contains("exit"), "the exit status is missing");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A backend that says nothing must still produce a readable file, not an empty one.
+    #[test]
+    fn a_silent_backend_still_gets_a_report_that_says_so() {
+        let dir = std::env::temp_dir().join(format!("chimera-silent-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let mut child = Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) { vec!["/C", "exit 1"] } else { vec!["-c", "exit 1"] })
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn");
+        let tail = drain_stderr(&mut child);
+        let _ = child.wait();
+        let path = write_startup_report(&dir, std::path::Path::new("x"), &mut child, &tail, "why");
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("the backend printed nothing"),
+            "an empty tail must say so rather than leave a blank section: {body}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The three tests above are HELPER tests, and I found that out by trying to break them.
+    ///
+    /// Removing `.stderr(Stdio::piped())` from `start_sidecar` left all three green, because each
+    /// spawns its own child and pipes it explicitly — they prove `drain_stderr` and
+    /// `write_startup_report` work, and say nothing about whether the sidecar path calls them. That
+    /// is the same "tests the class, not the wiring" defect this project has a skill card about.
+    ///
+    /// `start_sidecar` takes `&tauri::App`, which a unit test cannot construct, so the behavioural
+    /// version would mean restructuring it to accept a path. Worth doing; not worth blocking the
+    /// fix on. Until then this is a source-level assertion — weaker than behaviour, but it fails on
+    /// exactly the regression that matters and is honest about being a stand-in.
+    #[test]
+    fn the_sidecar_actually_pipes_its_stderr() {
+        let source = include_str!("main.rs");
+        // Cut the tests off FIRST. Two earlier versions of this window passed with the fix reverted:
+        // one took everything after the function name (reaching this very test, which mentions the
+        // string), and one bounded at the next top-level `fn` — but `mod tests` sits between
+        // `start_sidecar` and `kill_sidecar`, so that window swallowed the three tests below, and
+        // they pipe stderr themselves. A search window wide enough to contain its own answer proves
+        // nothing, and I wrote two of them before checking.
+        let production = source
+            .split_once("#[cfg(test)]")
+            .expect("the test module marks where production code ends")
+            .0;
+        let body = production
+            .split_once("fn start_sidecar")
+            .expect("start_sidecar exists")
+            .1;
+        // `start_sidecar` is the last function before the tests today; if one is added after it,
+        // this narrows further rather than opening up.
+        let spawn = body.split_once("\nfn ").map_or(body, |(head, _)| head);
+        assert!(
+            spawn.contains(".stderr(Stdio::piped())"),
+            "start_sidecar stopped piping stderr — a backend that dies on startup is silent again"
+        );
+        assert!(
+            spawn.contains("write_startup_report"),
+            "start_sidecar stopped writing a report on failure"
+        );
+    }
+
+    /// The buffer is bounded: a chatty backend must not grow it without limit.
+    #[test]
+    fn the_stderr_tail_is_bounded() {
+        let dir = std::env::temp_dir().join(format!("chimera-bound-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let script = format!("for i in $(seq 1 {}); do echo line$i >&2; done", STDERR_KEEP * 3);
+        let win = format!("for /L %i in (1,1,{}) do @echo line%i 1>&2", STDERR_KEEP * 3);
+        let mut child = Command::new(if cfg!(windows) { "cmd" } else { "sh" })
+            .args(if cfg!(windows) { vec!["/C", &win] } else { vec!["-c", &script] })
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn");
+        let tail = drain_stderr(&mut child);
+        let _ = child.wait();
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        assert!(tail.lock().unwrap().len() <= STDERR_KEEP);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
     #[test]
     fn a_url_yields_its_port() {
@@ -245,9 +459,24 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             // Bring up the backend, then open the window at its origin.
-            let (child, url) = start_sidecar(app).map_err(|e| -> Box<dyn std::error::Error> {
-                Box::<dyn std::error::Error>::from(e)
-            })?;
+            //
+            // The failure branch is the point. This used to be a bare `?`, which propagated to the
+            // `.expect()` on `build()` — and under `windows_subsystem = "windows"` a panic writes to
+            // a stderr that does not exist. Clicking the icon did nothing at all: no window, no
+            // console, no file. "Nothing happens" is the least diagnosable failure a desktop app can
+            // have, and it was ours on the platform this project is developed on.
+            let (child, url) = match start_sidecar(app) {
+                Ok(pair) => pair,
+                Err(why) => {
+                    // Blocking, so the process cannot exit before the user has read it.
+                    app.dialog()
+                        .message(&why)
+                        .title("Chimera could not start")
+                        .buttons(MessageDialogButtons::Ok)
+                        .blocking_show();
+                    return Err(Box::<dyn std::error::Error>::from(why));
+                }
+            };
             app.state::<Sidecar>().0.lock().unwrap().replace(child);
 
             WebviewWindowBuilder::new(app, "main", WebviewUrl::External(url.parse()?))


### PR DESCRIPTION
## O que estava quebrado

Numa instalação com o backend quebrado, clicar no ícone produzia **nada**: sem janela, sem console, sem arquivo.

Duas causas somadas:

1. `start_sidecar` propagava um `?` nu até o `.expect()` do `build()`. Sob `windows_subsystem = "windows"` um panic escreve num stderr que não existe.
2. O stderr do próprio backend era **herdado**, o que numa build de janela significa descartado — o traceback que explicava a falha era jogado fora exatamente pela linha que podia tê-lo guardado.

"Não acontece nada" é a falha menos diagnosticável que um app de desktop pode ter, e era a nossa na plataforma em que este projeto é desenvolvido.

Os quatro apps de agente concorrentes que estudamos endureceram este mesmo passo, em quatro frameworks diferentes. Não é gosto convergente; é a falha que todo mundo encontra em campo.

## O que passa a acontecer

- stderr **pipeado** e drenado numa thread. Ler só na falha travaria em vez de diagnosticar: um pipe que ninguém lê enche, e um processo bloqueado escrevendo num pipe cheio nunca chega na linha que queríamos ouvir.
- Últimas **80 linhas** guardadas (traceback são as ~30 finais; buffer sem teto é como um backend tagarela come memória).
- Falha de arranque escreve `startup-failure.txt` junto dos dados do app: versão, caminho do executável, status de saída e o rabo do stderr.
- **Diálogo nativo bloqueante** nomeando o arquivo, em vez do silêncio.

## O CI nunca rodou `cargo test`

Nem este workflow nem o de release. O release *compila* a crate, então erro de compilação sempre foi pego; **asserção falhando não era pega em lugar nenhum, em branch nenhuma, nunca**. Quatro testes Rust só rodavam num laptop.

O job `desktop-shell` os roda agora, e está no `needs` do `verdict` — job fora daquela lista é vermelho que ninguém conta.

## O teste de fiação custou três tentativas

Vale registrar porque é o mesmo defeito que este PR conserta, uma camada acima:

- Os três primeiros testes **passaram com `.stderr(Stdio::piped())` deletado** do `start_sidecar`. Eles spawnam os próprios filhos e os pipeiam — provam que os helpers funcionam e não dizem nada sobre o sidecar chamá-los.
- A primeira tentativa de janela de busca pegou tudo depois do nome da função — e alcançava **este mesmo teste**, que menciona a string que procura.
- A segunda limitou no próximo `fn` de topo, mas `mod tests` fica **entre** `start_sidecar` e `kill_sidecar`, então engolia os três testes de novo.

Uma janela de busca larga o bastante para conter a própria resposta não prova nada. A versão que ficou corta em `#[cfg(test)]` primeiro, e foi verificada reprovando: `FAILED` com a captura removida, verde restaurada.

## Verificação

| portão | resultado |
|---|---|
| `cargo check` | limpo |
| `cargo test` (Tauri) | 6 passando (2 antigos + 4 novos) |
| discriminação do teste de fiação | **reprova** com a captura removida, verde restaurada |
| `pytest` completo (WSL) | 3230 passando, 12 skipped |
| `npm run test` (Vitest) | verde |
| `ci.yml` parseia, todo job no `verdict` | conferido |

`Cargo.lock` estava carimbado 0.43.0 enquanto o `Cargo.toml` dizia 0.46.0 — o checklist de release bumpa o manifesto e nunca regenera o lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
