### PR TITLE
fix(desktop): an installed app was permanently one release behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ You could not choose which model answered you. The endpoint accepted one all alo
   say the descriptions stay English; it now says what is true, which is that the names do.
 ### Fixed
 
+- **An installed app showed the PREVIOUS release's interface.** The service worker served the
+  document , so Chimera opened the last release's index.html — which names the
+  last release's bundle — and only refreshed the cache for next time. Every install was therefore one
+  version behind, permanently, and nothing on screen could say so: the version in the status bar
+  comes from the API, which the worker never touches, so it read 0.48.0rc4 while the interface was
+  rc3's, with bugs rc4 had fixed still visible. It also means the two releases before this one
+  reached nobody who already had the app. The document is now fetched network-first with the cache
+  kept only as the offline net; hashed assets stay cache-first, which is always safe because their
+  name changes when their content does. Activating discards older caches and reloads the window it
+  just took over, so an update applies on the launch that installs it rather than the one after.
 - **The model dialog was never centred, and its own action sat off the screen.** The footer holds
   "make it the default", and opening the model list pushed it below the bottom edge — a button that
   disappears exactly when someone has decided to use it. Two defects, stacked, and the first one had

--- a/apps/desktop/public/sw.js
+++ b/apps/desktop/public/sw.js
@@ -1,17 +1,72 @@
 // Minimal service worker — its only jobs are (1) satisfy the PWA install criterion (a fetch handler)
-// and (2) stale-while-revalidate the hashed static assets so the shell opens instantly. It NEVER
-// touches /api: the chat stream is a POST + Server-Sent Events, and a caching SW must not sit in that
-// path, so those requests fall straight through to the network.
-const CACHE = "chimera-shell-v1";
+// and (2) make the shell open instantly from cache. It NEVER touches /api: the chat stream is a
+// POST + Server-Sent Events, and a caching SW must not sit in that path, so those requests fall
+// straight through to the network.
+//
+// The document is fetched network-first, and that is the whole lesson of this file. It used to be
+// stale-while-revalidate like everything else — `cached || network` — which meant the app opened the
+// PREVIOUS release's index.html, pointing at the PREVIOUS release's bundle, and only refreshed the
+// cache in the background for next time. An installed app was therefore permanently one version
+// behind: 0.48.0rc4 installed cleanly, the backend served the new bundle, and the window showed
+// rc3's interface — with the bugs rc4 had fixed still on screen and no way to tell from inside the
+// app that anything was stale. index.html is the map of which hashed assets to load, so caching it
+// first pins the whole application to a moment in the past. Hashed assets under /assets are the
+// opposite case: their name changes whenever their content does, so cache-first is always correct
+// for them and there is nothing to revalidate.
+const CACHE = "chimera-shell-v2";
 
 self.addEventListener("install", () => self.skipWaiting());
-self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+self.addEventListener("activate", (event) =>
+  event.waitUntil(
+    (async () => {
+      // Drop every older cache, v1 included. Without this the old index.html survives the upgrade
+      // and the offline fallback below would serve it — the same one-version-behind bug, wearing a
+      // different hat.
+      const stale = (await caches.keys()).filter((name) => name !== CACHE);
+      await Promise.all(stale.map((name) => caches.delete(name)));
+      await self.clients.claim();
+
+      // Only when something was actually replaced: the window on screen is still running the old
+      // bundle it loaded before this worker took over, and nothing else will ever tell it. A reload
+      // at this exact moment is the difference between "the update applied" and "the update applies
+      // the time after next".
+      if (stale.length) {
+        for (const client of await self.clients.matchAll({ type: "window" })) {
+          client.navigate(client.url);
+        }
+      }
+    })(),
+  ),
+);
 
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
   if (event.request.method !== "GET") return; // POSTs (incl. the chat stream) pass through
   if (url.origin !== self.location.origin) return; // only our own origin
   if (url.pathname.startsWith("/api")) return; // never cache the API (SSE/streaming) — let it hit net
