### PR TITLE
an edit's body was judged as a shell command and written to the log

### DIFF
--- a/chimera/governance/governed_tool.py
+++ b/chimera/governance/governed_tool.py
@@ -27,17 +27,96 @@ ContextFn = Callable[[], str]
 #: values — `run_shell {'command': 'git push --force origin main'}` is the whole point of the
 #: record, and a blanket length cap would keep the first 200 characters of a `.env` while throwing
 #: away the command someone opens the log to read.
+#:
+#: The criterion, so the next person extends it by rule instead of by anecdote: a **body** is text
+#: the tool writes to disk, executes, or transmits whole — the kind of value that can carry an
+#: entire secret. An **identifier** says *which* thing is being acted on (`path`, `url`, `ref`) or
+#: *what to look for* (`query`, `pattern`, `prompt`); those stay, because they are the half of an
+#: audit line worth reading. `tests/test_document_args_match_the_tools.py` holds every argument the
+#: shipped tools declare, on one side of that line or the other, and fails when a new one appears.
+#:
+#: This list had drifted from the tools it is supposed to describe. Measured against every `Tool`
+#: subclass in the package: it named five arguments **no tool has** (`data`, `diff`, `new_str`,
+#: `old_str`, `new_text`) and missed four that carry bodies — `old`/`new` (`edit_file`), `code`
+#: (`execute_code`, `code_interpreter`) and `spec` (`render_chart`). The dead names are deleted
+#: rather than kept "for future tools": a name with no tool behind it cannot be tested, gives false
+#: assurance that `diff` is covered, and costs real safety the day some tool uses `data` as an
+#: identifier — it would drop out of the command scope and out of the audit, silently. The
+#: exhaustiveness test is what covers the future case, and it does it by forcing a decision.
 _DOCUMENT_ARGS = frozenset(
-    {"content", "patch", "diff", "text", "body", "data", "new_str", "old_str", "new_text"}
+    {
+        "content",  # write_file: the file body. extract: the page text to pull fields from.
+        "patch",  # apply_patch: SEARCH/REPLACE hunks — both halves are file content.
+        "old",  # edit_file: the text being removed (it was in the file, so it is file content).
+        "new",  # edit_file: the replacement text.
+        "code",  # execute_code, code_interpreter — but see _EXECUTED_DOCUMENT_ARGS.
+        "body",  # send_email: the message body.
+        "text",  # echo; browser(action=type) — a password is typed through this one; text_to_speech.
+        "spec",  # render_chart: a Vega-Lite document, whose `data.values` can embed a whole dataset.
+    }
 )
