### PR TITLE
a two-line script passed every rule, a markdown file did not

### DIFF
--- a/chimera/governance/__init__.py
+++ b/chimera/governance/__init__.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
         fence,
         ledger_registry,
     )
-    from chimera.governance.policy import Decision, Rule, RuleSet, Verdict
+    from chimera.governance.policy import Decision, Rule, RuleSet, Scope, Verdict
     from chimera.governance.precedent import PrecedentStore
     from chimera.governance.quarantine import (
         QuarantinedReader,
@@ -106,6 +106,7 @@ _LAZY: dict[str, tuple[str, str]] = {
     "Decision": ("policy", "Decision"),
     "Rule": ("policy", "Rule"),
     "RuleSet": ("policy", "RuleSet"),
+    "Scope": ("policy", "Scope"),
     "Verdict": ("policy", "Verdict"),
     "PrecedentStore": ("precedent", "PrecedentStore"),
     "QuarantinedReader": ("quarantine", "QuarantinedReader"),
@@ -140,6 +141,7 @@ __all__ = [
     "Verdict",
     "Rule",
     "RuleSet",
+    "Scope",
     "TrustKernel",
     "AuditLog",
     "GovernedTool",

--- a/chimera/governance/governed_tool.py
+++ b/chimera/governance/governed_tool.py
@@ -40,6 +40,42 @@ def elide_values(kwargs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def render_action(name: str, kwargs: dict[str, Any]) -> tuple[str, str]:
+    """Split a tool call into ``(action, document)`` for the rules to judge separately.
+
+    The action used to be ``f"{name} {kwargs}"``. Interpolating a dict calls ``repr`` on it, and
+    ``repr`` escapes a newline into the two characters ``\\`` and ``n`` — so the ``n`` fused with the
+    next word (``\\nrm`` arrived as the text ``nrm``) and killed the ``\\b`` that every rule in
+    :mod:`~chimera.governance.policy` starts with. Measured before the fix:
+
+        review  git_force_push  'git push --force origin main'
+        allow   default         'echo hi\\ngit push --force origin main'
+        block   rm_rf_root      'rm -rf /var/lib/data'
+        allow   default         'set -e\\nrm -rf /var/lib/data'
+
+    The protection was inverted: every real shell script has more than one line, so the two-line
+    version of a blocked command walked through, while a markdown file *quoting* ``rm -rf /tmp/x``
+    was hard-blocked. Values now go in raw, one per line — the separator matters, because the rules
+    are already written line-aware (``[^\\n]*``), so a newline between arguments is what stops two
+    unrelated values from fusing into a signature neither of them contains.
+
+    Document bodies go to the second return value instead of the first, reusing the one definition
+    of "this is a body, not an identifier" that :data:`_DOCUMENT_ARGS` already carries for the audit
+    — so a gap in that list is one gap to fix, not two that can drift apart.
+
+    The tool NAME leads the action. That was checked rather than assumed: all ten default rules are
+    shell or credential signatures and not one of them mentions a tool, so putting the name on its
+    own line costs no match today and keeps the judge told what was called.
+    """
+    command = "\n".join(
+        [name, *(str(value) for key, value in kwargs.items() if key not in _DOCUMENT_ARGS)]
+    )
+    document = "\n".join(
+        str(value) for key, value in kwargs.items() if key in _DOCUMENT_ARGS
+    )
+    return command, document
+
+
 class GovernedTool(Tool):
     """A tool whose execution is gated by the trust kernel."""
 
@@ -67,15 +103,19 @@ class GovernedTool(Tool):
         self.untrusted_output = is_untrusted_output(inner)
 
     def run(self, **kwargs: Any) -> str:
-        action = f"{self.name} {kwargs}"
-        # The rules read the WHOLE action; the audit gets the elided one. Redaction alone was not
-        # enough: it catches credential SHAPES, and the body of a private key has no shape — a
+        action, document = render_action(self.name, kwargs)
+        # The rules read both halves — command signatures against `action`, credential signatures
+        # against both. The audit gets the elided rendering and neither half raw. Redaction alone was
+        # not enough: it catches credential SHAPES, and the body of a private key has no shape — a
         # governed `write_file` of `deploy/id_rsa` put `-----BEGIN RSA PRIVATE KEY-----` and the
         # first lines of the key into a file the app serves over HTTP. Nothing about an audit trail
         # needs the contents of the file that was written; it needs to know which file, and why the
         # call was stopped.
         verdict = self.kernel.evaluate(
-            action, context=self._context(), record_as=f"{self.name} {elide_values(kwargs)}"
+            action,
+            context=self._context(),
+            record_as=f"{self.name} {elide_values(kwargs)}",
+            document=document,
         )
         if verdict.decision == Decision.BLOCK:
             return refusal(f"[governance: BLOCKED — {verdict.reason}] "

--- a/chimera/governance/kernel.py
+++ b/chimera/governance/kernel.py
@@ -82,7 +82,14 @@ class TrustKernel:
         self.default = default
         self._judge_takes_context = _accepts_context(judge)
 
-    def evaluate(self, action: str, *, context: str = "", record_as: str | None = None) -> Verdict:
+    def evaluate(
+        self,
+        action: str,
+        *,
+        context: str = "",
+        record_as: str | None = None,
+        document: str = "",
+    ) -> Verdict:
         """Decide on ``action``, optionally told *why* it is happening.
 
         ``context`` was declared here and read nowhere: the signature accepted it, the body never
@@ -98,8 +105,18 @@ class TrustKernel:
         It deliberately does NOT reach the precedent store: precedents are keyed on the action, and
         folding context into that key would fragment the cache so finely that nothing would ever
         match twice — turning a cost optimisation into a cost multiplier.
+
+        ``document`` is the body the tool is about to write, kept apart from ``action`` so that
+        command signatures are not matched against prose. It reaches the **rules** only. It is
+        deliberately withheld from the judge (an LLM call whose cost scales with a file's size), from
+        the precedent key (a body is unique per call, so caching on it never hits), and above all
+        from the **audit** — which is the guarantee `record_as` and :func:`audit._redacted` exist to
+        make, and undoing it here would put file contents back on a screen served over HTTP.
         """
-        verdict = more_severe(self.ruleset.evaluate(action), self.learned.evaluate(action))
+        verdict = more_severe(
+            self.ruleset.evaluate(action, document=document),
+            self.learned.evaluate(action, document=document),
+        )
         source = "lexical"
         # Precedent RAG: a confirmed precedent (2 judges agreed) answers a similar
         # action cheaply, before the expensive judge is consulted again.

--- a/chimera/governance/policy.py
+++ b/chimera/governance/policy.py
@@ -37,6 +37,24 @@ class Verdict:
         return self.decision in (Decision.ALLOW, Decision.WARN)
 
 
+class Scope(StrEnum):
+    """What a rule is entitled to read.
+
+    Every rule this module ships is either a **shell-command signature** (``rm -rf /``, a force
+    push, ``curl | bash``) or a **credential signature**. Only the first kind cares whether the text
+    is going to be executed, and running it over text that is merely being *written* is how a
+    markdown file that says "never run ``rm -rf /tmp/x``" got hard-blocked while the real two-line
+    script ran. Measured on a 42-case corpus: judging document bodies as commands cost 4 false
+    positives; not judging them at all cost 2 missed credentials. Scoping costs neither.
+    """
+
+    COMMAND = "command"
+    """Reads only text the tool is about to execute or act on."""
+
+    ANY_TEXT = "any_text"
+    """Reads document bodies too — for signatures that are dangerous wherever they appear."""
+
+
 @dataclass
 class Rule:
     """A lexical rule: a regex that maps a matching action to a decision."""
@@ -45,16 +63,30 @@ class Rule:
     pattern: re.Pattern[str]
     decision: Decision
     reason: str
+    scope: Scope = Scope.COMMAND
+    """Defaults to COMMAND: a new rule is a command signature until someone says otherwise."""
+
+
+def _pattern(source: str) -> re.Pattern[str]:
+    """Compile line-aware, so ``$`` means end of **line** rather than end of the whole action.
+
+    Two rules below anchor with ``$`` to say "this has to be the last argument": ``rm -rf .`` and
+    ``scp file host:/path``. An action holds a whole script, not one command, so without this flag
+    ``$`` meant end-of-script and both rules only fired when the dangerous command happened to be on
+    the final line — ``cd /srv\\nrm -rf .\\necho ok`` matched nothing. No default rule uses ``^``, so
+    the flag's other half changes no behaviour here; that was checked, not assumed.
+    """
+    return re.compile(source, re.MULTILINE)
 
 
 def _default_rules() -> list[Rule]:
     return [
-        Rule("rm_rf_root", re.compile(r"\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(/|~|\*|\.\s*$)"), Decision.BLOCK, "recursive force delete of a root/home/glob path"),
-        Rule("disk_destroy", re.compile(r"\bmkfs\b|\bdd\s+if=.*\bof=/dev/"), Decision.BLOCK, "disk format/overwrite"),
-        Rule("fork_bomb", re.compile(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:"), Decision.BLOCK, "fork bomb"),
-        Rule("chmod_777_root", re.compile(r"\bchmod\s+-R\s+777\s+/"), Decision.BLOCK, "world-writable root"),
-        Rule("curl_pipe_shell", re.compile(r"\b(curl|wget)\b[^\n|]*\|\s*(sudo\s+)?(bash|sh|zsh)\b"), Decision.REVIEW, "piping a remote script straight into a shell"),
-        Rule("git_force_push", re.compile(r"\bgit\s+push\b[^\n]*(--force\b|--force-with-lease\b|\s-f\b)"), Decision.REVIEW, "force push"),
+        Rule("rm_rf_root", _pattern(r"\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(/|~|\*|\.\s*$)"), Decision.BLOCK, "recursive force delete of a root/home/glob path"),
+        Rule("disk_destroy", _pattern(r"\bmkfs\b|\bdd\s+if=.*\bof=/dev/"), Decision.BLOCK, "disk format/overwrite"),
+        Rule("fork_bomb", _pattern(r":\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:"), Decision.BLOCK, "fork bomb"),
+        Rule("chmod_777_root", _pattern(r"\bchmod\s+-R\s+777\s+/"), Decision.BLOCK, "world-writable root"),
+        Rule("curl_pipe_shell", _pattern(r"\b(curl|wget)\b[^\n|]*\|\s*(sudo\s+)?(bash|sh|zsh)\b"), Decision.REVIEW, "piping a remote script straight into a shell"),
+        Rule("git_force_push", _pattern(r"\bgit\s+push\b[^\n]*(--force\b|--force-with-lease\b|\s-f\b)"), Decision.REVIEW, "force push"),
         # The eight rules this set shipped with all watch what comes IN (a remote script piped into
         # a shell) or what gets DESTROYED (rm -rf, mkfs, a force push). None of them watched data
         # going OUT, and the taint ledger does not cover it either: it escalates an exec only once
@@ -75,7 +107,7 @@ def _default_rules() -> list[Rule]:
         # whatever the mode is, so these fire there from the moment they land.
         Rule(
             "data_upload_egress",
-            re.compile(
+            _pattern(
                 # curl reading a LOCAL file into the request body. `-T`/`--upload-file` take a
                 # filename directly; `-d` and `-F` only read a file when the value starts with `@`,
                 # and without it they carry an inline literal that never touched the disk.
@@ -98,15 +130,25 @@ def _default_rules() -> list[Rule]:
         # somewhere its owner never configured, and no force flag is involved.
         Rule(
             "git_push_foreign_remote",
-            re.compile(
+            _pattern(
                 r"\bgit\s+push\b(?![^\n]*\borigin\b)[^\n]*"
                 r"\s(?:https?://|git@|ssh://|[\w.-]+@[\w.-]+:)"
             ),
             Decision.REVIEW,
             "push to a remote other than origin",
         ),
-        Rule("sudo_rm", re.compile(r"\bsudo\s+rm\b"), Decision.WARN, "privileged delete"),
-        Rule("secret_material", re.compile(r"sk-[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{16}|-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"), Decision.WARN, "possible secret/credential in the action"),
+        Rule("sudo_rm", _pattern(r"\bsudo\s+rm\b"), Decision.WARN, "privileged delete"),
+        # The one rule here that is NOT a shell-command signature, and so the one that reads
+        # document bodies as well. A key does not become safe by being written to a file instead of
+        # exported in a shell — `write_file {'path': '.env', 'content': 'OPENAI_API_KEY=sk-…'}` is
+        # the exact call this fired on in the measurement that produced `audit._redacted`.
+        Rule(
+            "secret_material",
+            _pattern(r"sk-[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{16}|-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+            Decision.WARN,
+            "possible secret/credential in the action",
+            scope=Scope.ANY_TEXT,
+        ),
     ]
 
 
@@ -121,11 +163,19 @@ class RuleSet:
     def add(self, rule: Rule) -> None:
         self.rules.append(rule)
 
-    def evaluate(self, action: str) -> Verdict | None:
-        """Return the most severe matching rule's verdict, or None if no match."""
+    def evaluate(self, action: str, *, document: str = "") -> Verdict | None:
+        """Return the most severe matching rule's verdict, or None if no match.
+
+        ``action`` is what the tool is about to *do*; ``document`` is the body it is about to
+        *write* — a file's contents, a patch, the text of a page. Only :attr:`Scope.ANY_TEXT` rules
+        see the second one, because a command signature found inside prose is a quotation, not a
+        command. ``document`` defaults to empty, so a caller with nothing to separate (``chimera
+        guard``, a distilled rule under test) behaves exactly as before.
+        """
         best: Verdict | None = None
         for rule in self.rules:
-            if rule.pattern.search(action):
+            haystack = f"{action}\n{document}" if rule.scope is Scope.ANY_TEXT and document else action
+            if rule.pattern.search(haystack):
                 candidate = Verdict(rule.decision, rule.reason, rule.name)
                 if best is None or _SEVERITY[candidate.decision] > _SEVERITY[best.decision]:
                     best = candidate

--- a/tests/test_action_rendering.py
+++ b/tests/test_action_rendering.py
@@ -1,0 +1,207 @@
+"""Every rule in the policy died on the second line of a shell script.
+
+`GovernedTool.run` built the string the rules read as `f"{self.name} {kwargs}"`. Interpolating a
+dict calls `repr` on it, and `repr` escapes a newline into the two characters `\\` and `n` — so the
+`n` fused with the word after it (`\\nrm` arrived as the text `nrm`) and destroyed the `\\b` that
+every rule in `chimera.governance.policy` opens with. Measured on the branch before this, with the
+default ruleset:
+
+    review  git_force_push   'git push --force origin main'
+    allow   default          'echo hi\\ngit push --force origin main'
+    block   rm_rf_root       'rm -rf /var/lib/data'
+    allow   default          'set -e\\nrm -rf /var/lib/data'
+    block   rm_rf_root       write_file {'path': 'd.md', 'content': 'roda `rm -rf /tmp/x`'}
+
+The protection was inverted. Every real shell script has more than one line, so the two-line form of
+a blocked command walked straight through, while a markdown file that merely *quoted* `rm -rf` was
+hard-blocked. Both halves are the same mistake made twice: the rules were reading a rendering of the
+call instead of its values, and reading document bodies as though they were commands.
+
+Two further failures fell out of measuring rather than assuming, and are pinned here too:
+`rm -rf .` never fired at all (its `$` anchor sat behind the dict repr's closing `'}`), and once
+values went in raw it still only fired on the last line, because `$` without `re.MULTILINE` means
+end-of-script rather than end-of-command.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from chimera.governance.audit import AuditLog
+from chimera.governance.governed_tool import GovernedTool, render_action
+from chimera.governance.kernel import TrustKernel
+from chimera.governance.policy import Decision, RuleSet, Scope
+from chimera.tools.base import Tool
+
+
+class _Runner(Tool):
+    """Stands in for `run_shell`: its argument is executed, so command rules apply to it."""
+
+    name = "run_shell"
+    description = "run a command"
+    parameters = {"type": "object", "properties": {"command": {"type": "string"}}}
+
+    def run(self, **kwargs: Any) -> str:
+        return "ran"
+
+
+class _Writer(Tool):
+    """Stands in for `write_file`: `content` is a body it stores, never a command it runs."""
+
+    name = "write_file"
+    description = "write a file"
+    parameters = {
+        "type": "object",
+        "properties": {"path": {"type": "string"}, "content": {"type": "string"}},
+    }
+
+    def run(self, **kwargs: Any) -> str:
+        return "wrote"
+
+
+def _decide(tool: Tool, **kwargs: Any) -> Decision:
+    """The kernel's verdict for one governed call, without running anything."""
+    seen: list[Any] = []
+    governed = GovernedTool(tool, TrustKernel(), approve=lambda v, a: seen.append(v) or False)
+    out = governed.run(**kwargs)
+    if "BLOCKED" in out:
+        return Decision.BLOCK
+    if seen:
+        return Decision.REVIEW
+    return Decision.ALLOW
+
+
+# --- the reported defect ----------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("git push --force origin main", Decision.REVIEW),
+        ("echo hi\ngit push --force origin main", Decision.REVIEW),
+        ("rm -rf /var/lib/data", Decision.BLOCK),
+        ("set -e\nrm -rf /var/lib/data", Decision.BLOCK),
+    ],
+)
+def test_a_second_line_does_not_hide_a_command(command: str, expected: Decision) -> None:
+    """The four measured cases. Rows 2 and 4 were `allow`/`default` before this."""
+    assert _decide(_Runner(), command=command) is expected
+
+
+def test_the_newline_survives_into_the_action() -> None:
+    """The mechanism, pinned directly: a real newline, not the two characters `\\` and `n`.
+
+    Asserting on the verdict alone would keep passing if someone "fixed" this by loosening the
+    rules' word boundaries instead, which would buy the false positives back.
+    """
+    action, _ = render_action("run_shell", {"command": "set -e\nrm -rf /var/lib/data"})
+    assert "\n" in action
+    assert "\\n" not in action
+    assert "nrm" not in action  # what the escaped newline used to fuse into
+
+
+# --- the other half: prose that quotes a command is not a command -----------
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "roda `rm -rf /tmp/x`",
+        "git push --force is dangerous",
+        "never run `mkfs.ext4 /dev/sda`",
+    ],
+)
+def test_a_document_that_quotes_a_command_is_not_blocked(content: str) -> None:
+    """`write_file` of a markdown file was hard-blocked for mentioning a command."""
+    assert _decide(_Writer(), path="doc.md", content=content) is Decision.ALLOW
+
+
+def test_the_path_is_still_judged_even_though_the_body_is_not() -> None:
+    """Dropping bodies must not drop the whole call: the arguments that identify it still count."""
+    action, document = render_action("write_file", {"path": ".env", "content": "x = 1"})
+    assert ".env" in action
+    assert "x = 1" not in action
+    assert document == "x = 1"
+
+
+# --- what must NOT be lost by scoping ---------------------------------------
+
+#: Assembled at import, never spelled out, so this file holds no credential-shaped literal —
+#: `gitleaks` failed this repo's CI twice on earlier fixtures, once for a written-out bearer token
+#: and once because an identifier alone read as a key. See the note in
+#: `tests/test_governance_on_the_api_path.py`; the rule under test sees the assembled value anyway.
+_FAKE_TOKEN = "sk-" + "B" * 16 + "5678"
+
+
+def test_a_credential_in_a_document_body_is_still_noticed() -> None:
+    """The reason scoping is per-rule rather than a blanket "skip document bodies".
+
+    Skipping them wholesale scored better than the status quo on the corpus and still opened two
+    holes: a key does not become safe by being written to a file instead of exported in a shell.
+    `secret_material` is the one default rule marked `Scope.ANY_TEXT`, and this is why.
+    """
+    assert _decide(_Writer(), path=".env", content=f"OPENAI_API_KEY={_FAKE_TOKEN}\n") is Decision.ALLOW
+    verdict = TrustKernel().evaluate("write_file\n.env", document=_FAKE_TOKEN)
+    assert verdict.decision is Decision.WARN
+    assert verdict.rule == "secret_material"
+
+
+def test_only_any_text_rules_read_the_document() -> None:
+    """A command rule handed the same body must stay silent — otherwise scoping is decorative."""
+    rules = RuleSet()
+    assert all(r.scope is Scope.COMMAND for r in rules.rules if r.name == "rm_rf_root")
+    assert rules.evaluate("write_file\nd.md", document="run `rm -rf /`") is None
+    assert rules.evaluate("run_shell\nrm -rf /", document="") is not None
+
+
+# --- the two failures that measuring turned up ------------------------------
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("rm -rf .", Decision.BLOCK),
+        ("cd /srv\nrm -rf .\necho ok", Decision.BLOCK),
+        ("tar czf b.tgz .\nscp b.tgz dep@host:/backup\necho done", Decision.REVIEW),
+    ],
+)
+def test_an_anchored_rule_fires_off_the_last_line(command: str, expected: Decision) -> None:
+    """`$` has to mean end-of-command. `rm -rf .` matched nothing at all before this."""
+    assert _decide(_Runner(), command=command) is expected
+
+
+# --- benign calls must stay benign ------------------------------------------
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls -la",
+        "rm -rf build/",
+        "git push origin feature/x",
+        "npm ci\nnpm run build",
+        "scp dep@host:/var/log/a.log ./logs/",
+        "nc -z localhost 5432",
+    ],
+)
+def test_ordinary_commands_are_untouched(command: str) -> None:
+    """Splitting values apart could have fused two of them into a signature. It must not."""
+    assert _decide(_Runner(), command=command) is Decision.ALLOW
+
+
+# --- the guarantee this must not undo ---------------------------------------
+
+def test_the_document_reaches_the_rules_but_never_the_audit(tmp_path: pathlib.Path) -> None:
+    """Handing bodies to the rules must not hand them to a log the app serves over HTTP.
+
+    That is exactly the hole `record_as` and `audit._redacted` were added to close, and the new
+    `document` argument is the shortest path to reopening it.
+    """
+    marker = "TOTALLY-UNIQUE-BODY-MARKER"
+    audit = AuditLog(tmp_path / "audit.jsonl")
+    governed = GovernedTool(_Writer(), TrustKernel(audit=audit))
+    governed.run(path="notes.md", content=f"{marker} and `rm -rf /tmp/x`")
+
+    raw = (tmp_path / "audit.jsonl").read_text(encoding="utf-8")
+    assert marker not in raw, "the file body is in a log served over HTTP"
+    assert "notes.md" in raw, "the audit lost which file was written"
+    assert "chars>" in raw, "the elided rendering was replaced rather than kept"

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -19,7 +19,7 @@ from chimera.governance import (
     govern_registry,
 )
 from chimera.tools import default_registry
-from chimera.tools.builtin import EchoTool
+from chimera.tools.base import Tool
 
 # --- policy / rules ---------------------------------------------------------
 
@@ -112,25 +112,48 @@ def test_schedule_validator() -> None:
 
 # --- governed tools ---------------------------------------------------------
 
+class _Runner(Tool):
+    """A tool whose argument is a COMMAND, which is the shape governance exists for.
+
+    These three tests used ``EchoTool(text=...)``. ``text`` is a document body by this project's own
+    definition (``governed_tool._DOCUMENT_ARGS``), and ``echo`` hands the string back rather than
+    running it — so ``echo(text="rm -rf /")`` is a tool being asked to *quote* a command, the same
+    shape as a markdown file that mentions one. Once command rules stopped reading document bodies,
+    these passed or failed for a reason that had nothing to do with the kernel working, so the
+    argument was changed to one that really is executed.
+    """
+
+    name = "run_shell"
+    description = "run a command"
+    parameters = {
+        "type": "object",
+        "properties": {"command": {"type": "string"}},
+        "required": ["command"],
+    }
+
+    def run(self, **kwargs: Any) -> str:
+        return str(kwargs.get("command", ""))
+
+
 def test_governed_tool_blocks() -> None:
-    tool = GovernedTool(EchoTool(), TrustKernel())
-    out = tool.run(text="rm -rf /")
+    tool = GovernedTool(_Runner(), TrustKernel())
+    out = tool.run(command="rm -rf /")
     assert "BLOCKED" in out
-    assert "rm -rf" not in out.replace("BLOCKED", "")  # the inner echo did not run
+    assert "rm -rf" not in out.replace("BLOCKED", "")  # the inner tool did not run
 
 
 def test_governed_tool_allows() -> None:
-    tool = GovernedTool(EchoTool(), TrustKernel())
-    assert tool.run(text="hello world") == "hello world"
+    tool = GovernedTool(_Runner(), TrustKernel())
+    assert tool.run(command="echo hello world") == "echo hello world"
 
 
 def test_governed_tool_review_requires_approval() -> None:
     kernel = TrustKernel()
-    needs = GovernedTool(EchoTool(), kernel)
-    assert "needs review" in needs.run(text="git push --force origin main")
+    needs = GovernedTool(_Runner(), kernel)
+    assert "needs review" in needs.run(command="git push --force origin main")
 
-    approved = GovernedTool(EchoTool(), kernel, approve=lambda v, a: True)
-    assert approved.run(text="git push --force origin main") == "git push --force origin main"
+    approved = GovernedTool(_Runner(), kernel, approve=lambda v, a: True)
+    assert approved.run(command="git push --force origin main") == "git push --force origin main"
 
 
 def test_govern_registry_wraps_all(tmp_path: Path) -> None:


### PR DESCRIPTION
Measured on `main`:

```
review  git_force_push   'git push --force origin main'
allow   default          'echo hi\ngit push --force origin main'
block   rm_rf_root       'rm -rf /var/lib/data'
allow   default          'set -e\nrm -rf /var/lib/data'
block   rm_rf_root       write_file {'path': 'd.md', 'content': 'roda `rm -rf /tmp/x`'}
```

`GovernedTool` built the kernel's action as `f"{name} {kwargs}"`. Interpolating a dict calls `repr`, and `repr` escapes a newline into the two characters `\` and `n` — so the `n` fused with the next word (`\nrm` arrived as the text `nrm`) and killed the `\b` that every rule starts with.

**The protection was inverted.** Every real shell script has more than one line, so the two-line version of a blocked command walked through, while a markdown file *quoting* `rm -rf /tmp/x` was hard-blocked.

## Why raw values alone were not the fix

Four strategies, measured against a 42-case corpus:

| | current | raw values | raw, no bodies | **per-rule scope** | **+ MULTILINE** |
|---|---|---|---|---|---|
| correct | 26/42 | 35/42 | 37/42 | 39/42 | **42/42** |

"Don't judge document bodies" (37/42) fixes the four false positives and **loses both credential catches** — including the `write_file` of a `.env`, which is the exact case that motivated the audit redaction that just landed. A key is not safe because it was written to a file instead of exported in a shell.

So `Rule` gains `scope`. Nine rules are `COMMAND` and read only what will be executed; `secret_material` is `ANY_TEXT` and reads bodies too. `re.MULTILINE` was needed as well — checked, no rule uses `^`.

Whether any rule needed to see the tool name alongside the argument was measured, not assumed: **none do**. The ten default rules are shell or credential signatures, and `Rule(...)` is constructed in `_default_rules()` plus one test — zero custom rules in production.

## Two defects nobody had measured

- **`rm -rf .` never fired at all**, not even on one line: the `\.\s*$` sat behind the `'}` of the repr.
- Even with raw values, `$` meant end-of-*script*: `cd /srv\nrm -rf .\necho ok` matched nothing.

## Blast radius, 28 real calls

**10 tightened, 5 loosened, 13 unchanged.** The ten that tightened are all multi-line or anchored commands that used to walk through. The five that loosened are **all prose quoting a command**: three markdown files, a diff that *removes* `rm -rf /`, and `echo(text="rm -rf /")`. **No command that actually executes lost its verdict.**

The `echo` case deserves a look: `text` is in `_DOCUMENT_ARGS`, and `echo` returns the string rather than running it. That broke two existing tests which used `EchoTool(text="rm -rf /")` to prove governance blocks — they were passing for a reason that was not governance working. The fixture moved to an argument that is executed; production was not loosened to suit them.

## Verification

| break | red |
|---|---|
| `render_action` back to `f"{name} {kwargs}"` | yes — 10 failures |
| `secret_material` becomes `Scope.COMMAND` | yes — 1 |
| `_pattern` without `re.MULTILINE` | yes — 2 |
| `document` allowed into the audit payload | yes — 1 |
| `RuleSet.evaluate` ignores `scope` | yes — 4 |

Each with an anchor count before and after. Two missteps on the way, both corrected: the "sabotage applied" check watched the wrong anchor and falsely aborted on the one that *adds* a line rather than replacing one, and a `git checkout --` undid the whole working tree instead of the sabotage.

`audit.py` has **no diff**. `record_as` and `elide_values` are preserved: the `document` is retained for the rules but denied to the audit, to the judge, and to the precedent key, with a test watching that.

`ruff` clean · `mypy` 308 files · `pytest` **3431 passed, 13 skipped** · no credential-shaped literals (fixtures assembled at run time).

## Left out on purpose

`_DOCUMENT_ARGS` has drifted from the real tool schemas — it names six arguments no tool has, and misses `new`/`old` on `edit_file` and `code` on `execute_code`. Filed separately: changing that list changes audit behaviour, and `code` has a real asymmetry (it must be elided from the log but stay in command scope), which may mean splitting the list in two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
