### PR TITLE
fix(core): Stop meant "finish this attempt first"

### DIFF
--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -38,6 +38,10 @@ _log = get_logger("core.agent")
 # Bound on a single live per-edit unified diff (chars), so a huge write can't flood the event stream.
 _MAX_EDIT_DIFF_CHARS = 4000
 
+# What a cancelled run answers. Not "" — an empty answer reads as "it produced nothing", which is a
+# different claim from "somebody asked it to stop", and callers render the two identically.
+_CANCELLED_ANSWER = "Stopped at your request. The work up to this point is in the transcript."
+
 # Cached builtin skill registry for context retrieval (name/description only — no backend, no network).
 _DEFAULT_SKILLS: SkillRegistry | None = None
 
@@ -184,7 +188,7 @@ class AgentResult:
 
     answer: str
     steps: int
-    stopped_reason: str  # "final" | "max_steps" | "tool_loop" | "budget"
+    stopped_reason: str  # "final" | "max_steps" | "tool_loop" | "budget" | "cancelled"
     transcript: list[MessageLike] = field(default_factory=list)
     tool_calls_made: int = 0
     # Token/cost accounting, summed across every model call in the run (0 when the backend reported
@@ -278,6 +282,7 @@ class Agent:
         on_edit: Callable[[str, str], None] | None = None,
         history: list[MessageLike] | None = None,
         images: list[str] | None = None,
+        should_stop: Callable[[], bool] | None = None,
     ) -> AgentResult:
         """Run the tool loop. ``on_token`` streams model text deltas as they arrive (when the backend
         supports it); ``on_tool`` fires once per tool call with its outcome. ``on_edit`` fires with
@@ -291,7 +296,12 @@ class Agent:
         difference between a second turn that remembers reading a file and one that reads it again:
         a caller that flattens the conversation to prose (as ``ChatSession`` does, by design, for
         chat) necessarily discards every tool call, so the agent starts each turn blind. None keeps
-        the historical single-shot behaviour, byte-identical."""
+        the historical single-shot behaviour, byte-identical.
+
+        ``should_stop`` is polled once per step and ends the run with ``stopped_reason="cancelled"``,
+        keeping everything done so far. A model call already in flight cannot be interrupted, so a
+        step boundary is as fine as cancellation gets — but it is far finer than an attempt
+        boundary, which is where the only cancel check used to live."""
         system_prompt = self.config.system_prompt
         skill_block = self._skill_context(task)
         if skill_block:
@@ -354,6 +364,19 @@ class Agent:
         drift_reported = False
 
         for step in range(1, self.config.max_steps + 1):
+            # Cooperative cancel, checked once per step. A model call in flight cannot be
+            # interrupted, so a step boundary is the finest grain available — and it is much finer
+            # than what the caller had before. `AutonomousLoop` checked its stop flag only BETWEEN
+            # attempts, so Stop in the app meant "finish the whole attempt first": up to `max_steps`
+            # model calls plus every tool they trigger, which on a real task is minutes of work and
+            # money after the user asked for it to end. Nothing is discarded — the partial answer is
+            # the work already paid for.
+            if should_stop is not None and should_stop():
+                _log.info("run cancelled at step %d", step)
+                return self._result(
+                    _CANCELLED_ANSWER, step - 1, "cancelled", messages, tool_calls_made, tool_names,
+                    usage, self.config.model or "", None, steplog, task,
+                )
             # Timed here and nowhere else: this call is the only thing in the loop that is the
             # model. Measuring around the whole iteration would fold the tool calls into the rate
             # and report a shell command as slow generation.

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -157,10 +157,13 @@ def _format_requirements(requirements: list[Any]) -> str:
 class Worker(Protocol):
     """Anything that can execute a task and return a result (the agent loop).
 
