### PR TITLE
fix(desktop,events): the conversation showed less than the backend knew

### DIFF
--- a/apps/desktop/src/components/Code.budget.test.tsx
+++ b/apps/desktop/src/components/Code.budget.test.tsx
@@ -1,0 +1,60 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Code } from "@/components/Code";
+import { getFsTree, getGitStatus, getPostureFacts, getRuns, streamCodeTurn } from "@/lib/api";
+import { emptyTree, gitStatus, postureFacts, scriptTurn } from "@/test/code-api-mock";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", async () => (await import("@/test/code-api-mock")).makeCodeApiMock());
+
+/**
+ * A chat window has nobody standing by to restart it.
+ *
+ * `context_budget` is off by default in the library, and that default is deliberate: compaction
+ * discards messages and an API caller who never asked for it should not silently get it. For a
+ * conversation the user has been building for an hour, the same default is the wrong one — without
+ * a budget the message list only grows, an overflow is terminal (the failover table maps
+ * CONTEXT_OVERFLOW to ABORT), and the thread ends on a provider error with no way to continue.
+ *
+ * The field existed on the request type and on the endpoint the whole time. Nothing sent it, so the
+ * compaction machinery could not run from this screen at all.
+ */
+describe("Code — the conversation asks for a context budget", () => {
+  beforeEach(() => {
+    vi.mocked(getFsTree).mockResolvedValue(emptyTree());
+    vi.mocked(getGitStatus).mockResolvedValue(gitStatus());
+    vi.mocked(getRuns).mockResolvedValue([]);
+    vi.mocked(getPostureFacts).mockResolvedValue(postureFacts());
+    vi.mocked(streamCodeTurn).mockImplementation(scriptTurn());
+  });
+
+  async function ask(text: string) {
+    const user = userEvent.setup();
+    renderWithProviders(<Code />);
+    await user.type(screen.getByPlaceholderText(/^Ask about this code/), `${text}{Enter}`);
+    await waitFor(() => expect(streamCodeTurn).toHaveBeenCalled());
+    return user;
+  }
+
+  it("sends a budget the server can act on", async () => {
+    await ask("what is this?");
+    const sent = vi.mocked(streamCodeTurn).mock.calls[0][0].context_budget;
+    // Not just "present": null and 0 both read as OFF server-side, so a field that arrives empty is
+    // the bug wearing the fix's clothes.
+    expect(sent).toBeGreaterThan(0);
+    expect(sent).toBeLessThanOrEqual(1);
+  });
+
+  it("sends it on the second turn too, not only the first", async () => {
+    // The agent is rebuilt per turn from this request. A budget sent once is a budget that applied
+    // once — and the turn where it matters is the late one, never the first.
+    const user = await ask("first");
+    await waitFor(() => expect(screen.getByPlaceholderText(/^Ask about this code/)).toBeEnabled());
+    await user.type(screen.getByPlaceholderText(/^Ask about this code/), "second{Enter}");
+    await waitFor(() => expect(vi.mocked(streamCodeTurn).mock.calls.length).toBeGreaterThan(1));
+
+    const budgets = vi.mocked(streamCodeTurn).mock.calls.map((c) => c[0].context_budget);
+    expect(budgets.every((b) => typeof b === "number" && b > 0)).toBe(true);
+  });
+});

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -28,6 +28,21 @@ import { useAgent } from "@/lib/agent-context";
 import { useStickToBottom } from "@/lib/useStickToBottom";
 import { cn } from "@/lib/utils";
 
