### PR TITLE
fix(repomap): the map walked into agent worktrees and lost the entry point

### DIFF
--- a/chimera/core/repomap.py
+++ b/chimera/core/repomap.py
@@ -46,6 +46,16 @@ _log = get_logger("core.repomap")
 _DEFAULT_IGNORE = {
     ".git", "__pycache__", ".venv", "venv", "node_modules", ".mypy_cache",
     ".pytest_cache", ".ruff_cache", "dist", "build", ".chimera", ".idea", ".vscode",
+    # `.claude/worktrees/` is where an agent harness puts an isolated checkout, so it holds one FULL
+    # COPY of the repository per concurrent agent. Measured with four of them running: 9,870 extra
+    # Python files, and `chimera/api/app.py` dropped out of the map's budget entirely — the same
+    # file whose disappearance `tests/test_repomap_ranking.py` exists to catch.
+    #
+    # It fails in the worst direction. The map does not shrink and does not error; it stays the same
+    # size and quietly fills with duplicates, so the agent receives something that "looks like a
+    # map" — this module's own opening words — while the entry point it needed is missing. Nobody
+    # would report that, because the only symptom is an agent looking in the wrong place.
+    ".claude",
 }
 
 #: Extensions the map understands. Anything else is invisible to it — stated here rather than

--- a/tests/test_repomap_ranking.py
+++ b/tests/test_repomap_ranking.py
@@ -146,3 +146,41 @@ def test_the_cache_does_not_serve_a_stale_file(tmp_path: Path, monkeypatch: obje
     target.write_text("def after(): ...\ndef also_after(): ...\n", encoding="utf-8")
     digest = build_repo_map(tmp_path)
     assert "after()" in digest and "before()" not in digest
+
+
+def test_an_agent_worktree_never_enters_the_map(tmp_path: Path) -> None:
+    """A nested checkout is not part of the repository, and the map must not think it is.
+
+    Agent harnesses put isolated worktrees under `.claude/worktrees/`, which puts one FULL COPY of
+    the repository inside the repository per concurrent agent. Measured on this tree with four of
+    them running: 9,870 extra Python files, and `chimera/api/app.py` dropped out of the map's budget
+    entirely — the same file whose disappearance the first test in this module exists to catch.
+
+    The DIRECTION is what makes it worth pinning. The map does not shrink and does not error; it
+    stays the same size and quietly fills with duplicates, so the agent receives something that
+    looks like a map while the file it needed is missing. The only symptom is an agent looking in
+    the wrong place, which nobody reports as a bug.
+
+    What is asserted here is the containment, not the crowding. Reproducing the crowd-out
+    synthetically needs a fixture as lopsided as the real repository, and two earlier versions of
+    this test passed against the bug while pretending otherwise — one because fifty short files do
+    not fill a 4000-character budget, and one because it looked for a `".claude/"` prefix the map
+    never prints (paths arrive as `claude/worktrees/...`, no leading dot). The crowd-out is real and
+    was measured; it is documented above rather than faked below.
+    """
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "core.py").write_text("def real() -> None: ...\n", encoding="utf-8")
+    (tmp_path / "main.py").write_text("from pkg.core import real\n", encoding="utf-8")
+
+    clone = tmp_path / ".claude" / "worktrees" / "agent-1" / "pkg"
+    clone.mkdir(parents=True)
+    body = "".join(f"def sym_{i}() -> None: ...\n" for i in range(12))
+    for i in range(300):
+        (clone / f"copy{i}.py").write_text(body, encoding="utf-8")
+
+    digest = build_repo_map(tmp_path)
+
+    # Matched on the substring rather than a prefix: the map strips the leading dot, and pinning the
+    # exact rendering would make this pass again the day that changes.
+    assert "worktrees/agent-1" not in digest, "a copy inside .claude reached the map"
+    assert _rank_of(digest, "pkg/core.py") >= 0, "the real file must still be there"


### PR DESCRIPTION
Descoberto pela suíte ficando vermelha numa branch que **não toca em Python nenhum** — o que já era a primeira pista de que era ambiental.

## O que acontece

`.claude/worktrees/` é onde um harness de agente coloca checkout isolado. Ou seja: **uma cópia COMPLETA do repositório dentro do repositório, por agente concorrente.**

Medido nesta árvore com quatro rodando: **9.870 arquivos `.py` a mais**, e o `chimera/api/app.py` caiu inteiro para fora do orçamento do mapa — exatamente o arquivo cujo sumiço o `test_this_repositorys_core_survives_the_budget` existe para pegar.

## Confirmado ambiental, não regressão

Construí o mapa contra um `git archive` **limpo do main**: os quatro arquivos centrais presentes, `app.py` na **posição 13**. Nada estava quebrado; a árvore é que estava.

## Mas é bug de produto, não só sujeira minha

Qualquer pessoa rodando o Chimera com isolamento por worktree pega isso. E falha na **pior direção**:

> O mapa **não encolhe** e **não dá erro**. Ele mantém o mesmo tamanho e se enche de duplicatas em silêncio.

Então o agente recebe algo que *"parece um mapa"* — as palavras de abertura do próprio módulo — enquanto o ponto de entrada de que ele precisava está faltando. O único sintoma é um agente procurando no lugar errado, o que ninguém reporta como bug.

## O teste levou três tentativas, e as duas primeiras não valiam nada

| versão | o que fazia | por que era inútil |
|---|---|---|
| v1 | 50 arquivos de uma linha, afirmava que o arquivo real sobrevivia | verde **com o conserto revertido** — 50 arquivos curtos não esgotam 4000 caracteres |
| v2 | 300 arquivos com 12 símbolos + afirmava que nenhuma linha começava com `".claude/"` | também verde, e por um motivo mais afiado: **o mapa imprime `claude/worktrees/…`, sem o ponto inicial**. A asserção procurava uma string que o sistema nunca emite |
| v3 | afirma contenção por substring, e diz que o crowd-out é **medição na árvore real**, não algo que o fixture reproduz | **reprova** quando `.claude` sai do ignore |

> Guarda que procura uma string que o sistema nunca emite é a forma mais pura de teste que não pode falhar.

| portão | resultado |
|---|---|
| `ruff check .` | limpo |
| `mypy chimera` | 308 arquivos |
| `pytest -q` | **3374 passando**, 13 skipped |
| discriminação | tirar `.claude` do ignore **reprova** o teste novo |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