-    Both callbacks are optional and structural: ``on_edit`` receives ``(path, patch)`` for each file
-    the worker changes mid-run (the live per-edit diff), and ``on_tool`` fires once per tool call
-    with its outcome. The loop passes each one only to workers whose ``run`` actually accepts it
-    (checked by signature), so a Worker that supports neither is never broken.
+    All three keyword arguments are optional and structural: ``on_edit`` receives ``(path, patch)``
+    for each file the worker changes mid-run (the live per-edit diff), ``on_tool`` fires once per
+    tool call with its outcome, and ``should_stop`` is polled by the worker so a cancel takes effect
+    inside an attempt rather than at the end of it. The loop passes each one only to workers whose
+    ``run`` actually accepts it (checked by signature), so a Worker that supports none is never
+    broken — an external agent driven over ACP accepts none of the three, and the loop's own
+    between-attempt cancel still applies to it.
     """
 
     def run(
@@ -169,6 +172,7 @@ class Worker(Protocol):
         *,
         on_edit: Callable[[str, str], None] | None = None,
         on_tool: Callable[[Any], None] | None = None,
+        should_stop: Callable[[], bool] | None = None,
     ) -> AgentResult: ...
 
 
@@ -442,18 +446,25 @@ class AutonomousAgent:
         ``worker.run(prompt)`` it always was, and a worker whose ``run`` accepts neither callback
         (any Worker implementation that predates them) is called the same way. The support check
         reads the real signature; a TypeError fallback covers a wrapper whose signature lied.
+
+        ``should_stop`` travels the same way, and it is NOT an event: it is checked even with no
+        sink, because a cancel must work in a headless run too. Passing it down is what makes Stop
+        take effect within a step instead of at the end of the attempt — the loop's own checks are
+        between attempts, so without this a stop request waits out every remaining model call and
+        every tool they trigger.
         """
-        if self.on_event is None:
-            return worker.run(prompt)
         try:
             accepted = set(inspect.signature(worker.run).parameters)
         except (TypeError, ValueError):  # unintrospectable callable (C impl / odd wrapper)
             accepted = set()
         kwargs: dict[str, Any] = {}
-        if "on_edit" in accepted:
-            kwargs["on_edit"] = self._emit_edit
-        if "on_tool" in accepted:
-            kwargs["on_tool"] = self._emit_tool
+        if self.should_stop is not None and "should_stop" in accepted:
+            kwargs["should_stop"] = self.should_stop
+        if self.on_event is not None:
+            if "on_edit" in accepted:
+                kwargs["on_edit"] = self._emit_edit
+            if "on_tool" in accepted:
+                kwargs["on_tool"] = self._emit_tool
         if not kwargs:
             return worker.run(prompt)
         try:
@@ -617,11 +628,25 @@ class AutonomousAgent:
             )
             if worker is self.escalate_worker:
                 _log.debug("attempt %d: task proved hard, escalating retry to fusion worker", index)
-            # Re-check right before the (uninterruptible) worker call, so a stop that arrived while the
-            # snapshot was being taken still halts before we pay for a model step.
+            # Re-check right before the worker call, so a stop that arrived while the snapshot was
+            # being taken still halts before we pay for a model step. The call is no longer
+            # uninterruptible: `_run_worker` hands `should_stop` down, and a worker that accepts it
+            # returns at its next step boundary.
             if self.should_stop is not None and self.should_stop():
                 return self._finalize_cancelled(task, attempts, plan, thread_id)
             agent_result = self._run_worker(worker, prompt)
+            # A worker that cut itself short produced a PARTIAL attempt, and verifying, reviewing and
+            # scoring one is worse than useless: those are model calls the user has already asked us
+            # not to make, spent to judge work that stopped halfway — and the failing verdict would
+            # be recorded as evidence the task is hard.
+            #
+            # On `stopped_reason`, deliberately NOT on the flag. The flag says a stop was requested
+            # at some point; only the reason says THIS attempt is incomplete. A worker that does not
+            # accept `should_stop` runs to the end even after a stop arrives, and that attempt is
+            # whole — discarding it would throw away a finished piece of work and, with
+            # `max_attempts=1`, return a run with no attempts at all.
+            if getattr(agent_result, "stopped_reason", "") == "cancelled":
+                return self._finalize_cancelled(task, attempts, plan, thread_id)
             answer = agent_result.answer
             # Surface a degrading trajectory where a person will see it, not only in the trace. It
             # is advisory: the attempt is judged on its result as always, and the run continues.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -181,6 +181,50 @@ def test_agent_hits_max_steps_and_forces_answer() -> None:
     assert backend.final_calls == 1
 
 