+
+  // The document. Network first, cache only as the offline net.
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      (async () => {
+        try {
+          const fresh = await fetch(event.request);
+          if (fresh && fresh.ok)
+            (await caches.open(CACHE)).put(event.request, fresh.clone());
+          return fresh;
+        } catch {
+          const cache = await caches.open(CACHE);
+          return (
+            (await cache.match(event.request)) ||
+            (await cache.match("/")) ||
+            Response.error()
+          );
+        }
+      })(),
+    );
+    return;
+  }
 
   event.respondWith(
     caches.open(CACHE).then(async (cache) => {

--- a/apps/desktop/src/sw.test.ts
+++ b/apps/desktop/src/sw.test.ts
@@ -1,0 +1,287 @@
+/**
+ * The service worker, executed — not grepped.
+ *
+ * It earns a test because it shipped a bug that was invisible from inside the app and survived two
+ * releases: the document was served `cached || network`, so an installed Chimera opened the PREVIOUS
+ * release's index.html, which pointed at the PREVIOUS release's bundle. 0.48.0rc4 installed cleanly,
+ * the backend served the new files, and the window showed rc3 — with the bugs rc4 had fixed still on
+ * screen. Nothing in the app could tell you that: the version in the status bar comes from the API,
+ * which the worker never touches, so it read rc4 while the interface was rc3.
+ *
+ * `public/sw.js` is plain JS run by the browser, not imported by the bundle, so it is loaded here as
+ * text and evaluated against a fake `self`, `caches` and `fetch`. That means the assertions are
+ * about behaviour — what comes back from a request — rather than about the source containing some
+ * string, which is the only kind of assertion that would have caught the original bug.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const SOURCE = readFileSync(join(process.cwd(), "public", "sw.js"), "utf8");
+
+type Handler = (event: FakeEvent) => void;
+
+interface FakeEvent {
+  request: FakeRequest;
+  respondWith: (r: Promise<unknown> | unknown) => void;
+  waitUntil: (p: Promise<unknown>) => void;
+}
+
+interface FakeRequest {
+  url: string;
+  method: string;
+  mode?: string;
+}
+
+/** A cache that remembers what was put in it, keyed by URL. */
+class FakeCache {
+  constructor(
+    public entries = new Map<string, { body: string; ok: boolean }>(),
+  ) {}
+  async match(request: FakeRequest | string) {
+    const key =
+      typeof request === "string" ? request : new URL(request.url).pathname;
+    const hit = this.entries.get(key);
+    return hit ? { ...hit, clone: () => hit } : undefined;
+  }
+  async put(
+    request: FakeRequest | string,
+    response: { body: string; ok: boolean },
+  ) {
+    const key =
+      typeof request === "string" ? request : new URL(request.url).pathname;
+    this.entries.set(key, response);
+  }
+}
+
+/** Load sw.js against fakes and hand back its listeners plus the world it sees. */
+function loadWorker(
+  options: { caches?: Record<string, FakeCache>; network?: typeof fetch } = {},
+) {
+  const listeners: Record<string, Handler> = {};
+  const stores: Record<string, FakeCache> = options.caches ?? {
+    "chimera-shell-v2": new FakeCache(),
+  };
+  const clients: { url: string; navigated: number }[] = [
+    { url: "http://127.0.0.1:59592/", navigated: 0 },
+  ];
+
+  const self = {
+    location: { origin: "http://127.0.0.1:59592" },
+    addEventListener: (name: string, fn: Handler) => {
+      listeners[name] = fn;
+    },
+    skipWaiting: vi.fn(),
+    clients: {
+      claim: vi.fn(async () => undefined),
+      matchAll: async () =>
+        clients.map((c) => ({
+          url: c.url,
+          navigate: async (url: string) => {
+            c.navigated += 1;
+            c.url = url;
+          },
+        })),
+    },
+  };
+
+  const cachesApi = {
+    open: async (name: string) => (stores[name] ??= new FakeCache()),
+    keys: async () => Object.keys(stores),
+    delete: async (name: string) => {
+      const had = name in stores;
+      delete stores[name];
+      return had;
+    },
+    match: async (request: FakeRequest | string) => {
+      for (const store of Object.values(stores)) {
+        const hit = await store.match(request);
+        if (hit) return hit;
+      }
+      return undefined;
+    },
+  };
+
+  const fetchImpl =
+    options.network ??
+    (async () => ({
+      body: "from network",
+      ok: true,
+      clone: () => ({ body: "from network", ok: true }),
+    }));
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  new Function("self", "caches", "fetch", "URL", "Response", SOURCE)(
+    self,
+    cachesApi,
+    fetchImpl,
+    URL,
+    { error: () => ({ body: "", ok: false }) },
+  );
+
+  return { listeners, stores, self, clients };
+}
+
+function request(path: string, over: Partial<FakeRequest> = {}): FakeRequest {
+  return { url: `http://127.0.0.1:59592${path}`, method: "GET", ...over };
+}
+
+/** Fire a fetch event and return whatever the worker responded with (undefined = passed through). */
+async function respond(listeners: Record<string, Handler>, req: FakeRequest) {
+  let answered: unknown;
+  listeners.fetch({
+    request: req,
+    respondWith: (r) => {
+      answered = r;
+    },
+    waitUntil: () => {},
+  });
+  return answered === undefined
+    ? undefined
+    : ((await answered) as { body: string });
+}
+
+describe("the service worker", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("was actually loaded", () => {
+    // Every test below asserts on listeners this call registers. If the file stops evaluating, they
+    // would all throw rather than pass — but say so here, once, in a sentence.
+    const { listeners } = loadWorker();
+    expect(Object.keys(listeners).sort()).toEqual([
+      "activate",
+      "fetch",
+      "install",
+    ]);
+  });
+
+  it("fetches the document from the network even when a copy is cached", async () => {
+    // THE bug. A cached index.html is the previous release's map of which bundle to load, so
+    // serving it first pins the whole app to the previous version — permanently, since each launch
+    // refreshes the cache for the launch after it.
+    const cache = new FakeCache(
+      new Map([["/", { body: "OLD index.html", ok: true }]]),
+    );
+    const { listeners } = loadWorker({
+      caches: { "chimera-shell-v2": cache },
+      network: (async () => ({
+        body: "NEW index.html",
+        ok: true,
+        clone: () => ({ body: "NEW index.html", ok: true }),
+      })) as unknown as typeof fetch,
+    });
+
+    const answer = await respond(listeners, request("/", { mode: "navigate" }));
+
+    expect(answer?.body).toBe("NEW index.html");
+  });
+
+  it("falls back to the cached document when the network is gone", async () => {
+    // The other half: network-first must not mean network-only. A backend that has not finished
+    // booting would otherwise leave the window blank.
+    const cache = new FakeCache(
+      new Map([["/", { body: "OLD index.html", ok: true }]]),
+    );
+    const { listeners } = loadWorker({
+      caches: { "chimera-shell-v2": cache },
+      network: (async () => {
+        throw new Error("offline");
+      }) as unknown as typeof fetch,
+    });
+
+    const answer = await respond(listeners, request("/", { mode: "navigate" }));
+
+    expect(answer?.body).toBe("OLD index.html");
+  });
+
+  it("answers a hashed asset from cache rather than waiting on the network", async () => {
+    // Cache-first is correct exactly here: the name changes when the content does, so a hit can
+    // never be stale, and the shell opens without a round trip. The request still goes out to
+    // refresh the entry — that is the revalidate half — but the answer does not wait for it, which
+    // is what this asserts.
+    const cache = new FakeCache(
+      new Map([
+        ["/assets/index-abc123.js", { body: "cached bundle", ok: true }],
+      ]),
+    );
+    let resolveNetwork: (v: unknown) => void = () => {};
+    const network = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveNetwork = resolve;
+        }),
+    );
+    const { listeners } = loadWorker({
+      caches: { "chimera-shell-v2": cache },
+      network: network as unknown as typeof fetch,
+    });
+
+    const answer = await respond(listeners, request("/assets/index-abc123.js"));
+
+    expect(answer?.body).toBe("cached bundle");
+    expect(network).toHaveBeenCalled();
+    resolveNetwork({
+      body: "fresher",
+      ok: true,
+      clone: () => ({ body: "fresher", ok: true }),
+    });
+  });
+
+  it("never puts itself in front of the API", async () => {
+    // The chat stream is a POST + SSE. A caching worker in that path breaks streaming outright.
+    const { listeners } = loadWorker();
+
+    expect(
+      await respond(listeners, request("/api/code/turn", { method: "POST" })),
+    ).toBeUndefined();
+    expect(await respond(listeners, request("/api/doctor"))).toBeUndefined();
+  });
+
+  it("discards older caches when it activates, and reloads the window it just took over", async () => {
+    // Both halves matter. Leaving v1 behind keeps the old index.html reachable through the offline
+    // fallback; not reloading leaves the window running the bundle it loaded before the new worker
+    // existed, so the update would only appear the time after next.
+    const { listeners, stores, clients } = loadWorker({
+      caches: {
+        "chimera-shell-v1": new FakeCache(
+          new Map([["/", { body: "OLD", ok: true }]]),
+        ),
+        "chimera-shell-v2": new FakeCache(),
+      },
+    });
+
+    let waited: Promise<unknown> = Promise.resolve();
+    listeners.activate({
+      request: request("/"),
+      respondWith: () => {},
+      waitUntil: (p) => {
+        waited = p;
+      },
+    });
+    await waited;
+
+    expect(Object.keys(stores)).toEqual(["chimera-shell-v2"]);
+    expect(clients[0].navigated).toBe(1);
+  });
+
+  it("does not reload anything on a first install", async () => {
+    // Nothing was replaced, so there is no stale window to rescue — and a reload here would
+    // interrupt someone who just opened the app for the first time.
+    const { listeners, clients } = loadWorker({
+      caches: { "chimera-shell-v2": new FakeCache() },
+    });
+
+    let waited: Promise<unknown> = Promise.resolve();
+    listeners.activate({
+      request: request("/"),
+      respondWith: () => {},
+      waitUntil: (p) => {
+        waited = p;
+      },
+    });
+    await waited;
+
+    expect(clients[0].navigated).toBe(0);
+  });
+});


