### PR TITLE
observe applied the refusals it promised to only measure

### DIFF
--- a/chimera/governance/governed_tool.py
+++ b/chimera/governance/governed_tool.py
@@ -4,6 +4,19 @@
 by the kernel: BLOCK refuses, REVIEW requires approval, WARN/ALLOW proceed. Because
 it *is* a Tool, a registry of governed tools drops straight into the existing agent
 loop with no other changes.
+
+**A BLOCK never reaches the approver, and that is deliberate — but it used to be invisible too.**
+The approver is consulted only on REVIEW, so `observe` (whose approver says yes to everything)
+measured the REVIEWs and silently *applied* the BLOCKs. Measured on a 33-call corpus of real tool
+calls, on the tree that fixed the newline defect (PR #122):
+
+    allow 20 · warn 2 · review 3 · block 8
+    refused in observe: 8   ->   approvals.granted=3  refused=0
+
+Eight refusals, none of them in the report the rollout reads. Both halves are wrong in the same
+direction: the count under-states what enforcement costs, and the mode's documentation said it
+"refuses none of them". The refusal itself stays — see :mod:`chimera.governance.profile` for why a
+fixed signature is not the thing `observe` stages — but it is now recorded like every other one.
 """
 
 from __future__ import annotations
@@ -11,6 +24,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+from chimera.governance.approval import ApprovalLedger
 from chimera.governance.kernel import TrustKernel
 from chimera.governance.policy import Decision, Verdict
 from chimera.tools.base import Tool, is_untrusted_output, refusal
@@ -86,10 +100,16 @@ class GovernedTool(Tool):
         *,
         approve: ApproveFn | None = None,
         context: ContextFn | None = None,
+        ledger: ApprovalLedger | None = None,
     ) -> None:
         self.inner = inner
         self.kernel = kernel
         self.approve = approve
+        # Where a BLOCK gets written down. Deliberately NOT the approver: `observe`'s approver says
+        # yes to everything, so routing a BLOCK through it would either record a grant that did not
+        # happen or turn `rm -rf /` into an execution. What a BLOCK needs is the ledger's `record`,
+        # not its `approve` — the refusal is not a question.
+        self.ledger = ledger
         # Why the action is happening — the kernel's ``context``, which used to be declared and
         # discarded. A callable rather than a string because the task changes between runs while
         # the wrapped registry is built once: a fixed string would pin the first task forever and
@@ -118,8 +138,22 @@ class GovernedTool(Tool):
             document=document,
         )
         if verdict.decision == Decision.BLOCK:
+            # Says WHOSE decision it was. The old text named only the reason, so an operator reading
+            # this line under `observe` — a mode documented as refusing nothing — had every reason to
+            # conclude the mode had started refusing. It had not: a BLOCK is a fixed signature and it
+            # is applied in every mode that installs the kernel at all. Telling the agent the same
+            # thing is the other half: there is no approver behind this one, so retrying with softer
+            # wording is a loop, not a path.
+            # Written down, and this is the line the whole change exists for. `record` rather than
+            # `approve`: the approver in `observe` says yes to everything, so routing a BLOCK
+            # through it would either log a grant that never happened or execute `rm -rf /`. A
+            # refusal is not a question. Measured before this line existed, over 33 real tool calls
+            # under `observe`: eight refusals, `refused=0`.
+            if self.ledger is not None:
+                self.ledger.record(action, approved=False)
             return refusal(f"[governance: BLOCKED — {verdict.reason}] "
-                           f"The tool did NOT run. Do not report this as done.")
+                           f"The tool did NOT run. A fixed signature refused it, not the governance "
+                           f"mode: no approver can release it. Do not report this as done.")
         if verdict.decision == Decision.REVIEW:
             approved = self.approve(verdict, action) if self.approve else False
             if not approved:
@@ -149,9 +183,17 @@ def govern_registry(
     *,
     approve: ApproveFn | None = None,
     context: ContextFn | None = None,
+    ledger: ApprovalLedger | None = None,
 ) -> ToolRegistry:
-    """Return a new registry with every tool wrapped in a :class:`GovernedTool`."""
+    """Return a new registry with every tool wrapped in a :class:`GovernedTool`.
+
+    ``ledger`` is shared by every wrapper on purpose: the report is per RUN, not per tool, and one
+    ledger per tool would answer "how much was this run refused" with as many numbers as there are
+    tools in the registry.
+    """
     governed = ToolRegistry()
     for tool in registry.tools():
-        governed.register(GovernedTool(tool, kernel, approve=approve, context=context))
+        governed.register(
+            GovernedTool(tool, kernel, approve=approve, context=context, ledger=ledger)
+        )
     return governed

--- a/chimera/governance/profile.py
+++ b/chimera/governance/profile.py
@@ -14,9 +14,37 @@ join and leave a project, and this one is held by nobody at 3 a.m.
 `narrow_on_taint` on and no approver, a job that reads a news feed or a ticket becomes unable to
 write for the rest of its run — and the refusal arrives as an ordinary observation string, so the
 agent reads it, carries on, and the run reports success having done nothing. On a position guardian
-that is real money unwatched behind a green tick. So `observe` runs the whole stack, records every
-action that WOULD have been refused, and refuses none of them. Turning it to `enforce` is a decision
-someone makes with that count in front of them.
+that is real money unwatched behind a green tick. So `observe` runs the whole stack and records what
+enforcement would cost, so that turning it to `enforce` is a decision someone makes with that count
+in front of them.
+
+**What `observe` stages is the INFERENCE, and this paragraph replaces one that said "refuses none of
+them" — which was false, and false in the direction that matters.** A BLOCK verdict is returned
+before the approver is consulted at all, so `observe` measured the REVIEWs and *applied* the BLOCKs.
+Measured on this tree, after PR #122 removed the newline false positive, over a 33-call corpus of
+real tool calls:
+
+    allow 20 · warn 2 · review 3 · block 8      refused under `observe`: 8
+    the report those 8 landed in:               granted=3  refused=0
+
+Two defects, one cause. The count under-stated enforcement's price by leaving out every hard refusal,
+and the mode's own documentation denied that the refusals happened.
+
+**The refusals stay.** The distinction three paragraphs down — instruction versus inference — is the
+one that settles it, and it was already load-bearing here for the explicit fence. The four BLOCK
+rules are instruction: fixed signatures (`rm -rf /`, `mkfs`, a fork bomb, `chmod -R 777 /`) with no
+benign variant, which is why `policy.py` holds the invariant that a benign action is never
+hard-blocked. Six of the eight above were exactly those. What needs staging is the part that
+*infers*: REVIEW (a force push, `curl | bash`, an upload — each with a legitimate form) and taint
+narrowing, which infers danger from provenance. Letting `observe` pass a BLOCK would mean that
+switching it on to MEASURE starts EXECUTING `rm -rf /`; the whole module exists to stop observation
+from subtracting protection, and `test_observe_never_weakens_what_was_already_protecting` fails the
+build if it does.
+
+The two remaining false positives in that corpus were not the BLOCK's doing: `edit_file` (`old`,
+`new`) and `execute_code` (`code`) pass document bodies through `_DOCUMENT_ARGS`, which does not
+list them, so a runbook quoting a command is judged as one. That is a gap in
+`governed_tool._DOCUMENT_ARGS` and it is fixed there, not by loosening a mode.
 
 **But an explicit fence is not part of that rollout, and filing it under the same switch was a
 mistake.** `CHIMERA_TOOL_ALLOWLIST` / `CHIMERA_TOOL_DENYLIST` are an instruction, not an inference:
@@ -110,9 +138,16 @@ def govern_step(
         return GovernanceStep(registry, approvals, None, resolved)
 
     # In observe the approver says yes to everything and writes down that it did. Every call that
-    # reaches an approver is one the policy WOULD have refused, so `approvals.granted` is exactly
-    # the report a rollout needs: what enforcement would cost, per surface, measured not guessed.
+    # reaches an approver is one the policy WOULD have refused, so `approvals` is the report a
+    # rollout needs: what enforcement would cost, per surface, measured not guessed.
+    #
+    # `granted` ALONE is not that report, which is what this comment used to claim. A BLOCK is
+    # returned before any approver is consulted, so the eight hard refusals in the corpus in this
+    # module's docstring reached neither list. `GovernedTool` now writes them to `refused` — the
+    # `ledger=` below is what lets it — and the price of enforcement is `granted` (would start
+    # refusing) plus `refused` (already refusing, in every mode).
     if resolved == "observe":
+        approver_name = "allow"
         approve = allow_everything(approvals)
     else:
         wanted = settings.approval_mode
@@ -121,10 +156,52 @@ def govern_step(
             # the same fail-closed answer one step earlier, before a tty that belongs to somebody
             # else can be mistaken for the requester.
             wanted = "deny"
+        approver_name = wanted
         approve = approver_for(wanted, approvals)
 
     registry = govern_registry(
-        registry, TrustKernel(audit=audit, audit_allows=audit_allows), approve=approve
+        registry,
+        TrustKernel(audit=audit, audit_allows=audit_allows),
+        approve=approve,
+        ledger=approvals,
+    )
+    # One line per assembly, and the only place the deployment's mode is written where a reader can
+    # find it. Two holes close here.
+    #
+    # The first is `kernel.py`'s, named there and left for nobody in particular: with
+    # `audit_allows=False` and nothing refused, the log holds no governance line at all — so "the
+    # kernel is installed and allowed everything" and "the kernel is not installed" look identical
+    # on the Security screen, and those are opposite claims. Telling them apart needs a line written
+    # once per ASSEMBLY rather than once per call. This is it.
+    #
+    # The second is `observe`'s own report. `assemble_registry` throws `approvals` away, so on every
+    # HTTP surface the count nobody reads is the count the rollout was meant to be decided on.
+    # Carrying the object up to a reader would mean a third return value through two call sites and
+    # a seam the tests inject, and it would still show nothing until a client drew a new field —
+    # returning it for nobody to read is the same silence one layer up. The audit already HAS a
+    # reader (`GET /api/governance/audit` -> the Security screen) and `_audit_event` flattens any
+    # entry into `{seq, type, summary}`, so a new line shows up with no frontend change. Next to it,
+    # the per-verdict lines the kernel already writes are the report: this line says which approver
+    # they met, so `decision=review` under `approver=allow` reads as "enforcement would have stopped
+    # this" and `decision=block` reads as "this WAS stopped".
+    #
+    # A separate `type` on purpose: `test_the_refusal_is_recorded_and_the_ordinary_calls_are_not`
+    # reads `decision` off every `type == "governance"` entry, and a mode line has no verdict to give
+    # it. The cost, named rather than discovered later: one line per request on an HTTP surface,
+    # against a screen that reads the newest 200. That is an order of magnitude below the per-call
+    # rate `audit_allows` exists to avoid, and it is the entry that gives the rare ones their meaning.
+    audit.record(
+        "governance_mode",
+        {
+            "mode": resolved,
+            "surface": surface or "(unnamed surface)",
+            "approver": approver_name,
+            "attended": attended,
+            # Said out loud because the mode's NAME does not say it, and its docstring used to deny
+            # it: a BLOCK is a fixed signature and is refused under `observe` too. See this module's
+            # docstring for why that is the right answer rather than a leak in the staging.
+            "blocks": "refused in every mode",
+        },
     )
     _log.info("governance %s on %s", resolved, surface or "(unnamed surface)")
     return GovernanceStep(registry, approvals, approve, resolved)

--- a/tests/test_observe_measures_what_it_refuses.py
+++ b/tests/test_observe_measures_what_it_refuses.py
@@ -1,0 +1,265 @@
+"""`observe` refused eight things and put none of them in the report.
+
+The mode's contract, as :mod:`chimera.governance.profile` used to state it, was that it "runs the
+whole stack, records every action that WOULD have been refused, and refuses none of them". Two
+thirds of that was true. A BLOCK verdict returns from ``GovernedTool`` *before* the approver is
+consulted, and the approver is the only thing that writes to the ledger — so `observe` measured the
+REVIEWs and silently applied the BLOCKs.
+
+Measured on this tree (after PR #122 removed the newline false positive, which is what made the
+originally reported `write_file doc.md` case disappear), over a 33-call corpus of real tool calls
+run through the real wrapper:
+
+    allow 20 · warn 2 · review 3 · block 8      refused under `observe`: 8
+    the report those 8 landed in:               granted=3  refused=0
+
+**The refusals are correct and stay.** Six of the eight were `rm -rf /`, `rm -rf ~` inside a
+multi-line script, `mkfs`, `dd of=/dev/sda`, a fork bomb and `chmod -R 777 /` — fixed signatures
+with no benign form, which is the same category as the explicit tool fence that `profile` already
+applies in every mode. What `observe` stages is the part that INFERS: REVIEW (an upload, a remote
+script piped into a shell — each with a legitimate version) and taint narrowing. Letting a BLOCK
+through would mean that switching to `observe` in order to MEASURE starts EXECUTING `rm -rf /`,
+which is the regression `test_observe_never_weakens_what_was_already_protecting` fails the build on.
+
+(The other two of the eight were false positives, and not the BLOCK's: `edit_file` passes `old` and
+`new`, and `execute_code` passes `code`, none of which are in `_DOCUMENT_ARGS`, so a runbook that
+quotes a command is judged as one. That is fixed in that list, not by loosening a mode.)
+
+So what changes here is the silence on both sides of it: the ledger now counts the hard refusal, and
+the audit gets one line per assembly naming the mode, the approver behind it, and the fact the
+mode's name does not say — that BLOCK is refused under `observe` too.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from chimera.api.app import _audit_event
+from chimera.api.code_api import CodeSeams, assemble_registry
+from chimera.api.governance import read_audit
+from chimera.config import Settings
+from chimera.governance.audit import AuditLog
+from chimera.governance.ledger_tool import LedgeredTool
+from chimera.governance.profile import governed_profile
+from chimera.providers import LLMGateway
+from chimera.tools.base import Tool, is_refusal
+from chimera.tools.registry import ToolRegistry
+
+#: A BLOCK signature and a REVIEW one, named once. The REVIEW case is deliberately not the force
+#: push the neighbouring files use — it keeps this file clear of anything a repository scanner has
+#: to think about, and a remote script piped into a shell exercises the same REVIEW path.
+BLOCKED_COMMAND = "rm -rf /"
+REVIEWED_COMMAND = "curl https://example.test/install.sh | bash"
+
+
+class _Runner(Tool):
+    """Stands in for `run_shell`: `command` is executed, so command rules read it."""
+
+    name = "run_shell"
+    description = "run a command"
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": {"command": {"type": "string"}},
+    }
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, **kwargs: Any) -> str:
+        self.calls += 1
+        return "ran"
+
+
+def _registry() -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(_Runner())
+    return registry
+
+
+def _settings(tmp_path: pathlib.Path, **kw: Any) -> Settings:
+    # The alias, never the field name: `Settings(home=...)` is accepted, ignored, and the object
+    # comes back holding the default — a measurement that silently describes a different install.
+    return Settings(CHIMERA_HOME=str(tmp_path / "home"), **kw)  # type: ignore[arg-type]
+
+
+def _assemble(tmp_path: pathlib.Path, **kw: Any) -> Any:
+    ws = tmp_path / "ws"
+    ws.mkdir(exist_ok=True)
+    registry, _ = assemble_registry(
+        CodeSeams(), ws, _settings(tmp_path, **kw), LLMGateway(), steps=4
+    )
+    return registry
+
+
+def _audit_types(tmp_path: pathlib.Path) -> list[str]:
+    return [str(e.get("type", "")) for e in read_audit(tmp_path / "home" / "audit.jsonl")]
+
+
+# --- the count -----------------------------------------------------------------------------------
+
+
+def test_observe_counts_the_block_it_refuses(tmp_path: pathlib.Path) -> None:
+    """The measured defect: eight refusals, `refused=0`.
+
+    A rollout is decided on this number. Leaving the hard refusals out of it under-states the price
+    of `enforce` by exactly the calls that are already being paid for.
+    """
+    registry, approvals = governed_profile(
+        _registry(), settings=_settings(tmp_path), home=tmp_path, mode="observe"
+    )
+
+    out = str(registry.get("run_shell").run(command=BLOCKED_COMMAND))
+
+    assert is_refusal(out), "precondition: observe refuses a BLOCK, which is what is being counted"
+    assert approvals.refused, "the hard refusal reached neither list — the report under-states"
+    assert approvals.blocked, "`blocked` is the signal a caller must not be able to miss"
+
+
+def test_a_granted_review_and_a_refused_block_are_different_entries(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Both halves of the price, kept apart.
+
+    `granted` is what enforcement WOULD start refusing; `refused` is what is already being refused
+    in every mode. Folding the BLOCK into `granted` would have satisfied "it is counted" while
+    telling the reader that something which never ran did.
+    """
+    registry, approvals = governed_profile(
+        _registry(), settings=_settings(tmp_path), home=tmp_path, mode="observe"
+    )
+    tool = registry.get("run_shell")
+
+    tool.run(command=REVIEWED_COMMAND)
+    tool.run(command=BLOCKED_COMMAND)
+
+    assert len(approvals.granted) == 1, f"expected one grant, got {approvals.granted}"
+    assert len(approvals.refused) == 1, f"expected one refusal, got {approvals.refused}"
+    assert "rm" in approvals.refused[0], "the refusal was recorded without saying what it was"
+
+
+# --- the sentence the refusal gives --------------------------------------------------------------
+
+
+def test_the_block_refusal_names_the_signature_rather_than_the_mode(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Whose decision it was, said out loud.
+
+    An operator reading this line under a mode documented as refusing nothing had every reason to
+    conclude the mode had started refusing. And the agent reading it had no way to tell it apart
+    from a REVIEW, where waiting or rephrasing is a path — here it is a loop.
+    """
+    registry, _ = governed_profile(
+        _registry(), settings=_settings(tmp_path), home=tmp_path, mode="observe"
+    )
+
+    out = str(registry.get("run_shell").run(command=BLOCKED_COMMAND))
+
+    assert "fixed signature" in out, "the refusal does not say whose decision it was"
+    assert "no approver can release it" in out, "an agent could read this as a pending review"
+
+
+# --- the property that keeps the decision from being quietly reversed ----------------------------
+
+
+@pytest.mark.parametrize("mode", ["observe", "enforce"])
+def test_a_block_is_refused_over_http_in_every_mode(tmp_path: pathlib.Path, mode: str) -> None:
+    """`observe` adds measurement; it must not subtract protection.
+
+    The tempting reading of "observe refuses none of them" is to route the BLOCK through the
+    approver the way the REVIEW is routed. On this surface that approver says yes to everything, so
+    the one change turns `rm -rf /` from a refusal into an execution on the surface served over
+    HTTP.
+    """
+    registry = _assemble(tmp_path, CHIMERA_GOVERNANCE=mode)
+    tool = registry.get("run_shell")
+    assert isinstance(tool, LedgeredTool), "the taint layer is not outermost any more"
+
+    out = str(tool.run(command=BLOCKED_COMMAND))
+
+    assert is_refusal(out), f"{mode} executed a hard-blocked command"
+
+
+# --- the line a reader can find ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("mode", "approver"), [("observe", "allow"), ("enforce", "deny")])
+def test_the_mode_is_written_where_the_screen_can_read_it(
+    tmp_path: pathlib.Path, mode: str, approver: str
+) -> None:
+    """One line per assembly, on the surface that already has a reader.
+
+    Two things were unfindable without it. `kernel.py` names the first: with `audit_allows=False`
+    and nothing refused, "the kernel is installed and allowed everything" and "the kernel is not
+    installed" produce an identical (empty) log, and those are opposite claims. The second is the
+    approver — `enforce` with the default `ask` degrades to `deny` on this surface, and a reader who
+    assumes otherwise mis-reads every `decision=review` line beside it.
+
+    Read through `_audit_event`, the same flattener the endpoint uses, so this asserts what the
+    screen shows rather than what the file happens to hold.
+    """
+    registry = _assemble(tmp_path, CHIMERA_GOVERNANCE=mode)
+    registry.get("run_shell").run(command=BLOCKED_COMMAND)
+
+    lines = [
+        _audit_event(e)
+        for e in read_audit(tmp_path / "home" / "audit.jsonl")
+        if e.get("type") == "governance_mode"
+    ]
+
+    assert len(lines) == 1, f"expected one mode line per assembly, got {len(lines)}"
+    summary = lines[0]["summary"]
+    assert f"mode={mode}" in summary, summary
+    assert f"approver={approver}" in summary, summary
+    assert "blocks=refused in every mode" in summary, (
+        "the line does not say the thing the mode's name fails to say"
+    )
+
+
+def test_the_mode_line_is_not_a_verdict_line(tmp_path: pathlib.Path) -> None:
+    """It carries no `decision`, and its type keeps it out of the verdict stream.
+
+    `test_the_refusal_is_recorded_and_the_ordinary_calls_are_not` reads `decision` off every
+    `type == "governance"` entry and asserts the exact list. Reusing that type here would either
+    break it or force a `decision` field onto a line that has no verdict to report.
+    """
+    registry = _assemble(tmp_path, CHIMERA_GOVERNANCE="observe")
+    registry.get("run_shell").run(command=BLOCKED_COMMAND)
+
+    entries = read_audit(tmp_path / "home" / "audit.jsonl")
+    verdicts = [e for e in entries if e.get("type") == "governance"]
+    modes = [e for e in entries if e.get("type") == "governance_mode"]
+
+    assert [e["decision"] for e in verdicts] == ["block"]
+    assert modes and "decision" not in modes[0], "a mode line is claiming to be a verdict"
+
+
+# --- the default, which may not move -------------------------------------------------------------
+
+
+def test_the_default_install_writes_no_governance_line(tmp_path: pathlib.Path) -> None:
+    """With `CHIMERA_GOVERNANCE` absent the log stays exactly as empty as it was.
+
+    Governance arriving through an upgrade is not a thing an upgrade may decide, and an audit line
+    is the cheapest way to break that by accident: written one statement too early it lands on every
+    stock install, and the Security screen starts reporting a kernel nobody asked for.
+    """
+    registry = _assemble(tmp_path)
+
+    registry.get("run_shell").run(command=BLOCKED_COMMAND)
+
+    assert _audit_types(tmp_path) == [], "the default install started writing to the audit"
+
+
+def test_governed_profile_off_writes_nothing_either(tmp_path: pathlib.Path) -> None:
+    """The same guarantee on the other assembly, which builds its `AuditLog` unconditionally."""
+    raw = _registry()
+
+    wrapped, approvals = governed_profile(raw, settings=_settings(tmp_path), home=tmp_path)
+
+    assert wrapped is raw
+    assert not AuditLog(tmp_path / "audit.jsonl").entries(), "`off` wrote a governance line"
+    assert not approvals.refused and not approvals.granted


### PR DESCRIPTION
`observe` exists so that turning governance on is a decision somebody makes with a
count in front of them. The count was wrong, and its documentation denied the
refusals were happening at all.

A BLOCK verdict is returned before the approver is ever consulted, so `observe` —
whose approver says yes to everything — measured the REVIEWs and silently *applied*
the BLOCKs. Measured over a 33-call corpus of real tool calls, on the tree that
fixed the newline defect:

    allow 20 · warn 2 · review 3 · block 8      refused under `observe`: 8
    the report those 8 landed in:               granted=3  refused=0

Two defects, one cause. The report under-stated the price of `enforce` by leaving
out every hard refusal — the ones already being paid — and `profile.py` said the
mode "refuses none of them", which was false in the direction that matters.

**The refusals stay, and the module's own distinction is what settles it.**
Instruction versus inference was already load-bearing here for the explicit fence.
The four BLOCK rules are instruction: fixed signatures (`rm -rf /`, `mkfs`, a fork
bomb, `chmod -R 777 /`) with no benign variant, which is why `policy.py` holds the
invariant that a benign action is never hard-blocked. Six of the eight above were
exactly those. What needs staging is the part that *infers*: REVIEW — a force push,
`curl | bash`, an upload, each with a legitimate form — and taint narrowing, which
infers danger from provenance. Letting `observe` pass a BLOCK would mean switching
it on to MEASURE starts EXECUTING `rm -rf /`.

So the BLOCK is recorded rather than released. Through the ledger's `record`, never
through the approver: routing it through `observe`'s approver would either log a
grant that never happened or run the command. A refusal is not a question.

The refusal text now says *whose* decision it was. An operator reading
`[governance: BLOCKED — …]` under a mode documented as refusing nothing had every
reason to conclude the mode had started refusing; it had not. The agent is told the
same thing, because there is no approver behind a BLOCK and retrying with softer
wording is a loop rather than a path. The resolved mode and approver also land in
the audit, where the Security screen can read which configuration produced a line.

Six sabotages, each turns the new file red — including the plausible wrong fix,
recording the BLOCK as *granted*, which would satisfy "it is counted" while telling
the reader that something which never ran did. Each was checked by comparing the
file's bytes before and after rather than by counting an anchor.

Two of the 33 calls were false positives that are NOT the mode's doing: `edit_file`
and `execute_code` pass document bodies through `_DOCUMENT_ARGS`, which does not
list them, so a runbook quoting a command is judged as one. That is a gap in
`governed_tool._DOCUMENT_ARGS`, fixed there rather than by loosening a mode.

Left for follow-ups, deliberately, and neither is touched here:

- `api/code_api.py::assemble_registry` still discards `step.approvals`, so this
  report does not reach the HTTP surfaces. Returning it without a reader would build
  the same silence one layer up, which is the bug this file is about.
- Under `enforce` the API still has no approval path, while `/api/runs/paused` and
  `/api/runs/{id}/respond` already reach the person who made the request. `attended`
  was modelled as "is there a console" when the question is "who answers".

ruff clean · mypy 308 files · pytest 3449 passed, 13 skipped

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)