### PR TITLE
fix(ci): the Rust job was not flaky, it was timing out on apt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,8 +240,21 @@ jobs:
     # which is precisely the code a user hits when nothing else works, so a guard that only runs on
     # the author's laptop is the same defect one layer up.
     name: desktop shell (Rust tests)
-    timeout-minutes: 25
-    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # WINDOWS, and for two reasons that point the same way.
+    #
+    # The flake: on ubuntu this job needs `apt-get install libwebkit2gtk-4.1-dev …`, and that step
+    # hung on three consecutive runs (#104, #106, #107) — each killed at exactly 25m00s by the old
+    # timeout, which GitHub reports as `cancelled` rather than `failure`, so the verdict job
+    # correctly called it infrastructure and each PR needed a manual re-run. The usual cause is the
+    # dpkg lock held by unattended-upgrades at runner boot. Windows needs no system deps at all:
+    # WebView2 ships with the OS, which is why `desktop-release.yml` gates its apt step to ubuntu.
+    #
+    # The better reason: this crate's bugs are Windows bugs. `windows_subsystem = "windows"` is what
+    # made a panic write to a stderr that does not exist, which is the failure the tests in
+    # `main.rs` exist to prevent — and on Linux that code path is not the one that runs. Testing the
+    # startup path on the platform where it broke is worth more than testing it where it never did.
+    runs-on: windows-latest
     needs: quality
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -254,24 +267,20 @@ jobs:
         with:
           workspaces: apps/desktop/src-tauri -> target
 
-      # The same four packages desktop-release.yml installs — tauri does not compile on Linux without
-      # them, and `cargo test` compiles the whole crate.
-      - name: Linux system deps for Tauri
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-
       # Two placeholders, because `tauri-build` resolves the bundle manifest before it compiles
       # anything and refuses on either: `frontendDist` points at ../dist, and `bundle.resources`
       # globs the PyInstaller output, which only the release workflow produces. Building the real
       # SPA and freezing the real backend here would duplicate two other jobs for no gain — these
       # tests never load a page and never launch the sidecar; they exercise the code that runs when
       # launching it FAILS.
+      #
+      # `shell: bash` because the runner's default here is pwsh, where `mkdir -p` is a parse error.
       - name: Placeholders the build script insists on
+        shell: bash
         run: |
           mkdir -p apps/desktop/dist apps/desktop/src-tauri/sidecar-dist/chimera-backend
           touch apps/desktop/dist/index.html
-          touch apps/desktop/src-tauri/sidecar-dist/chimera-backend/chimera-backend
+          touch apps/desktop/src-tauri/sidecar-dist/chimera-backend/chimera-backend.exe
 
       - name: cargo test
         run: cargo test --manifest-path apps/desktop/src-tauri/Cargo.toml


### PR DESCRIPTION
## Não era flaky

Três PRs seguidos ([#104](https://github.com/brcampidelli/chimera-agent/pull/104), [#106](https://github.com/brcampidelli/chimera-agent/pull/106), [#107](https://github.com/brcampidelli/chimera-agent/pull/107)) tiveram o job `desktop shell (Rust tests)` voltando **`cancelled`**, cada um exigindo re-run manual que então passava em menos de dois minutos.

**Eu re-rodei os dois primeiros antes de olhar** — que é exatamente o que o texto do próprio job `verdict` avisa para não fazer:

> *"If it cancels again at the same place, it is a pattern rather than a hiccup and the queue wait is worth investigating instead of retrying."*

## Era padrão

| run | duração da tentativa 1 |
|---|---|
| 32089482662 | **25m15s** |
| 32091181797 | **25m15s** |
| 32091494703 | **25m14s** |

O `timeout-minutes: 25`, no segundo. E um job morto pelo timeout o GitHub reporta como **`cancelled`, não `failure`** — então o `verdict` acertou a **categoria** enquanto a **causa** era nossa.

Os três morreram no mesmo passo: `apt-get install libwebkit2gtk-4.1-dev …`, vítima habitual do lock do dpkg segurado pelo `unattended-upgrades` no boot do runner.

## O conserto não é esperar o apt com mais paciência

É **não precisar dele**. Windows traz o WebView2, então a crate compila **sem dependência de sistema nenhuma** — que é justamente por que o `desktop-release.yml` já limita o passo de apt ao ubuntu.

E Windows é o host certo para este job por mérito próprio: **os bugs desta crate são bugs de Windows**. O `windows_subsystem = "windows"` é o que fazia um panic escrever num stderr que não existe — a falha que os testes do `main.rs` existem para impedir — e no Linux esse caminho **não é o que roda**. Testar a sequência de arranque onde ela de fato quebrou vale mais que testá-la onde nunca quebrou.

Timeout para 30 (primeiro cache é frio) e `shell: bash` no passo de placeholders, porque o default lá é pwsh, onde `mkdir -p` é erro de sintaxe.

## ⚠️ Não verificável localmente

Isto é uma mudança de **qual máquina o CI usa**. A run deste PR **é** a verificação: se o job ficar verde no Windows, o conserto vale; se falhar ao compilar lá, é achado real e não flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
