### PR TITLE
fix(core): the attached image never reached the model, and the provider answered 500

### DIFF
--- a/apps/desktop/src/components/Tools.test.tsx
+++ b/apps/desktop/src/components/Tools.test.tsx
@@ -133,4 +133,23 @@ describe("Tools", () => {
 
     expect(await screen.findByText("read_file")).toBeInTheDocument();
   });
+
+  it("keeps each description verbatim while the screen around it is translated, and says why", async () => {
+    // A tool's description and parameter names are the function schema sent to the model, not our
+    // copy about the agent. Translating them would make the one screen whose job is an honest
+    // inventory describe an agent that does not exist — so the screen explains the English instead
+    // of hiding it, and this asserts both halves: the chrome translates, the schema does not.
+    localStorage.setItem("chimera.lang", "pt");
+    try {
+      mockGetTools.mockResolvedValue(toolsOut([tool()]));
+      renderWithProviders(<Tools />);
+
+      expect(await screen.findByText("1 ferramentas")).toBeInTheDocument();
+      expect(screen.getByText("Read a file from the workspace.")).toBeInTheDocument();
+      expect(screen.getByText("path")).toBeInTheDocument();
+      expect(screen.getByText(/schema enviado ao modelo/)).toBeInTheDocument();
+    } finally {
+      localStorage.removeItem("chimera.lang");
+    }
+  });
 });

--- a/apps/desktop/src/components/Tools.tsx
+++ b/apps/desktop/src/components/Tools.tsx
@@ -171,6 +171,12 @@ export function Tools({ embedded = false }: { embedded?: boolean } = {}) {
         )}
       </Panel>
       <p className="px-1 text-xs text-muted-foreground">{t("tools.note")}</p>
+      {/* Why every row above is English even when the app is not. A tool's description and its
+          parameter names are not our copy about the agent — they ARE the function schema sent to
+          the model, so a translated copy on this screen would describe an agent that does not
+          exist, on the one screen whose whole job is to be an honest inventory. Saying so is
+          cheaper than either lying or leaving it unexplained. */}
+      <p className="px-1 text-xs text-muted-foreground">{t("tools.langNote")}</p>
     </Screen>
   );
 }

