### PR TITLE
the Security screen called the audit tampered when nobody had touched it

### DIFF
--- a/chimera/governance/audit.py
+++ b/chimera/governance/audit.py
@@ -14,15 +14,32 @@ What this does and does not buy you, stated plainly:
   attacker does not control (a receipt, another host) is what closes that gap.
 - Entries written before this change carry no digest. :meth:`verify` reports them as *unchained*
   rather than as tampered — an honest "cannot say", not a false pass.
+
+A chain also has to survive **two writers**, and it did not. The head digest and the entry count
+were read once per :class:`AuditLog` and advanced only in memory, so two instances over one file
+each believed they were alone. Measured, four alternating appends::
+
+    entries=4 seqs=[0, 0, 1, 1]
+    verify -> ok=False broken_at=1 reason='broken link to previous entry'
+
+Which is the worse half of the failure: a log nobody had touched reported itself as tampered, on a
+screen whose whole job is to say whether it was. A chain that cries wolf is not a weaker guarantee
+than a missing one, it is the same lost trust arriving from the other side. So every append now
+re-reads the head from disk while holding a lock — see :meth:`AuditLog.record` for which writers
+that does and does not cover.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import os
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from chimera.core.filelock import locked
 
 # Reserved on every entry; a payload may not override them, or the chain would be forgeable by the
 # caller that is supposed to be audited.