+/** Share of the model's window this screen spends on the prompt before compacting.
+ *
+ *  The library default is OFF, deliberately: compaction discards messages, and an API caller who
+ *  never asked for that should not silently get it. A long-running chat is the case where that
+ *  default is wrong. Without a budget the message list only grows and an overflow is terminal —
+ *  the provider raises, the failover table maps CONTEXT_OVERFLOW to ABORT, and a conversation the
+ *  user has been building for an hour ends on a provider error with no way to continue it. Nobody
+ *  is standing by to restart a chat window the way an operator restarts a job.
+ *
+ *  0.6 is the library's own `DEFAULT_BUDGET_FRACTION`, matched on purpose so the app and `chimera
+ *  solve --context-budget` behave the same at the same number. Compaction here is free: no
+ *  summarising model call, just a structural note plus the recent tail, and it fires at 80% of the
+ *  budget so there is still room to compact into. */
+const CONTEXT_BUDGET = 0.6;
+
 /** One exchange. The assistant side carries what the agent DID (tools, edits) alongside what it
  *  said, because in a coding conversation the tool calls are the substance and the prose is the
  *  caption — a transcript that shows only the prose is a transcript of the wrong half. */
@@ -313,6 +328,9 @@ export function Conversation({
         session_id: sessionId,
         workspace: workspace || null,
         open_file: openFile,
+        // See CONTEXT_BUDGET. Sent on every turn because the agent is rebuilt per turn from this
+        // request — a budget sent once is a budget that applied once.
+        context_budget: CONTEXT_BUDGET,
         posture,
         profile,
         fuse,

--- a/chimera/core/events.py
+++ b/chimera/core/events.py
@@ -65,7 +65,27 @@ TOOL_OBSERVATION_CHARS = 400
 
 
 def _clip(text: str, limit: int) -> str:
+    """Keep the head. Right for an *argument*, whose first characters are what identify it."""
     return text if len(text) <= limit else text[:limit] + f"… (+{len(text) - limit} chars)"
+
+
+def _clip_observation(text: str, limit: int) -> str:
+    """Keep both ends of an *observation*, because the useful half of a tool result is the last one.
+
+    Head-clipping is how a failing test run becomes invisible in the UI. The first 400 characters of
+    pytest are the platform banner, the rootdir and the plugin list; the assertion, the traceback and
+    the ``FAILED …`` summary are all at the other end, and the caption therefore showed the part that
+    is identical whether the suite passed or failed. The same holds for a compiler, a linter, an npm
+    build, and for a Python traceback, whose exception line is last by construction.
+
+    The head is kept too, and deliberately: it carries the command, the path, or the first error,
+    which is what tells the reader *which* of several running things they are looking at.
+    """
+    if len(text) <= limit:
+        return text
+    head = limit * 2 // 5
+    tail = limit - head
+    return f"{text[:head]}\n… (+{len(text) - limit} chars)\n{text[-tail:]}"
 
 
 def tool(name: str, arguments: dict[str, Any], ok: bool, observation: str = "") -> AgentEvent:
@@ -88,7 +108,7 @@ def tool(name: str, arguments: dict[str, Any], ok: bool, observation: str = "") 
             "name": name,
             "arguments": clipped,
             "ok": ok,
-            "observation": _clip(observation or "", TOOL_OBSERVATION_CHARS),
+            "observation": _clip_observation(observation or "", TOOL_OBSERVATION_CHARS),
         },
     )
 

--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -262,8 +262,32 @@ def test_tool_event_clips_arguments_and_observation_visibly() -> None:
     assert event.data["arguments"]["path"] == "a.py"  # a big sibling never crowds out a small one
     content = event.data["arguments"]["content"]
     assert content.startswith("x" * TOOL_ARG_CHARS) and "+4800 chars" in content