--- a/apps/desktop/src/components/code/ModelPicker.tsx
+++ b/apps/desktop/src/components/code/ModelPicker.tsx
@@ -144,6 +144,12 @@ export function ModelDialog({
   const t = useT();
   const qc = useQueryClient();
   const [query, setQuery] = useState("");
+  /** Narrow the list to models the provider says accept images.
+   *
+   *  Off by default, because most turns are text. It exists because the alternative was a dead end:
+   *  someone attaches a screenshot, the composer says this model cannot look at it, and the only way
+   *  to find one that can was to open four hundred rows and read the badges. */
+  const [seeingOnly, setSeeingOnly] = useState(false);
 
   // Fetched when the dialog first opens, not on mount: this is a round-trip to a public catalogue,
   // and paying for it before anybody asks for a model is paying for a menu most turns never open.
@@ -162,17 +168,20 @@ export function ModelDialog({
   const defaultSlug = listing.data?.default ?? "";
 
   const filtered = useMemo(() => {
+    // `=== true` and not truthiness: `null` means the source did not say, and a model we were told
+    // nothing about must not be presented as one that reads images.
+    const eligible = seeingOnly ? models.filter((m) => m.vision === true) : models;
     const needle = query.trim().toLowerCase();
-    if (!needle) return models;
+    if (!needle) return eligible;
     // Matched against the slug as well as the label: someone pasting `deepseek/deepseek-chat-v3.1`
     // from a terminal is searching with the string they already have.
-    return models.filter(
+    return eligible.filter(
       (m) =>
         m.label.toLowerCase().includes(needle) ||
         m.slug.toLowerCase().includes(needle) ||
         m.vendor.toLowerCase().includes(needle),
     );
-  }, [models, query]);
+  }, [models, query, seeingOnly]);
 
   const shown = filtered.slice(0, MAX_ROWS);
   const hidden = filtered.length - shown.length;
@@ -192,8 +201,13 @@ export function ModelDialog({
       onOpenChange={onOpenChange}
       title={t("model.pick.title")}
       description={t("model.pick.blurb")}
+      // The footer holds "Make it the default", and on a short window it was being pushed below the
+      // fold — with the list itself scrolling, so nothing hinted there was anything under it. The
+      // dialog is bounded to the viewport and the LIST is the only part that scrolls, which puts the
+      // action back on screen at every window height.
+      className="flex max-h-dialog flex-col"
     >
-      <div className="space-y-3">
+      <div className="flex min-h-0 flex-col gap-3">
         <label className="flex items-center gap-2">
           <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="sr-only">{t("model.pick.search")}</span>
@@ -206,6 +220,19 @@ export function ModelDialog({
           />
         </label>
 
+        {/* One question the search box cannot answer: which of these can look at the picture I just
+            attached. The badge was already on every row; this turns it into a filter, because
+            reading four hundred rows for a badge is not an answer. */}
+        <label className="flex items-center gap-2 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            className="accent-accent"
+            checked={seeingOnly}
+            onChange={(e) => setSeeingOnly(e.target.checked)}
+          />
+          {t("model.pick.onlyVision")}
+        </label>
+
         {/* Why the list is short, when it is short. Said NEXT TO the list rather than instead of it:
             the models below are real and callable, and hiding them behind an error would answer
             "your key buys nothing", which is not what a failed fetch means. */}
@@ -216,7 +243,7 @@ export function ModelDialog({
           </p>
         ) : null}
 
-        <div className="max-h-80 space-y-1 overflow-y-auto">
+        <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
           {/* Always first, and never filtered out by the search: it is the way back, and a way back
               you can lose by typing is not one. */}
           <Row

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -92,7 +92,10 @@ export function Dialog({
             </RadixDialog.Close>
           </div>
 
-          <div className="mt-4">{children}</div>
+          {/* `min-h-0` so a flex-column dialog can bound its own body: without it the content sets
+              the height, the body never scrolls, and a long list pushes the footer past the bottom
+              of the window. Inert for every dialog that is not a flex column. */}
+          <div className="mt-4 min-h-0 flex-1">{children}</div>
           {footer && <div className="mt-5 flex justify-end gap-2">{footer}</div>}
         </RadixDialog.Content>
       </RadixDialog.Portal>

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -62,6 +62,8 @@ const en: Dict = {
   "tools.noParams": "no parameters",
   "tools.note":
     "The agent's registered tools (native + any that light up when a credential or dependency is present). Capability tags are derived from the tool name against the governance sets — not from running anything.",
+  "tools.langNote":
+    "Each tool's description and parameter names stay in English in every language: that exact text is the schema sent to the model, and a translated copy here would show you something the agent never reads.",
   "tools.tag.network": "network",
   "tools.tag.read": "read",
   "tools.tag.write": "write",
@@ -421,6 +423,7 @@ const en: Dict = {
   "model.pick.context": "{n}k context",
   "model.pick.noTools": "no tools",
   "model.pick.vision": "images",
+  "model.pick.onlyVision": "Only models that read images",
   "model.pick.noToolsWarning": "Cannot call tools — this turn would describe an edit instead of making it.",
   "model.pick.makeDefault": "Make it the default",
   "model.pick.makeDefaultHint": "Otherwise the pick lasts for this conversation only.",
@@ -852,6 +855,8 @@ const pt: Dict = {
   "tools.noParams": "sem parâmetros",
   "tools.note":
     "As ferramentas registradas do agente (nativas + as que se ativam quando há uma credencial ou dependência). As tags de capacidade são derivadas do nome da ferramenta contra os conjuntos de governança — não da execução de nada.",
+  "tools.langNote":
+    "A descrição e os nomes dos parâmetros de cada ferramenta ficam em inglês em todos os idiomas: esse texto exato é o schema enviado ao modelo, e uma cópia traduzida aqui mostraria algo que o agente nunca lê.",
   "tools.tag.network": "rede",
   "tools.tag.read": "leitura",
   "tools.tag.write": "escrita",
@@ -1211,6 +1216,7 @@ const pt: Dict = {
   "model.pick.context": "{n}k de contexto",
   "model.pick.noTools": "sem ferramentas",
   "model.pick.vision": "imagens",
+  "model.pick.onlyVision": "Só modelos que leem imagens",
   "model.pick.noToolsWarning": "Não chama ferramentas — este turno descreveria a edição em vez de fazê-la.",
   "model.pick.makeDefault": "Tornar padrão",
   "model.pick.makeDefaultHint": "Sem isso, a escolha vale só para esta conversa.",
@@ -1667,6 +1673,8 @@ const es: Dict = {
   "tools.noParams": "sin parámetros",
   "tools.note":
     "Las herramientas registradas del agente (nativas + las que se activan cuando hay una credencial o dependencia). Las etiquetas de capacidad se derivan del nombre de la herramienta frente a los conjuntos de gobernanza — no de ejecutar nada.",
+  "tools.langNote":
+    "La descripción y los nombres de los parámetros de cada herramienta se mantienen en inglés en todos los idiomas: ese texto exacto es el esquema que se envía al modelo, y una copia traducida aquí mostraría algo que el agente nunca lee.",
   "tools.tag.network": "red",
   "tools.tag.read": "lectura",
   "tools.tag.write": "escritura",
@@ -2001,6 +2009,7 @@ const es: Dict = {
   "model.pick.context": "{n}k de contexto",
   "model.pick.noTools": "sin herramientas",
   "model.pick.vision": "imágenes",
+  "model.pick.onlyVision": "Solo modelos que leen imágenes",
   "model.pick.noToolsWarning": "No llama herramientas: este turno describiría la edición en vez de hacerla.",
   "model.pick.makeDefault": "Hacerlo predeterminado",
   "model.pick.makeDefaultHint": "Si no, la elección vale solo para esta conversación.",
@@ -2457,6 +2466,8 @@ const fr: Dict = {
   "tools.noParams": "aucun paramètre",
   "tools.note":
     "Les outils enregistrés de l'agent (natifs + ceux qui s'activent avec une clé ou une dépendance). Les tags de capacité sont dérivés du nom de l'outil face aux ensembles de gouvernance — pas de l'exécution de quoi que ce soit.",
+  "tools.langNote":
+    "La description et les noms de paramètres de chaque outil restent en anglais dans toutes les langues : ce texte exact est le schéma envoyé au modèle, et une copie traduite ici montrerait quelque chose que l'agent ne lit jamais.",
   "tools.tag.network": "réseau",
   "tools.tag.read": "lecture",
   "tools.tag.write": "écriture",
@@ -2791,6 +2802,7 @@ const fr: Dict = {
   "model.pick.context": "{n}k de contexte",
   "model.pick.noTools": "sans outils",
   "model.pick.vision": "images",
+  "model.pick.onlyVision": "Uniquement les modèles qui lisent les images",
   "model.pick.noToolsWarning": "N'appelle pas d'outils — ce tour décrirait la modification au lieu de la faire.",
   "model.pick.makeDefault": "En faire le modèle par défaut",
   "model.pick.makeDefaultHint": "Sinon, le choix ne vaut que pour cette conversation.",
@@ -3247,6 +3259,8 @@ const de: Dict = {
   "tools.noParams": "keine Parameter",
   "tools.note":
     "Die registrierten Werkzeuge des Agenten (native + solche, die sich mit einem Schlüssel oder einer Abhängigkeit aktivieren). Fähigkeits-Tags werden aus dem Werkzeugnamen gegen die Governance-Mengen abgeleitet — nicht aus dem Ausführen von irgendetwas.",
+  "tools.langNote":
+    "Beschreibung und Parameternamen jedes Werkzeugs bleiben in allen Sprachen englisch: genau dieser Text ist das Schema, das an das Modell geht, und eine übersetzte Fassung hier würde etwas zeigen, was der Agent nie liest.",
   "tools.tag.network": "Netzwerk",
   "tools.tag.read": "Lesen",
   "tools.tag.write": "Schreiben",
@@ -3581,6 +3595,7 @@ const de: Dict = {
   "model.pick.context": "{n}k Kontext",
   "model.pick.noTools": "keine Werkzeuge",
   "model.pick.vision": "Bilder",
+  "model.pick.onlyVision": "Nur Modelle, die Bilder lesen",
   "model.pick.noToolsWarning": "Ruft keine Werkzeuge auf — dieser Zug würde die Änderung beschreiben statt sie zu machen.",
   "model.pick.makeDefault": "Als Standard setzen",
   "model.pick.makeDefaultHint": "Sonst gilt die Wahl nur für dieses Gespräch.",
@@ -4037,6 +4052,8 @@ const zh: Dict = {
   "tools.noParams": "无参数",
   "tools.note":
     "智能体已注册的工具（原生 + 在具备凭据或依赖时启用的工具）。能力标签依据工具名称与治理集合推导得出——并非通过运行任何东西。",
+  "tools.langNote":
+    "每个工具的描述和参数名在所有语言下都保持英文：这段文字正是发送给模型的 schema，在这里翻译只会让你看到智能体从未读到的内容。",
   "tools.tag.network": "网络",
   "tools.tag.read": "读取",
   "tools.tag.write": "写入",
@@ -4371,6 +4388,7 @@ const zh: Dict = {
   "model.pick.context": "{n}k 上下文",
   "model.pick.noTools": "不支持工具",
   "model.pick.vision": "图像",
+  "model.pick.onlyVision": "只看能读图的模型",
   "model.pick.noToolsWarning": "不能调用工具 — 这一轮只会描述修改，而不会真正动文件。",
   "model.pick.makeDefault": "设为默认",
   "model.pick.makeDefaultHint": "不设的话，这次选择只在本段对话有效。",
@@ -4824,6 +4842,8 @@ const ja: Dict = {
   "tools.noParams": "パラメータなし",
   "tools.note":
     "エージェントに登録されたツール（ネイティブ + 認証情報や依存関係があると有効になるもの）。能力タグはツール名をガバナンス集合と照合して導出されます — 何かを実行して得るものではありません。",
+  "tools.langNote":
+    "各ツールの説明とパラメータ名は、どの言語でも英語のままです。その文面そのものがモデルに送られるスキーマであり、ここで訳すとエージェントが決して読まないものを見せることになります。",
   "tools.tag.network": "ネットワーク",
   "tools.tag.read": "読み取り",
   "tools.tag.write": "書き込み",
@@ -5158,6 +5178,7 @@ const ja: Dict = {
   "model.pick.context": "コンテキスト {n}k",
   "model.pick.noTools": "ツール非対応",
   "model.pick.vision": "画像",
+  "model.pick.onlyVision": "画像を読めるモデルだけ",
   "model.pick.noToolsWarning": "ツールを呼べません — このターンは編集を説明するだけで、実際には変更しません。",
   "model.pick.makeDefault": "既定にする",
   "model.pick.makeDefaultHint": "しなければ、この選択はこの会話だけです。",
@@ -5586,6 +5607,8 @@ const it: Dict = {
   "tools.params": "parametri:",
   "tools.noParams": "nessun parametro",
   "tools.note": "Gli strumenti registrati dell'agente (nativi + quelli che si attivano quando una credenziale o una dipendenza è presente). Le etichette di capacità derivano dal nome dello strumento confrontato con gli insiemi di governance — non dall'esecuzione di alcunché.",
+  "tools.langNote":
+    "La descrizione e i nomi dei parametri di ogni strumento restano in inglese in tutte le lingue: quel testo esatto è lo schema inviato al modello, e una copia tradotta qui mostrerebbe qualcosa che l'agente non legge mai.",
   "tools.tag.network": "rete",
   "tools.tag.read": "lettura",
   "tools.tag.write": "scrittura",
@@ -5942,6 +5965,7 @@ const it: Dict = {
   "model.pick.context": "{n}k di contesto",
   "model.pick.noTools": "senza strumenti",
   "model.pick.vision": "immagini",
+  "model.pick.onlyVision": "Solo modelli che leggono immagini",
   "model.pick.noToolsWarning": "Non chiama strumenti — questo turno descriverebbe la modifica invece di farla.",
   "model.pick.makeDefault": "Rendilo predefinito",
   "model.pick.makeDefaultHint": "Altrimenti la scelta vale solo per questa conversazione.",
@@ -6351,6 +6375,8 @@ const pl: Dict = {
   "tools.params": "parametry:",
   "tools.noParams": "brak parametrów",
   "tools.note": "Zarejestrowane narzędzia agenta (natywne + te, które włączają się, gdy obecne są poświadczenia lub zależność). Etykiety możliwości wynikają z nazwy narzędzia zestawionej ze zbiorami governance — a nie z uruchomienia czegokolwiek.",
+  "tools.langNote":
+    "Opis i nazwy parametrów każdego narzędzia pozostają po angielsku we wszystkich językach: dokładnie ten tekst jest schematem wysyłanym do modelu, a przetłumaczona kopia pokazałaby tu coś, czego agent nigdy nie czyta.",
   "tools.tag.network": "sieć",
   "tools.tag.read": "odczyt",
   "tools.tag.write": "zapis",
@@ -6707,6 +6733,7 @@ const pl: Dict = {
   "model.pick.context": "{n}k kontekstu",
   "model.pick.noTools": "bez narzędzi",
   "model.pick.vision": "obrazy",
+  "model.pick.onlyVision": "Tylko modele, które czytają obrazy",
   "model.pick.noToolsWarning": "Nie wywołuje narzędzi — ta tura opisałaby zmianę, zamiast ją wykonać.",
   "model.pick.makeDefault": "Ustaw jako domyślny",
   "model.pick.makeDefaultHint": "Inaczej wybór obowiązuje tylko w tej rozmowie.",
@@ -7116,6 +7143,8 @@ const ru: Dict = {
   "tools.params": "параметры:",
   "tools.noParams": "без параметров",
   "tools.note": "Зарегистрированные инструменты агента (встроенные плюс те, что появляются при наличии учётных данных или зависимости). Метки возможностей выводятся из имени инструмента по спискам управления — ничего для этого не запускается.",
+  "tools.langNote":
+    "Описание и имена параметров каждого инструмента остаются на английском во всех языках: именно этот текст — схема, отправляемая модели, и переведённая копия показала бы здесь то, чего агент никогда не читает.",
   "tools.tag.network": "сеть",
   "tools.tag.read": "чтение",
   "tools.tag.write": "запись",
@@ -7472,6 +7501,7 @@ const ru: Dict = {
   "model.pick.context": "{n}k контекста",
   "model.pick.noTools": "без инструментов",
   "model.pick.vision": "изображения",
+  "model.pick.onlyVision": "Только модели, читающие изображения",
   "model.pick.noToolsWarning": "Не вызывает инструменты — этот ход опишет правку вместо того, чтобы её сделать.",
   "model.pick.makeDefault": "Сделать по умолчанию",
   "model.pick.makeDefaultHint": "Иначе выбор действует только в этом разговоре.",

--- a/apps/desktop/tailwind.config.js
+++ b/apps/desktop/tailwind.config.js
@@ -41,6 +41,9 @@ export default {
         "toggle-on": "var(--toggle-on)",
       },
       borderRadius: { chip: "1.5rem", xl2: "1.15rem" },
+      // As tall as a dialog may get before it starts pushing its own footer off the screen. Named
+      // rather than written inline: it is the same decision every scrolling dialog has to make.
+      maxHeight: { dialog: "85vh" },
       fontFamily: {
         sans: ["ui-sans-serif", "system-ui", "-apple-system", "Segoe UI", "sans-serif"],
         mono: ["ui-monospace", "SFMono-Regular", "Menlo", "Consolas", "monospace"],

--- a/chimera/api/attachments.py
+++ b/chimera/api/attachments.py
@@ -154,6 +154,21 @@ def vision_support(model: str) -> str:
     """
     if not model:
         return "unknown"
+
+    # The provider's own answer first, when we have it. LiteLLM's table was wrong in BOTH directions
+    # on the two models a user hit in one sitting: it had never heard of `deepseek-v4-flash` (so the
+    # app read "unknown", sent the image, and OpenRouter killed the turn with `No endpoints found
+    # that support image input`), and it reports `no` for `mistral-small-3.2-24b-instruct`, which
+    # reads images perfectly well — so trusting it there withholds an image from a model that could
+    # have used it. The index the model picker fetches carries the modalities the provider publishes
+    # for every model it serves, remembered on disk; that is a fact about the model rather than a
+    # table someone has to maintain.
+    from chimera.providers.listing import known_vision
+
+    published = known_vision(model)
+    if published is not None:
+        return "yes" if published else "no"
+
     try:
         import litellm
     except ImportError:  # pragma: no cover — litellm is a hard dependency of the gateway

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -125,7 +125,41 @@ MessageLike = Message | dict[str, Any]
 
 
 def _to_message_dicts(messages: list[MessageLike]) -> list[dict[str, Any]]:
-    return [m.as_dict() if isinstance(m, Message) else m for m in messages]
+    """Every message in the shape a provider accepts — including the ones that arrive as plain dicts.
+
+    This used to be `m.as_dict() if isinstance(m, Message) else m`, and the `else` branch is where
+    attached images went to die. `Agent.run` builds this turn's user message as a LITERAL dict —
+    `{"role": "user", "content": task, "images": [...]}` — because it is assembling a list that also
+    holds the history's dicts. A `Message` would have been converted; a dict was passed through, so:
+
+    - the images never became `image_url` parts, and the model never saw the picture; and
+    - the key `images` travelled to the provider, carrying a local file path. OpenRouter answered
+      `500 Internal Server Error`, which is what a user attaching a screenshot actually got.
+
+    Both halves were invisible in the obvious place: the composer showed the attachment, the upload
+    succeeded, the vision check said the model could see — and the request quietly contained neither
+    a picture nor a valid body. Converting here rather than at the call site is the fix that cannot
+    be forgotten by the next caller: this function is the single door to the provider.
+    """
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        if isinstance(message, Message):
+            out.append(message.as_dict())
+            continue
+        images = message.get("images")
+        if not images:
+            # No images to fold in — but drop the key if it is present-and-empty, since no provider
+            # knows it and an empty list is not worth a round trip's risk.
+            out.append({k: v for k, v in message.items() if k != "images"} if "images" in message else message)
+            continue
+        out.append(
+            Message(
+                role=message.get("role", "user"),
+                content=str(message.get("content") or ""),
+                images=list(images),
+            ).as_dict()
+        )
+    return out
 
 
 class SupportsComplete(Protocol):

--- a/chimera/providers/listing.py
+++ b/chimera/providers/listing.py
@@ -350,7 +350,7 @@ def available_models(
     # receipt under a turn can price a model nobody hand-added to the static table — including the
     # product default, which reported "price unknown" for as long as it was GPT-5.5.
     if remote:
-        remember_prices(remote)
+        remember_models(remote)
 
     local = _ollama_options(getattr(settings, "ollama_base_url", ""))
     for option in local:
@@ -386,12 +386,26 @@ def available_models(
 # - **Only real prices.** A model OpenRouter quotes per request has no number here — the receipt says
 #   "unknown", which is true, rather than "$0", which is both false and divisible.
 
-#: Where the map lives, under ``settings.home``.
+#: Where the remembered index lives, under ``settings.home``. The name is historical: the file began
+#: as prices alone and now carries capabilities too, and renaming it would strand every install that
+#: has one.
 PRICE_CACHE_NAME = "model-prices.json"
+
+
+@dataclass(frozen=True)
+class Remembered:
+    """What we kept about one model, from the last time the index was fetched."""
+
+    input_per_m: float | None
+    output_per_m: float | None
+    #: Whether the PROVIDER says this model accepts images. None = it did not say.
+    vision: bool | None
+    tools: bool | None
+
 
 # (path, mtime, table). Keyed by path and mtime so a test that repoints CHIMERA_HOME, or a fetch that
 # rewrites the file, is picked up without a process restart.
-_price_cache: tuple[Path, float, dict[str, tuple[float, float]]] | None = None
+_index_cache: tuple[Path, float, dict[str, Remembered]] | None = None
 
 
 def _price_cache_path() -> Path:
@@ -400,19 +414,29 @@ def _price_cache_path() -> Path:
     return Path(get_settings().home) / PRICE_CACHE_NAME
 
 
-def remember_prices(models: Sequence[ModelOption]) -> None:
-    """Persist every KNOWN price from a freshly fetched listing. Never raises.
+def remember_models(models: Sequence[ModelOption]) -> None:
+    """Persist what a freshly fetched listing knows about each model. Never raises.
 
     Called from :func:`available_models`, so the map refreshes as a side effect of the picker being
-    used — there is no second code path that has to remember to run. A failure to write is a debug
-    line: the app must not fall over because a cache directory is read-only.
+    used — there is no second code path that has to remember to run.
+
+    It began as prices and grew to carry capabilities, because the capability answer the app had was
+    WRONG in both directions. LiteLLM's table said `unknown` for DeepSeek V4 Flash (so the app sent
+    an image and the provider killed the turn) and said `no` for Mistral Small 3.2, which reads
+    images perfectly well (so the app would have withheld one it could have used). The provider
+    publishes the modalities of every model it serves; that is a fact about the model, and it belongs
+    here rather than in a table somebody has to maintain.
     """
-    priced = {
-        m.slug: (m.input_per_m, m.output_per_m)
+    kept = {
+        m.slug: {
+            "in": m.input_per_m,
+            "out": m.output_per_m,
+            "vision": m.vision,
+            "tools": m.tools,
+        }
         for m in models
-        if m.input_per_m is not None and m.output_per_m is not None
     }
-    if not priced:
+    if not kept:
         return
     path = _price_cache_path()
     try:
@@ -420,40 +444,77 @@ def remember_prices(models: Sequence[ModelOption]) -> None:
         # `fetched_at` is stored for a human reading the file, not consulted: a price from last month
         # is a better estimate than no price, and expiring it would put "unknown" back on screen for
         # anyone who has been offline for a while.
-        payload = {"fetched_at": _now_iso(), "prices": {k: list(v) for k, v in priced.items()}}
+        payload = {"fetched_at": _now_iso(), "models": kept}
         path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     except Exception as exc:  # noqa: BLE001 — a read-only home must not break a turn
-        _log.debug("could not write the price cache at %s: %s", path, exc)
+        _log.debug("could not write the model cache at %s: %s", path, exc)
 
 
-def known_price(slug: str) -> tuple[float, float] | None:
-    """USD per 1M (input, output) for this EXACT slug, or None when we have never seen it priced.
+def _remembered(slug: str) -> Remembered | None:
+    """What the last fetch knew about this EXACT slug, or None.
 
     Reads the file at most once per (path, mtime) — this is called inside the loop that prices a
     turn, so it must not touch the disk on every call, and it must never do I/O over the network.
+
+    Reads the OLD shape too (`{"prices": {slug: [in, out]}}`), because an install that upgraded from
+    0.48.0rc2 has one on disk and deleting its prices to gain capabilities would be a downgrade.
     """
-    global _price_cache
+    global _index_cache
     path = _price_cache_path()
     try:
         mtime = path.stat().st_mtime
     except OSError:
         return None  # no cache yet: the caller falls back to its own table, as it always did
 
-    if _price_cache is None or _price_cache[0] != path or _price_cache[1] != mtime:
+    if _index_cache is None or _index_cache[0] != path or _index_cache[1] != mtime:
+        table: dict[str, Remembered] = {}
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))
-            entries = raw["prices"]
-            table = {
-                str(k): (float(v[0]), float(v[1]))
-                for k, v in entries.items()
-                if isinstance(v, list) and len(v) == 2
-            }
+            for key, value in (raw.get("models") or {}).items():
+                if isinstance(value, dict):
+                    table[str(key)] = Remembered(
+                        _as_price(value.get("in")),
+                        _as_price(value.get("out")),
+                        value.get("vision") if isinstance(value.get("vision"), bool) else None,
+                        value.get("tools") if isinstance(value.get("tools"), bool) else None,
+                    )
+            for key, value in (raw.get("prices") or {}).items():  # the 0.48.0rc2 shape
+                if isinstance(value, list) and len(value) == 2 and str(key) not in table:
+                    table[str(key)] = Remembered(_as_price(value[0]), _as_price(value[1]), None, None)
         except Exception as exc:  # noqa: BLE001 — a truncated cache is a missing cache
-            _log.debug("could not read the price cache at %s: %s", path, exc)
+            _log.debug("could not read the model cache at %s: %s", path, exc)
             table = {}
-        _price_cache = (path, mtime, table)
+        _index_cache = (path, mtime, table)
 
-    return _price_cache[2].get(slug)
+    return _index_cache[2].get(slug)
+
+
+def _as_price(value: Any) -> float | None:
+    return float(value) if isinstance(value, int | float) else None
+
+
+def known_price(slug: str) -> tuple[float, float] | None:
+    """USD per 1M (input, output) for this EXACT slug, or None when we have never seen it priced."""
+    found = _remembered(slug)
+    if found is None or found.input_per_m is None or found.output_per_m is None:
+        return None
+    return (found.input_per_m, found.output_per_m)
+
+
+def known_vision(slug: str) -> bool | None:
+    """Does the PROVIDER say this exact model accepts images? None = we have not been told.
+
+    The reason this exists is a turn that died: LiteLLM's capability table had never heard of
+    DeepSeek V4 Flash, the app read `unknown` as "send it and find out", and OpenRouter answered
+    `No endpoints found that support image input` — killing the whole turn over an attachment. The
+    same table also reports `no` for Mistral Small 3.2, which does read images; trusting it there
+    would have withheld an image from a model that could have used it.
+
+    Exact slugs only, and only what the provider published. A model we have never fetched returns
+    None and the caller falls back to whatever it did before.
+    """
+    found = _remembered(slug)
+    return found.vision if found is not None else None
 
 
 def _now_iso() -> str:
@@ -479,6 +540,6 @@ def warm_price_cache(settings: Any) -> None:
             return
         models, reason = openrouter_models()
         if reason == "":
-            remember_prices(models)
+            remember_models(models)
     except Exception as exc:  # noqa: BLE001 — a warm-up must never take the process with it
         _log.debug("price cache warm-up failed: %s", exc)

--- a/tests/test_attachment_vision_and_dictation.py
+++ b/tests/test_attachment_vision_and_dictation.py
@@ -141,3 +141,130 @@ def test_vision_is_asked_about_the_model_that_will_answer() -> None:
     # Omitted still means the install's default — what a caller with no picker means.
     default = client.get("/api/vision").json()
     assert default["model"] and default["model"] != asked["model"]
+
+
+# --- the capability table that was wrong in both directions ---------------------------------------
+
+
+def test_the_providers_own_answer_beats_the_static_table(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """Both halves of the bug, in one test.
+
+    LiteLLM's table had never heard of DeepSeek V4 Flash, so the app read "unknown", sent the image
+    and OpenRouter killed the turn. The same table reports "no" for Mistral Small 3.2, which reads
+    images — so believing it there withholds an image from a model that could have used it. One
+    unknown that costs a turn, one false negative that removes a capability, from the same source.
+    """
+    import json
+
+    from chimera.api.attachments import vision_support
+    from chimera.providers import listing
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path))
+    listing._index_cache = None
+    (tmp_path / listing.PRICE_CACHE_NAME).write_text(
+        json.dumps(
+            {
+                "fetched_at": "2026-08-19T00:00:00+00:00",
+                "models": {
+                    "openrouter/deepseek/deepseek-v4-flash": {"vision": False, "tools": True},
+                    "openrouter/mistralai/mistral-small-3.2-24b-instruct": {"vision": True},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert vision_support("openrouter/deepseek/deepseek-v4-flash") == "no"
+    assert vision_support("openrouter/mistralai/mistral-small-3.2-24b-instruct") == "yes"
+
+
+def test_a_model_the_index_never_saw_still_falls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    # A local Ollama tag, a vendor not on OpenRouter, an install that has never fetched: the answer
+    # has to come from wherever it came from before, not from an absence read as "no".
+    from chimera.api.attachments import vision_support
+    from chimera.providers import listing
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "empty"))
+    listing._index_cache = None
+
+    assert vision_support("ollama/llama3") in {"yes", "no", "unknown"}
+
+
+def test_the_remembered_index_survives_the_older_file_shape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+) -> None:
+    """0.48.0rc2 wrote `{"prices": {slug: [in, out]}}`. Upgrading must not throw those prices away to
+    gain capabilities — the user would silently lose the receipt figures they already had."""
+    import json
+
+    from chimera.providers import listing
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path))
+    listing._index_cache = None
+    (tmp_path / listing.PRICE_CACHE_NAME).write_text(
+        json.dumps({"fetched_at": "x", "prices": {"openrouter/vendor/model": [0.25, 0.95]}}),
+        encoding="utf-8",
+    )
+
+    assert listing.known_price("openrouter/vendor/model") == (0.25, 0.95)
+    assert listing.known_vision("openrouter/vendor/model") is None
+
+
+# --- the picture that never left the building ----------------------------------------------------
+
+
+def test_a_plain_dict_with_images_still_becomes_a_multimodal_message() -> None:
+    """The bug that made every attached image useless, and one provider answer 500.
+
+    `Agent.run` builds this turn's user message as a LITERAL dict, because it is assembling a list
+    that also holds the history's dicts:
+
+        {"role": "user", "content": task, "images": [...]}
+
+    `_to_message_dicts` converted `Message` objects and passed dicts through untouched. So the
+    images never became `image_url` parts — the model was never shown the picture — and the key
+    `images`, carrying a local file path, travelled to the provider, which answered
+    `500 Internal Server Error`. The composer showed the attachment, the upload succeeded and the
+    vision check said yes; the request contained neither a picture nor a valid body.
+    """
+    from chimera.providers.gateway import _to_message_dicts
+
+    out = _to_message_dicts(
+        [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "what is this?", "images": ["https://example.invalid/a.png"]},
+        ]
+    )
+
+    assert out[0] == {"role": "system", "content": "be brief"}
+    parts = out[1]["content"]
+    assert [p["type"] for p in parts] == ["text", "image_url"]
+    assert parts[1]["image_url"]["url"] == "https://example.invalid/a.png"
+    # And the key no provider knows must not survive the trip.
+    assert "images" not in out[1]
+
+
+def test_an_empty_images_key_is_dropped_rather_than_sent() -> None:
+    from chimera.providers.gateway import _to_message_dicts
+
+    out = _to_message_dicts([{"role": "user", "content": "hello", "images": []}])
+
+    assert out == [{"role": "user", "content": "hello"}]
+
+
+def test_a_local_path_is_encoded_rather_than_named(tmp_path: Any) -> None:
+    """A file path means nothing on the other end of an HTTP request — the bytes have to go."""
+    from chimera.providers.gateway import _to_message_dicts
+
+    png = tmp_path / "shot.png"
+    png.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+
+    out = _to_message_dicts([{"role": "user", "content": "read it", "images": [str(png)]}])
+
+    url = out[0]["content"][1]["image_url"]["url"]
+    assert url.startswith("data:image/png;base64,")
+    assert str(png) not in url

--- a/tests/test_model_listing.py
+++ b/tests/test_model_listing.py
@@ -368,9 +368,14 @@ def test_a_fetched_listing_leaves_the_prices_on_disk(
     available_models(_Settings(["openrouter"]))
 
     cache = tmp_path / listing.PRICE_CACHE_NAME
-    assert cache.exists(), "the fetched index did not leave its prices anywhere"
+    assert cache.exists(), "the fetched index did not leave anything behind"
     saved = json.loads(cache.read_text(encoding="utf-8"))
-    assert saved["prices"]["openrouter/vendor/model"] == [0.25, 0.95]
+    kept = saved["models"]["openrouter/vendor/model"]
+    assert (kept["in"], kept["out"]) == (0.25, 0.95)
+    # Capabilities ride along, and that is the point of keeping the file at all: the provider knows
+    # which models accept images, and LiteLLM's table was wrong about that in both directions.
+    assert kept["tools"] is True
+    assert kept["vision"] is False
 
 
 def test_a_model_quoted_per_request_is_not_written_as_a_price(
@@ -397,8 +402,11 @@ def test_a_model_quoted_per_request_is_not_written_as_a_price(
     available_models(_Settings(["openrouter"]))
 
     saved = json.loads((tmp_path / listing.PRICE_CACHE_NAME).read_text(encoding="utf-8"))
-    assert "openrouter/vendor/priced" in saved["prices"]
-    assert "openrouter/vendor/variable" not in saved["prices"]
+    assert saved["models"]["openrouter/vendor/priced"]["in"] == 0.25
+    # The row is kept — its capabilities are still worth knowing — but the price stays null rather
+    # than becoming a zero, and nothing downstream may read it as one.
+    assert saved["models"]["openrouter/vendor/variable"]["in"] is None
+    assert listing.known_price("openrouter/vendor/variable") is None
 
 
 def test_the_price_is_read_back_for_that_exact_slug_only(
@@ -413,6 +421,9 @@ def test_the_price_is_read_back_for_that_exact_slug_only(
     assert listing.known_price("openrouter/vendor/model") == (0.25, 0.95)
     assert listing.known_price("openrouter/vendor/model-mini") is None
     assert listing.known_price("vendor/model") is None
+    # Same rule for the capability, which is the one that decides whether an image is sent.
+    assert listing.known_vision("openrouter/vendor/model") is False
+    assert listing.known_vision("openrouter/vendor/model-mini") is None
 
 
 def test_no_cache_is_an_absent_price_not_a_crash(


### PR DESCRIPTION
Reported as "I attach an image and the models do not read it", with a log full of
`500 Internal Server Error`. Three defects in one path.

## 1. The image was dropped between the agent and the provider

`Agent.run` builds this turn's user message as a **literal dict** — it is assembling a list that
also holds the history's dicts:

```python
{"role": "user", "content": task, "images": [...]}
```

`_to_message_dicts` converted `Message` objects and passed dicts through untouched. So:

- the images never became `image_url` parts — the model was shown text and no picture; and
- the key `images`, carrying a **local file path**, went to the provider, which answered **500**.

Everything around it looked fine, which is why it survived: the composer showed the attachment, the
upload returned 200, the vision check said yes. Only the request body was wrong, and nothing prints
the request body. Converted at the gateway now — the single door to the provider.

## 2. The capability table was wrong in both directions

| model | provider says | LiteLLM said | consequence |
|---|---|---|---|
| `deepseek-v4-flash` | no vision | **unknown** | image sent → provider killed the turn |
| `mistral-small-3.2-24b-instruct` | **reads images** | **no** | image withheld from a model that could use it |

The index the model picker already fetches carries the modalities the provider publishes. It is now
remembered on disk beside the prices and consulted before the static table. The file grew a `models`
map and still reads the 0.48.0rc2 `prices` shape, so upgrading does not discard the prices already
there.

## 3. No way to find a model that can see

The dialog gets a filter for models the provider says accept images (`vision === true` — a `null` is
never read as yes). Reading four hundred rows for a badge is not an answer.

Plus: the dialog is bounded to the viewport with only the list scrolling, so **Make it the default**
stops being pushed under the fold on a short window — the reason setting a default was hard to reach.

## Connections screen: already translated, except the part that must not be

Investigated the report that the screen is in English. Servers and MCP are fully translated; what is
in English on Capabilities is the tool `description` and parameter names — and those are the exact
strings sent to the model as its tool schema. Translating the source would degrade the agent, and a
UI-only translation would describe an agent that does not exist. Added one translated line saying
so, in all ten languages.

## Verification

Attached a 320x140 PNG reading `CHIMERA 42` and asked what it says:

```
before: 500 Internal Server Error, and no image in the request body
after : "CHIMERA 42", $0.0003, request body [text, image_url], no stray keys
```

3.498 Python tests, 576 desktop tests, ruff and mypy clean. Nine new tests cover the dropped image,
the empty-images key, path encoding, the capability precedence and the old on-disk shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