### PR DESCRIPTION
The reason rc3 and rc4 appeared to change nothing on an installed app.

### What happened

The service worker served the document `cached || network`. `index.html` is the map of which hashed bundle to load, so serving it from cache pins the entire application to the previous release — and the background refresh only ever helps the *next* launch, which then serves that copy and caches the one after. Every installed Chimera was one version behind, permanently.

Nothing inside the app could say so. The version in the status bar comes from `/api/doctor`, which the worker never touches, so it read **0.48.0rc4** while the window was running **rc3's bundle** — with the very bugs rc4 had fixed still on screen.

### How it was found

Measured, not guessed. In the reporting user's own install, the backend was serving the new bundle — `settings.value.unset` and the translated tool descriptions were all present in the JS it returned on the app's own port — while the window showed the old interface. The only thing between those two facts is this file.

Opening that same backend in a browser with no worker registered confirmed the other half: the rc4 fixes are all there and working (the model list scrolls, the footer button is hit-testable, the card fits the viewport).

### The fix

- **Document: network-first**, cache kept only as the offline net, so a launch cannot render a stale map of the app.
- **Hashed assets: still cache-first** — always correct, because their name changes when their content does.
- **Activation drops older caches.** Leaving `v1` in place would keep the stale index reachable through the offline fallback — the same bug wearing a different hat.
- **Activation reloads the window it just claimed**, and only when something was actually replaced, so an update applies on the launch that installs it rather than the one after. A first install is left alone.

### Tests

`src/sw.test.ts` evaluates `public/sw.js` against a fake `caches`, `fetch` and `clients`, so the assertions are about what a request answers rather than about the source containing a word — which is the only kind that would have caught this. Seven cases, including the document-from-cache one that fails against the old file, the offline fallback, and `/api` passing straight through.

585 desktop tests · `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)