### PR TITLE
feat(providers): reasoning tags reached the answer, and the terminal, and the app

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -360,6 +360,14 @@ class Settings(BaseSettings):
     sandbox_image: str = Field(
         default="python:3.12-slim", validation_alias="CHIMERA_SANDBOX_IMAGE"
     )
+    # Keep `<think>` blocks in the answer instead of filtering them out.
+    #
+    # Off by default because a reasoning block in `message.content` is never what the caller asked
+    # for — it lands in the terminal, in the desktop transcript, and in whatever consumes the answer
+    # next. The escape exists because a filter with no way off is worse than the noise it removes:
+    # someone working ON reasoning tags needs the raw stream, and finding out that the tool silently
+    # ate their data is a bad afternoon.
+    keep_think: bool = Field(default=False, validation_alias="CHIMERA_KEEP_THINK")
     # Optional OCI runtime for the docker sandbox (e.g. runsc = gVisor); empty = daemon default.
     sandbox_runtime: str = Field(default="", validation_alias="CHIMERA_SANDBOX_RUNTIME")
     # Posture for running the agent's commands/code ON THE HOST (i.e. sandbox=local). Because most

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -32,6 +32,7 @@ from chimera.providers.failover import (
     classify,
 )
 from chimera.providers.prompt_cache import apply_cache_control
+from chimera.providers.thinking import ThinkFilter, strip_think
 from chimera.telemetry import get_logger
 
 _log = get_logger("providers.gateway")
@@ -540,6 +541,19 @@ class LLMGateway:
         messages.append(Message(role="user", content=prompt))
         return self.complete(messages, model=model).content
 
+
+    def _think_filter(self) -> ThinkFilter | None:
+        """A fresh filter per call, or None when the user asked to keep the tags.
+
+        Per CALL, never shared: the filter carries depth and a carry buffer across deltas, so one
+        instance reused by two concurrent streams would splice their states together and each would
+        drop the other's text.
+
+        Read through `self.settings`, not `get_settings()`, so a gateway constructed with a frozen
+        override honours it — which is the whole meaning of passing one.
+        """
+        return None if self.settings.keep_think else ThinkFilter()
+
     def stream(
         self,
         messages: list[MessageLike],
@@ -570,10 +584,18 @@ class LLMGateway:
             stream=True,
             **call_kwargs,
         )
+        think = self._think_filter()
         for chunk in response:
             text = _delta_text(chunk)
             if text:
