### PR TITLE
feat(tools): a full overwrite that does not parse is never what anyone meant

### DIFF
--- a/chimera/tools/files.py
+++ b/chimera/tools/files.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ast
+import json
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +56,31 @@ class ReadFileTool(_WorkspaceTool):
         return text
 
 
+def syntax_error(path: Path, content: str) -> str | None:
+    """Why ``content`` cannot be the whole of ``path``, or None if it can.
+
+    Only formats we can check for free with the standard library, and only on a FULL overwrite.
+    That scope is the whole idea: a surgical edit may legitimately pass through a state that does
+    not parse — a half-applied rename, a function being moved — while a complete file that does not
+    parse is never what anyone meant. Checking both would turn a normal editing rhythm into a fight.
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        try:
+            ast.parse(content)
+        except SyntaxError as exc:
+            where = f" (line {exc.lineno}" + (f", col {exc.offset}" if exc.offset else "") + ")"
+            return f"{exc.msg}{where}"
+        except ValueError as exc:  # e.g. source with NUL bytes
+            return str(exc)
+    elif suffix == ".json":
+        try:
+            json.loads(content)
+        except json.JSONDecodeError as exc:
+            return f"{exc.msg} (line {exc.lineno}, col {exc.colno})"
+    return None
+
+
 class WriteFileTool(_WorkspaceTool):
     name = "write_file"
     description = "Write (create or overwrite) a UTF-8 text file in the workspace."
@@ -62,6 +89,13 @@ class WriteFileTool(_WorkspaceTool):
         "properties": {
             "path": {"type": "string", "description": "Path relative to the workspace."},
             "content": {"type": "string", "description": "Full file content to write."},
+            "allow_invalid": {
+                "type": "boolean",
+                "description": (
+                    "Write even if the content does not parse (.py/.json). Use for templates, "
+                    "fixtures and partial files that are invalid on purpose."
+                ),
+            },
         },
         "required": ["path", "content"],
     }
@@ -71,6 +105,20 @@ class WriteFileTool(_WorkspaceTool):
         if err := refuse_write(self.workspace, path, self.write_region):
             return err
         content = str(kwargs.get("content", ""))
+        # Refused BEFORE the write, not reported after. A file that does not parse is one the next
+        # step cannot read, import or test, so writing it costs a whole verify cycle to discover
+        # something `ast.parse` knew for free — and on a full overwrite it also destroys the version
+        # that did parse.
+        #
+        # The escape hatch is not optional. Templates, fixtures and deliberately-broken examples are
+        # real files, and a guard with no way past turns "the agent wrote something odd" into "the
+        # agent cannot do this at all".
+        if not bool(kwargs.get("allow_invalid", False)) and (why := syntax_error(path, content)):
+            return (
+                f"error: refused to overwrite {path.name} — the content is not valid "
+                f"{path.suffix.lstrip('.')}: {why}. Fix it, or pass allow_invalid=true if the file "
+                f"is meant to be invalid."
+            )
         path.parent.mkdir(parents=True, exist_ok=True)
         # Byte-exact atomic write: never OS-translate the model's newlines, and never truncate an
         # existing file if the write is interrupted (temp + replace).

--- a/tests/test_write_file_syntax.py
+++ b/tests/test_write_file_syntax.py
@@ -1,0 +1,114 @@
+"""A full overwrite that does not parse is never what anyone meant.
+
+Three write paths call `atomic_write_text` and none of them validated anything. The right scope is
+narrower than "validate every write", and for a reason: a surgical edit may legitimately pass
+through a state that does not parse — a half-applied rename, a function mid-move — while a COMPLETE
+file that does not parse is a mistake by construction. Checking both would turn a normal editing
+rhythm into a fight with the tool.
+
+The cost of not checking is not cosmetic. A broken file is one the next step cannot import or test,
+so the agent spends a whole verify cycle discovering something `ast.parse` knew for free — and on an
+overwrite it has also destroyed the version that did parse.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.tools.files import WriteFileTool
+
+
+def write(ws: Path, name: str, content: str, **kw: object) -> str:
+    return WriteFileTool(ws).run(path=name, content=content, **kw)
+
+
+def test_valid_python_is_written(tmp_path: Path) -> None:
+    out = write(tmp_path, "ok.py", "def f() -> int:\n    return 1\n")
+    assert "wrote" in out
+    assert (tmp_path / "ok.py").exists()
+
+
+def test_broken_python_is_refused_and_nothing_is_written(tmp_path: Path) -> None:
+    out = write(tmp_path, "bad.py", "def f(:\n    return 1\n")
+    assert out.startswith("error:")
+    assert not (tmp_path / "bad.py").exists(), "the refusal must not leave a partial file"
+
+
+def test_the_refusal_says_where(tmp_path: Path) -> None:
+    """A message that only says "invalid" costs the agent a read to find out what.
+
+    It is about to retry; the line number is the difference between a fix and a guess.
+    """
+    out = write(tmp_path, "bad.py", "x = 1\ny = (\n")
+    assert "line" in out
+
+
+def test_an_existing_good_file_survives_a_broken_overwrite(tmp_path: Path) -> None:
+    """The expensive half. An overwrite destroys the version that worked.
+
+    Without the check the agent replaces a parsing file with a non-parsing one, and the only way
+    back is the checkpoint — if there is one.
+    """
+    target = tmp_path / "keep.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    write(tmp_path, "keep.py", "VALUE = (\n")
+    assert target.read_text(encoding="utf-8") == "VALUE = 1\n"
+
+
+def test_broken_json_is_refused_too(tmp_path: Path) -> None:
+    out = write(tmp_path, "c.json", '{"a": 1,}')
+    assert out.startswith("error:")
+    assert not (tmp_path / "c.json").exists()
+
+
+def test_valid_json_is_written(tmp_path: Path) -> None:
+    write(tmp_path, "c.json", '{"a": 1}')
+    assert json.loads((tmp_path / "c.json").read_text(encoding="utf-8")) == {"a": 1}
+
+
+def test_the_escape_hatch_writes_it_anyway(tmp_path: Path) -> None:
+    """Not optional. Templates, fixtures and deliberately-broken examples are real files.
+
+    A guard with no way past turns "the agent wrote something odd" into "the agent cannot do this
+    at all", which is the more expensive failure of the two.
+    """
+    out = write(tmp_path, "fixture.py", "def broken(:\n", allow_invalid=True)
+    assert "wrote" in out
+    assert (tmp_path / "fixture.py").read_text(encoding="utf-8") == "def broken(:\n"
+
+
+def test_formats_we_cannot_check_are_written_untouched(tmp_path: Path) -> None:
+    """Only what the standard library checks for free. Everything else passes through.
+
+    A guess at "valid" for Markdown, YAML or plain text would refuse real files, and a writer that
+    refuses real files is worse than one that writes a broken one.
+    """
+    for name, content in (
+        ("notes.md", "# Title\n\nnot { valid json ("),
+        ("a.txt", "def f(:"),
+        ("t.yaml", "a: [1, 2"),
+        ("t.py.j2", "def {{ name }}(:\n"),
+    ):
+        assert "wrote" in write(tmp_path, name, content)
+        assert (tmp_path / name).read_text(encoding="utf-8") == content
+
+
+def test_an_empty_python_file_is_valid(tmp_path: Path) -> None:
+    """`__init__.py` is the commonest file in a Python repository and it is usually empty."""
+    assert "wrote" in write(tmp_path, "__init__.py", "")
+
+
+def test_the_other_writers_are_deliberately_not_checked(tmp_path: Path) -> None:
+    """`edit_file` may legitimately leave a file mid-change, and it stays that way.
+
+    Pinned so the scope is a decision rather than an oversight: someone extending this to every
+    write path would break the editing rhythm the tools exist to support.
+    """
+    from chimera.tools.edit import EditFileTool
+
+    target = tmp_path / "m.py"
+    target.write_text("def f():\n    return 1\n", encoding="utf-8")
+    out = EditFileTool(tmp_path).run(path="m.py", old="return 1", new="return (")
+    assert "error" not in out.lower()
+    assert "return (" in target.read_text(encoding="utf-8")


### PR DESCRIPTION
Item 13 do roteiro do terminal, e o **último** dos onze que restavam (9 ao 15).

Três caminhos de escrita chamam `atomic_write_text` e nenhum validava nada.

## O escopo é mais estreito que "validar toda escrita", de propósito

Uma **edição cirúrgica** pode legitimamente atravessar um estado que não parseia — um rename pela metade, uma função no meio da mudança. Uma **sobrescrita completa** que não parseia é erro por construção.

Validar as duas transformaria o ritmo normal de edição numa briga com a ferramenta. Então `edit_file` e companhia ficam intactos — e há um **teste fixando isso**, para o escopo ler como decisão em vez de esquecimento.

## Não é cosmético

Arquivo quebrado é arquivo que o passo seguinte não consegue importar nem testar. O agente queima um **ciclo inteiro de verify** para descobrir algo que o `ast.parse` sabia de graça — e, numa sobrescrita, ele **já destruiu a versão que parseava**.

Esse caso tem teste próprio: um arquivo bom sobrevive a uma sobrescrita quebrada, porque sem a checagem ele não sobreviveria.

## Só `.py` e `.json`

O que a biblioteca padrão checa de graça. Markdown, YAML, texto e templates `.py.j2` passam intocados: um chute sobre "válido" recusaria arquivos reais, e um escritor que recusa arquivo real é pior que um que às vezes escreve um quebrado.

## `allow_invalid=true` não é opcional

Template, fixture e exemplo deliberadamente quebrado são arquivos reais. Guarda sem saída transforma *"o agente escreveu algo estranho"* em *"o agente não consegue fazer isso"* — a mais cara das duas falhas.

A recusa **nomeia a linha**. Ele vai tentar de novo; uma mensagem que só diz "inválido" custa uma leitura pra descobrir o quê.

| quebra | resultado |
|---|---|
| remover a checagem | **4 de 10 reprovam** |

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 305 arquivos |
| `pytest -q` (WSL) | 3281 passando, 12 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
