### PR TITLE
one stuck worker held the whole batch, forever

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -132,6 +132,10 @@
             "title": "Diffs",
             "type": "array"
           },
+          "error": {
+            "title": "Error",
+            "type": "string"
+          },
           "index": {
             "title": "Index",
             "type": "integer"
@@ -156,7 +160,8 @@
           "attempts",
           "reverted",
           "changed_paths",
-          "diffs"
+          "diffs",
+          "error"
         ],
         "title": "AgentResultOut",
         "type": "object"

--- a/apps/desktop/src/components/Agents.test.tsx
+++ b/apps/desktop/src/components/Agents.test.tsx
@@ -20,6 +20,7 @@ function result(over: Partial<AgentResult> = {}): AgentResult {
     reverted: false,
     changed_paths: [],
     diffs: [],
+    error: "",
     ...over,
   };
 }
@@ -119,6 +120,32 @@ describe("Agents", () => {
     expect(within(passed).queryByText("failed")).not.toBeInTheDocument();
     expect(within(failed).getByText("failed")).toBeInTheDocument();
     expect(within(failed).getByText(/Attempts: 3/)).toBeInTheDocument();
+  });
+
+  it("prints why a card has no result, so a timed-out task cannot read as a failed one", async () => {
+    // The batch's wall-clock deadline blew while task 1 was still running. It comes back with the
+    // same `success: false` + zero attempts + no files as a task that genuinely did not pass, so
+    // without the server's reason on screen the two are the same card.
+    await runBatch(
+      batch({
+        results: [
+          result({ index: 0, task: "add a test" }),
+          result({
+            index: 1,
+            task: "fix the lint",
+            success: false,
+            attempts: 0,
+            error: "timed out after 14400.0s",
+          }),
+        ],
+      }),
+    );
+
+    const stalled = screen.getByTitle("fix the lint").closest("div.flex-col") as HTMLElement;
+    const passed = screen.getByTitle("add a test").closest("div.flex-col") as HTMLElement;
+    expect(within(stalled).getByText("timed out after 14400.0s")).toBeInTheDocument();
+    // And a card that really ran says nothing extra — the line is a reason, not decoration.
+    expect(within(passed).queryByText(/timed out/)).not.toBeInTheDocument();
   });
 
   it("renders cross-task conflicts prominently and marks the colliding file on its card", async () => {

--- a/apps/desktop/src/components/Agents.tsx
+++ b/apps/desktop/src/components/Agents.tsx
@@ -113,6 +113,14 @@ function AgentCard({
 
         {done ? (
           <>
+            {/* Why this card has nothing on it. A task the batch stopped waiting for and a task
+                that ran and did not pass both arrive as `success: false` with zero attempts and
+                no files — identical on screen, and the first of the two is not the user's code
+                being wrong. Printed verbatim from the server (`timed out after Ns`, or the
+                exception that killed the unit); this component never invents the reason. */}
+            {result.error ? (
+              <p className="break-words font-mono text-xs text-bad">{result.error}</p>
+            ) : null}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
               <span>
                 {t("agents.attempts")}: {result.attempts}

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -1851,6 +1851,8 @@ export interface components {
             changed_paths: string[];
             /** Diffs */
             diffs: components["schemas"]["FileDiffOut"][];
+            /** Error */
+            error: string;
             /** Index */
             index: number;
             /** Reverted */

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -970,8 +970,24 @@ def build_api_app(
                     },
                 )
                 units = [(f"task{i}", make_run(i, t)) for i, t in enumerate(req.tasks)]
+                # Named here rather than left to the default, for the reason every other
+                # user-editable knob on this endpoint is read from ``live_settings()``: an app
+                # built with an injected ``Settings`` (a test, a bench) would otherwise silently
+                # run under the PROCESS-wide value instead of the one it was handed.
+                #
+                # This is the surface where the bound stops being a nicety. There is no terminal
+                # to Ctrl-C, so a hung worker held the SSE stream open with no way to interrupt
+                # it — and, worse because it outlives the request, the ``finally`` below never
+                # ran, so ``_agents_cancels[batch_id]`` leaked for the life of the process. When
+                # the deadline fires the batch still LANDS: the timed-out tasks come back as
+                # failures carrying ``timed out after Ns``, which is why this is a bound and not
+                # a crash.
                 batch = run_isolated(
-                    ws, units, succeeded=lambda r: r.success, max_workers=max_workers
+                    ws,
+                    units,
+                    succeeded=lambda r: r.success,
+                    max_workers=max_workers,
+                    timeout=live_settings().batch_timeout,
                 )
                 emit("batch_done", _agents_batch_dict(req, ws, batch))
             except Exception as exc:  # noqa: BLE001 — surfaced to the client as an error event
@@ -1547,10 +1563,19 @@ def _agents_batch_dict(req: AgentsRequest, ws: Path, batch: IsolatedBatch[Any]) 
                     "reverted": any(a.reverted for a in auto.attempts),
                     "changed_paths": isolated.changed_paths,
                     "diffs": diffs,
+                    # Empty here by construction — a unit that returned a result has no error —
+                    # but read from the same field as the branch below so there is one source of
+                    # truth for it rather than a literal that could drift.
+                    "error": isolated.error,
                 }
             )
         else:
-            # The unit crashed before returning a result (isolation caught it) — honest empty shape.
+            # No result at all: the unit crashed, or the batch's deadline blew before it finished.
+            # Both used to arrive as the same anonymous ``success: false`` with zero attempts, which
+            # is the shape of a task that simply did not pass — so "we stopped waiting for it" was
+            # indistinguishable from "it tried and failed". ``error`` carries the real reason
+            # (``timed out after Ns`` or the exception type), which is the only part of this shape
+            # that was ever missing; everything else stays honestly empty.
             results.append(
                 {
                     "index": index,
@@ -1560,6 +1585,7 @@ def _agents_batch_dict(req: AgentsRequest, ws: Path, batch: IsolatedBatch[Any]) 
                     "reverted": False,
                     "changed_paths": isolated.changed_paths,
                     "diffs": [],
+                    "error": isolated.error,
                 }
             )
     return {

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -953,6 +953,10 @@ class AgentResultOut(BaseModel):
     reverted: bool  # any attempt was rolled back after verification failed
     changed_paths: list[str]  # files this task's worktree changed (merged back unless a conflict)
     diffs: list[FileDiffOut]  # the terminal attempt's real per-file unified diffs (never fabricated)
+    error: str  # why this task produced NO result: "timed out after Ns" (the batch's wall-clock
+    # deadline blew while this task was still running) or the exception that killed the unit. Empty
+    # whenever the task actually ran — a task that ran and did not pass says so through ``success``,
+    # and the two must not look alike on screen.
 
 
 class AgentsBatchOut(BaseModel):

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -416,6 +416,26 @@ class Settings(BaseSettings):
     # completion is not cut short; 0 disables the bound (the pre-2026-07 behaviour).
     request_timeout: float = Field(default=600.0, validation_alias="CHIMERA_REQUEST_TIMEOUT")
 
+    # The outermost deadline (seconds) for ONE parallel fan-out of isolated agents — the batch
+    # behind POST /api/agents, `chimera solve-batch` and parallel kanban dispatch. Not the same
+    # bound as CHIMERA_REQUEST_TIMEOUT above, which bounds a single model CALL: a worker can stop
+    # making progress with no call in flight at all (a shell tool that never returns, a lock, a
+    # loop), and then the batch waited forever. On the API that meant an SSE client pinned open and
+    # the batch's cancel registry never popped, with nobody at a terminal to press Ctrl-C.
+    #
+    # Wall-clock for the WHOLE fan-out, not per task (see chimera.concurrency.run_all_with_deadline,
+    # which argues the case): a bigger batch on fewer workers therefore gets less time per task.
+    # That is deliberate — what this bounds is how long one request may hold the process, not each
+    # task's fairness.
+    #
+    # 4h is roughly 8x the heaviest batch anyone has a reason to run (8 tasks / 4 workers / 3
+    # attempts of single-digit minutes each ≈ 30 min) and far past what a human waits for. It does
+    # NOT clear the arithmetic worst case — 3 attempts × ~10 calls × the 600s call deadline is ~5h
+    # for ONE task — and that is the honest limit of this default: a run in which every single call
+    # parks at the provider's deadline is a broken provider, not work worth waiting out. 0 disables
+    # the bound entirely (the pre-2026-08 behaviour) for a deployment that disagrees.
+    batch_timeout: float = Field(default=14400.0, validation_alias="CHIMERA_BATCH_TIMEOUT")
+
     # Arm the taint-adaptive tool narrowing on the API server (`chimera app` / `chimera serve`).
     # Once a run consumes untrusted content, DANGEROUS_WHEN_TAINTED tools need approval; the server
     # has no tool-level approver yet, so that resolves to a refusal with an explanatory result —

--- a/chimera/orchestration/isolation.py
+++ b/chimera/orchestration/isolation.py
@@ -66,6 +66,30 @@ class IsolatedBatch(Generic[T]):
         return all(result.ok for result in self.results)
 
 
+def _batch_deadline(timeout: float | None) -> float | None:
+    """The deadline a batch actually runs under: the caller's if it named one, else the deployment's.
+
+    ``None`` used to mean *wait forever*, and every production caller but one left it at ``None`` —
+    so the deadline machinery below existed, was tested, and was reached by nobody. One hung worker
+    then held its whole batch. Two of the four call sites are served over HTTP — ``POST /api/agents``
+    and ``POST /api/kanban/run``, both dispatching on a worker thread behind an SSE stream — so
+    there is nobody at a terminal to Ctrl-C them. On the first, the client stayed pinned open *and*
+    the endpoint's ``finally`` — the one that pops ``_agents_cancels[batch_id]`` — never ran, so the
+    batch leaked for the life of the process.
+
+    Resolving it here rather than at each call site is the whole point: a safe default a caller has
+    to remember is the same bug holding a ticket for the next caller. An explicit ``timeout`` still
+    wins, and any non-positive value — here or in ``CHIMERA_BATCH_TIMEOUT`` — means *no deadline*.
+    ``0`` must never reach :func:`run_all_with_deadline`, where it would expire every unit at once.
+    """
+    if timeout is not None:
+        return timeout if timeout > 0 else None
+    from chimera.config import get_settings
+
+    configured = get_settings().batch_timeout
+    return configured if configured > 0 else None
+
+
 def run_isolated(
     workspace: Path,
     units: list[IsolatedUnit[T]],
@@ -80,11 +104,16 @@ def run_isolated(
     merge and listed in ``IsolatedBatch.conflicts`` for the caller to resolve. Outside a git
     repo, units run against ``workspace`` directly (no isolation) — safe, but concurrent
     edits are the caller's responsibility there.
+
+    ``timeout`` bounds the WHOLE batch in wall-clock seconds. Omitting it does **not** mean
+    *forever* — it means the deployment's ``CHIMERA_BATCH_TIMEOUT`` (see :func:`_batch_deadline`,
+    which explains why the default lives there and not in each caller). Pass ``0`` for no bound.
     """
     workspace = Path(workspace).resolve()
     if not units:
         return IsolatedBatch(results=[])
     git = is_git_repo(workspace)
+    deadline = _batch_deadline(timeout)
 
     # Create one worktree per unit up front (in the parent), so each worker only runs its fn.
     trees: dict[str, GitWorktree | None] = {}
@@ -99,10 +128,10 @@ def run_isolated(
         outcomes = run_all_with_deadline(
             [(name, partial(fn, paths[name])) for name, fn in units],
             max_workers=max_workers,
-            timeout=timeout,
+            timeout=deadline,
         )
         for name, _ in units:
-            results[name] = _collect(outcomes[name], trees[name], succeeded, timeout)
+            results[name] = _collect(outcomes[name], trees[name], succeeded, deadline)
         conflicts, merged = _merge_back(workspace, trees, results)
     finally:
         for tree in trees.values():
@@ -171,9 +200,14 @@ def run_in_processes(
     :class:`IsolatedResult` — the orchestrator survives, and a hung unit's *process* is killed
     rather than abandoned. Only data crosses the process boundary, so pass module-level callables
     that return picklable values (the RPC seam), not closures over live backends.
+
+    ``timeout`` resolves exactly as in :func:`run_isolated`: omitted means the deployment's
+    ``CHIMERA_BATCH_TIMEOUT``, not forever. Same rule in both siblings on purpose — a reader
+    should not have to know which of the two got the fix.
     """
     if not units:
         return []
+    deadline = _batch_deadline(timeout)
     out: dict[str, IsolatedResult[T]] = {}
     # As in run_isolated: the deadline belongs on as_completed (the call that waits), not on
     # future.result() of an already-finished future. Without it the documented "hangs past timeout
@@ -182,7 +216,7 @@ def run_in_processes(
     try:
         futures = {pool.submit(fn): name for name, fn in units}
         try:
-            for future in as_completed(futures, timeout=timeout):
+            for future in as_completed(futures, timeout=deadline):
                 name = futures[future]
                 try:
                     out[name] = IsolatedResult(name, ok=True, value=future.result())
@@ -193,7 +227,7 @@ def run_in_processes(
                 if name in out:
                     continue
                 future.cancel()
-                out[name] = IsolatedResult(name, ok=False, error=f"timed out after {timeout}s")
+                out[name] = IsolatedResult(name, ok=False, error=f"timed out after {deadline}s")
     finally:
         # Snapshot the workers BEFORE shutting down: `shutdown` sets the executor's process map to
         # None, so reading it afterwards finds nothing to kill and the straggler survives.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -424,6 +424,80 @@ def test_post_agents_non_git_repo_sets_is_repo_false(tmp_path: Any) -> None:
     assert (ws / "x.txt").read_text(encoding="utf-8") == "t"  # the edit happened in-place
 
 
+def test_post_agents_a_hung_task_does_not_hold_the_batch(tmp_path: Any) -> None:
+    """A task that stops making progress must not pin the stream open — and must SAY that is why.
+
+    This endpoint is the one surface with nobody at a terminal. Before the batch had a deadline, a
+    worker that never returned held `run_isolated` forever: the client sat on an SSE stream that
+    would never end, and the `finally` that pops `_agents_cancels[batch_id]` never ran, so the
+    batch's cancel Events leaked for the life of the process. Both are asserted below, because
+    "the response came back" alone would still pass if the registry leaked.
+
+    The stub blocks for 15s and then reports SUCCESS rather than blocking forever. That is
+    deliberate: a unit that truly never returns turns a regression here into a hung test suite, and
+    a hang is the one failure that does not read as a failure. Reporting success on the far side
+    means an unbounded batch comes back *wrong* (a pass, no error) instead of not coming back.
+    """
+    import threading as _threading
+
+    from chimera.api import app as app_module
+    from chimera.api import build_api_app
+    from chimera.api.app import RunRequest
+    from chimera.core.events import EventSink
+
+    ws = tmp_path / "ws"
+    _init_repo(ws)
+    release = _threading.Event()
+
+    class _HungAgent:
+        def run(self, task: str) -> Any:
+            from chimera.core.autonomous import Attempt, AutonomousResult
+
+            release.wait(15.0)
+            return AutonomousResult(
+                answer="late",
+                success=True,
+                attempts=[
+                    Attempt(
+                        index=0, answer="late", approved=True, verified=True, reverted=False, success=True
+                    )
+                ],
+            )
+
+    def factory(
+        _req: RunRequest,
+        _ws: Any,
+        _on_event: EventSink,
+        _settings: Any,
+        _should_stop: Callable[[], bool] | None = None,
+    ) -> Any:
+        return _HungAgent()
+
+    # 1s via the INJECTED settings — an app built with its own Settings must run under those, which
+    # is only true because the endpoint reads the deadline from live_settings() instead of leaving
+    # run_isolated to fall back on the process-wide value.
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"), CHIMERA_BATCH_TIMEOUT=1.0)
+    client = TestClient(
+        build_api_app(lambda: ChatSession(_FakeAgent()), settings=settings, solve_agent_factory=factory)
+    )
+    try:
+        resp = client.post("/api/agents", json={"tasks": [{"task": "hangs"}], "workspace": str(ws)})
+    finally:
+        release.set()  # let the abandoned worker finish instead of parking a thread for 15s
+
+    assert resp.status_code == 200
+    events = _read_sse(resp.text)
+    assert [e for e, _ in events][-1] == "batch_done"  # the stream ENDED, on the batch's own terms
+    only = next(d for e, d in events if e == "batch_done")["results"][0]
+    assert only["success"] is False
+    # The reason is named. A timeout that arrives as a bare `success: false` is indistinguishable
+    # from a task that ran and did not pass, which is the lie this field exists to stop.
+    assert only["error"].startswith("timed out after"), only["error"]
+    assert only["attempts"] == 0 and only["changed_paths"] == [] and only["diffs"] == []
+    batch_id = next(d for e, d in events if e == "batch")["batch_id"]
+    assert batch_id not in app_module._agents_cancels  # the finally ran: nothing leaked
+
+
 def test_post_agents_emits_batch_id_frame_and_leaves_no_cancel_path_untouched(tmp_path: Any) -> None:
     """The batch stream leads with a `batch` frame carrying its id (the cancel handle), and the DEFAULT
     path — no cancel requested — still streams exactly as before: start → tagged events → batch_done,

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import threading
 import time
 from pathlib import Path
 
@@ -136,6 +137,52 @@ def _sleep_forever() -> int:
 
     time.sleep(600)
     return 0
+
+
+def test_run_isolated_bounds_a_hung_unit_nobody_asked_it_to_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No `timeout=` argument, and the batch still comes back.
+
+    The deadline machinery was in place and covered by the test above — and three of the four
+    production call sites never passed a timeout, so `None` meant "wait forever" and none of it ran.
+    A default that each caller has to remember is the same bug waiting for the next caller, so the
+    default now lives in `_batch_deadline` and this asserts the *no-argument* path, which is the one
+    every caller actually takes.
+
+    Bounded at 15s rather than forever for the same reason as the API test: a regression must make
+    this go RED, not make the suite hang.
+    """
+    release = threading.Event()
+
+    def blocks(_ws: Path) -> str:
+        release.wait(15.0)
+        return "finished after all"
+
+    monkeypatch.setenv("CHIMERA_BATCH_TIMEOUT", "1")
+    try:
+        batch = run_isolated(tmp_path, [("hung", blocks)])
+    finally:
+        release.set()
+
+    assert not batch.ok
+    # Names the deadline it actually enforced, so a bound quietly substituted for another one shows.
+    assert batch.results[0].error == "timed out after 1.0s", batch.results[0].error
+
+
+def test_a_zero_batch_timeout_disables_the_bound_it_does_not_expire_everything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """0 means "no deadline", and the failure it guards against is the loud one.
+
+    `run_all_with_deadline` computes `now + timeout`, so a 0 forwarded verbatim gives every unit
+    `remaining == 0` and the whole batch times out *instantly* — an opt-out that behaves as its exact
+    opposite, and one that would look like the units themselves being broken. `_batch_deadline`
+    therefore turns any non-positive value into `None` before it can get there.
+    """
+    monkeypatch.setenv("CHIMERA_BATCH_TIMEOUT", "0")
+    batch = run_isolated(tmp_path, [("quick", _writer("z.txt", "Z"))])
+    assert batch.ok and batch.results[0].value == "Z"
 
 
 def test_run_in_processes_timeout_bounds_a_hung_unit() -> None:


### PR DESCRIPTION
`run_isolated` has accepted a `timeout` since it was written, `run_all_with_deadline` implements it, and `tests/test_isolation.py` covers it. Every production caller but one left it at `None`, which meant *wait forever* — so the machinery existed, was tested, and was reached by nobody.

**Two of the four call sites are served over HTTP**, and that corrects the framing this started with. `POST /api/agents` was the known one. `POST /api/kanban/run` is the second: `api/features.py:435` calls `dispatch(workers>1)` → `run_isolated`, on a worker thread behind an SSE stream. Neither has anybody at a terminal to Ctrl-C. On the agents endpoint the client also stayed pinned open **and** the `finally` that pops `_agents_cancels[batch_id]` never ran, so the batch leaked for the life of the process.

## Where the deadline is resolved, and why not at the call sites

In `_batch_deadline()` inside `isolation.py`, used by `run_isolated` **and** `run_in_processes`. `timeout=None` stops meaning *forever* and starts meaning *the deployment's `CHIMERA_BATCH_TIMEOUT`*. All four sites inherit it — including `crew`, whose own default was `None` — and no future caller can forget. A safe default a caller has to remember is the same bug holding a ticket for the next caller.

The agents endpoint still passes `timeout=live_settings().batch_timeout` explicitly, for a measured reason: `live_settings()` returns `settings_override or get_settings()`, so an app built with injected `Settings` (test, bench) would otherwise run under the process-wide value rather than the one it was handed.

`POST /api/kanban/run` takes the ambient default instead. `dispatch()` is a public function whose signature is about lanes, and threading a `timeout` through it to satisfy one endpoint would be inventing API for a default that already reaches it.

## The knob

`CHIMERA_BATCH_TIMEOUT`, default **14400.0** (4 h), `0` disables — the same convention `request_timeout` uses. Not reused from `request_timeout`: that one bounds a *model call*, and a worker can hang with no call in flight at all (a shell that never returns, a lock, a loop).

The default is wall-clock for the whole fan-out, and the comment carries the honest arithmetic: about 8× a realistic heavy batch (8 tasks / 4 workers / 3 attempts of minutes ≈ 30 min), **and** that it does not cover the worst case on paper (3 × ~10 calls × 600 s ≈ 5 h for a single task) — with the argument that a run where every call touches the provider deadline is a broken provider, and `0` exists for whoever disagrees.

## What the client sees

An expiry used to arrive as `success: false`, `attempts: 0`, no files — the same shape as a task that ran and failed. `AgentResultOut` gains `error`, filled from `IsolatedResult.error` in both branches of `_agents_batch_dict`, and the board card prints the server's string verbatim. `_collect` takes `deadline` rather than `timeout`, or the message would read `timed out after Nones`.

## Verification

Six sabotages, each turns its test red:

| break | test | red |
|---|---|---|
| API stops passing `timeout=` | `test_post_agents_a_hung_task_does_not_hold_the_batch` | yes — `assert True is False`, 17.4 s |
| `_batch_deadline` returns `timeout` unchanged | `test_run_isolated_bounds_a_hung_unit_nobody_asked_it_to_bound` | yes — `ok=True`, 16.1 s |
| drop the non-positive guard | `test_a_zero_batch_timeout_disables_the_bound` | yes — `timed out after 0.0s` |
| drop `"error"` from the no-result branch | `test_post_agents_a_hung_task_does_not_hold_the_batch` | yes — KeyError |
| `_collect(..., timeout)` instead of `deadline` | `test_run_isolated_bounds_a_hung_unit…` | yes — `timed out after Nones` |
| UI: `{result.error ?` → `{false ?` | vitest, `prints why a card has no result` | yes — 1 failed / 18 passed |

Each application and reversal printed the anchor count and checked the file actually changed. On the first attempt at the last one the *reversal* silently did not take — replacing with an empty string poisons `count("")` — and vitest then failed on alias resolution rather than on the sabotage; redone with a non-degenerate anchor and a green control before sabotaging.

`ruff` clean · `mypy` 308 files · `pytest` **3413 passed, 13 skipped** · desktop **564 tests** · no OpenAPI drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
