### PR TITLE
feat(worktree): a killed run left its litter in the user's repository

### DIFF
--- a/chimera/core/worktree.py
+++ b/chimera/core/worktree.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import shutil
 import subprocess
 import tempfile
+import time
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TypeVar
 
@@ -40,6 +42,90 @@ def is_git_repo(path: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
+#: A leftover temp directory younger than this is assumed to belong to a run that is still starting.
+#: `GitWorktree.create` makes the directory and registers it with git a moment later, and pruning
+#: inside that window would delete a live worktree out from under a concurrent process.
+_ORPHAN_MIN_AGE_SECONDS = 3600
+
+
+def live_worktree_paths(repo_root: Path) -> set[Path]:
+    """Paths git currently knows as worktrees of this repo."""
+    result = _git(["worktree", "list", "--porcelain"], repo_root)
+    paths: set[Path] = set()
+    for line in result.stdout.splitlines():
+        if line.startswith("worktree "):
+            with suppress(OSError, ValueError):
+                paths.add(Path(line[len("worktree ") :].strip()).resolve())
+    return paths
+
+
+def prune_orphans(repo_root: Path, *, prefix: str = "chimera") -> dict[str, int]:
+    """Clean up what a killed run leaves behind. Returns what was removed, by kind.
+
+    `GitWorktree.remove` runs in a `finally`, so the ordinary paths — success, failure, an
+    exception — all clean up. SIGKILL does not run `finally`, and neither does a power cut or a
+    container stop, and there was nothing anywhere that collected the remains:
+
+      * an entry under `.git/worktrees`,
+      * a branch `chimera/attempt-<hex>`,
+      * a temp directory.
+
+    All three land in the USER's repository. `git worktree list` and `git branch` are things people
+    read, so this is litter we leave in someone's house — and `git worktree prune` was not called
+    from anywhere in the codebase.
+
+    DELIBERATELY NOT a registry of our own, which is what the proposal asked for. Git already keeps
+    a durable one in `.git/worktrees`, and a second record can disagree with it — at which point the
+    cleanup is deciding between two sources of truth about whether a directory is live. What git
+    does not track is the branch and the temp directory, and those are handled from git's own state
+    rather than from a file we would have to keep correct across crashes.
+
+    HONEST STARTING POINT: this repository has zero `chimera/*` branches right now. The item is
+    justified by the shape of the failure, not by observed leakage.
+    """
+    removed = {"worktrees": 0, "branches": 0, "directories": 0}
+    if not is_git_repo(repo_root):
+        return removed
+    repo_root = Path(repo_root).resolve()
+
+    # 1. Git's own pruning: drops `.git/worktrees` entries whose directory is gone. Safe by
+    #    construction — it only forgets what is already missing.
+    before = live_worktree_paths(repo_root)
+    _git(["worktree", "prune"], repo_root)
+    live = live_worktree_paths(repo_root)
+    removed["worktrees"] = max(0, len(before) - len(live))
+
+    # 2. Branches with no worktree attached. `git branch -D` refuses a branch checked out in a live
+    #    worktree, so a run in flight cannot be harmed even if the listing raced.
+    result = _git(["branch", "--list", f"{prefix}/attempt-*", "--format=%(refname:short)"], repo_root)
+    for branch in (b.strip() for b in result.stdout.splitlines() if b.strip()):
+        if _git(["branch", "-D", branch], repo_root).returncode == 0:
+            removed["branches"] += 1
+
+    # 3. Temp directories git no longer knows about. Age-gated: `create` makes the directory and
+    #    registers it a moment later, and pruning inside that window would delete a live worktree
+    #    belonging to another process.
+    now = time.time()
+    with suppress(OSError):
+        for candidate in Path(tempfile.gettempdir()).glob("chimera-wt-*"):
+            if not candidate.is_dir() or candidate.resolve() in live:
+                continue
+            with suppress(OSError):
+                if now - candidate.stat().st_mtime < _ORPHAN_MIN_AGE_SECONDS:
+                    continue
+                shutil.rmtree(candidate, ignore_errors=True)
+                removed["directories"] += 1
+
+    if any(removed.values()):
+        _log.info("pruned orphaned worktrees: %s", removed)
+    return removed
+
+
+#: Pruned once per process, before the first worktree is created — "on boot" in the only sense that
+#: matters, and free for the runs that never use one.
+_pruned_repos: set[Path] = set()
+
+
 class GitWorktree:
     """A throwaway git worktree on its own branch, created from the repo's HEAD."""
 
@@ -51,6 +137,12 @@ class GitWorktree:
     @classmethod
     def create(cls, repo_root: Path, *, prefix: str = "chimera") -> GitWorktree:
         repo_root = Path(repo_root).resolve()
+        if repo_root not in _pruned_repos:
+            _pruned_repos.add(repo_root)
+            with suppress(Exception):
+                # Best-effort and never fatal: failing to tidy up after a previous crash is not a
+                # reason to refuse to start this run.
+                prune_orphans(repo_root, prefix=prefix)
         branch = f"{prefix}/attempt-{uuid.uuid4().hex[:8]}"
         path = Path(tempfile.mkdtemp(prefix="chimera-wt-"))
         path.rmdir()  # `git worktree add` needs the target not to exist yet

--- a/tests/test_worktree_prune.py
+++ b/tests/test_worktree_prune.py
@@ -1,0 +1,133 @@
+"""What a killed run leaves in someone else's repository.
+
+`GitWorktree.remove` runs in a `finally`, so success, failure and exceptions all clean up. SIGKILL
+does not run `finally` — and neither does a power cut, a `docker stop`, or the OOM killer. What
+survives is an entry under `.git/worktrees`, a branch `chimera/attempt-<hex>`, and a temp directory,
+and nothing in the codebase collected any of it: `git worktree prune` was called from nowhere.
+
+That litter is in the USER's repository. `git worktree list` and `git branch` are things people
+read, so a run that dies leaves a mess in a place its owner looks.
+
+HONEST STARTING POINT, kept out of the commit message where it would rot: this repository has zero
+`chimera/*` branches today. The item is justified by the construction of the failure, not by
+leakage anyone observed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from chimera.core.worktree import GitWorktree, live_worktree_paths, prune_orphans
+
+
+def git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=60)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    git(["init", "-q"], root)
+    git(["config", "user.email", "t@example.com"], root)
+    git(["config", "user.name", "t"], root)
+    (root / "a.txt").write_text("hello\n", encoding="utf-8")
+    git(["add", "-A"], root)
+    git(["commit", "-qm", "init"], root)
+    return root
+
+
+def branches(root: Path) -> list[str]:
+    out = git(["branch", "--list", "chimera/attempt-*", "--format=%(refname:short)"], root).stdout
+    return [b.strip() for b in out.splitlines() if b.strip()]
+
+
+def test_a_run_that_never_cleaned_up_leaves_all_three_traces(repo: Path) -> None:
+    """The state this exists to fix, asserted before fixing it — otherwise the fix proves nothing."""
+    wt = GitWorktree.create(repo)
+    assert wt.path.exists()
+    assert branches(repo) == [wt.branch]
+    assert wt.path.resolve() in live_worktree_paths(repo)
+
+
+def test_pruning_collects_the_branch_a_killed_run_left(repo: Path) -> None:
+    """The directory is gone (the OS reclaimed /tmp, or the user deleted it) but git still has both.
+
+    This is the shape after a hard kill plus a reboot, and it is the one that pollutes what a person
+    reads: `git branch` in their own repository, listing our attempts forever.
+    """
+    wt = GitWorktree.create(repo)
+    import shutil
+
+    shutil.rmtree(wt.path)  # the run died; nothing called remove()
+
+    assert branches(repo) == [wt.branch], "precondition: the branch is still there"
+    removed = prune_orphans(repo)
+
+    assert branches(repo) == []
+    assert removed["branches"] == 1
+    assert removed["worktrees"] == 1
+
+
+def test_pruning_does_not_touch_a_live_worktree(repo: Path) -> None:
+    """The half that matters more than the cleanup.
+
+    A prune that removes a worktree another process is working in destroys real work — worse than
+    the litter it was collecting. `git branch -D` refuses a branch checked out in a live worktree,
+    which is what makes this safe even if the listing raced.
+    """
+    wt = GitWorktree.create(repo)
+    prune_orphans(repo)
+
+    assert wt.path.exists(), "a live worktree was deleted"
+    assert branches(repo) == [wt.branch], "a live branch was deleted"
+    assert (wt.path / "a.txt").read_text(encoding="utf-8") == "hello\n"
+
+
+def test_a_fresh_temp_directory_is_left_alone(repo: Path, tmp_path: Path) -> None:
+    """`create` makes the directory and registers it with git a moment later.
+
+    Pruning inside that window would delete a live worktree out from under a concurrent process, so
+    the directory sweep is age-gated. Nothing here is old enough to collect.
+    """
+    import tempfile
+
+    fresh = Path(tempfile.mkdtemp(prefix="chimera-wt-"))
+    try:
+        assert prune_orphans(repo)["directories"] == 0
+        assert fresh.exists()
+    finally:
+        import shutil
+
+        shutil.rmtree(fresh, ignore_errors=True)
+
+
+def test_pruning_a_directory_that_is_not_a_repo_is_a_no_op(tmp_path: Path) -> None:
+    assert prune_orphans(tmp_path) == {"worktrees": 0, "branches": 0, "directories": 0}
+
+
+def test_the_first_create_in_a_process_prunes_first(repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wiring, which is a separate claim from the pruning working.
+
+    `prune_orphans` passing its own tests says nothing about anything ever calling it — and a
+    cleanup nobody invokes is the same as no cleanup. Pruning happens once per repo per process,
+    before the first worktree: "on boot" in the only sense that matters, and free for the runs that
+    never make one.
+    """
+    import chimera.core.worktree as mod
+
+    monkeypatch.setattr(mod, "_pruned_repos", set())
+    calls: list[Path] = []
+    real = mod.prune_orphans
+    monkeypatch.setattr(mod, "prune_orphans", lambda root, **kw: (calls.append(root), real(root, **kw))[1])
+
+    first = GitWorktree.create(repo)
+    second = GitWorktree.create(repo)
+    try:
+        assert calls == [repo.resolve()], "pruned on the first create, and only once"
+    finally:
+        first.remove()
+        second.remove()


### PR DESCRIPTION
Item 11 do roteiro do terminal.

## O que sobra quando um run morre

`GitWorktree.remove` roda num `finally`, então sucesso, falha e exceção limpam tudo. **SIGKILL não roda `finally`** — nem queda de energia, nem `docker stop`, nem o OOM killer.

O que sobrevive:

- uma entrada em `.git/worktrees`
- um branch `chimera/attempt-<hex>`
- um diretório temporário

E **nada** no código recolhia isso: `git worktree prune` não era chamado de lugar nenhum.

Os três caem no repositório **do usuário**. `git branch` e `git worktree list` são coisas que as pessoas leem — então um run que morre deixa sujeira exatamente onde o dono olha.

## Como fica

`prune_orphans` roda **uma vez por repo por processo**, antes da primeira worktree — "no boot" no único sentido que importa, e de graça para os runs que nunca criam uma. Best-effort e nunca fatal: não conseguir limpar o estrago de um crash alheio não é motivo pra recusar começar.

## Onde eu diverge do que foi pedido

A proposta pedia **registro próprio**. Não fiz, e é o único ponto em que fui pro outro lado.

O git **já mantém** um registro durável em `.git/worktrees`. Um segundo registro pode **discordar** dele — e aí a limpeza vira um juiz entre duas fontes de verdade sobre se um diretório está vivo. O que o git **não** rastreia é o branch e o diretório temporário, e esses saem do estado do próprio git em vez de um arquivo que eu teria que manter correto **através exatamente dos crashes** que isto existe para sobreviver.

## Duas propriedades de segurança, e a segunda importa mais que a limpeza

- **`git branch -D` recusa** branch que está em worktree viva — então um run concorrente não é ferido nem se a listagem correr.
- **A varredura de diretório é limitada por idade**: `create` cria o diretório e registra no git um instante depois, e podar dentro dessa janela apagaria uma worktree viva de outro processo.

> Poda que come trabalho real é pior que o lixo que ela recolhe.

## Ponto de partida honesto

Este repositório tem **zero** branches `chimera/*` hoje. O item se justifica pela **construção** do modo de falha, não por vazamento observado — e é por isso que o primeiro teste **afirma que a sujeira existe** antes dos outros provarem que ela é recolhida.

| quebra | resultado |
|---|---|
| remover a poda de branch | 1 de 6 reprova |
| remover a chamada no `create` | outro 1 reprova |

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 306 arquivos |
| `pytest -q` (WSL) | 3257 passando, 12 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
