### PR TITLE
fix(desktop): attaching an image killed the turn, and said nothing useful

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -9212,8 +9212,26 @@
     },
     "/api/vision": {
       "get": {
-        "description": "Can the model that answers a turn look at an image?\n\nAsked when someone attaches one, so the answer arrives while they can still act on it. An\nimage sent to a model without vision is either a provider error or \u2014 worse \u2014 silently\nignored, and a confident answer about a picture nobody looked at is indistinguishable from\none about a picture that was.",
+        "description": "Can the model that answers a turn look at an image?\n\nAsked when someone attaches one, so the answer arrives while they can still act on it. An\nimage sent to a model without vision is either a provider error or \u2014 worse \u2014 silently\nignored, and a confident answer about a picture nobody looked at is indistinguishable from\none about a picture that was.\n\n``model`` is the one the composer has picked. It used to be unaskable: this always answered\nabout ``default_model``, so the moment a per-conversation picker existed the warning started\nnaming a model the turn was not going to use \u2014 and the sentence under the paperclip was about\nsomebody else's capability. Omitted still means the default, which is what a caller with no\npicker means.",
         "operationId": "vision_api_vision_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -9224,6 +9242,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Vision"

--- a/apps/desktop/src/components/code/Attachments.tsx
+++ b/apps/desktop/src/components/code/Attachments.tsx
@@ -37,17 +37,23 @@ import { cn } from "@/lib/utils";
 export function AttachmentTray({
   items,
   onRemove,
+  model = "",
 }: {
   items: Attachment[];
   onRemove: (id: string) => void;
+  /** The model this message will run on, or "" for the install's default. The warning is about a
+   *  specific model's capability, so it has to be asked about the one that will actually answer —
+   *  otherwise picking a vision model leaves a caveat on screen describing a different one. */
+  model?: string;
 }) {
   const t = useT();
   const hasImage = items.some((a) => a.kind === "image");
   // Asked only once an image is actually attached: it is a question about THIS message, and asking
   // it up front would put a caveat about vision on a screen where nobody had mentioned pictures.
+  // Keyed on the model, so changing the picker re-asks rather than serving the previous answer.
   const vision = useQuery({
-    queryKey: ["vision"],
-    queryFn: getVisionSupport,
+    queryKey: ["vision", model],
+    queryFn: () => getVisionSupport(model || undefined),
     enabled: hasImage,
     staleTime: 60_000,
   });

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -862,7 +862,11 @@ export function Conversation({
           />
         ) : null}
         {controls ? <div className="pb-1">{controls}</div> : null}
-        <AttachmentTray items={attached} onRemove={(id) => setAttached((p) => p.filter((a) => a.id !== id))} />
+        <AttachmentTray
+          items={attached}
+          model={model}
+          onRemove={(id) => setAttached((p) => p.filter((a) => a.id !== id))}
+        />
         {/* Shown, never silent. A message that vanished into an invisible queue is indistinguishable
             from one that was dropped, and the user would retype it — which is two sends, not one. */}
         {queued ? (

--- a/apps/desktop/src/components/code/ModelPicker.tsx
+++ b/apps/desktop/src/components/code/ModelPicker.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Check, Cpu, Search } from "lucide-react";
 
-import { getModels, patchConfig } from "@/lib/api";
+import { getDoctor, getModels, patchConfig } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Dialog } from "@/components/ui/dialog";
 import { focusRing } from "@/components/ui/focus";
@@ -57,15 +57,28 @@ export function ModelPicker({
   const t = useT();
   const [open, setOpen] = useState(false);
 
-  // The chosen slug's own tail rather than its label, because the label is a sentence ("DeepSeek:
-  // DeepSeek V3.1") and this is a chip in an already crowded row.
-  const buttonLabel = value ? shortName(value) : t("model.pick.default");
-
   // Read from the cache the dialog fills, to answer one question: can the picked model call tools?
   // `enabled: false` means this never fetches on its own — a composer nobody has touched costs no
   // request, and before the list has been opened once there is simply nothing to warn about.
   const listing = useQuery({ queryKey: ["models", ""], queryFn: () => getModels(), enabled: false });
   const chosen = listing.data?.models?.find((m) => m.slug === value);
+
+  // What "default" actually resolves to. `doctor` is already fetched by the worker row beside this
+  // one and by three other screens, so naming the model costs no request — and without it the chip
+  // says "default" and the user has to open the dialog to discover that the word means DeepSeek at
+  // $0.25 rather than GPT-5.5 at $5. A control that hides what it is set to is a control you have to
+  // click to read.
+  const doctor = useQuery({ queryKey: ["doctor"], queryFn: getDoctor });
+  const fallback = doctor.data?.default_model ?? "";
+
+  // The chosen slug's own tail rather than its label, because the label is a sentence ("DeepSeek:
+  // DeepSeek V3.1") and this is a chip in an already crowded row. Same for the default's name: the
+  // word plus the model, so the chip reads as a setting rather than as a category.
+  const buttonLabel = value
+    ? shortName(value)
+    : fallback
+      ? `${t("model.pick.default")} · ${shortName(fallback)}`
+      : t("model.pick.default");
 
   return (
     <>

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -1749,6 +1749,12 @@ export interface paths {
          *     image sent to a model without vision is either a provider error or — worse — silently
          *     ignored, and a confident answer about a picture nobody looked at is indistinguishable from
          *     one about a picture that was.
+         *
+         *     ``model`` is the one the composer has picked. It used to be unaskable: this always answered
+         *     about ``default_model``, so the moment a per-conversation picker existed the warning started
+         *     naming a model the turn was not going to use — and the sentence under the paperclip was about
+         *     somebody else's capability. Omitted still means the default, which is what a caller with no
+         *     picker means.
          */
         get: operations["vision_api_vision_get"];
         put?: never;
@@ -7078,7 +7084,9 @@ export interface operations {
     };
     vision_api_vision_get: {
         parameters: {
-            query?: never;
+            query?: {
+                model?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -7092,6 +7100,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VisionOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -877,7 +877,13 @@ export interface VisionSupport {
   support: "yes" | "no" | "unknown";
 }
 
-export const getVisionSupport = () => json<VisionSupport>("/api/vision");
+/** Can THIS model look at an image? `model` is the one the composer has picked; omitted asks about
+ *  the install's default, which is what a caller with no picker means.
+ *
+ *  It used to take no argument, and the moment a per-conversation picker existed that made the
+ *  warning under the paperclip describe a model the turn was not going to use. */
+export const getVisionSupport = (model?: string) =>
+  json<VisionSupport>(`/api/vision${model ? `?model=${encodeURIComponent(model)}` : ""}`);
 
 /** Whether speech can become text on this machine, and by which route.
  *

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import threading
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -210,6 +211,67 @@ _MAX_PENDING_REVERTS = 8
 #: FastAPI's upload marker, hoisted out of the signatures so a call in an argument default does not
 #: trip the linter. Same object, same behaviour.
 _UPLOAD = File(...)
+
+
+#: Provider errors whose text is about the REQUEST rather than about our internals — the user can act
+#: on every one of them, and none of them names anything private. Matched loosely on purpose: a
+#: provider rewords its messages far more often than it changes what they mean.
+_ACTIONABLE = (
+    "image input",
+    "does not exist",
+    "not found",
+    "no endpoints",
+    "context length",
+    "maximum context",
+    "rate limit",
+    "quota",
+    "insufficient",
+    "credit",
+    "invalid api key",
+    "authentication",
+    "unauthorized",
+    "moderation",
+    "tool use",
+    "tool_use",
+    "function calling",
+)
+
+
+def _native_failure(exc: Exception) -> str:
+    """What to tell the user when Chimera's own loop failed.
+
+    "the coding turn failed" used to be the whole answer, on the reasoning that a native failure is
+    ours to debug. That holds for a bug in this repository and not at all for the more common case:
+    the provider refused, and said exactly why. Attaching an image to a model without vision produced
+    `No endpoints found that support image input` — fixable in four seconds — and the app rendered a
+    sentence indistinguishable from a crash.
+
+    Only the recognised classes are forwarded, and only the first line: a stack trace or an internal
+    path in the composer is noise, and the point is the one sentence that says what to change.
+    """
+    text = str(exc).strip()
+    if not text:
+        return "the coding turn failed"
+    first = text.splitlines()[0].strip()
+    if not any(marker in first.lower() for marker in _ACTIONABLE):
+        return "the coding turn failed"
+
+    # The provider's sentence, without the wrapping. LiteLLM stacks its own class names in front of
+    # the body and the body is usually JSON, so the raw string reads
+    # `litellm.NotFoundError: NotFoundError: OpenrouterException - {"error":{"message":"No endpoints
+    # found that support image input","code":404}}` — which contains the one useful clause and buries
+    # it behind four names that mean nothing to the person reading. Unwrapped when the shape is
+    # recognisable, left alone when it is not: a regex that half-matches would be worse than the
+    # noise it removes.
+    embedded = re.search(r'"message"\s*:\s*"((?:[^"\\]|\\.)*)"', first)
+    if embedded:
+        try:
+            first = json.loads(f'"{embedded.group(1)}"')
+        except ValueError:
+            first = embedded.group(1)
+
+    # Bounded: a provider that answers with a wall of JSON must not paste it into the transcript.
+    return first if len(first) <= 300 else f"{first[:297]}…"
 
 
 def resolve_posture(posture: Posture | None) -> ResolvedPosture:
@@ -491,7 +553,9 @@ def register_code_api(
         with locks_guard:
             return locks.setdefault(session_id, threading.Lock())
 
-    def build_agent(req: CodeTurnRequest, ws: Path, facts: list[str]) -> tuple[Agent, Any]:
+    def build_agent(
+        req: CodeTurnRequest, ws: Path, facts: list[str], note: str = ""
+    ) -> tuple[Agent, Any]:
         """The agent for this turn, and the ledger watching it.
 
         The ledger used to be built and thrown away, which left the turn unable to answer the one
@@ -517,6 +581,9 @@ def register_code_api(
             system_prompt += "\n\nRelevant facts from memory:\n" + "\n".join(
                 f"- {f}" for f in facts
             )
+        # Same placement, same reason: true for this turn, absent from the stored transcript.
+        if note:
+            system_prompt += f"\n\n{note}"
         agent = Agent(
             gateway,
             registry,
@@ -560,14 +627,31 @@ def register_code_api(
         # Attachments: images the model looks at, documents it reads. Resolved here rather than in
         # the request so a stale or forged id is simply skipped instead of reaching the model.
         from chimera.api.attachments import load as load_attachment
+        from chimera.api.attachments import vision_support
+
+        # What the composer already told the user, applied. The warning under the paperclip says an
+        # image "will not be seen" by a model without vision — and until now the server sent it
+        # anyway, so OpenRouter answered `No endpoints found that support image input` and the whole
+        # turn died as a generic "the coding turn failed". The interface promised a degraded turn and
+        # the system delivered no turn at all.
+        #
+        # Only for a model LiteLLM's table positively says cannot see. `unknown` still sends: a table
+        # that has not heard of a model is not evidence about the model, and refusing on that basis
+        # would break every new vision model on the day it ships. When a send does fail this way, the
+        # provider's own sentence now reaches the user — see `_native_failure`.
+        blind = vision_support(req.model or live().default_model) == "no"
 
         images: list[str] = []
+        dropped_images: list[str] = []
         doc_blocks: list[str] = []
         for ident in req.attachments:
             found = load_attachment(settings.home, ident)
             if found is None:
                 continue
             if found.kind == "image":
+                if blind:
+                    dropped_images.append(found.name)
+                    continue
                 images.append(str(found.path))
             else:
                 # Extracted at upload and fenced there. Folded into the message rather than handed
@@ -582,10 +666,26 @@ def register_code_api(
         message = req.message
         if doc_blocks:
             message = message + "\n\n" + "\n\n".join(doc_blocks)
+        # What the model is told about the image it did not get. In the SYSTEM prompt, not
+        # appended to the user's message, and that placement is the difference between a note and
+        # a defacement: `absorb` drops system messages when it stores the transcript, so this
+        # reaches the model for this turn and never becomes part of what the user said. Appended
+        # to the message it also became the conversation's TITLE in the sidebar — a row reading
+        # "what do you see in this image? [The user attached `6d2b57e5…" — because a title is the
+        # first thing the user asked, and this was pretending to be part of it.
+        #
+        # No filename either: the stored name is the attachment id, and an id in a sentence meant
+        # for a model is noise that reads like a fact.
+        note = (
+            "The user attached an image, which was NOT sent to you: this model cannot accept "
+            "images. Say so plainly rather than describing anything."
+            if dropped_images
+            else ""
+        )
 
         # Read memory BEFORE building the agent: the facts go into this turn's system prompt.
         facts, memory_layer = recall_facts(req.message, memory=memory, graph=graph)
-        agent, ledger = build_agent(req, ws, facts)
+        agent, ledger = build_agent(req, ws, facts, note)
         session = store.load(req.session_id, agent) if req.session_id else CodeSession(agent)
         session.agent = agent  # a loaded session carries messages, not the agent that made them
         # A conversation belongs to the project it STARTED in, and keeps it. Overwriting on every
@@ -763,7 +863,7 @@ def register_code_api(
                 message_out = (
                     failure_message(exc)
                     if (req.provider or "").strip()
-                    else "the coding turn failed"
+                    else _native_failure(exc)
                 )
                 emit("error", {"message": message_out})
             finally:
@@ -847,18 +947,24 @@ def register_code_api(
         )
 
     @app.get("/api/vision", dependencies=[guard], response_model=VisionOut)
-    def vision() -> VisionOut:
+    def vision(model: str | None = None) -> VisionOut:
         """Can the model that answers a turn look at an image?
 
         Asked when someone attaches one, so the answer arrives while they can still act on it. An
         image sent to a model without vision is either a provider error or — worse — silently
         ignored, and a confident answer about a picture nobody looked at is indistinguishable from
         one about a picture that was.
+
+        ``model`` is the one the composer has picked. It used to be unaskable: this always answered
+        about ``default_model``, so the moment a per-conversation picker existed the warning started
+        naming a model the turn was not going to use — and the sentence under the paperclip was about
+        somebody else's capability. Omitted still means the default, which is what a caller with no
+        picker means.
         """
         from chimera.api.attachments import vision_support
 
-        model = live().default_model
-        return VisionOut(model=model, support=vision_support(model))
+        chosen = (model or "").strip() or live().default_model
+        return VisionOut(model=chosen, support=vision_support(chosen))
 
     @app.get("/api/dictation", dependencies=[guard], response_model=DictationOut)
     def dictation() -> DictationOut:

--- a/chimera/tools/media.py
+++ b/chimera/tools/media.py
@@ -243,7 +243,13 @@ class TranscribeAudioTool(Tool):
         path = resolve_in_workspace(self.workspace, rel)
         if not path.is_file():
             return f"error: audio file not found: {rel}"
-        language = str(kwargs.get("language", "")).strip() or None
+        # `str(None)` is `"None"` — a five-character string that is not empty, so `or None` never
+        # fires and the literal word travels on as a language code. faster-whisper then refuses the
+        # whole call with `'None' is not a valid language code`, and dictation in the desktop app
+        # has never worked on the local model because of it: the API layer passes `language=None`
+        # for "detect it", which is precisely the case this line converted into a wrong answer.
+        raw = kwargs.get("language")
+        language = (str(raw).strip() or None) if isinstance(raw, str) else None
         try:
             text = _transcribe_faster_whisper(str(path), language)  # local first (offline/private)
             if text is None:  # no stt extra -> hosted Whisper

--- a/tests/test_attachment_vision_and_dictation.py
+++ b/tests/test_attachment_vision_and_dictation.py
@@ -1,0 +1,143 @@
+"""Three defects a user hit within a minute of opening the app, and what each one broke.
+
+They arrived together and they are the same kind of bug: something that was *known* to the system
+and never reached the person who needed it.
+
+1. **The composer warned about the wrong model.** ``/api/vision`` always answered about
+   ``default_model``, so the moment the model became a per-conversation choice, the sentence under
+   the paperclip described a model the turn was not going to use.
+2. **Then the turn died anyway.** The warning says an image "will not be seen" — and the server sent
+   it regardless, so OpenRouter answered ``No endpoints found that support image input`` and the
+   whole turn failed. The interface promised a degraded turn; the system delivered no turn.
+3. **And the reason was hidden.** Every native failure rendered as "the coding turn failed", which
+   cannot be told apart from a crash. The one sentence the user could have acted on was in the
+   exception and nowhere else.
+
+Plus the oldest of the four: dictation never worked on the local model, because ``str(None)`` is
+``"None"`` and that five-character string travelled all the way to faster-whisper as a language code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.code_api import _native_failure
+
+# --- the language code that was the word "None" --------------------------------------------------
+
+
+def test_no_language_hint_means_detect_it_not_the_word_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The API layer passes ``language=None`` for "work it out", and that is the case that broke.
+
+    ``str(None).strip() or None`` never yields None: the string is five characters long, so the
+    ``or`` never fires. faster-whisper then refused the whole call — `'None' is not a valid language
+    code` — which is what the app showed under the microphone button, for every dictation, forever.
+    """
+    from chimera.tools.media import TranscribeAudioTool
+
+    seen: dict[str, Any] = {}
+
+    def fake(path: str, language: str | None) -> str:
+        seen["language"] = language
+        return "transcribed"
+
+    monkeypatch.setattr("chimera.tools.media._transcribe_faster_whisper", fake)
+
+    tool = TranscribeAudioTool(Path.cwd())
+    audio = Path.cwd() / "speech.webm"
+    audio.write_bytes(b"not really audio")
+    try:
+        tool.run(path="speech.webm", language=None)
+    finally:
+        audio.unlink()
+
+    assert seen["language"] is None, "the absence of a hint was turned into the string 'None'"
+
+
+def test_a_real_language_hint_still_travels(monkeypatch: pytest.MonkeyPatch) -> None:
+    from chimera.tools.media import TranscribeAudioTool
+
+    seen: dict[str, Any] = {}
+    monkeypatch.setattr(
+        "chimera.tools.media._transcribe_faster_whisper",
+        lambda path, language: seen.setdefault("language", language) or "ok",
+    )
+
+    tool = TranscribeAudioTool(Path.cwd())
+    audio = Path.cwd() / "speech2.webm"
+    audio.write_bytes(b"not really audio")
+    try:
+        tool.run(path="speech2.webm", language="pt")
+    finally:
+        audio.unlink()
+
+    assert seen["language"] == "pt"
+
+
+# --- the failure message the user was not shown --------------------------------------------------
+
+
+def test_the_provider_sentence_reaches_the_user() -> None:
+    """The exact string that cost a user two failed turns and told them nothing."""
+    raw = (
+        "litellm.NotFoundError: NotFoundError: OpenrouterException - "
+        '{"error":{"message":"No endpoints found that support image input","code":404}}'
+    )
+
+    assert _native_failure(Exception(raw)) == "No endpoints found that support image input"
+
+
+def test_an_internal_failure_stays_generic() -> None:
+    """A bug in this repository is ours to debug, and a stack trace in the composer helps nobody.
+
+    This is the half of the old behaviour worth keeping: the reason "the coding turn failed" existed
+    at all. What was wrong was applying it to the provider's refusals too.
+    """
+    assert _native_failure(KeyError("some internal state")) == "the coding turn failed"
+    assert _native_failure(Exception("")) == "the coding turn failed"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "litellm.RateLimitError: rate limit exceeded",
+        "litellm.AuthenticationError: invalid api key",
+        "litellm.BadRequestError: this model does not exist",
+        "litellm.ContextWindowExceededError: maximum context length is 8192 tokens",
+    ],
+)
+def test_every_class_the_user_can_act_on_is_forwarded(raw: str) -> None:
+    assert _native_failure(Exception(raw)) != "the coding turn failed"
+
+
+def test_a_wall_of_json_is_bounded() -> None:
+    # A provider that answers with a page of JSON must not paste it into the transcript.
+    raw = "litellm.BadRequestError: not found " + ("x" * 1000)
+    out = _native_failure(Exception(raw))
+    assert len(out) <= 300
+    assert out.endswith("…")
+
+
+# --- the image the model could not see -----------------------------------------------------------
+
+
+def test_vision_is_asked_about_the_model_that_will_answer() -> None:
+    """The endpoint takes the composer's pick. Before, it always answered about the default — so the
+    warning named one model while a different one ran, which is worse than no warning: it reads as
+    authoritative."""
+    from fastapi.testclient import TestClient
+
+    from chimera.api import build_api_app
+    from chimera.interface import ChatSession
+
+    client = TestClient(build_api_app(lambda: ChatSession(None)))  # type: ignore[arg-type]
+
+    asked = client.get("/api/vision", params={"model": "openrouter/google/gemini-2.5-flash"}).json()
+    assert asked["model"] == "openrouter/google/gemini-2.5-flash"
+
+    # Omitted still means the install's default — what a caller with no picker means.
+    default = client.get("/api/vision").json()
+    assert default["model"] and default["model"] != asked["model"]


### PR DESCRIPTION
Found by using the app for a minute after installing the rc. Four defects, all the same shape:
something the system knew and never told the person who needed it.

## 1. The warning named the wrong model

`/api/vision` always answered about `default_model`. The moment the model became a per-conversation
choice, the sentence under the paperclip described a model the turn was not going to use — and it
reads as authoritative. It takes the composer's pick now, keyed on the model so switching re-asks.

## 2. Then the turn died anyway

That warning says the image "will not be seen". The server sent it regardless, OpenRouter answered
`No endpoints found that support image input`, and the whole turn failed. The interface promised a
degraded turn; the system delivered no turn.

An image is now withheld from a model LiteLLM positively reports as blind, and the model is told it
was withheld — so it says "I cannot see it" instead of describing a picture it never received.
`unknown` still sends: a table that has not heard of a model is not evidence about the model.

## 3. And the reason was hidden

Every native failure rendered as "the coding turn failed". That is right for a bug in this
repository and wrong for the common case: the provider refused and said exactly why. The provider's
sentence now reaches the user when it belongs to a class they can act on — no vision, wrong model,
rate limit, context, credit, auth — unwrapped from LiteLLM's class-name stack, one line, bounded.
Anything else stays generic.

## 4. Dictation never worked on the local model

`str(None)` is `"None"`, so `str(kwargs.get("language", "")).strip() or None` never yielded None.
The five-character word reached faster-whisper as a language code and every dictation failed with
`'None' is not a valid language code` — because the API layer passes None for "detect it", which is
exactly the case that line converted into a wrong answer.

## Plus the chip says which model

`default · deepseek-chat-v3.1` instead of `default`. You had to open the dialog to learn that the
word meant $0.25 rather than $5. The name comes from `doctor`, already fetched by the row beside it.

## Verified against a live provider, not only in tests

| case | before | after |
|---|---|---|
| image + model known blind | turn failed | model answers "I cannot see the image", $0.0009 |
| image + model unknown to the table | `the coding turn failed` | `No endpoints found that support image input` |
| `/api/vision?model=…gemini-2.5-flash` | answered about the default | `support: yes` |
| conversation title with a withheld image | `…? [The user attached \`6d2b57e5…` | `o que voce ve nesta imagem?` |

3.492 Python tests, 575 desktop tests, ruff and mypy clean. Ten new tests cover the four defects.

While in there I also exercised the rest of the app against the running backend: memory (add +
recall), the skill library (23 cards), cron (schedule, list, delete), the agent registry, maturity
(37/37), the tool registry (22 tools) and an autonomous run with a verify command — which wrote the
file, read it back and passed. No further defects surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
