### PR TITLE
fix(core): the run restored its plan inside the field labelled "the task"

### DIFF
--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -1766,17 +1766,13 @@ def _build_solve_agent(
     # Plan mode: an approved/edited plan is injected verbatim (parsed the same way the planner parses
     # its own output), so the run follows the human-reviewed steps and makes no planning call.
     provided_plan = Plan.from_text(req.plan) if req.plan else None
-    # What a compaction has to put back. Without this the budget above would compact blind: it would
-    # keep the recent tail and drop the plan the run is executing, which is the one thing an agent
-    # cannot re-derive from its own tail. Seeded only from what is known here — the task and the
-    # approved plan; the open file arrives per-turn from the UI and is set there, not remembered.
-    for agent in (worker, escalate_worker):
-        if agent is None:
-            continue
-        agent.run_state.current_state = req.task
-        if provided_plan is not None:
-            agent.run_state.plan = provided_plan.as_text()
-            agent.run_state.tasks = list(provided_plan.steps)
+    # No run_state seeding here any more, deliberately. Assigning it per entry point is how the
+    # fields drifted: this endpoint filled `plan`/`tasks` and put `req.task` in `current_state` — a
+    # field documented as "what the agent was doing and how far it had got" — while a run that
+    # planned for itself filled neither. The solve loop now writes `task` and `plan` once per
+    # attempt, downstream of all four points where the plan is decided and of the checkpoint restore
+    # this code cannot see. Duplicating `req.task` into `current_state` from here would only restore
+    # the same sentence twice under two headings. The open file still arrives per-turn from the UI.
     # The verify command: what the caller typed, or what the project says about itself.
     #
     # `None` means "look", not "none". The field is gone from the screen, and deleting it without

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from chimera.core.context_budget import RunState
     from chimera.evolution.diff_gate import FileDiff
     from chimera.fusion.probe_log import ProbeLog
 
@@ -472,6 +473,46 @@ class AutonomousAgent:
         except TypeError:  # signature lied (e.g. **kwargs-only) — fall back to the plain call
             return worker.run(prompt)
 
+    def _seed_run_state(self, worker: Worker, task: str, plan: Plan | None) -> None:
+        """Tell the worker what it was asked and which plan it is on, in the fields that mean those.
+
+        Not "the plan was missing". The plan already survived compaction, by accident: the worker is
+        prompted with ``_compose`` output, which embeds ``Plan:\\n…``, and ``Agent.run`` copies its
+        whole prompt into ``run_state.task`` when no caller set one. So the real defect is FORM —
+        the plan was restored inside the field labelled *"The task you were given"*, along with the
+        entire spine/repo-map/lessons context block that compaction had just paid to remove.
+
+        That accident turns harmful on a re-plan. ``Agent.run`` freezes ``task`` on the first
+        attempt, so it keeps the composed prompt of attempt 1 — plan A — verbatim, and
+        ``as_message`` renders it FIRST, above the tail where the worker is executing plan B.
+        Writing plan B into ``plan`` and leaving ``task`` alone would restore both and let the agent
+        pick. Seeding the raw task here pre-empts the copy (``Agent.run`` only fills a task nobody
+        set), which is what makes one plan the only plan.
+
+        Here rather than in each caller because the plan is a local written at four points — given
+        by the caller, self-planned, restored from a checkpoint, replaced by a stall re-plan — and
+        no caller sees the last three. This is the one place downstream of all four, so it is also
+        after the checkpoint restore *discards* the plan the run made moments earlier: seeded at the
+        planning call instead, a resumed run would carry the plan it threw away.
+
+        ``RunState.tasks`` is deliberately untouched. It is a task list *with status* — it exists so
+        finished work is not redone — and bare steps assert that nothing is done. This loop counts
+        attempts, not steps, so it has no completion to report and inventing one would be a lie in
+        the field whose entire purpose is to be believed.
+
+        Duck-typed for the same reason ``_run_worker`` introspects: ``Worker`` promises only
+        ``run``. An agent driven over ACP has no ``run_state``, and a worker we cannot restore into
+        is not a broken worker.
+        """
+        state: RunState | None = getattr(worker, "run_state", None)
+        if state is None:
+            return
+        # Both assigned every attempt, and the escalate worker is a different Agent with its own
+        # RunState that only ever runs attempts > 1 — the same attempts a re-plan lands on. Values
+        # written once would be stale exactly where they are read.
+        state.task = task
+        state.plan = plan.as_text() if plan is not None else ""
+
     def run(self, task: str, *, thread_id: str | None = None) -> AutonomousResult:
         spine = assemble_spine(self.spine_workspace, task) if self.spine_workspace else ""
         # Behavioural loop: fold lessons from PRIOR runs (recalled before this run
@@ -628,6 +669,11 @@ class AutonomousAgent:
             )
             if worker is self.escalate_worker:
                 _log.debug("attempt %d: task proved hard, escalating retry to fusion worker", index)