+
+#: The subset of :data:`_DOCUMENT_ARGS` that the tool **executes**.
+#:
+#: This is the one place the two consumers of the list must disagree, so they are given two lists
+#: instead of one. `execute_code(code=...)` is a body — the whole program lands in the audit line
+#: otherwise, truncated at 200 characters and served over HTTP by `GET /api/governance/audit`. But
+#: it is a body that then *runs*, so taking it out of the command half would stop every shell rule
+#: from reading it: `code="import os; os.system('rm -rf /')"` is BLOCK today (rule `rm_rf_root`) and
+#: would become ALLOW. Eliding it from the log is a privacy fix; moving it out of the command scope
+#: would be a hole. One list could only do one of the two.
+_EXECUTED_DOCUMENT_ARGS = frozenset({"code", "command"})
+
+#: Arguments that do not *hold* a body but *contain* ones, in nested items.
+#:
+#: `edit_batch(edits=[{"path": …, "old": …, "new": …}, …])` is the only one today, and it is the
+#: reason this is a third set rather than a third entry in the first. Treating `edits` as a plain
+#: document elides the whole array, and with it every `path` — on the one tool that writes to
+#: SEVERAL files at once, which is exactly when "which file was touched" is worth the most. The
+#: audit therefore walks into these and elides only the nested bodies, while the rules treat the
+#: whole thing as a document (no nested field is a command, and `secret_material`, being
+#: `Scope.ANY_TEXT`, reads it either way).
+_NESTED_DOCUMENT_ARGS = frozenset({"edits"})
+
+
+def _summarise(value: Any) -> str:
+    return f"<{len(str(value))} chars>"
+
+
+def _elide_nested(value: Any) -> Any:
+    """Elide bodies inside a container, keeping the identifiers that say what was touched."""
+    if isinstance(value, list):
+        return [_elide_nested(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: (_summarise(inner) if key in _DOCUMENT_ARGS else inner)
+            for key, inner in value.items()
+        }
+    return value
 
 
 def elide_values(kwargs: dict[str, Any]) -> dict[str, Any]:
     """``kwargs`` with document-shaped values replaced by their size."""
-    return {
-        key: (f"<{len(str(value))} chars>" if key in _DOCUMENT_ARGS else value)
-        for key, value in kwargs.items()
-    }
+    out: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if key in _NESTED_DOCUMENT_ARGS:
+            out[key] = _elide_nested(value)
+        elif key in _DOCUMENT_ARGS:
+            out[key] = _summarise(value)
+        else:
+            out[key] = value
+    return out
+
+
+def _is_document(key: str) -> bool:
+    """True if ``key``'s value must be judged as prose rather than as a command.
+
+    Bodies the tool executes are the exception: they are documents for the audit and commands for
+    the rules. See :data:`_EXECUTED_DOCUMENT_ARGS`.
+    """
+    return (
+        key in _DOCUMENT_ARGS or key in _NESTED_DOCUMENT_ARGS
+    ) and key not in _EXECUTED_DOCUMENT_ARGS
 
 
 def render_action(name: str, kwargs: dict[str, Any]) -> tuple[str, str]:
@@ -63,15 +142,21 @@ def render_action(name: str, kwargs: dict[str, Any]) -> tuple[str, str]:
     of "this is a body, not an identifier" that :data:`_DOCUMENT_ARGS` already carries for the audit
     — so a gap in that list is one gap to fix, not two that can drift apart.
 
+    With ONE deliberate exception, :data:`_EXECUTED_DOCUMENT_ARGS`: a body the tool *executes* stays
+    in the command half. Sharing a single list would have forced a choice between leaking
+    `execute_code`'s program into the audit and letting `os.system('rm -rf /')` through the shell
+    rules; the two consumers want opposite things about that one argument, so they get two lists and
+    this paragraph saying why they differ.
+
     The tool NAME leads the action. That was checked rather than assumed: all ten default rules are
     shell or credential signatures and not one of them mentions a tool, so putting the name on its
     own line costs no match today and keeps the judge told what was called.
     """
     command = "\n".join(
-        [name, *(str(value) for key, value in kwargs.items() if key not in _DOCUMENT_ARGS)]
+        [name, *(str(value) for key, value in kwargs.items() if not _is_document(key))]
     )
     document = "\n".join(
-        str(value) for key, value in kwargs.items() if key in _DOCUMENT_ARGS
+        str(value) for key, value in kwargs.items() if _is_document(key)
     )
     return command, document
 

--- a/tests/test_document_args_match_the_tools.py
+++ b/tests/test_document_args_match_the_tools.py
@@ -1,0 +1,212 @@
+"""The list that decides what counts as a document body had drifted from the tools it describes.
+
+`_DOCUMENT_ARGS` has two consumers that read it for different reasons: `elide_values()` keeps bodies
+out of `audit.jsonl` — which `GET /api/governance/audit` serves onto the Security screen — and
+`render_action()` keeps bodies from being judged by shell rules. Both were reading a hand-written
+list, and a hand-written list against tools that keep changing drifts by construction.
+
+Measured against every `Tool` subclass in the package, before this: the list named five arguments
+**no tool has** (`data`, `diff`, `new_str`, `old_str`, `new_text`) and missed four that carry whole
+bodies — `old`/`new` on `edit_file`, `code` on `execute_code` and `code_interpreter`, and `spec` on
+`render_chart`. So `edit_file(new="rm -rf /")` was judged as a shell command *and* had its entire
+replacement text written to a log the app serves over HTTP.
+
+This file is the guard that stops it drifting again, and it does it by forcing a decision rather than
+by guessing: every argument every shipped tool declares must be on one side of the line, and a new
+one fails the build until somebody says which side it is on.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any
+
+import chimera
+from chimera.governance.governed_tool import (
+    _DOCUMENT_ARGS,
+    _EXECUTED_DOCUMENT_ARGS,
+    _NESTED_DOCUMENT_ARGS,
+    elide_values,
+    render_action,
+)
+from chimera.tools.base import Tool
+
+#: Arguments that say *which* thing is acted on, or *what to look for*. They stay in the audit line
+#: and in the command half, because they are the half of a record worth reading: `run_shell` with a
+#: command, `edit_file` with a path, `send_email` with a recipient.
+#:
+#: Two entries here are judgement calls rather than obvious ones, named so the next reader can
+#: disagree on purpose: `task` (`spawn_subagent`) is a paragraph of prose, and `subject`
+#: (`send_email`) is author-written text — but both are the *identity* of the action from an
+#: auditor's point of view ("what did it delegate?", "what did it send?"), and eliding them would
+#: leave a line that records a delegation nobody can identify. Neither is a place a secret goes by
+#: accident, which is the criterion `_DOCUMENT_ARGS` exists to serve.
+_IDENTIFIERS = frozenset({
+    "action",
+    "allow_invalid",
+    "audio_only",
+    "command",
+    "cwd",
+    "exclude",
+    "fields",
+    "format",
+    "glob",
+    "include",
+    "include_links",
+    "language",
+    "limit",
+    "max_depth",
+    "max_results",
+    "out",
+    "out_dir",
+    "path",
+    "pattern",
+    "prompt",
+    "query",
+    "ref",
+    "render",
+    "replace_all",
+    "reset",
+    "respect_robots",
+    "resume",
+    "same_domain",
+    "search",
+    "selectors",
+    "size",
+    "subject",
+    "task",
+    "timeout",
+    "to",
+    "tools",
+    "url",
+    "video",
+    "voice_id",
+})
+
+
+def _declared_arguments() -> dict[str, set[str]]:
+    """Every argument every `Tool` subclass in the package declares, keyed by argument name.
+
+    Walked from the package rather than from `default_registry`, deliberately: a tool that is only
+    registered under an optional extra (the media and browser families) still ships, still runs when
+    that extra is installed, and its body arguments leak exactly the same. Reading the registry would
+    have made this guard's coverage depend on which extras the test environment happened to have.
+    """
+    found: dict[str, set[str]] = {}
+    for module in pkgutil.walk_packages(chimera.__path__, "chimera."):
+        try:
+            loaded = importlib.import_module(module.name)
+        except Exception:  # noqa: BLE001 — an optional extra that is not installed here
+            continue
+        for _, obj in inspect.getmembers(loaded, inspect.isclass):
+            if not (issubclass(obj, Tool) and obj is not Tool):
+                continue
+            properties: dict[str, Any] = (getattr(obj, "parameters", None) or {}).get(
+                "properties"
+            ) or {}
+            name = getattr(obj, "name", "") or ""
+            for argument in properties:
+                found.setdefault(argument, set()).add(str(name) or obj.__name__)
+    return found
+
+
+def test_every_argument_a_shipped_tool_declares_is_classified() -> None:
+    """The guard. A new tool argument fails the build until somebody decides what it is.
+
+    The criterion, so this is extended by rule and not by anecdote: a **body** is text the tool
+    writes to disk, executes, or transmits whole — the kind of value that can carry an entire secret.
+    An **identifier** says which thing is being acted on, or what to look for.
+    """
+    declared = _declared_arguments()
+    assert len(declared) > 30, f"the walk found only {len(declared)} arguments; it is not walking"
+
+    classified = _DOCUMENT_ARGS | _NESTED_DOCUMENT_ARGS | _IDENTIFIERS
+    unclassified = {arg: sorted(tools) for arg, tools in declared.items() if arg not in classified}
+    assert not unclassified, (
+        "new tool arguments nobody has classified as a document body or an identifier: "
+        f"{unclassified}. Add each to _DOCUMENT_ARGS (it can carry a whole secret) or to "
+        "_IDENTIFIERS in this file (it says which thing was acted on)."
+    )
+
+
+def test_the_list_names_no_argument_that_no_tool_has() -> None:
+    """Five dead names were in there, and a dead name is not harmless.
+
+    It cannot be tested, it gives false assurance that `diff` is covered, and it costs real safety
+    the day a tool uses `data` as an identifier — that argument would silently drop out of the
+    command scope and out of the audit at once.
+    """
+    declared = set(_declared_arguments())
+    for name, group in (
+        ("_DOCUMENT_ARGS", _DOCUMENT_ARGS),
+        ("_NESTED_DOCUMENT_ARGS", _NESTED_DOCUMENT_ARGS),
+        ("_EXECUTED_DOCUMENT_ARGS", _EXECUTED_DOCUMENT_ARGS),
+    ):
+        orphans = sorted(group - declared)
+        assert not orphans, f"{name} names arguments no shipped tool declares: {orphans}"
+
+
+# --- the two behaviours the split exists for ------------------------------------------------------
+
+
+def test_an_edit_body_is_neither_logged_nor_read_as_a_command() -> None:
+    """`edit_file(new=…)` was both, and it is the case that started this.
+
+    `old`/`new` were missing from the list, so the replacement text went into the audit line whole
+    and was judged by every shell rule — which is how a legitimate edit that happens to contain
+    `rm -rf` got blocked while its content was written to a file the app serves.
+    """
+    kwargs = {"path": "deploy.sh", "old": "rm -rf ./build", "new": "rm -rf /var/lib/data"}
+    command, document = render_action("edit_file", kwargs)
+    logged = str(elide_values(kwargs))
+
+    assert "rm -rf /var/lib/data" not in command, "an edit body is still judged as a shell command"
+    assert "rm -rf /var/lib/data" in document, "the body must still be read for credentials"
+    assert "rm -rf /var/lib/data" not in logged, "the edit body reaches a log served over HTTP"
+    assert "deploy.sh" in logged, "the path was elided too, so the line says nothing useful"
+
+
+def test_an_executed_body_is_kept_out_of_the_log_and_still_judged() -> None:
+    """The one place the two consumers must disagree, and the reason there are two lists.
+
+    `execute_code(code=…)` is a body: the whole program lands in the audit line otherwise. But it is
+    a body that then RUNS, so taking it out of the command half would stop every shell rule from
+    reading it. Both halves are asserted here, because a single list could only get one of them
+    right — and getting the second one wrong turns `os.system('rm -rf /')` from BLOCK into ALLOW.
+    """
+    program = "import os\nos.system('rm -rf /')\n"
+    kwargs = {"code": program, "timeout": 30}
+    command, _document = render_action("execute_code", kwargs)
+    logged = str(elide_values(kwargs))
+
+    assert "rm -rf /" in command, "an executed body left the command scope: the shell rules are blind"
+    assert program not in logged, "the program body reaches a log served over HTTP"
+
+    # And end to end, because the assertion above is about the rendering rather than the verdict.
+    from chimera.governance.kernel import TrustKernel
+
+    verdict = TrustKernel().evaluate(command)
+    assert verdict.decision.value == "block", (
+        f"executed code stopped being judged: {verdict.decision.value} ({verdict.rule})"
+    )
+
+
+def test_a_nested_body_is_elided_without_losing_which_files_were_touched() -> None:
+    """`edit_batch(edits=[…])` is why nesting is a third set rather than a third entry.
+
+    Treating `edits` as a plain document elides the whole array, and with it every `path` — on the
+    one tool that writes to SEVERAL files at once, which is exactly when "which file was touched" is
+    worth the most.
+    """
+    kwargs = {
+        "edits": [
+            {"path": "a.py", "old": "x", "new": "SECRET_BODY_ONE"},
+            {"path": "b.py", "old": "y", "new": "SECRET_BODY_TWO"},
+        ]
+    }
+    logged = str(elide_values(kwargs))
+
+    assert "SECRET_BODY_ONE" not in logged and "SECRET_BODY_TWO" not in logged
+    assert "a.py" in logged and "b.py" in logged, "the paths went with the bodies"


### PR DESCRIPTION
`_DOCUMENT_ARGS` decides two different things: what `elide_values()` keeps out of
`audit.jsonl` — which `GET /api/governance/audit` serves onto the Security screen —
and what `render_action()` keeps from being judged by shell rules. Both read one
hand-written list, and a hand-written list against tools that keep changing drifts
by construction.

Measured against every `Tool` subclass in the package: it named five arguments
**no tool has** (`data`, `diff`, `new_str`, `old_str`, `new_text`) and missed four
that carry whole bodies — `old`/`new` on `edit_file`, `code` on `execute_code` and
`code_interpreter`, and `spec` on `render_chart`.

So `edit_file(new="rm -rf /var/lib/data")` was judged as a shell command *and* had
its entire replacement text written to a log the app serves over HTTP. Two bugs
from one missing entry, pointing opposite ways.

**The one place the two consumers must disagree, so they get two lists.**
`execute_code(code=…)` is a body — the whole program lands in the audit line
otherwise. But it is a body that then RUNS, so taking it out of the command half
would stop every shell rule from reading it:
`code="import os; os.system('rm -rf /')"` is BLOCK today and would become ALLOW.
Eliding it from the log is a privacy fix; moving it out of command scope would be
a hole. `_EXECUTED_DOCUMENT_ARGS` is that exception, with the paragraph saying why
the lists differ.

**Nesting is a third set, not a third entry.** `edit_batch(edits=[…])` treated as a
plain document elides the whole array, and with it every `path` — on the one tool
that writes to SEVERAL files at once, which is exactly when "which file was
touched" is worth the most. The audit walks into these and elides only the nested
bodies.

The five dead names are deleted rather than kept "for future tools". A name with no
tool behind it cannot be tested, gives false assurance that `diff` is covered, and
costs real safety the day some tool uses `data` as an identifier — it would drop
out of the command scope and out of the audit at once, silently.

What stops the drift returning is a test, not discipline:
`tests/test_document_args_match_the_tools.py` walks every `Tool` subclass in the
package and fails when an argument appears that nobody has classified as a body or
an identifier. It walks the PACKAGE rather than `default_registry`, because a tool
behind an optional extra still ships and still leaks; reading the registry would
make the guard's coverage depend on which extras the test environment happened to
have. 32 tools, 48 arguments, all classified.

Two of the identifiers are judgement calls and are named as such in the file, so
the next reader can disagree on purpose: `task` (`spawn_subagent`) and `subject`
(`send_email`) are author-written prose, but they are the IDENTITY of the action to
an auditor, and eliding them leaves a line recording a delegation nobody can
identify.

Six sabotages, each turns the new file red: the old list restored, `old`/`new`
dropped, `code` no longer executed, `_is_document` ignoring the exception,
`elide_values` no longer walking nested items, and one identifier removed from the
test's own table — that last one is what proves the exhaustiveness guard rather
than assuming it. Each was checked by comparing the file's bytes before and after
rather than by counting an anchor: a replacement whose new text contains the anchor
leaves the count at 1 and reads as "not applied" when it was.

ruff clean · mypy 308 files · pytest 3444 passed, 13 skipped

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)