-    assert event.data["observation"].startswith("y" * TOOL_OBSERVATION_CHARS)
-    assert "+4600 chars" in event.data["observation"]
+    observation = event.data["observation"]
+    assert len(observation.replace("\n", "")) - len("… (+4600 chars)") == TOOL_OBSERVATION_CHARS
+    assert "+4600 chars" in observation
+
+
+def test_a_clipped_observation_keeps_the_end_where_the_failure_is() -> None:
+    """A failing test run says what failed at the END, and the caption used to keep only the start.
+
+    The first 400 characters of pytest are the platform banner, the rootdir and the plugin list —
+    byte-identical whether the suite passed or failed. Clipping to them meant the desktop showed a
+    red tool call whose caption contained no evidence of anything being wrong, and a user with the
+    UI open had to go read the transcript to learn what a failure was. Same shape for a compiler, a
+    linter, and a Python traceback, whose exception line is last by construction.
+    """
+    from chimera.core.events import TOOL_OBSERVATION_CHARS, tool
+
+    banner = "=" * 30 + " test session starts " + "=" * 30 + "\n"
+    log = banner + "collected 3230 items\n" + "." * 4000 + "\nE   assert 1 == 2\nFAILED tests/test_x.py"
+    observation = tool("run_shell", {"cmd": "pytest"}, False, log).data["observation"]
+
+    assert "FAILED tests/test_x.py" in observation, "the verdict must survive the clip"
+    assert "assert 1 == 2" in observation, "so must the assertion that produced it"
+    assert "test session starts" in observation, "the head still says which run this is"
+    assert "chars)" in observation, "and the gap is marked, never silent"
+    # Still bounded: this is a progress caption, not the transcript.
+    assert len(observation) <= TOOL_OBSERVATION_CHARS + len("… (+9999 chars)") + 2
 
 
 class ScriptedBackend:


### PR DESCRIPTION
Dois itens do estudo dos apps concorrentes. A tela de código mostrava menos do que o backend já sabia.

## 1. O corte guardava a ponta errada

`_clip` truncava a observação de uma tool nos **primeiros** 400 caracteres.

Numa rodada de pytest esses 400 caracteres são o banner de plataforma, o rootdir e a lista de plugins — **byte a byte idênticos** tenha a suíte passado ou falhado. A asserção, o traceback e a linha `FAILED …` ficam todos na outra ponta.

Resultado: uma tool vermelha na interface trazia uma legenda sem evidência nenhuma de erro, e quem estava com o app aberto tinha que ir ler o transcript pra descobrir o que era a falha. Mesma forma para compilador, linter, build de npm, e para traceback de Python, cuja linha da exceção é a última por construção.

Observações agora guardam **as duas pontas** com o vão marcado. Argumentos continuam guardando a cabeça, que é onde estão os caracteres que identificam a coisa.

## 2. A conversa nunca pedia orçamento de contexto

O campo existe no tipo do request e no endpoint. Nada o setava.

A apuração foi pior que o item: **nada em lugar nenhum o seta**. Não há flag de CLI nem setting — só o corpo do request HTTP, e o app é o único cliente HTTP que a gente envia. Ou seja, a maquinaria de compactação não conseguia rodar em nenhuma superfície que a gente publica.

**O default da biblioteca fica desligado**, e de propósito: é decisão escrita (compactação descarta mensagens, e um chamador de API que não pediu não deve receber calado). Mas é o default errado para um chat — o caso em que não há ninguém de plantão para reiniciar. Sem orçamento a lista só cresce, o estouro é terminal (a tabela de failover mapeia `CONTEXT_OVERFLOW` para `ABORT`) e uma thread de uma hora termina num erro de provedor sem como continuar.

O app passa a mandar **0.6** — o próprio `DEFAULT_BUDGET_FRACTION` da biblioteca — em **todo** turno, porque o agente é reconstruído por turno e orçamento mandado uma vez valeu uma vez. A compactação aqui é grátis: nota estrutural, sem chamada de modelo pra resumir.

## Verificação

Os dois testes foram conferidos quebrando o que vigiam:

| quebra | resultado |
|---|---|
| voltar `_clip` para head-only | reprova, e a mensagem mostra a legenda virando parede de pontinhos |
| remover `context_budget` do request | reprovam os 2 casos novos de vitest |

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 305 arquivos |
| `pytest -q` (WSL) | 3231 passando, 12 skipped |
| `npm run test` | 488 passando, 63 arquivos |
| `npm run build` | ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