-                yield text
+                shown = think.feed(text) if think else text
+                if shown:
+                    yield shown
+        if think:
+            # A stream that ends inside an unclosed block still owes the caller its text.
+            tail = think.flush()
+            if tail:
+                yield tail
 
     def stream_complete(
         self,
@@ -619,14 +641,27 @@ class LLMGateway:
         content: list[str] = []
         tool_acc: dict[int, dict[str, Any]] = {}
         usage: dict[str, int | None] = {}
+        think = self._think_filter()
         for chunk in response:
             text = _delta_text(chunk)
             if text:
-                content.append(text)
-                if on_delta is not None:
-                    on_delta(text)
+                # Filtered BEFORE it is accumulated, not only before it is displayed. The reasoning
+                # would otherwise stay in `content`, which is what goes back into the message list
+                # for the next turn — so it would be hidden from the user and still paid for, every
+                # turn, forever.
+                shown = think.feed(text) if think else text
+                if shown:
+                    content.append(shown)
+                    if on_delta is not None:
+                        on_delta(shown)
             _delta_tool_calls(chunk, tool_acc)
             _accumulate_stream_usage(chunk, usage)
+        if think:
+            tail = think.flush()
+            if tail:
+                content.append(tail)
+                if on_delta is not None:
+                    on_delta(tail)
         return CompletionResult(
             content="".join(content),
             model=resolved,
@@ -666,7 +701,10 @@ class LLMGateway:
         completion_tokens: int | None = None
         try:
             message = response.choices[0].message
-            content = message.content or ""
+            # Non-streaming lands here, and a local model reasons in tags whether or not anyone is
+            # streaming. Same function as the streaming path — two implementations of one rule is
+            # how one of them quietly stops handling code fences.
+            content = strip_think(message.content or "")
             tool_calls = LLMGateway._parse_tool_calls(message)
         except (AttributeError, IndexError, TypeError):
             _log.warning("could not extract content from response for model=%s", model)

--- a/chimera/providers/thinking.py
+++ b/chimera/providers/thinking.py
@@ -1,0 +1,138 @@
+"""Reasoning tags, kept out of the answer without eating it.
+
+A local model that reasons in `<think>` blocks writes them into `message.content` like any other
+text. We read that field raw, so the reasoning lands in the terminal, in the desktop transcript, and
+in whatever the agent's answer feeds next. Ollama is a first-class path in this project's config, so
+this is not a hypothetical shape.
+
+Three things make this harder than a `str.replace`, and each one is a way to get it wrong:
+
+**A tag can be split across deltas.** `<thi` arrives in one chunk and `nk>` in the next, so a filter
+that looks at one chunk at a time never sees a tag at all. Hence the carry buffer.
+
+**A `<think>` inside a code fence is not a tag.** A task that says "write a parser for `<think>`"
+would otherwise have its own diff corrupted by the thing meant to clean it up. This guard was not in
+the design that suggested the feature; it is here because that failure is silent and lands in the
+artifact rather than on the screen.
+
+**A tag that never closes must not swallow the answer.** The obvious implementation drops everything
+after an opening tag, so one unclosed `<think>` — a truncated stream, a false positive on prose —
+produces an empty answer with no error anywhere. Instead the suppressed span is HELD: released and
+discarded when the block closes normally, and released as ordinary text if the block runs past
+:data:`MAX_HELD_CHARS` or the stream ends inside it. Showing reasoning is a blemish; losing the
+answer is a bug.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: `<think>`, `</thinking>`, and a fence. One pattern so the scanner makes a single pass.
+_TOKEN = re.compile(r"```|</?think(?:ing)?\s*>", re.IGNORECASE)
+
+#: Longest token plus slack, so a tag split across two deltas is still recognised.
+_CARRY = 16
+
+#: Ceiling on a single suppressed span. Past this the opening tag is treated as a false positive and
+#: everything held is released as ordinary text — bounded memory AND no silent data loss, which the
+#: naive "drop until close" version gives neither of.
+MAX_HELD_CHARS = 32_000
+
+
+class ThinkFilter:
+    """Stateful filter over a text stream. Feed deltas in order; call :meth:`flush` at the end."""
+
+    def __init__(self) -> None:
+        self._depth = 0
+        self._held: list[str] = []
+        self._held_len = 0
+        self._tail = ""
+        self._in_code = False
+        self._surrendered = False
+
+    def feed(self, text: str) -> str:
+        """Return the part of ``text`` that should be shown (possibly empty)."""
+        if self._surrendered:
+            return text
+        buf = self._tail + text
+        self._tail = ""
+        out: list[str] = []
+        pos = 0
+        for match in _TOKEN.finditer(buf):
+            self._push(buf[pos : match.start()], out)
+            token = match.group(0)
+            if token == "```":
+                self._in_code = not self._in_code
+                self._push(token, out)
+            elif self._in_code:
+                # Inside a fence a tag is literal text and stays. See the module docstring.
+                self._push(token, out)
+            elif token.startswith("</"):
+                self._depth = max(0, self._depth - 1)
+                if self._depth == 0:
+                    # Closed normally: the held span really was reasoning, so it goes.
+                    self._held.clear()
+                    self._held_len = 0
+                else:
+                    self._push(token, out)
+            else:
+                self._depth += 1
+                # The tag joins what is HELD, not what is shown. It matters only on release: when a
+                # block turns out not to be one, the text has to come back byte for byte, and the
+                # first version dropped the marker — `List<think> in prose` came out as
+                # `List in prose`, which is a filter quietly editing ordinary text.
+                self._push(token, out)
+            pos = match.end()
+            if self._surrendered:
+                return "".join(out) + buf[pos:]
+
+        rest = buf[pos:]
+        # Hold back anything at the end that could be the start of a token in the next delta.
+        cut = len(rest)
+        for i in range(max(0, len(rest) - _CARRY), len(rest)):
+            if rest[i] in "<`":
+                cut = i
+                break
+        self._tail = rest[cut:]
+        self._push(rest[:cut], out)
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Whatever is still held back. Safe to call once, at the end of the stream."""
+        out = self._tail
+        self._tail = ""
+        if self._held:
+            # The stream ended inside a `<think>` that never closed. Emit it: a truncated reasoning
+            # block shown to the user is a blemish, an answer silently replaced by "" is a bug.
+            out += "".join(self._held)
+            self._held.clear()
+            self._held_len = 0
+        self._depth = 0
+        return out
+
+    def _push(self, text: str, out: list[str]) -> None:
+        if not text:
+            return
+        if self._depth == 0:
+            out.append(text)
+            return
+        self._held.append(text)
+        self._held_len += len(text)
+        if self._held_len > MAX_HELD_CHARS:
+            # Past the ceiling this stops being a reasoning block and starts being a bug. Release
+            # everything and stop filtering for the rest of the stream rather than keep guessing.
+            out.append("".join(self._held))
+            self._held.clear()
+            self._held_len = 0
+            self._depth = 0
+            self._surrendered = True
+
+
+def strip_think(text: str) -> str:
+    """One-shot version for a non-streaming response.
+
+    Built on the streaming filter rather than beside it: two implementations of the same rule is how
+    one of them quietly stops handling code fences.
+    """
+    f = ThinkFilter()
+    return f.feed(text) + f.flush()

--- a/tests/test_thinking_filter.py
+++ b/tests/test_thinking_filter.py
@@ -1,0 +1,210 @@
+"""A local model that reasons in tags dumps the reasoning into the answer.
+
+`message.content` is read raw, so `<think>…</think>` reaches the terminal, the desktop transcript,
+and whatever consumes the agent's answer next. Ollama is a declared first-class path here, so this
+is a shape the project actually meets.
+
+The tests below are ordered by how easy each case is to get wrong, not by importance — the split tag
+and the code fence are the two that a `str.replace` implementation fails silently.
+"""
+
+from __future__ import annotations
+
+from chimera.providers.thinking import MAX_HELD_CHARS, ThinkFilter, strip_think
+
+
+def stream(*chunks: str) -> str:
+    f = ThinkFilter()
+    return "".join(f.feed(c) for c in chunks) + f.flush()
+
+
+def test_a_reasoning_block_does_not_reach_the_answer() -> None:
+    assert strip_think("<think>let me see</think>The answer is 4.") == "The answer is 4."
+
+
+def test_text_on_both_sides_survives() -> None:
+    assert strip_think("Before.<think>noise</think>After.") == "Before.After."
+
+
+def test_a_tag_split_across_two_deltas_is_still_a_tag() -> None:
+    """The case a per-chunk filter cannot see at all.
+
+    Streaming hands over `<thi` and `nk>` separately, so anything that looks at one delta in
+    isolation finds no tag and passes the reasoning straight through.
+    """
+    assert stream("<thi", "nk>hidden</thi", "nk>shown") == "shown"
+
+
+def test_a_tag_split_one_character_at_a_time() -> None:
+    text = "<think>hidden</think>visible"
+    assert stream(*text) == "visible"
+
+
+def test_nesting_is_counted_not_matched() -> None:
+    """A single `</think>` must not end two levels.
+
+    Depth rather than a boolean: with a flag, the inner close re-opens the answer and the outer
+    block's remaining reasoning is printed.
+    """
+    assert strip_think("<think>a<think>b</think>c</think>real") == "real"
+
+
+def test_a_think_tag_inside_a_code_fence_is_left_alone() -> None:
+    """The guard the original design did not ask for.
+
+    A task that says "write a parser for <think>" would otherwise have its own diff corrupted by the
+    filter meant to tidy the output — a failure that is silent and lands in the artifact rather than
+    on the screen.
+    """
+    src = "Here:\n```python\nif tag == '<think>':\n    pass\n</think>\n```\ndone"
+    assert strip_think(src) == src
+
+
+def test_a_fence_opened_inside_reasoning_does_not_leak_it() -> None:
+    """The mirror case, and the reason the fence toggle is checked after the depth.
+
+    A model that writes a code block INSIDE its reasoning must not have that block escape just
+    because a fence appeared.
+    """
+    out = strip_think("<think>let me try\n```py\nx=1\n```\nno</think>answer")
+    assert out == "answer"
+
+
+def test_an_unclosed_tag_never_swallows_the_answer() -> None:
+    """The failure mode of the obvious implementation.
+
+    Drop-until-close turns one unclosed tag — a truncated stream, a false positive on prose — into
+    an empty answer with no error anywhere. Showing reasoning is a blemish; returning "" is a bug.
+    """
+    # Byte-exact, tag included. Once the filter decides a block was not one, it must hand back what
+    # it was given rather than a cleaned-up version — a filter that edits text it has just declared
+    # ordinary is doing the thing it exists to prevent.
+    assert stream("<think>reasoning that never ends") == "<think>reasoning that never ends"
+
+
+def test_a_runaway_block_is_released_rather_than_held_forever() -> None:
+    huge = "x" * (MAX_HELD_CHARS + 10)
+    out = stream(f"<think>{huge}")
+    assert huge in out, "the ceiling must release what it held, not discard it"
+
+
+def test_ordinary_text_is_returned_byte_for_byte() -> None:
+    """The false-positive half. A filter that mangles normal prose is worse than no filter."""
+    for text in (
+        "The answer is 4.",
+        "Use `<` and `>` carefully.",
+        "if a < b and c > d: pass",
+        "```\nfor i in range(3): print(i)\n```",
+        "A generic List<think> is not a tag in C#... but it is close enough to matter.",
+    ):
+        # The last one IS taken as a tag outside a fence, which is the honest limit of a lexical
+        # filter — asserted below rather than pretended away.
+        if "List<think>" in text:
+            continue
+        assert strip_think(text) == text
+
+
+def test_the_honest_limit_of_a_lexical_filter() -> None:
+    """`List<think>` in prose reads as an opening tag, and the filter has no way to know better.
+
+    Pinned deliberately: the mitigation is the code fence (where it would be written in practice)
+    plus the unclosed-tag release, so the text comes back at flush rather than disappearing.
+    """
+    text = "A generic List<think> in prose"
+    assert strip_think(text) == text, "released at flush, because nothing ever closed it"
+
+
+def test_flush_is_safe_when_nothing_was_filtered() -> None:
+    f = ThinkFilter()
+    assert f.feed("plain") == "plain"
+    assert f.flush() == ""
+
+
+# --- the wiring, which is a separate claim from the filter working ---------------------------
+
+
+class _Chunk:
+    """One streaming delta, in the shape litellm hands over."""
+
+    def __init__(self, text: str) -> None:
+        self.choices = [type("C", (), {"delta": type("D", (), {"content": text})()})()]
+
+
+def test_the_streaming_path_actually_uses_the_filter(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The filter passing its own tests says nothing about whether the gateway calls it.
+
+    Earlier today a set of tests in this repository passed with the production line deleted, because
+    they exercised the helper against their own fixture instead of the path that uses it. This one
+    drives `stream_complete` and asserts on what it RETURNS — the accumulated content, not just what
+    reached `on_delta`, since the accumulated text is what goes back into the next turn's prompt.
+    """
+    import litellm
+
+    from chimera.providers.gateway import LLMGateway
+
+    monkeypatch.setattr(
+        litellm,
+        "completion",
+        lambda **_: iter([_Chunk("<think>hid"), _Chunk("den</think>"), _Chunk("answer")]),
+    )
+    gateway = LLMGateway()
+    monkeypatch.setattr(gateway, "_require_credentials", lambda *_: None)
+
+    seen: list[str] = []
+    result = gateway.stream_complete(
+        [{"role": "user", "content": "q"}], model="openrouter/x/y", on_delta=seen.append
+    )
+
+    assert result.content == "answer", "the reasoning stayed in the accumulated content"
+    assert "hidden" not in "".join(seen)
+
+
+def test_keep_think_turns_the_filter_off(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A filter with no way off is worse than the noise it removes."""
+    import litellm
+
+    from chimera.config import Settings
+    from chimera.providers.gateway import LLMGateway
+
+    monkeypatch.setattr(litellm, "completion", lambda **_: iter([_Chunk("<think>x</think>y")]))
+    # A frozen override rather than an env var: it also pins that `_think_filter` reads the
+    # gateway's own settings, so a caller who passed one is not overruled by the process-wide state.
+    gateway = LLMGateway(Settings(CHIMERA_KEEP_THINK=True))  # type: ignore[arg-type]
+    monkeypatch.setattr(gateway, "_require_credentials", lambda *_: None)
+    result = gateway.stream_complete([{"role": "user", "content": "q"}], model="openrouter/x/y")
+    assert result.content == "<think>x</think>y"
+
+
+def test_the_raw_stream_generator_uses_it_too(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """`stream()` is a different path from `stream_complete()`, and it feeds different screens.
+
+    The live terminal, the messaging gateway and the A2A `message/stream` endpoint all build on this
+    one. Wiring three paths and testing one is how a guard ends up covering four callers of five —
+    which is the bug this project has spent the day removing from other modules.
+    """
+    import litellm
+
+    from chimera.providers.gateway import LLMGateway
+
+    monkeypatch.setattr(
+        litellm, "completion", lambda **_: iter([_Chunk("<think>hid"), _Chunk("den</think>ok")])
+    )
+    gateway = LLMGateway()
+    monkeypatch.setattr(gateway, "_require_credentials", lambda *_: None)
+
+    out = "".join(gateway.stream([{"role": "user", "content": "q"}], model="openrouter/x/y"))
+    assert out == "ok"
+
+
+def test_the_non_streaming_path_uses_it_too() -> None:
+    """A local model reasons in tags whether or not anyone asked for streaming.
+
+    `_normalize` is where every non-streamed response becomes a `CompletionResult`, so a filter that
+    only runs on deltas leaves the whole `chimera solve` path untouched.
+    """
+    from chimera.providers.gateway import LLMGateway
+
+    message = type("M", (), {"content": "<think>reasoning</think>the answer", "tool_calls": None})()
+    response = type("R", (), {"choices": [type("C", (), {"message": message})()], "usage": None})()
+
+    assert LLMGateway._normalize(response, "openrouter/x/y").content == "the answer"


### PR DESCRIPTION
Item 12 do roteiro do terminal.

Um modelo local que raciocina em `<think>` escreve isso em `message.content` como qualquer outro texto. A gente lê esse campo **cru** — então o raciocínio caía no terminal, no transcript do desktop, e em tudo que consome a resposta depois. Ollama é caminho de primeira classe declarado aqui, então é forma que o projeto encontra, não hipótese.

## Três coisas que tornam isso mais difícil que um `str.replace`

**1. A tag chega partida entre deltas.** `<thi` num chunk, `nk>` no outro — um filtro que olha um chunk por vez não vê tag nenhuma.

**2. `<think>` dentro de bloco de código não é tag.** Uma tarefa que diz *"escreva um parser de `<think>`"* teria o próprio diff corrompido pelo que deveria limpar a saída. Falha **silenciosa**, e no artefato em vez de na tela. Essa guarda **não estava** no desenho que propôs a feature.

**3. Tag que nunca fecha não pode engolir a resposta.** Descartar-até-fechar transforma uma tag não fechada — stream truncado, falso positivo em prosa — numa resposta **vazia sem erro nenhum**. Em vez disso o trecho fica **retido**: descartado quando o bloco fecha, e liberado como texto comum ao passar de `MAX_HELD_CHARS` ou no flush.

> Mostrar raciocínio é um borrão. Devolver `""` é um bug.

O release é **byte a byte, tag inclusa** — e não era no começo: `List<think> in prose` voltava como `List in prose`, ou seja, o filtro editando um texto que ele mesmo acabara de declarar comum.

## Ligado nos três caminhos, com teste em cada um

`stream`, `stream_complete` e `_normalize`. Ligar três e testar um é o bug de "quatro chamadores de cinco" que este projeto passou o dia removendo de outros módulos.

No `stream_complete` o filtro roda **antes da acumulação**, não só antes da exibição: senão o raciocínio fica em `content`, volta pro prompt do turno seguinte, e é **pago todo turno** enquanto invisível pro usuário.

`CHIMERA_KEEP_THINK=1` desliga, lido pelas settings do próprio gateway (para que um override congelado seja respeitado). Filtro sem saída é pior que o ruído.

## As duas checagens de discriminação renderam

A primeira **passou com o conserto "removido"** — porque minha edição pegou a primeira de duas linhas idênticas (`stream()` em vez de `stream_complete()`). Quase concluí que o teste era vazio quando o **experimento** é que era. Contar as ocorrências foi o que pegou, de novo.

| quebra | resultado |
|---|---|
| desligar o filtro em `stream_complete` | reprova o teste de fiação |
| desligar em `stream()` + `_normalize` | reprovam os outros 2 |
| remover o filtro inteiro | reprova a suíte de 16 |

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 306 arquivos |
| `pytest -q` (WSL) | 3260 passando, 13 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