+def test_a_stop_request_ends_the_loop_at_the_next_step() -> None:
+    """A cancel must cost at most one more model call, not the rest of the attempt.
+
+    Before this the only cancel check lived in `AutonomousLoop`, between attempts. Stop therefore
+    meant "finish this attempt first": every remaining step of the tool loop, each a model call plus
+    whatever tools it triggers. On a real task that is minutes and money spent after the user asked
+    for it to end.
+    """
+    always_tool = CompletionResult(
+        content="", model="fake", tool_calls=[ToolCall(id="c", name="echo", arguments={"text": "x"})],
+    )
+
+    class CountingBackend:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, messages: list[Any], *, tools: Any = None, **kwargs: Any) -> CompletionResult:
+            self.calls += 1
+            return CompletionResult(content="forced", model="fake") if tools is None else always_tool
+
+    backend = CountingBackend()
+    agent = Agent(backend, _echo_registry(), AgentConfig(max_steps=20))
+    # Up after the second model call: the loop must stop at the top of step 3, not grind to 20.
+    result = agent.run("loop forever", should_stop=lambda: backend.calls >= 2)
+
+    assert result.stopped_reason == "cancelled"
+    assert backend.calls == 2, "one more model call than the flag allowed is one too many"
+    assert result.steps == 2, "the steps actually taken, not the step it was about to start"
+    assert result.answer, "an empty answer reads as 'it produced nothing', which is a different claim"
+
+
+def test_without_a_stop_check_the_loop_is_byte_for_byte_what_it_was() -> None:
+    """The default path must not move. `should_stop=None` is every existing caller."""
+    backend = ScriptedBackend([CompletionResult(content="done", model="fake")])
+    plain = Agent(backend, _echo_registry(), AgentConfig()).run("x")
+
+    backend2 = ScriptedBackend([CompletionResult(content="done", model="fake")])
+    explicit = Agent(backend2, _echo_registry(), AgentConfig()).run("x", should_stop=None)
+
+    assert plain.stopped_reason == explicit.stopped_reason == "final"
+    assert plain.answer == explicit.answer == "done"
+    assert plain.steps == explicit.steps
+
+
 def test_agent_handles_unknown_tool_gracefully() -> None:
     backend = ScriptedBackend(
         [

--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -124,6 +125,104 @@ def test_cooperative_stop_halts_before_next_attempt() -> None:
     assert result.success is False
     assert result.stopped_reason == "cancelled"
     assert len(result.attempts) == 1 and result.attempts[0].answer == "partial"
+
+
+def test_stop_reaches_inside_an_attempt_not_only_between_them() -> None:
+    """Stop used to mean "finish the whole attempt first".
+
+    The loop checked its flag between attempts and right before the worker call, and then handed the
+    task to a worker it could not interrupt. On a real task that is up to `max_steps` model calls
+    plus every tool they trigger — minutes of work and money spent after the user asked for it to
+    end. The flag now travels INTO the worker, which returns at its next step boundary.
+
+    This is the wiring half: the worker is actually HANDED the callback, and it is the loop's real
+    flag rather than some fresh lambda that always answers False.
+    """
+    seen: dict[str, object] = {}
+    flag = {"stop": False}
+
+    class StoppableWorker:
+        runs = 0
+
+        def run(
+            self,
+            task: str,
+            *,
+            should_stop: Callable[[], bool] | None = None,
+            **_: object,
+        ) -> AgentResult:
+            type(self).runs += 1
+            seen["callback"] = should_stop
+            # Ask it, the way `Agent.run` asks it at each step boundary.
+            seen["answer_before"] = should_stop() if should_stop else None
+            flag["stop"] = True
+            seen["answer_after"] = should_stop() if should_stop else None
+            return AgentResult(answer="whole", steps=2, stopped_reason="final", transcript=[])
+
+    auto = AutonomousAgent(
+        StoppableWorker(),
+        should_stop=lambda: flag["stop"],
+        config=AutonomousConfig(max_attempts=1, use_planner=False, use_manager=False),
+    )
+    auto.run("watch the flag")
+
+    assert seen["callback"] is not None, "the worker was never given the stop check"
+    # Live, not a snapshot: the same callable answers differently once the flag flips, which is what
+    # makes a mid-attempt poll worth anything.
+    assert seen["answer_before"] is False and seen["answer_after"] is True
+
+
+def test_a_cancelled_attempt_is_not_verified_or_reviewed() -> None:
+    """The expensive half: a partial attempt must not be graded.
+
+    `should_stop` flips only once the worker has been entered, so attempt 1 really runs and comes
+    back marked cancelled. Nothing downstream of it may fire — the verifier here counts calls, and
+    one call is one command the user paid for after pressing Stop.
+    """
+
+    class CountingVerifier:
+        """A real verifier that counts. Returning the true `VerificationResult` matters: a stub that
+        returns the wrong shape makes this test fail with an AttributeError whether or not the fix
+        is present, which would pass the discrimination check for the wrong reason."""
+
+        calls = 0
+
+        def verify(self) -> VerificationResult:
+            type(self).calls += 1
+            return VerificationResult(False, "nope")
+
+    entered = {"yes": False}
+
+    class StoppableWorker:
+        runs = 0
+
+        def run(
+            self,
+            task: str,
+            *,
+            should_stop: Callable[[], bool] | None = None,
+            **_: object,
+        ) -> AgentResult:
+            type(self).runs += 1
+            entered["yes"] = True
+            reason = "cancelled" if (should_stop and should_stop()) else "final"
+            return AgentResult(answer="half", steps=1, stopped_reason=reason, transcript=[])
+
+    worker = StoppableWorker()
+    verifier = CountingVerifier()
+    auto = AutonomousAgent(
+        worker,
+        # False until the worker has been entered: attempt 1 gets past the two pre-checks, runs,
+        # and returns cancelled.
+        should_stop=lambda: entered["yes"],
+        verifier=verifier,
+        config=AutonomousConfig(max_attempts=3, use_planner=False, use_manager=False),
+    )
+    result = auto.run("cancel me")
+
+    assert StoppableWorker.runs == 1, "the worker must not be retried after a cancel"
+    assert CountingVerifier.calls == 0, "a cancelled attempt must not be verified"
+    assert result.stopped_reason == "cancelled" and result.success is False
 
 
 def test_no_stop_check_leaves_loop_unchanged() -> None:


### PR DESCRIPTION
Item 4 do estudo dos apps concorrentes: **o botão Parar esperava o ataque inteiro terminar.**

## O que acontecia

`AutonomousLoop` checava o flag de cancelamento **entre ataques** e mais uma vez logo antes de chamar o worker — e então entregava a tarefa a um worker que não conseguia interromper.

Resultado: apertar Stop não comprava nada até o ataque corrente acabar. Até `max_steps` chamadas de modelo, mais todas as tools que elas disparam. Numa tarefa real isso é minutos de trabalho e dinheiro gastos **depois** de o usuário pedir para parar.

O comentário no laço já dizia o motivo — *"an in-flight model call can't be interrupted"* — o que é verdade de uma **chamada** de modelo e estava sendo aplicado calado a um **ataque** inteiro.

## O que passa a acontecer

`Agent.run` recebe `should_stop` e o consulta **uma vez por passo**, devolvendo `stopped_reason="cancelled"` com tudo que já foi feito. Fronteira de passo é o mais fino que o cancelamento chega — a chamada em voo é mesmo ininterruptível — mas é muito mais fino que fronteira de ataque.

`_run_worker` repassa o flag pela mesma checagem de assinatura que já usava para `on_tool`/`on_edit`. Um worker que não aceita (um agente externo por ACP) fica intacto e continua tendo a checagem entre ataques.

## A metade que era fácil deixar de fora

O laço também precisa **perceber que o ataque voltou incompleto**. Verificar, revisar e pontuar um ataque pela metade gasta exatamente as chamadas de modelo que o usuário cancelou — e o veredito de falha seria registrado como evidência de que a tarefa é difícil.

Essa checagem lê `stopped_reason`, **não** o flag. Minha primeira versão lia o flag, e **um teste que já existia pegou o erro**: um worker que nunca aceitou o callback roda até o fim mesmo depois do stop chegar, e esse ataque está **inteiro** — descartá-lo joga fora trabalho concluído e, com `max_attempts=1`, devolve um run sem ataque nenhum.

## Detalhe pequeno e deliberado

A resposta de um run cancelado é uma frase, não `""`. Resposta vazia se lê como "não produziu nada", que é uma afirmação diferente, e todo chamador renderiza as duas igual.

## Verificação

Cada metade foi conferida quebrando o que ela vigia:

| quebra | resultado |
|---|---|
| tirar a checagem por passo do `Agent.run` | `assert 'tool_loop' == 'cancelled'` |
| tirar a passagem do `should_stop` ao worker | reprovam os 2 testes do laço |
| tirar a checagem pós-worker | `AssertionError: a cancelled attempt must not be verified — assert 1 == 0` |

Um quarto teste fixa o caminho default (`should_stop=None`): o laço não se mexe para quem não usa.

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 305 arquivos |
| `pytest -q` (WSL) | 3235 passando, 12 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