@@ -85,6 +102,90 @@ def _redacted(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+#: How much of the file's tail to pull per read while looking for the final line. Comfortably
+#: larger than any entry written here — the kernel truncates ``action`` and ``reason`` to 200
+#: characters — so the loop below finds its newline on the first read in the ordinary case.
+_TAIL_CHUNK = 8192
+
+#: One lock per audit file per process, shared by every :class:`AuditLog` naming that file. Bounded
+#: by how many distinct audit files a process touches, never by how much it writes to them.
+_PATH_LOCKS: dict[str, threading.Lock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+
+
+def _process_lock(path: Path) -> threading.Lock:
+    """The lock every :class:`AuditLog` naming ``path`` in this process shares.
+
+    Keyed by the normalised absolute path, which is pure string work: this sits on the append path
+    and ``Path.resolve()`` would add a syscall to every record. Two spellings that only the
+    filesystem can tell apart — a symlink — fall through to the file lock, which the OS keys by the
+    real file rather than by the name used to reach it.
+
+    A plain lock rather than a reentrant one, deliberately. Nothing reachable from ``record()``
+    records, and if something ever did, the file lock underneath would block on its own second
+    handle regardless — so an ``RLock`` here would buy the appearance of reentrancy without it.
+    """
+    key = os.path.normcase(os.path.abspath(path))
+    with _PATH_LOCKS_GUARD:
+        lock = _PATH_LOCKS.get(key)
+        if lock is None:
+            lock = _PATH_LOCKS[key] = threading.Lock()
+    return lock
+
+
+def _line_count(path: Path) -> int:
+    """Non-blank lines — what ``seq`` counts. Zero when absent, and never raises on garbage.
+
+    The fallback for the two cases the tail cannot answer, so it deliberately parses nothing: a
+    file whose last line was torn by a crash must still accept new entries. Reading it through
+    :meth:`AuditLog.entries` would raise on that line and turn one bad append into a log that
+    refuses every append after it.
+    """
+    try:
+        with path.open("rb") as handle:
+            return sum(1 for line in handle if line.strip())
+    except OSError:
+        return 0
+
+
+def _last_entry(path: Path) -> dict[str, Any] | None:
+    """Parse the newest entry by reading the END of the file, never the whole of it.
+
+    An append needs exactly two things from what is already on disk: the newest ``seq`` and the
+    newest ``hash``. Parsing the whole file to find them would make every append cost more than the
+    one before it, on a file that only ever grows under a host that runs 24/7. Measured, 200 appends
+    onto a file already holding M lines, microseconds per record:
+
+        M            0     500    2000     8000    20000
+        tail      62.6    62.4    65.9     65.3     63.9
+        whole    168.7   714.8  2318.4  11380.3  34606.6
+
+    Flat against quadratic, 542x apart by twenty thousand entries — a size this log reaches on its
+    own. That gap is the whole reason the head is read from the end of the file instead.
+
+    ``None`` means the tail cannot answer: absent, empty, or a final line that will not parse.
+    """
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            position = handle.tell()
+            buffer = b""
+            while position > 0:
+                step = min(_TAIL_CHUNK, position)
+                position -= step
+                handle.seek(position)
+                buffer = handle.read(step) + buffer
+                trimmed = buffer.rstrip()  # the trailing newline, and any blank lines after it
+                cut = trimmed.rfind(b"\n")
+                if cut == -1 and position:
+                    continue  # the line straddles the chunk boundary — take another bite
+                parsed = json.loads(trimmed[cut + 1 :]) if trimmed else None
+                return parsed if isinstance(parsed, dict) else None
+    except (OSError, ValueError):
+        return None
+    return None
+
+
 class AuditLog:
     """An append-only, hash-chained JSONL audit trail."""
 
@@ -93,22 +194,55 @@ class AuditLog:
         entries = self.entries()
         self._count = len(entries)
         # Resume the chain from whatever is already on disk, so appending to an existing log keeps
-        # one continuous chain instead of silently starting a second one.
+        # one continuous chain instead of silently starting a second one. Both fields are a cache
+        # for `head` and `len()` to answer from before anything is written; `record()` re-reads them
+        # from disk under a lock rather than trusting what this snapshot said.
         last = entries[-1] if entries else None
         self._head = str(last.get("hash", "")) if last else GENESIS
         if not self._head:  # legacy tail with no digest — chain restarts, and verify() will say so
             self._head = GENESIS
 
+    def _tail_state(self) -> tuple[int, str]:
+        """``(seq, prev)`` for the next entry, taken from DISK rather than from this instance."""
+        last = _last_entry(self.path)
+        if last is None:
+            # Absent, empty, or a final line torn by a crash. Counting the lines still gives an
+            # honest `seq`, and the chain restarts from GENESIS — the same answer this file has
+            # always given for a gap it cannot span, which `verify()` reports as unchained rather
+            # than as tampering.
+            return _line_count(self.path), GENESIS
+        seq = last.get("seq")
+        # `seq` is not reserved — only `prev` and `hash` are written after the payload, so a payload
+        # carrying its own "seq" overwrites it. Counting the lines is the honest answer when one has.
+        if isinstance(seq, int) and not isinstance(seq, bool):
+            count = seq + 1
+        else:
+            count = _line_count(self.path)
+        head = last.get("hash")
+        return count, head if isinstance(head, str) and head else GENESIS
+
     def record(self, event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
-        entry: dict[str, Any] = {"seq": self._count, "type": event_type, **_redacted(payload)}
-        # Chain fields are written last on purpose: a payload cannot overwrite them.
-        entry["prev"] = self._head
-        entry["hash"] = _digest(entry)
-        self._count += 1
-        self._head = entry["hash"]
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        # Two locks, always in this order, so there is one ordering and no cycle to deadlock on.
+        #
+        # The process lock is not redundant with the file one. Measured on Windows, a second handle
+        # on the same lock file from the SAME process blocks for 9.1s and then raises `[Errno 36]
+        # Resource deadlock avoided`, at which point `locked()` takes its degraded path and writes
+        # unlocked — dropping the guarantee in precisely the case that dominates here, because
+        # `assemble_registry` builds an AuditLog per request and the API serves each request on its
+        # own thread. Holding the process lock first leaves the file lock arbitrating only BETWEEN
+        # processes, which is the job it is good at and the one `chimera serve` needs: the cron
+        # daemon and the HTTP gateway write this same file from different processes, all day.
+        with _process_lock(self.path), locked(self.path):
+            seq, prev = self._tail_state()
+            entry: dict[str, Any] = {"seq": seq, "type": event_type, **_redacted(payload)}
+            # Chain fields are written last on purpose: a payload cannot overwrite them.
+            entry["prev"] = prev
+            entry["hash"] = _digest(entry)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            self._count = seq + 1
+            self._head = entry["hash"]
         return entry
 
     def entries(self) -> list[dict[str, Any]]:

--- a/tests/test_audit_two_writers.py
+++ b/tests/test_audit_two_writers.py
@@ -1,0 +1,259 @@
+"""Two writers, one audit file. The chain has to survive that, and it did not.
+
+:meth:`AuditLog.__init__` read the head digest and the entry count once and advanced them in memory
+only, so two instances over one path each believed they were the only writer: both claimed the same
+``seq``, both chained onto the same ``prev``. Measured on the code before this file existed, four
+alternating appends::
+
+    entries=4 seqs=[0, 0, 1, 1]
+    verify -> ok=False broken_at=1 reason='broken link to previous entry'
+
+That direction of failure is the dangerous one. ``GET /api/governance/audit`` feeds the Security
+screen, so a log nobody had touched showed itself as tampered — which destroys confidence in the
+file exactly as thoroughly as a tamper nobody detects, and is far easier to trigger.
+
+Two writers is the ordinary configuration here, not a corner. ``assemble_registry`` builds a fresh
+``AuditLog`` per request and the API serves each request on its own thread; ``chimera serve`` runs
+the cron daemon and the HTTP gateway as separate processes over one home, all day. Both cases are
+covered below.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import chimera.governance.audit as audit_mod
+from chimera.governance.audit import AuditLog
+
+LIMITE_SEGUNDOS = 90.0
+"""Ceiling for anything here that waits, so a lost writer fails the run instead of hanging it."""
+
+
+def _chain_is_sound(path: Path, esperado: int) -> None:
+    """Every claim this file makes about a finished log, in one place.
+
+    ``list(range(n))`` is the strong assertion: it says the sequence numbers are unique, ascending,
+    and gapless in one line. The uniqueness check above it is redundant on purpose — it is the
+    property being defended, and a failure should name it rather than make the reader derive it.
+    """
+    log = AuditLog(path)
+    entradas = log.entries()
+    seqs = [entrada["seq"] for entrada in entradas]
+
+    assert len(entradas) == esperado, f"esperava {esperado} entradas, achei {len(entradas)}"
+    assert len(set(seqs)) == len(seqs), f"seq duplicado: {seqs}"
+    assert seqs == list(range(esperado)), f"seq nao crescente/contiguo: {seqs}"
+
+    check = log.verify()
+    assert check.ok, f"cadeia reprovada em {check.broken_at}: {check.reason}"
+    assert check.checked == esperado
+    assert check.unchained == 0
+
+
+def test_two_logs_on_one_path_write_one_unbroken_chain(tmp_path: Path) -> None:
+    """The reported failure, reduced: two instances, alternating appends, no threads involved."""
+    path = tmp_path / "audit.jsonl"
+    primeiro, segundo = AuditLog(path), AuditLog(path)
+
+    for indice in range(6):
+        escritor = primeiro if indice % 2 == 0 else segundo
+        escritor.record("governance", {"decision": "review", "n": indice})
+
+    _chain_is_sound(path, 6)
+
+
+def test_threads_each_building_their_own_log_do_not_collide(tmp_path: Path) -> None:
+    """The API's actual shape: one ``AuditLog`` per request, one thread per request, one file.
+
+    Each instance is built *before* the barrier releases, so every one of them snapshots the same
+    empty file. That is the stale-head condition the fix has to survive, made deterministic rather
+    than waited for.
+    """
+    path = tmp_path / "audit.jsonl"
+    fios, por_fio = 6, 8
+    largada = threading.Barrier(fios, timeout=LIMITE_SEGUNDOS)
+    falhas: list[BaseException] = []
+
+    def trabalhador() -> None:
+        log = AuditLog(path)  # what `assemble_registry` does, once per request
+        try:
+            largada.wait()
+            for indice in range(por_fio):
+                log.record("governance", {"decision": "review", "n": indice})
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the main thread below
+            falhas.append(exc)
+
+    equipe = [threading.Thread(target=trabalhador) for _ in range(fios)]
+    for fio in equipe:
+        fio.start()
+    for fio in equipe:
+        fio.join(timeout=LIMITE_SEGUNDOS)
+        assert not fio.is_alive(), "um escritor nao terminou dentro do limite"
+
+    assert not falhas, f"escritor levantou: {falhas[0]!r}"
+    _chain_is_sound(path, fios * por_fio)
+
+
+def test_the_file_lock_never_arbitrates_between_two_threads_of_one_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two threads of one process must be separated *before* they reach the OS file lock.
+
+    This is the one property the test above cannot show, because on Linux ``flock`` happens to
+    serialise two descriptors of the same process correctly, so the process lock looks redundant
+    there. It is not redundant on Windows, where it was measured: a second handle on the same lock
+    file from the SAME process blocks for 9.1s and then raises ``[Errno 36] Resource deadlock
+    avoided``, at which point ``locked()`` takes its documented degraded path and writes *unlocked*.
+    On that platform the file lock would be arbitrating a fight it cannot win, in the case that
+    dominates this file.
+
+    So the claim under test is platform-independent and checkable here: no two threads are ever
+    inside ``locked()`` at the same time. The sleep widens the window enough for an overlap to be
+    observed rather than raced past.
+    """
+    path = tmp_path / "audit.jsonl"
+    real = audit_mod.locked
+    contagem = threading.Lock()
+    dentro = pico = 0
+
+    @contextmanager
+    def espiao(alvo: Path) -> Iterator[bool]:
+        nonlocal dentro, pico
+        with contagem:
+            dentro += 1
+            pico = max(pico, dentro)
+        try:
+            with real(alvo) as tomado:
+                time.sleep(0.002)
+                yield tomado
+        finally:
+            with contagem:
+                dentro -= 1
+
+    monkeypatch.setattr(audit_mod, "locked", espiao)
+
+    fios = 5
+    largada = threading.Barrier(fios, timeout=LIMITE_SEGUNDOS)
+
+    def trabalhador() -> None:
+        log = AuditLog(path)
+        largada.wait()
+        log.record("governance", {"decision": "review"})
+
+    equipe = [threading.Thread(target=trabalhador) for _ in range(fios)]
+    for fio in equipe:
+        fio.start()
+    for fio in equipe:
+        fio.join(timeout=LIMITE_SEGUNDOS)
+        assert not fio.is_alive()
+
+    assert pico == 1, f"{pico} threads entraram no lock de arquivo ao mesmo tempo"
+    _chain_is_sound(path, fios)
+
+
+# The child of the cross-process test. Held as source rather than as a function because the two
+# portable ways to get a real second process both fail here: `fork` is POSIX-only, and `spawn`
+# re-imports the worker's module, which pytest loaded from a directory the fresh child has no reason
+# to have on its path. A subprocess sidesteps both, and is the shape production actually has — the
+# cron daemon and the gateway are separate processes, not forks of one.
+_FILHO = """
+import sys, time
+from pathlib import Path
+from chimera.governance.audit import AuditLog
+
+destino, largada, pronto, quantos = Path(sys.argv[1]), Path(sys.argv[2]), Path(sys.argv[3]), int(sys.argv[4])
+log = AuditLog(destino)          # snapshot taken before any sibling writes: the stale-head condition
+pronto.write_text("1", encoding="utf-8")
+limite = time.monotonic() + 60
+while not largada.exists():      # every child appends from the same instant
+    if time.monotonic() > limite:
+        raise SystemExit("largada nunca veio")
+    time.sleep(0.005)
+for indice in range(quantos):
+    log.record("governance", {"decision": "review", "n": indice})
+"""
+
+
+def test_separate_processes_append_to_one_chain(tmp_path: Path) -> None:
+    """``chimera serve``: the cron daemon and the HTTP gateway write this file from two processes.
+
+    The children inherit this interpreter's ``chimera`` explicitly rather than whatever the venv
+    happens to have installed. Without that, an editable install pointing somewhere else would let
+    the child exercise a different copy of the code and the test would pass while proving nothing —
+    which is not hypothetical: the venv used to develop this fix points at a different worktree.
+    """
+    path = tmp_path / "audit.jsonl"
+    largada = tmp_path / "largada"
+    prontos = tmp_path / "prontos"
+    prontos.mkdir()
+    processos_n, por_processo = 3, 6
+
+    raiz = Path(audit_mod.__file__).resolve().parents[2]
+    ambiente: dict[str, str] = {**os.environ, "PYTHONPATH": str(raiz)}
+
+    filhos = [
+        subprocess.Popen(
+            [
+                sys.executable, "-c", _FILHO,
+                str(path), str(largada), str(prontos / str(indice)), str(por_processo),
+            ],
+            env=ambiente,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for indice in range(processos_n)
+    ]
+
+    try:
+        limite = time.monotonic() + LIMITE_SEGUNDOS
+        while len(list(prontos.iterdir())) < processos_n:
+            assert time.monotonic() < limite, "os filhos nunca ficaram prontos"
+            time.sleep(0.02)
+        largada.write_text("go", encoding="utf-8")
+
+        for filho in filhos:
+            _, erro = filho.communicate(timeout=LIMITE_SEGUNDOS)
+            assert filho.returncode == 0, f"filho falhou: {erro}"
+    finally:
+        for filho in filhos:
+            if filho.poll() is None:  # pragma: no cover - only on a timeout above
+                filho.kill()
+
+    _chain_is_sound(path, processos_n * por_processo)
+
+
+def test_a_torn_final_line_does_not_block_an_open_log_from_appending(tmp_path: Path) -> None:
+    """Re-reading the head opened a way to brick the log, and it must stay shut.
+
+    Before this fix ``record()`` read nothing, so an open ``AuditLog`` kept appending no matter what
+    the file had become — measured against the base commit, a final line torn by a crash left
+    ``record()`` on an already-open instance working. The head now comes from disk, so that same
+    torn line is input to every later append; taken through :meth:`AuditLog.entries` it would raise,
+    and one interrupted write would stop every write after it. Trading a broken chain for a log that
+    refuses to record is not a fix.
+
+    Scope, stated rather than implied: this covers the *open* instance, which is the writer a
+    neighbour's crash surprises. Constructing a **new** ``AuditLog`` over a torn file still raises,
+    as it did before this change — the constructor parses the whole file and always has. That is
+    pre-existing and deliberately left alone here.
+    """
+    path = tmp_path / "audit.jsonl"
+    log = AuditLog(path)
+    log.record("governance", {"decision": "review"})
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"seq": 1, "type": "governance", "deci')  # killed mid-write, no newline
+
+    entrada: dict[str, Any] = log.record("governance", {"decision": "block"})
+
+    assert entrada["seq"] == 2  # both lines counted, including the one it could not parse
+    assert path.read_text(encoding="utf-8").splitlines()[-1].endswith("}")

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -217,6 +217,10 @@ def test_ledgered_escalation_is_audited() -> None:
         assert any(e["type"] == "taint_review" for e in audit.entries())
     finally:
         audit.path.unlink(missing_ok=True)
+        # `record()` now takes an advisory lock on a sibling `.lock` before appending, so a probe
+        # that writes into the source tree leaves two files behind rather than one. Untracked junk
+        # after a test run is how a `git status` check starts lying.
+        Path(str(audit.path) + ".lock").unlink(missing_ok=True)
 
 
 def test_ledger_registry_wraps_every_tool() -> None:
@@ -363,3 +367,7 @@ def test_narrowing_is_audited() -> None:
         assert any(e["type"] == "taint_narrowed" for e in audit.entries())
     finally:
         audit.path.unlink(missing_ok=True)
+        # `record()` now takes an advisory lock on a sibling `.lock` before appending, so a probe
+        # that writes into the source tree leaves two files behind rather than one. Untracked junk
+        # after a test run is how a `git status` check starts lying.
+        Path(str(audit.path) + ".lock").unlink(missing_ok=True)


### PR DESCRIPTION
Measured on `main`:

```
[overlapping]  entries=4 seqs=[0, 0, 1, 1]
               verify -> ok=False checked=1 broken_at=1 'broken link to previous entry'
[sequential]   entries=2 seqs=[0, 1]
               verify -> ok=True  checked=2 'ok'
```

`AuditLog.__init__` read the file once and kept `seq` and `prev` in memory. Two objects over the same path each believed they were alone: duplicate `seq`, each linking to a `prev` the other had superseded, and `verify()` reporting the chain broken. `assemble_registry` builds one per request, and the API runs a thread per request.

A falsely-failed chain is as bad as an undetected tamper — both destroy trust in the file, and this one was self-inflicted.

## Both cases, and why the cheap half is not redundant

- **Within the process** (the dominant one): a per-path process lock.
- **Across processes** (`chimera serve` runs cron and the gateway writing the same file all day): `locked()` from `chimera/core/filelock.py` — the precedent `MemoryStore` already uses — taken **second**, so there is a single ordering.

The process lock is not redundant, and this was measured rather than assumed. On Windows, a second handle on the same `.lock` **from the same process** blocks for 9.1 s and then raises `[Errno 36] Resource deadlock avoided` — at which point `locked()` falls into its degraded branch and writes *unlocked*, losing the guarantee in exactly the most common case.

## Performance

The head is read from the **end** of the file rather than by parsing it. Paired measurement, 200 appends onto a file of M lines (µs/record):

| M | 0 | 500 | 2000 | 8000 | 20000 |
|---|---|---|---|---|---|
| tail (chosen) | 62.6 | 62.4 | 65.9 | 65.3 | 63.9 |
| whole file | 168.7 | 714.8 | 2318.4 | 11380.3 | 34606.6 |

Flat against quadratic — **542× at twenty thousand entries**. Total cost of the lock plus the re-read: **44.9 → 69.2 µs/record (1.54×, +24.4 µs)**, on a write that happens once per governed decision.

## Verification

| break | two objects | threads | process lock | processes | torn line |
|---|---|---|---|---|---|
| back to the in-memory snapshot | **red** | **red** | **red** | **red** | **red** |
| remove the process lock | green | green | **red** | green | green |
| remove the file lock | green | green | **red** | **red** | green |
| use `entries()` in the fallback again | green | green | green | green | **red** |

The second row is the honest one: on Linux `flock` already serialises two threads of one process, so the process lock would be **invisible** to the chain tests. A dedicated test spies on `locked()` and proves two threads never enter it together — the property whose failure mode is only observable on Windows.

Two traps found on the way, both of which would have produced a measurement that proved nothing: the venv's editable install points at the **main** worktree, so a script run from outside imported the wrong tree and the first "after" measurement showed the bug unchanged; and the cross-process test has to pass `PYTHONPATH` explicitly to the child for the same reason.

## Left open, explicitly

Constructing a **new** `AuditLog` over a file whose last line was torn by a crash still raises. Checked against the base commit: that was already true, and this does not widen it. The new risk this change could have introduced — an **already-open** instance failing because `record()` now reads the disk — is closed by a line count and covered by a test.

Also fixed in passing: two probes in `test_ledger.py` write inside `tests/` and only deleted the `.jsonl`, leaving the sibling `.lock` as untracked litter every run.

`ruff` clean · `mypy` 308 files · `pytest` **3415 passed, 13 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