+            # After the choice, so this lands on the worker that actually runs the attempt: the
+            # escalate worker is a separate Agent with its own RunState. `task`, not `plan_task` —
+            # the field documents itself as the request verbatim, and a resume rebinds `task` from
+            # the checkpoint while `plan_task` was normalised before that and would be stale.
+            self._seed_run_state(worker, task, plan)
             # Re-check right before the worker call, so a stop that arrived while the snapshot was
             # being taken still halts before we pay for a model step. The call is no longer
             # uninterruptible: `_run_worker` hands `should_stop` down, and a worker that accepts it

--- a/chimera/core/context_budget.py
+++ b/chimera/core/context_budget.py
@@ -104,8 +104,14 @@ class RunState:
     #: removed. A file it can re-read; an instruction it cannot.
     #:
     #: Set by :meth:`Agent.run` itself rather than by each caller, because the callers that most
-    #: need it are the ones nobody remembered to update: `/api/runs` populates plan and tasks, and
+    #: need it are the ones nobody remembered to update: `/api/runs` populated plan and tasks, and
     #: the conversational coding turn — the screen that compacts most — set only ``open_file``.
+    #:
+    #: That default is a copy of whatever string ``run`` was called with, which is right for a chat
+    #: turn and wrong for the autonomous loop, where the argument is a composed prompt carrying the
+    #: plan and the whole retrieved-context block. So ``AutonomousAgent`` writes the raw request
+    #: here first and ``run`` leaves it alone. Anything else that prompts an agent with an assembled
+    #: string owes this field the request that string was assembled FROM.
     #:
     #: Two independent papers measure this failure class (arXiv 2608.11242: compactors retain 17%
     #: of injected session constraints; 2608.11392: rule-form items survive a compaction far better
@@ -114,9 +120,12 @@ class RunState:
     task: str = ""
     #: Path of the file currently being worked on, and its content — re-read, not remembered.
     open_file: tuple[str, str] | None = None
-    #: The plan the run is executing.
+    #: The plan the run is executing — the CURRENT one. Refreshed per attempt by the loop that owns
+    #: the plan, because a run that re-plans on a stall would otherwise restore the steps it just
+    #: abandoned: worse than restoring nothing, since the agent then works confidently from them.
     plan: str = ""
-    #: Task list with status, so finished work is not redone.
+    #: Task list with status, so finished work is not redone. Status is the point: a bare copy of
+    #: the plan's steps asserts that none are done, which is a claim, not a blank.
     tasks: list[str] = field(default_factory=list)
     #: One paragraph: what the agent was doing and how far it had got.
     current_state: str = ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -810,17 +810,22 @@ def test_a_batch_task_carries_the_ceiling_its_batch_was_given(tmp_path: Any) -> 
     assert seen == [0.5]
 
 
-def test_run_state_carries_the_plan_across_a_compaction(tmp_path: Any) -> None:
-    """Compaction keeps the recent tail; the plan is the one thing an agent cannot re-derive from it.
+def test_the_api_no_longer_seeds_run_state_by_hand(tmp_path: Any) -> None:
+    """Being the only entry point that filled these fields is how they drifted: this one wrote
+    `plan`, copied the steps into `tasks` (a field documented as carrying status) and put the raw
+    task in `current_state` (documented as progress) — while a run that planned for itself wrote
+    none of them and got the plan restored inside `task` instead, as part of the composed prompt.
 
