### PR TITLE
feat(sandbox): the container had one limit, and no way to set it

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -362,6 +362,20 @@ class Settings(BaseSettings):
     )
     # Optional OCI runtime for the docker sandbox (e.g. runsc = gVisor); empty = daemon default.
     sandbox_runtime: str = Field(default="", validation_alias="CHIMERA_SANDBOX_RUNTIME")
+    # Container network. "none" (the default) is the isolation the sandbox is for; "bridge" exists
+    # because a task that has to `pip install` cannot run without it, and the honest answer to "how
+    # many tasks need it" is a number nobody has measured yet. Setting this is what makes that
+    # measurable rather than theoretical.
+    #
+    # NOT an egress allowlist, and that is not an omission: Chimera is a pip install on a laptop,
+    # and there is no DOCKER-USER chain to hook on Docker Desktop for Windows or macOS. If the
+    # adoption number ever justifies filtering, the route is an egress proxy in a compose file,
+    # never iptables on the host.
+    sandbox_network: str = Field(default="none", validation_alias="CHIMERA_SANDBOX_NETWORK")
+    # Container limits. Memory was already a constructor parameter with no way to set it.
+    sandbox_memory: str = Field(default="512m", validation_alias="CHIMERA_SANDBOX_MEMORY")
+    sandbox_cpus: str = Field(default="2", validation_alias="CHIMERA_SANDBOX_CPUS")
+    sandbox_pids_limit: int = Field(default=256, validation_alias="CHIMERA_SANDBOX_PIDS")
     # Posture for running the agent's commands/code ON THE HOST (i.e. sandbox=local). Because most
     # `pip install` users have no Docker, host execution is the common path — so the model deciding to
     # run a shell command must not silently execute on the machine. Values:

--- a/chimera/sandbox/__init__.py
+++ b/chimera/sandbox/__init__.py
@@ -27,7 +27,17 @@ def get_sandbox(settings: Settings | None = None) -> Sandbox:
 
     settings = settings or get_settings()
     if (settings.sandbox or "local").lower() == "docker":
-        return DockerSandbox(image=settings.sandbox_image, runtime=settings.sandbox_runtime)
+        # Every one of these was a constructor parameter the factory never passed. `network` and
+        # `memory` in particular were accepted, documented, and dead: no caller could reach them, so
+        # the container was hard-wired to no-network/512m whatever the settings said.
+        return DockerSandbox(
+            image=settings.sandbox_image,
+            network=(settings.sandbox_network or "none").lower() == "bridge",
+            memory=settings.sandbox_memory,
+            cpus=settings.sandbox_cpus,
+            pids_limit=settings.sandbox_pids_limit,
+            runtime=settings.sandbox_runtime,
+        )
     return LocalSandbox()
 
 

--- a/chimera/sandbox/docker.py
+++ b/chimera/sandbox/docker.py
@@ -33,12 +33,16 @@ class DockerSandbox:
         *,
         network: bool = False,
         memory: str = "512m",
+        cpus: str = "2",
+        pids_limit: int = 256,
         runtime: str | None = None,
         fallback: Sandbox | None = None,
     ) -> None:
         self.image = image
         self.network = network
         self.memory = memory
+        self.cpus = cpus
+        self.pids_limit = pids_limit
         # Optional OCI runtime (e.g. "runsc" for gVisor); empty/None uses the daemon default.
         self.runtime = (runtime or "").strip() or None
         self.fallback: Sandbox = fallback or LocalSandbox()
@@ -58,6 +62,39 @@ class DockerSandbox:
                 self._available = False
         return self._available
 
+    def _argv(self, name: str, command: str, workdir: Path, env_args: list[str]) -> list[str]:
+        """The full `docker run` command line.
+
+        A method rather than an inline literal so the limits below can be asserted without a running
+        daemon — which is the only way they get checked at all, since CI has no Docker and the
+        machine this was written on had none either.
+        """
+        return [
+            "docker", "run", "--rm", "--name", name,
+            "--network", "bridge" if self.network else "none",
+            "--memory", self.memory,
+            # Pinned to `--memory` on purpose. Without it Docker grants swap equal to the memory
+            # limit ON TOP of it, so a `--memory 512m` container can touch a gigabyte and the cap
+            # reads as roughly decorative. Same value = no swap, which is what a limit should mean.
+            "--memory-swap", self.memory,
+            # A busy loop in a container with no CPU cap starves the machine the agent is running
+            # on — including the agent.
+            "--cpus", self.cpus,
+            # The one flag here that is not copied from anyone: a fork bomb inside the container
+            # exhausts the HOST's process table, because PIDs are not namespaced by default. The
+            # existing `fork_bomb` lexical rule only fires under governance, which is off by default.
+            "--pids-limit", str(self.pids_limit),
+            # Deliberately NOT here: `--storage-opt size=`. Docker refuses it outside xfs with
+            # pquota, and the common case (overlay2 on ext4, every default laptop install) would
+            # turn a working sandbox into a hard failure. A disk cap that only works on one
+            # filesystem is not a disk cap.
+            *(("--runtime", self.runtime) if self.runtime else ()),
+            *env_args,
+            "-v", f"{workdir}:/workspace",
+            "-w", "/workspace",
+            self.image, "sh", "-c", command,
+        ]
+
     def run(self, command: str, *, timeout: int = 60, cwd: Path | None = None) -> SandboxResult:
         if not self.available():
             _log.warning("docker unavailable; falling back to the local sandbox")
@@ -74,16 +111,7 @@ class DockerSandbox:
         import uuid
 
         name = f"chimera-{uuid.uuid4().hex[:12]}"
-        argv = [
-            "docker", "run", "--rm", "--name", name,
-            "--network", "bridge" if self.network else "none",
-            "--memory", self.memory,
-            *(("--runtime", self.runtime) if self.runtime else ()),
-            *env_args,
-            "-v", f"{workdir}:/workspace",
-            "-w", "/workspace",
-            self.image, "sh", "-c", command,
-        ]
+        argv = self._argv(name, command, workdir, env_args)
         try:
             proc = subprocess.run(
                 argv, capture_output=True, text=True, timeout=timeout + 15, stdin=subprocess.DEVNULL

--- a/tests/test_sandbox_limits.py
+++ b/tests/test_sandbox_limits.py
@@ -1,0 +1,135 @@
+"""The container had one limit, and no way to set it.
+
+`DockerSandbox` capped memory at 512m and stopped there. Worse, `network` and `memory` were
+constructor parameters that `get_sandbox` never passed — accepted, documented, and unreachable, so
+the container was hard-wired regardless of what the settings said.
+
+WHAT WAS NOT MEASURED, said here rather than in a commit message nobody re-reads: the roadmap asked
+for a fork bomb and a CPU loop run under the sandbox with and without these flags. That did not
+happen — Docker is not running on the machine this was written on, and CI has no daemon either. So
+what is verified below is that the flags reach the command line, which is a weaker claim than "the
+fork bomb was contained" and is stated as the weaker one.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from chimera.config import Settings
+from chimera.sandbox import get_sandbox
+from chimera.sandbox.docker import DockerSandbox
+
+
+def argv_of(sandbox: DockerSandbox) -> list[str]:
+    return sandbox._argv("test", "echo hi", Path.cwd(), [])
+
+
+def flag_value(argv: list[str], flag: str) -> str:
+    return argv[argv.index(flag) + 1]
+
+
+def test_the_memory_cap_does_not_leak_into_swap() -> None:
+    """`--memory` alone is roughly decorative.
+
+    Docker grants swap equal to the memory limit ON TOP of it unless `--memory-swap` says otherwise,
+    so a container capped at 512m can touch a gigabyte. Pinning swap to the same value is what makes
+    the number mean what it reads as.
+    """
+    argv = argv_of(DockerSandbox(memory="256m"))
+    assert flag_value(argv, "--memory") == "256m"
+    assert flag_value(argv, "--memory-swap") == "256m"
+
+
+def test_a_fork_bomb_cannot_exhaust_the_host_process_table() -> None:
+    """PIDs are not namespaced by default, so a fork bomb in the container takes the HOST down.
+
+    There is a `fork_bomb` lexical rule, but it only fires under governance, which is off by
+    default — and a limit that holds without governance is the point of having a sandbox at all.
+    """
+    assert flag_value(argv_of(DockerSandbox(pids_limit=64)), "--pids-limit") == "64"
+
+
+def test_a_busy_loop_cannot_take_the_whole_machine() -> None:
+    assert flag_value(argv_of(DockerSandbox(cpus="1.5")), "--cpus") == "1.5"
+
+
+def test_the_disk_limit_is_deliberately_absent() -> None:
+    """`--storage-opt size=` is the obvious fourth limit and it is the wrong one to add.
+
+    Docker refuses it outside xfs with pquota. The common case — overlay2 on ext4, every default
+    laptop install — would turn a working sandbox into a hard failure at the first command. A limit
+    that only works on one filesystem is not a limit; it is an outage waiting for the wrong host.
+    """
+    assert "--storage-opt" not in argv_of(DockerSandbox())
+
+
+def test_the_network_is_off_unless_asked() -> None:
+    assert flag_value(argv_of(DockerSandbox()), "--network") == "none"
+    assert flag_value(argv_of(DockerSandbox(network=True)), "--network") == "bridge"
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    [({}, "none"), ({"CHIMERA_SANDBOX_NETWORK": "bridge"}, "bridge"), ({"CHIMERA_SANDBOX_NETWORK": "none"}, "none")],
+)
+def test_the_factory_actually_passes_the_settings(env: dict[str, str], expected: str) -> None:
+    """The half that was broken.
+
+    Every limit above is reachable from a unit test because a unit test constructs the sandbox
+    directly. Nothing in the product does — it goes through `get_sandbox`, which built a
+    `DockerSandbox()` with the image and the runtime and dropped the rest on the floor. A knob the
+    factory does not forward is a knob that does not exist.
+    """
+    # Constructed by ALIAS, not by field name: every field here declares a `validation_alias`, and
+    # `Settings(sandbox="docker")` silently yields the default instead of raising — which is how the
+    # first version of this test read a LocalSandbox and blamed the factory.
+    settings = Settings(CHIMERA_SANDBOX="docker", **env)  # type: ignore[arg-type]
+    sandbox = get_sandbox(settings)
+    assert isinstance(sandbox, DockerSandbox)
+    assert flag_value(argv_of(sandbox), "--network") == expected
+
+
+def test_the_factory_forwards_the_limits_too() -> None:
+    settings = Settings(
+        **{  # type: ignore[arg-type]
+            "CHIMERA_SANDBOX": "docker",
+            "CHIMERA_SANDBOX_MEMORY": "1g",
+            "CHIMERA_SANDBOX_CPUS": "0.5",
+            "CHIMERA_SANDBOX_PIDS": "32",
+        }
+    )
+    argv = argv_of(get_sandbox(settings))  # type: ignore[arg-type]
+    assert flag_value(argv, "--memory") == "1g"
+    assert flag_value(argv, "--memory-swap") == "1g"
+    assert flag_value(argv, "--cpus") == "0.5"
+    assert flag_value(argv, "--pids-limit") == "32"
+
+
+def _docker_up() -> bool:
+    if not shutil.which("docker"):
+        return False
+    try:
+        return subprocess.run(["docker", "version"], capture_output=True, timeout=10).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+@pytest.mark.skipif(not _docker_up(), reason="no docker daemon — the argv tests above are what runs")
+def test_the_pid_limit_actually_holds_a_fork_bomb() -> None:
+    """The measurement the roadmap asked for, for whoever has a daemon.
+
+    Skipped where this was written and skipped in CI, which is exactly why it is written down rather
+    than assumed: a `--pids-limit` that reaches the command line and is silently ignored by the
+    runtime would pass every other test in this file.
+    """
+    sandbox = DockerSandbox(image="python:3.12-slim", pids_limit=32)
+    # Bounded on purpose: a real `:(){ :|:& };:` would not stop when the limit is hit, and a test
+    # that needs a `docker kill` to finish is a test that wedges someone's laptop.
+    result = sandbox.run("for i in $(seq 1 200); do sleep 5 & done; wait", timeout=30)
+    assert result.exit_code != 0 or "fork" in (result.stderr or "").lower(), (
+        "200 processes started under a 32-PID limit — the limit is not being enforced"
+    )


### PR DESCRIPTION
Itens **10 e 14** do roteiro do terminal — que na prática são o mesmo defeito visto de dois lados.

## O que estava lá

O `DockerSandbox` passava `--memory 512m` e parava aí. Pior: `network` e `memory` eram parâmetros de construtor que o `get_sandbox` **nunca repassava** — aceitos, documentados e inalcançáveis. O container ficava cravado em sem-rede/512m independente do que as settings dissessem.

**Knob que a fábrica não repassa é knob que não existe.**

## Três limites

- **`--memory-swap`**, fixado no mesmo valor de `--memory`. Sem ele o Docker concede swap **igual ao limite, por cima dele** — então um container de 512m encosta em um giga e o teto vira enfeite.
- **`--cpus`**, porque laço ocupado sem teto mata a máquina em que o agente está rodando, o agente incluído.
- **`--pids-limit`**, que não é copiado de ninguém: PID **não** é namespaced por padrão, então fork bomb dentro do container esgota a tabela de processos do **host**. Existe a regra léxica `fork_bomb`, mas ela só dispara sob governança — e governança é off por padrão.

## O que ficou de fora, de propósito

`--storage-opt size=` é o quarto limite óbvio e é o errado de adicionar. O Docker **recusa** a flag fora de xfs com pquota, então o caso comum (overlay2 em ext4, todo laptop) viraria falha dura no primeiro comando. Tem teste afirmando a **ausência** dela — "quarto limite óbvio" é exatamente o que um leitor futuro adiciona sem saber por que foi deixado fora.

## E os knobs

`CHIMERA_SANDBOX_NETWORK=none|bridge` (mais `MEMORY`/`CPUS`/`PIDS`). A rede continua `none`; o knob existe para o número de adoção virar **mensurável** em vez de teórico.

**Não é allowlist de egresso, e isso não é esquecimento:** o Chimera é um `pip install` em laptop, e Docker Desktop no Windows/macOS não tem cadeia `DOCKER-USER` para enganchar. Se o número um dia justificar filtrar, o caminho é proxy de saída no compose, nunca iptables no host.

## ⚠️ O que NÃO foi medido

O roteiro pedia **fork bomb e laço de CPU rodando sob o sandbox, com e sem as flags**. **Isso não aconteceu** — não há daemon Docker nesta máquina nem no CI.

O que está verificado é que as flags **chegam à linha de comando**. É uma alegação mais fraca que "o fork bomb foi contido", e está escrita como a mais fraca — inclusive no topo do módulo de teste, não só aqui. A medição real está no arquivo atrás de um `skipif`, para rodar em quem tiver daemon.

| quebra | resultado |
|---|---|
| fábrica voltar a não repassar | 2 de 10 reprovam |
| remover `--memory-swap` | outros 2 reprovam |

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 305 arquivos |
| `pytest -q` (WSL) | 3274 passando, 13 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