-    ``Agent.run_state`` existed with a comment saying it expected a caller and had none — so the
-    budget above would have compacted blind. This is that caller.
+    The solve loop now writes `task` and `plan` once per attempt, downstream of all four points
+    where the plan is decided. Asserted there, against a run that actually runs — see
+    `tests/test_autonomous.py`; an assembled-but-never-started agent cannot show what a compaction
+    would restore. What this pins is that the endpoint no longer writes a second, staler copy.
     """
     agent = _solve_agent(tmp_path, plan="1. do it\n2. verify it")
     state = agent.worker.run_state
-    assert state.current_state == "t"
-    assert state.tasks == ["do it", "verify it"]
-    assert "do it" in (state.as_message() or {}).get("content", "")
+    assert (state.task, state.plan, state.tasks, state.current_state) == ("", "", [], "")
+    assert agent.provided_plan is not None  # the approved plan still reaches the loop that seeds it
+    assert agent.provided_plan.steps == ["do it", "verify it"]
 
 
 def test_write_region_actually_refuses_a_write_outside_it(tmp_path: Any) -> None:

--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -1011,3 +1011,199 @@ def test_require_diff_cannot_fail_without_a_workspace_guard() -> None:
 
 def test_require_diff_defaults_off() -> None:
     assert AutonomousAgent(FakeWorker()).require_diff is False
+
+
+# --- what a compaction restores: seeded where the plan is decided, not by each caller ---
+
+
+class _StatefulWorker:
+    """A worker that owns a ``run_state`` like the real Agent, recording what it held per run.
+
+    Records the RESTORED MESSAGE, not just the fields: the message is what a compaction actually
+    re-injects, and the bug this section guards is a plan landing in the wrong field rather than a
+    plan going missing. A field-only assertion cannot see that.
+    """
+
+    def __init__(self, answer: str = "nope") -> None:
+        from chimera.core.context_budget import RunState
+
+        self.answer = answer
+        self.run_state = RunState()
+        self.plans_seen: list[str] = []
+        self.restored_seen: list[str] = []
+
+    def run(self, task: str) -> AgentResult:
+        # Exactly what `Agent.run` does with the prompt it is handed (chimera/core/agent.py:331-332),
+        # and NOT an incidental detail: the prompt is `_compose` output, which embeds the plan, so
+        # this copy is how an unset `task` comes to hold plan A and freeze it for the whole run. A
+        # double that skips it cannot fail against the bug — verified, not assumed: without this
+        # line the re-plan test below stays green when the fix is reduced to seeding `plan` alone.
+        if not self.run_state.task:
+            self.run_state.task = task
+        self.plans_seen.append(self.run_state.plan)
+        self.restored_seen.append(str((self.run_state.as_message() or {}).get("content", "")))
+        return AgentResult(answer=self.answer, steps=1, transcript=[], stopped_reason="done")
+
+
+class _FixedPlanner:
+    """Plans differently each call, so a re-plan is distinguishable from the plan it replaced."""
+
+    def __init__(self, *plans: list[str]) -> None:
+        from chimera.core.planner import Plan
+
+        self._plans = [Plan(steps=list(steps)) for steps in plans]
+        self.calls = 0
+
+    def plan(self, task: str, *, context: str = "") -> Any:
+        self.calls += 1
+        return self._plans[min(self.calls - 1, len(self._plans) - 1)]
+
+
+def test_a_run_that_plans_for_itself_puts_its_plan_in_the_plan_field() -> None:
+    """``run_state.plan`` was assigned by ``/api/runs`` and by nothing else, so a self-planning run
+    left it empty. Not a loss — ``_compose`` embeds the plan in the prompt and ``Agent.run`` copies
+    the prompt into ``task`` — but it put the plan under "The task you were given", which is what
+    makes a re-plan restore the abandoned steps below.
+    """
+    worker = _StatefulWorker()
+    auto = AutonomousAgent(
+        worker,  # type: ignore[arg-type]
+        planner=_FixedPlanner(["read the file", "write the fix"]),  # type: ignore[arg-type]
+        config=AutonomousConfig(max_attempts=1, use_planner=True, use_manager=False),
+    )
+    auto.run("fix the bug")
+
+    # Asserted on what the worker held WHILE it ran, not afterwards: a value written after the run
+    # is a value no compaction could ever have restored.
+    assert worker.plans_seen == ["1. read the file\n2. write the fix"]
+    assert "read the file" in worker.restored_seen[0]
+
+
+def test_the_task_field_holds_the_request_not_the_composed_prompt() -> None:
+    """``Agent.run`` fills ``task`` with whatever string it was called with, and on this path that
+    is ``_compose`` output — the plan plus the whole spine/lessons context block. Restoring that
+    verbatim re-injects, under the wrong label, the very context compaction just paid to drop."""
+    worker = _StatefulWorker()
+    auto = AutonomousAgent(
+        worker,  # type: ignore[arg-type]
+        planner=_FixedPlanner(["read the file"]),  # type: ignore[arg-type]
+        config=AutonomousConfig(max_attempts=1, use_planner=True, use_manager=False),
+    )
+    auto.run("fix the bug")
+
+    assert worker.run_state.task == "fix the bug"
+    # The prompt's own framing is the tell: `_compose` writes "Task: <task>", so its presence in the
+    # restored message means the composed prompt was copied in wholesale.
+    assert "Task: fix the bug" not in worker.restored_seen[0]
+
+
+def test_the_plan_is_not_duplicated_into_the_task_list() -> None:
+    """``tasks`` is a task list *with status* — it exists so finished work is not redone. The steps
+    carry none, so copying them there re-prints the plan under a heading claiming progress the loop
+    does not track."""
+    worker = _StatefulWorker()
+    auto = AutonomousAgent(
+        worker,  # type: ignore[arg-type]
+        planner=_FixedPlanner(["read the file", "write the fix"]),  # type: ignore[arg-type]
+        config=AutonomousConfig(max_attempts=1, use_planner=True, use_manager=False),
+    )
+    auto.run("fix the bug")
+
+    assert worker.run_state.tasks == []
+    restored = str((worker.run_state.as_message() or {}).get("content", ""))
+    assert "Tasks:" not in restored
+    assert restored.count("read the file") == 1  # once, under "Plan:" — not twice in two styles
+
+
+def test_after_a_replan_the_abandoned_plan_is_nowhere_in_what_is_restored() -> None:
+    """The one that matters, and the one a plan-field-only fix still fails.
+
+    On a stall the loop rebuilds the plan. Writing plan B into ``plan`` is not enough: ``Agent.run``
+    freezes ``task`` on attempt 1, so it still holds attempt 1's composed prompt — plan A, verbatim,
+    under the heading ``as_message`` renders FIRST. The agent would be handed both plans, with the
+    abandoned one presented as the task it was given, and nothing to tell it which is live.
+    """
+    from chimera.evolution.stagnation import StagnationDetector
+
+    worker = _StatefulWorker()
+    planner = _FixedPlanner(["A-step"], ["B-step"])
+    auto = AutonomousAgent(
+        worker,  # type: ignore[arg-type]
+        planner=planner,  # type: ignore[arg-type]
+        manager=_FeedbackManager(),  # type: ignore[arg-type]
+        stagnation=StagnationDetector(window=2),  # two identical failures = a stall
+        replan_on_stall=True,
+        config=AutonomousConfig(max_attempts=3, use_planner=True, use_manager=True),
+    )
+    auto.run("do the thing")
+
+    assert planner.calls >= 2  # the stall really did re-plan; without that this proves nothing
+    assert worker.plans_seen[0] == "1. A-step"
+    assert worker.plans_seen[-1] == "1. B-step"
+
+    restored = worker.restored_seen[-1]
+    assert "B-step" in restored  # the live plan is there
+    assert "A-step" not in restored  # and the abandoned one is not, in ANY field
+
+
+def test_the_escalate_worker_is_seeded_too_not_just_the_cheap_one() -> None:
+    """It is a separate Agent with its own RunState, and it runs every attempt after the first —
+    the same attempts a re-plan lands on. Seeding only ``self.worker`` would restore nothing on
+    exactly the retries that have the most history to compact away."""
+    cheap, fused = _StatefulWorker(), _StatefulWorker()
+    auto = AutonomousAgent(
+        cheap,  # type: ignore[arg-type]
+        escalate_worker=fused,  # type: ignore[arg-type]
+        planner=_FixedPlanner(["the only step"]),  # type: ignore[arg-type]
+        verifier=FlakyVerifier(fail_times=1),  # attempt 1 fails, so attempt 2 escalates
+        config=AutonomousConfig(max_attempts=2, use_planner=True, use_manager=False),
+    )
+    auto.run("do the thing")
+
+    assert fused.plans_seen == ["1. the only step"]
+    assert fused.run_state.task == "do the thing"
+
+
+def test_a_resumed_run_seeds_the_plan_it_restored_from_disk(tmp_path: Path) -> None:
+    """A checkpoint carries the plan, so a resumed run has to reach its worker with it too: that
+    path rebuilds `plan` from the stored steps and had no caller to re-seed it either."""
+    from chimera.core.runstate import RunCheckpointer
+
+    store = RunCheckpointer(tmp_path / "runs.db")
+    store.save(
+        "job",
+        {
+            "task": "do the thing",
+            "attempts": [],
+            "next_index": 2,
+            "feedback": "attempt 1 failed",
+            "plan_steps": ["the plan from before the crash"],
+            "plan_raw": "1. the plan from before the crash",
+        },
+    )
+    worker = _StatefulWorker()
+    auto = AutonomousAgent(
+        worker,  # type: ignore[arg-type]
+        planner=_FixedPlanner(["the plan this process just made"]),  # type: ignore[arg-type]
+        checkpointer=store,
+        config=AutonomousConfig(max_attempts=2, use_planner=True, use_manager=False),
+    )
+    auto.run("do the thing", thread_id="job")
+
+    # The resume DISCARDS the plan this process made moments earlier. Seeded at the planning call
+    # instead of here, the run would carry the plan it threw away while executing another.
+    assert worker.plans_seen == ["1. the plan from before the crash"]
+    assert "the plan this process just made" not in worker.restored_seen[0]
+
+
+def test_a_worker_without_a_run_state_still_runs() -> None:
+    # `Worker` promises only `run`; an agent driven over ACP has none, and a worker we cannot
+    # restore into is not a worker we may refuse to run.
+    worker = FakeWorker("done")
+    auto = AutonomousAgent(
+        worker,
+        planner=_FixedPlanner(["a step"]),  # type: ignore[arg-type]
+        config=AutonomousConfig(max_attempts=1, use_planner=True, use_manager=False),
+    )
+    assert auto.run("do the thing").success is True
+    assert not hasattr(worker, "run_state")


### PR DESCRIPTION
Arquivado como *"semeie `run_state.plan` quando a run planeja sozinha"*. Uma **leitura adversarial do mesmo código refutou essa moldura antes de qualquer linha ser escrita**, e o conserto é outro, menor.

---

## O plano nunca esteve perdido

`_compose` embute `"Plan:\n" + plan.as_text()` no prompt, e o `Agent.run` copia **o prompt inteiro** para `run_state.task` quando nenhum chamador definiu um.

Ou seja: a compactação vinha restaurando o plano esse tempo todo — **dentro do campo que o `as_message` renderiza PRIMEIRO**, rotulado *"The task you were given"*.

> Bug de **FORMA**, não de perda. A descrição arquivada tinha isso ao contrário.

## Os dois custos reais, que o chip não mencionava

**1.** O `task` carregava também o bloco inteiro de spine, mapa do repositório, lições e playbook. **Toda compactação em `/api/runs` re-injetava verbatim o contexto que ela acabara de pagar para remover.**

**2.** O `Agent.run` **congela** o `task` no ataque 1. Depois de um re-plan ele ainda guarda o plano A, **acima** do rabo onde o worker executa o plano B — então a falha do plano abandonado, contra a qual a tarefa avisava, **já existia**. Semear só `plan` não a removeria: restauraria **A e B**, e deixaria o agente escolher.

## Uma costura, os dois campos

A tarefa **crua** em `task` (antecipando a cópia do prompt, já que o `Agent.run` só preenche um `task` que ninguém definiu) e o plano **vivo** em `plan`, atualizado a cada ataque.

**No laço de ataques**, não nos quatro pontos onde um plano é decidido (fornecido, auto-planejado, restaurado do checkpoint, substituído por re-plan) — nenhum chamador enxerga os três últimos.

É também **a jusante do restore do checkpoint**, que **descarta** o plano que a run acabou de fazer: semeado na chamada de planejamento, uma run retomada carregaria justamente o plano que jogou fora.

E como a costura recebe o worker **selecionado**, o `escalate_worker` — um `Agent` separado, com `RunState` próprio, que roda em **todo** ataque depois do primeiro — fica coberto de graça.

## `tasks` fica vazio, de propósito

É lista de tarefas **com status**, existe para trabalho concluído não ser refeito. Passos crus afirmam que **nada** foi feito, e este laço conta **ataques, não passos**.

> Inventar conclusão seria mentir no único campo cujo propósito é ser acreditado.

A semeadura por chamador sai do `app.py`, inclusive `current_state = req.task` — que agora restauraria a mesma frase **duas vezes, sob dois títulos**.

---

## Verificação

Nove mutações, todas vermelhas. A que importa é a **M2 — o conserto ingênuo**: só `plan`, `task` intocado.

**Conferido independentemente antes de coletar:** apagar a linha do `task` reprova **3 testes**, incluindo `test_after_a_replan_the_abandoned_plan_is_nowhere_in_what_is_restored`.

E a M2 pegou um defeito no **dublê de teste do próprio agente**: o `_StatefulWorker` não emulava a cópia `if not run_state.task` do `Agent.run`, então o plano A nunca entrava no `task` do fake e o teste **não conseguia ver o bug para o qual foi escrito**. O **dublê** foi consertado — o teste não foi afrouxado.

| portão | resultado |
|---|---|
| `ruff check --no-cache .` | limpo |
| `mypy chimera` | 308 arquivos |
| `pytest -q` | **3386 passando**, 13 skipped |
| conflito com o #115 | resolvido por script: 2 testes de teto mantidos + o teste novo de `run_state` |

## Nota de escopo

A colisão `task`/compactação é **inalcançável hoje** — `replan_on_stall` só é ligado pelo CLI e `context_budget` só chega a um worker pela API. Esta mudança vive em código compartilhado: ela **teria armado** essa colisão, e em vez disso a **fecha**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
