### PR TITLE
feat(fusion): choose who answers, who grades and who writes

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -288,6 +288,42 @@
             "title": "Fuse",
             "type": "boolean"
           },
+          "fusion_judge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Judge"
+          },
+          "fusion_panel": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Panel"
+          },
+          "fusion_synthesizer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Synthesizer"
+          },
           "max_attempts": {
             "default": 3,
             "title": "Max Attempts",
@@ -1247,6 +1283,42 @@
             "title": "Fuse",
             "type": "boolean"
           },
+          "fusion_judge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Judge"
+          },
+          "fusion_panel": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Panel"
+          },
+          "fusion_synthesizer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Synthesizer"
+          },
           "max_steps": {
             "anyOf": [
               {
@@ -1509,6 +1581,9 @@
           },
           "cache": {
             "$ref": "#/components/schemas/CacheCfgOut"
+          },
+          "fusion": {
+            "$ref": "#/components/schemas/FusionCfgOut"
           },
           "guard": {
             "$ref": "#/components/schemas/GuardCfgOut"
@@ -2284,6 +2359,62 @@
           "capped"
         ],
         "title": "FsTreeOut",
+        "type": "object"
+      },
+      "FusionCfgOut": {
+        "description": "Who plays each part when a turn is fused: the panel answers, the judge grades, the\nsynthesizer writes. Editable, because the shipped default was the only cast anyone could run \u2014\nand a default that cannot be changed is not a choice.",
+        "properties": {
+          "judge": {
+            "default": "",
+            "title": "Judge",
+            "type": "string"
+          },
+          "kinship": {
+            "$ref": "#/components/schemas/FusionKinshipOut"
+          },
+          "mode": {
+            "default": "selective",
+            "title": "Mode",
+            "type": "string"
+          },
+          "panel": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Panel",
+            "type": "array"
+          },
+          "synthesizer": {
+            "default": "",
+            "title": "Synthesizer",
+            "type": "string"
+          }
+        },
+        "title": "FusionCfgOut",
+        "type": "object"
+      },
+      "FusionKinshipOut": {
+        "description": "How independent the judge is from the panel it grades \u2014 reported, never enforced.\n\nTwo degrees, and the second is the one a slug does not reveal: ``judge_is_panelist`` is the judge\ngrading its own answer, and ``judge_shares_vendor_with`` is the judge and a panelist coming from\nthe same lab \u2014 not the same model, and not two independent votes either.",
+        "properties": {
+          "independent": {
+            "default": true,
+            "title": "Independent",
+            "type": "boolean"
+          },
+          "judge_is_panelist": {
+            "default": false,
+            "title": "Judge Is Panelist",
+            "type": "boolean"
+          },
+          "judge_shares_vendor_with": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Judge Shares Vendor With",
+            "type": "array"
+          }
+        },
+        "title": "FusionKinshipOut",
         "type": "object"
       },
       "GitCommitOut": {
@@ -4697,6 +4828,42 @@
             "default": false,
             "title": "Fuse",
             "type": "boolean"
+          },
+          "fusion_judge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Judge"
+          },
+          "fusion_panel": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Panel"
+          },
+          "fusion_synthesizer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fusion Synthesizer"
           },
           "max_attempts": {
             "default": 3,

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -1,8 +1,26 @@
-import { useCallback, useEffect, useRef, useState , type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import Markdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowDown, Copy, Download, Eraser, MessageSquare, Network, Send, ShieldCheck, Square, Undo2, Wrench } from "lucide-react";
+import {
+  ArrowDown,
+  Copy,
+  Download,
+  Eraser,
+  MessageSquare,
+  Network,
+  Send,
+  ShieldCheck,
+  Square,
+  Undo2,
+  Wrench,
+} from "lucide-react";
 import {
   deleteCodeSession,
   getCodeSession,
@@ -27,6 +45,11 @@ import {
 } from "@/components/code/Attachments";
 import { BatchProposal } from "@/components/code/BatchProposal";
 import { DiffView } from "@/components/code/DiffView";
+import {
+  EMPTY_CAST,
+  FusionCast,
+  type Cast,
+} from "@/components/code/FusionCast";
 import { SpendCeiling } from "@/components/code/SpendCeiling";
 import { decompose } from "@/lib/decompose";
 import {
@@ -100,13 +123,20 @@ function Verdict({
   onFix: () => void;
   t: TFunc;
 }) {
-  if (v.state === "none") return <p className="text-xs text-warn">{t("code.chat.verdict.none")}</p>;
+  if (v.state === "none")
+    return <p className="text-xs text-warn">{t("code.chat.verdict.none")}</p>;
   const cmd = v.command ?? "";
   const args = { cmd, src: v.source };
   if (v.state === "abstained")
-    return <p className="text-xs text-warn">{t("code.chat.verdict.abstained", args)}</p>;
+    return (
+      <p className="text-xs text-warn">
+        {t("code.chat.verdict.abstained", args)}
+      </p>
+    );
   if (v.state === "passed")
-    return <p className="text-xs text-ok">{t("code.chat.verdict.passed", args)}</p>;
+    return (
+      <p className="text-xs text-ok">{t("code.chat.verdict.passed", args)}</p>
+    );
   return (
     <div className="space-y-1.5 rounded-chip border border-bad/40 p-2">
       <p className="text-xs text-bad">{t("code.chat.verdict.failed", args)}</p>
@@ -117,7 +147,11 @@ function Verdict({
       ) : null}
       {undone ? (
         <p className={cn("text-xs", undone === "ok" ? "text-ok" : "text-bad")}>
-          {t(undone === "ok" ? "code.chat.verdict.reverted" : "code.chat.verdict.revertFailed")}
+          {t(
+            undone === "ok"
+              ? "code.chat.verdict.reverted"
+              : "code.chat.verdict.revertFailed",
+          )}
         </p>
       ) : (
         <div className="flex flex-wrap gap-2">
@@ -145,7 +179,13 @@ function Verdict({
  *  the head and the tail of 400 characters — and this deliberately does not offer "full output",
  *  because there is no route on our side that has it. Promising it and then showing the same 400
  *  characters would be worse than the tooltip. */
-function ToolRow({ tool, onOpenFile }: { tool: CodeToolEvent; onOpenFile?: (p: string) => void }) {
+function ToolRow({
+  tool,
+  onOpenFile,
+}: {
+  tool: CodeToolEvent;
+  onOpenFile?: (p: string) => void;
+}) {
   const t = useT();
   const primary = String(Object.values(tool.arguments)[0] ?? "");
   const [copied, setCopied] = useState(false);
@@ -157,7 +197,9 @@ function ToolRow({ tool, onOpenFile }: { tool: CodeToolEvent; onOpenFile?: (p: s
   return (
     <div className="font-mono text-xs">
       <div className="flex items-baseline gap-2">
-        <span className={cn("shrink-0", tool.ok ? "text-ok" : "text-bad")}>{tool.ok ? "✓" : "✗"}</span>
+        <span className={cn("shrink-0", tool.ok ? "text-ok" : "text-bad")}>
+          {tool.ok ? "✓" : "✗"}
+        </span>
         <span className="shrink-0 text-foreground/80">{tool.name}</span>
         {looksLikePath && onOpenFile ? (
           <button
@@ -229,37 +271,62 @@ function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
       {/* First, ahead of every measurement, because it is what decides how to read them. */}
       {stopped ? <Badge tone="warn">{t(stopped)}</Badge> : null}
       {/* Who did the work, first — it is the fact that reframes every badge after it. */}
-      {done.external ? <Badge tone="warn">{t("code.chat.external", { agent: done.external })}</Badge> : null}
+      {done.external ? (
+        <Badge tone="warn">
+          {t("code.chat.external", { agent: done.external })}
+        </Badge>
+      ) : null}
       {/* Null, not zero: an external turn's steps happened inside somebody else's loop and it did
           not report them. Rendering "0 steps" would say it did nothing. */}
-      {done.steps !== null ? <Badge>{t("code.chat.steps", { n: done.steps })}</Badge> : null}
+      {done.steps !== null ? (
+        <Badge>{t("code.chat.steps", { n: done.steps })}</Badge>
+      ) : null}
       {done.model && !done.external ? <Badge>{done.model}</Badge> : null}
       {done.context_peak_tokens !== null && done.context_peak_tokens > 0 ? (
-        <Badge>{t("code.chat.peak", { n: done.context_peak_tokens.toLocaleString() })}</Badge>
+        <Badge>
+          {t("code.chat.peak", {
+            n: done.context_peak_tokens.toLocaleString(),
+          })}
+        </Badge>
       ) : null}
       {/* Measured inside the model calls, not divided out of the turn's duration — the tools and
           the verifier are not the model, and folding them in reports a shell command as slow
           generation. Absent (never 0) when nothing was timed. */}
       {done.tokens_per_second != null ? (
-        <Badge>{t("code.chat.speed", { n: Math.round(done.tokens_per_second) })}</Badge>
+        <Badge>
+          {t("code.chat.speed", { n: Math.round(done.tokens_per_second) })}
+        </Badge>
       ) : null}
       {/* Every permission we answered on the user's behalf, and every write the region refused.
           Both are the receipt's half of the bargain the posture note describes. */}
       {done.auto_approved?.length ? (
-        <Badge tone="warn">{t("code.chat.autoApproved", { n: done.auto_approved.length })}</Badge>
+        <Badge tone="warn">
+          {t("code.chat.autoApproved", { n: done.auto_approved.length })}
+        </Badge>
       ) : null}
       {done.refused_writes?.length ? (
-        <Badge tone="warn">{t("code.chat.refusedWrites", { n: done.refused_writes.length })}</Badge>
+        <Badge tone="warn">
+          {t("code.chat.refusedWrites", { n: done.refused_writes.length })}
+        </Badge>
       ) : null}
       <Badge tone={done.usd === null ? "warn" : undefined}>
-        {done.usd === null ? t("code.chat.unknownCost") : `$${done.usd.toFixed(4)}`}
+        {done.usd === null
+          ? t("code.chat.unknownCost")
+          : `$${done.usd.toFixed(4)}`}
       </Badge>
       {/* Only when a layer actually contributed. "0 facts" and "we did not look" render the same and
           mean different things, so the absent case says nothing rather than saying zero. */}
       {done.memory_facts_used ? (
-        <Badge>{t("code.chat.recalled", { n: done.memory_facts_used, layer: done.memory_layer ?? "" })}</Badge>
+        <Badge>
+          {t("code.chat.recalled", {
+            n: done.memory_facts_used,
+            layer: done.memory_layer ?? "",
+          })}
+        </Badge>
       ) : null}
-      {done.tainted ? <Badge tone="warn">{t("code.chat.tainted")}</Badge> : null}
+      {done.tainted ? (
+        <Badge tone="warn">{t("code.chat.tainted")}</Badge>
+      ) : null}
     </div>
   );
 }
@@ -285,7 +352,9 @@ async function notifyTurnFinished(title: string, body: string): Promise<void> {
     // Asked at the moment it is first needed, not on load: a permission prompt that appears before
     // the user has done anything is the one people deny reflexively.
     const permission =
-      Notification.permission === "default" ? await Notification.requestPermission() : Notification.permission;
+      Notification.permission === "default"
+        ? await Notification.requestPermission()
+        : Notification.permission;
     if (permission !== "granted") return;
     new Notification(title, { body });
   } catch {
@@ -348,7 +417,9 @@ export function Conversation({
 }) {
   const t = useT();
   const qc = useQueryClient();
-  const [sessionId, setSessionId] = useState<string | null>(resumeSession ?? null);
+  const [sessionId, setSessionId] = useState<string | null>(
+    resumeSession ?? null,
+  );
   const [exchanges, setExchanges] = useState<Exchange[]>([]);
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
@@ -390,6 +461,9 @@ export function Conversation({
 
   const [proposal, setProposal] = useState<string[] | null>(null);
   const [fuse, setFuse] = useState(false);
+  // Empty means "whatever this install is configured for", which is what every turn sent before the
+  // cast could be chosen at all. Per conversation, like the model and the ceiling beside it.
+  const [cast, setCast] = useState<Cast>(EMPTY_CAST);
   /** A dollar ceiling for each turn of this conversation, or null for none (the default, and the
    *  behaviour every earlier build had). Session-local like `provider` rather than persisted: a
    *  standing spend limit is a different promise from "cap this piece of work", and a ceiling that
@@ -424,7 +498,9 @@ export function Conversation({
   /** Mutate the turn currently streaming — always the last one, which is the only one that moves. */
   const patchLast = useCallback((fn: (e: Exchange) => Exchange) => {
     setExchanges((prev) =>
-      prev.length === 0 ? prev : [...prev.slice(0, -1), fn(prev[prev.length - 1])],
+      prev.length === 0
+        ? prev
+        : [...prev.slice(0, -1), fn(prev[prev.length - 1])],
     );
   }, []);
 
@@ -444,7 +520,9 @@ export function Conversation({
   // Send the released follow-up only once `busy` has actually gone false. Doing it inside `onDone`
   // would run before that `setBusy(false)` had landed, so `send()` would take the busy branch and
   // re-queue the very message it was releasing — a queue that never drains.
-  const sendRef = useRef<(force?: boolean, override?: string) => void>(() => {});
+  const sendRef = useRef<(force?: boolean, override?: string) => void>(
+    () => {},
+  );
   useEffect(() => {
     if (busy) return;
     const text = queuedToSendRef.current;
@@ -466,23 +544,33 @@ export function Conversation({
     let stored: TranscriptExchange[] | null = null;
     if (sessionId) {
       try {
-        stored = (await getCodeSession(sessionId)).exchanges as TranscriptExchange[];
+        stored = (await getCodeSession(sessionId))
+          .exchanges as TranscriptExchange[];
       } catch {
         // A transcript from memory is worth more than none. Say so rather than failing the export.
         setExportNote(t("code.chat.export.storedUnreachable"));
       }
     }
-    const { exchanges: rows, recovered } = reconcile(exchanges as TranscriptExchange[], stored);
-    if (recovered > 0) setExportNote(t("code.chat.export.recovered", { n: recovered }));
+    const { exchanges: rows, recovered } = reconcile(
+      exchanges as TranscriptExchange[],
+      stored,
+    );
+    if (recovered > 0)
+      setExportNote(t("code.chat.export.recovered", { n: recovered }));
 
     const exportedAt = new Date().toISOString();
-    const markdown = toMarkdown(rows, { workspace: workspace || undefined, exportedAt });
+    const markdown = toMarkdown(rows, {
+      workspace: workspace || undefined,
+      exportedAt,
+    });
     const name = transcriptFilename(exportedAt);
     try {
       // A Blob download inside the Tauri webview is the uncertain half of this item, so the failure
       // is caught rather than assumed away: if the anchor click does nothing, the text still reaches
       // the clipboard and the user is told where it went.
-      const url = URL.createObjectURL(new Blob([markdown], { type: "text/markdown" }));
+      const url = URL.createObjectURL(
+        new Blob([markdown], { type: "text/markdown" }),
+      );
       const a = document.createElement("a");
       a.href = url;
       a.download = name;
@@ -534,7 +622,10 @@ export function Conversation({
     setDraft("");
     setAttached([]);
     setBusy(true);
-    setExchanges((prev) => [...prev, { you: message, answer: "", tools: [], edits: [], done: null }]);
+    setExchanges((prev) => [
+      ...prev,
+      { you: message, answer: "", tools: [], edits: [], done: null },
+    ]);
     let touchedFiles = false;
     // Whether THIS turn's verifier failed. It decides what happens to a queued follow-up, and it
     // has to be a local rather than state: `onDone` fires in the same tick as the last `setState`,
@@ -544,7 +635,13 @@ export function Conversation({
     const controller = new AbortController();
     abortRef.current = controller;
     toolsRef.current = [];
-    publish({ status: "thinking", tools: [], report: null, busy: true, stop: abandon });
+    publish({
+      status: "thinking",
+      tools: [],
+      report: null,
+      busy: true,
+      stop: abandon,
+    });
 
     void streamCodeTurn(
       {
@@ -562,6 +659,13 @@ export function Conversation({
         posture,
         profile,
         fuse,
+        // Only with `fuse`: a cast on a turn that is not fused would be a second, invisible way to
+        // pick a model. Omitted rather than sent empty, so an unchosen role stays the install's.
+        ...(fuse && cast.panel.length ? { fusion_panel: cast.panel } : {}),
+        ...(fuse && cast.judge ? { fusion_judge: cast.judge } : {}),
+        ...(fuse && cast.synthesizer
+          ? { fusion_synthesizer: cast.synthesizer }
+          : {}),
         // "" means Chimera's own loop, and the field is omitted rather than sent empty — an empty
         // string is a value the server would have to special-case, and a caller that never heard of
         // providers must send exactly what it sent before.
@@ -579,7 +683,8 @@ export function Conversation({
         onSession: (id) => {
           // Invalidate on the FIRST turn's id, not on every turn: the sidebar lists conversations,
           // and a conversation that already exists in the list has not changed by gaining a message.
-          if (id !== sessionId) void qc.invalidateQueries({ queryKey: ["code-sessions"] });
+          if (id !== sessionId)
+            void qc.invalidateQueries({ queryKey: ["code-sessions"] });
           setSessionId(id);
         },
         onToken: (text) => {
@@ -587,8 +692,13 @@ export function Conversation({
           patchLast((e) => ({ ...e, answer: e.answer + text }));
         },
         onTool: (tool) => {
-          publish({ tools: [...toolsRef.current, { name: tool.name, ok: tool.ok }] });
-          toolsRef.current = [...toolsRef.current, { name: tool.name, ok: tool.ok }];
+          publish({
+            tools: [...toolsRef.current, { name: tool.name, ok: tool.ok }],
+          });
+          toolsRef.current = [
+            ...toolsRef.current,
+            { name: tool.name, ok: tool.ok },
+          ];
           patchLast((e) => ({ ...e, tools: [...e.tools, tool] }));
         },
         onEdit: (path, patch) => {
@@ -611,10 +721,17 @@ export function Conversation({
           // it finishes: `send` closes over this render's `maxUsd`, so the request above and this
           // line read one value that cannot change under either of them. (The control is disabled
           // while the turn runs as well, which is belt and braces rather than the mechanism.)
-          publish({ status: "done", busy: false, report: { ...done, max_usd: maxUsd } });
+          publish({
+            status: "done",
+            busy: false,
+            report: { ...done, max_usd: maxUsd },
+          });
           setBusy(false);
           if (notifyOnFinish) {
-            void notifyTurnFinished(t("code.chat.notify.title"), message.slice(0, 120));
+            void notifyTurnFinished(
+              t("code.chat.notify.title"),
+              message.slice(0, 120),
+            );
           }
           releaseQueued(verifyFailed);
           if (touchedFiles) {
@@ -635,7 +752,10 @@ export function Conversation({
           // A failure is MORE worth interrupting for than a success: the user walked away expecting
           // work to happen, and it stopped.
           if (notifyOnFinish) {
-            void notifyTurnFinished(t("code.chat.notify.failed"), message.slice(0, 120));
+            void notifyTurnFinished(
+              t("code.chat.notify.failed"),
+              message.slice(0, 120),
+            );
           }
           // A turn that errored is never a base to send the next one from — hand the text back.
           releaseQueued(true);
@@ -665,7 +785,9 @@ export function Conversation({
       // there. Saying "gone" is the honest read of both, and it is the one that does not imply the
       // files were restored.
     }
-    setExchanges((prev) => prev.map((e, j) => (j === index ? { ...e, undone: outcome } : e)));
+    setExchanges((prev) =>
+      prev.map((e, j) => (j === index ? { ...e, undone: outcome } : e)),
+    );
     if (outcome === "ok") {
       void qc.invalidateQueries({ queryKey: ["fs-file"] });
       void qc.invalidateQueries({ queryKey: ["git-status"] });
@@ -691,13 +813,19 @@ export function Conversation({
     <div className="relative flex min-h-0 flex-1 flex-col">
       <div className="flex items-center gap-2 border-b border-hairline px-3 py-2 text-accent">
         <MessageSquare className="h-4 w-4" />
-        <h2 className="text-sm font-semibold text-foreground">{t("code.chat.title")}</h2>
+        <h2 className="text-sm font-semibold text-foreground">
+          {t("code.chat.title")}
+        </h2>
         {exchanges.length > 0 ? (
           <div className="ml-auto flex items-center gap-1">
             {/* A record of what an agent did to a repository should be able to leave the window it
                 happened in. Until this, the only clipboard call in the whole app copied a `pip
                 install` line. */}
-            <Button size="sm" variant="ghost" onClick={() => void exportTranscript()}>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void exportTranscript()}
+            >
               <Download className="h-3.5 w-3.5" /> {t("code.chat.export.label")}
             </Button>
             {/* Off by default and remembered per install. An app that starts sending desktop
@@ -711,7 +839,10 @@ export function Conversation({
               onClick={() => {
                 const next = !notifyOnFinish;
                 setNotifyOnFinish(next);
-                localStorage.setItem("chimera.notifyOnFinish", next ? "1" : "0");
+                localStorage.setItem(
+                  "chimera.notifyOnFinish",
+                  next ? "1" : "0",
+                );
               }}
             >
               {t("code.chat.notify.label")}
@@ -725,111 +856,123 @@ export function Conversation({
       {/* Said out loud rather than logged. "Your export is missing four turns" is exactly the kind
           of thing that must not be discovered later, by someone reading the file. */}
       {exportNote ? (
-        <p className="border-b border-hairline px-3 py-1 text-xs text-warn">{exportNote}</p>
+        <p className="border-b border-hairline px-3 py-1 text-xs text-warn">
+          {exportNote}
+        </p>
       ) : null}
 
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
         {/* `role="log"` tells a screen reader this region accumulates; `aria-busy` says the agent is
             still writing. The streaming text is deliberately NOT a live region — announcing it would
             re-read the whole growing answer on every token. */}
-        <div role="log" aria-busy={busy} className="mx-auto max-w-3xl space-y-3 p-3">
-        {exchanges.length === 0 && replayed ? (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
-            <BrandMark className="mb-4 h-14 w-14" glow />
-            <h2 className="text-base font-semibold">Chimera</h2>
-            <p className="mt-1 max-w-sm text-sm text-muted-foreground">{t("code.chat.empty")}</p>
-          </div>
-        ) : null}
-        {exchanges.map((e, i) => (
-          <div key={i} className="space-y-2">
-            <div className="rounded-chip bg-surface-2 px-2.5 py-1.5 text-sm text-foreground/90">
-              {e.you}
+        <div
+          role="log"
+          aria-busy={busy}
+          className="mx-auto max-w-3xl space-y-3 p-3"
+        >
+          {exchanges.length === 0 && replayed ? (
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <BrandMark className="mb-4 h-14 w-14" glow />
+              <h2 className="text-base font-semibold">Chimera</h2>
+              <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                {t("code.chat.empty")}
+              </p>
             </div>
-            {e.tools.length > 0 ? (
-              <div className="space-y-1 rounded-chip border border-border p-2">
-                <div className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-muted-foreground">
-                  <Wrench className="h-3 w-3" /> {t("code.chat.tools")}
-                </div>
-                {e.tools.map((tool, j) => (
-                  <ToolRow key={j} tool={tool} onOpenFile={onOpenFile} />
-                ))}
+          ) : null}
+          {exchanges.map((e, i) => (
+            <div key={i} className="space-y-2">
+              <div className="rounded-chip bg-surface-2 px-2.5 py-1.5 text-sm text-foreground/90">
+                {e.you}
               </div>
-            ) : null}
-            {e.edits.map((edit, j) => (
-              <div key={j} className="space-y-1">
-                <button
-                  type="button"
-                  onClick={() => onOpenFile?.(edit.path)}
-                  className="font-mono text-xs text-accent underline decoration-dotted"
-                >
-                  {edit.path}
-                </button>
-                <DiffView patch={edit.patch} />
-              </div>
-            ))}
-            {e.answer ? (
-              // Markdown with syntax highlighting, which the chat had and this did not — a coding
-              // conversation rendering a fenced block as prose is the one formatting failure that
-              // matters here.
-              <div className="group relative">
-                <div className="md min-w-0 text-sm leading-relaxed text-foreground/90">
-                  <Markdown rehypePlugins={[rehypeHighlight]}>{e.answer}</Markdown>
+              {e.tools.length > 0 ? (
+                <div className="space-y-1 rounded-chip border border-border p-2">
+                  <div className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-muted-foreground">
+                    <Wrench className="h-3 w-3" /> {t("code.chat.tools")}
+                  </div>
+                  {e.tools.map((tool, j) => (
+                    <ToolRow key={j} tool={tool} onOpenFile={onOpenFile} />
+                  ))}
                 </div>
-                {/* Copies the exchange as MARKDOWN, not the rendered text: what the reader wants to
+              ) : null}
+              {e.edits.map((edit, j) => (
+                <div key={j} className="space-y-1">
+                  <button
+                    type="button"
+                    onClick={() => onOpenFile?.(edit.path)}
+                    className="font-mono text-xs text-accent underline decoration-dotted"
+                  >
+                    {edit.path}
+                  </button>
+                  <DiffView patch={edit.patch} />
+                </div>
+              ))}
+              {e.answer ? (
+                // Markdown with syntax highlighting, which the chat had and this did not — a coding
+                // conversation rendering a fenced block as prose is the one formatting failure that
+                // matters here.
+                <div className="group relative">
+                  <div className="md min-w-0 text-sm leading-relaxed text-foreground/90">
+                    <Markdown rehypePlugins={[rehypeHighlight]}>
+                      {e.answer}
+                    </Markdown>
+                  </div>
+                  {/* Copies the exchange as MARKDOWN, not the rendered text: what the reader wants to
                     paste into an issue is the fenced code that made it worth reading, and the
                     rendered version loses exactly that. */}
-                <button
-                  type="button"
-                  aria-label={t("code.chat.copyAnswer")}
-                  title={t("code.chat.copyAnswer")}
-                  className="absolute right-0 top-0 rounded-chip p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus:opacity-100"
-                  onClick={() => {
-                    void navigator.clipboard?.writeText(exchangeToMarkdown(e)).catch(() => undefined);
-                  }}
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            ) : null}
-            {e.failed ? (
-              <div className="space-y-1">
-                <p className="text-xs text-bad">{t("code.chat.error")}</p>
-                {/* Folded, not hidden: the headline stays one line for the common case where the
+                  <button
+                    type="button"
+                    aria-label={t("code.chat.copyAnswer")}
+                    title={t("code.chat.copyAnswer")}
+                    className="absolute right-0 top-0 rounded-chip p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100 focus:opacity-100"
+                    onClick={() => {
+                      void navigator.clipboard
+                        ?.writeText(exchangeToMarkdown(e))
+                        .catch(() => undefined);
+                    }}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ) : null}
+              {e.failed ? (
+                <div className="space-y-1">
+                  <p className="text-xs text-bad">{t("code.chat.error")}</p>
+                  {/* Folded, not hidden: the headline stays one line for the common case where the
                     user only wants to retry, and the raw provider message is one click away for
                     the case where it says `invalid_api_key` and settles the whole question. */}
-                {e.error ? (
-                  <details className="text-xs">
-                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-                      {t("code.chat.errorDetail")}
-                    </summary>
-                    <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded-chip bg-surface-2 p-2 font-mono text-muted-foreground">
-                      {e.error}
-                    </pre>
-                  </details>
-                ) : null}
-              </div>
-            ) : null}
-            {e.done?.fused ? (
-              // At the answer, which is the only place it lands in time. The composer warns before
-              // the click; neither warning is visible at the moment someone reads a confident
-              // description of a file that was never opened.
-              <p className="flex items-start gap-1.5 text-xs text-warn">
-                <Network className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                {t("composer.fusedAnswer")}
-              </p>
-            ) : null}
-            {e.verified ? (
-              <Verdict
-                v={e.verified}
-                undone={e.undone}
-                onUndo={() => void undo(i, e.verified?.revert_token ?? "")}
-                onFix={() => onHandOff(e.you)}
-                t={t}
-              />
-            ) : null}
-            {e.done ? <TurnReceipt done={e.done} t={t} /> : null}
-          </div>
-        ))}
+                  {e.error ? (
+                    <details className="text-xs">
+                      <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                        {t("code.chat.errorDetail")}
+                      </summary>
+                      <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded-chip bg-surface-2 p-2 font-mono text-muted-foreground">
+                        {e.error}
+                      </pre>
+                    </details>
+                  ) : null}
+                </div>
+              ) : null}
+              {e.done?.fused ? (
+                // At the answer, which is the only place it lands in time. The composer warns before
+                // the click; neither warning is visible at the moment someone reads a confident
+                // description of a file that was never opened.
+                <p className="flex items-start gap-1.5 text-xs text-warn">
+                  <Network className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  {t("composer.fusedAnswer")}
+                </p>
+              ) : null}
+              {e.verified ? (
+                <Verdict
+                  v={e.verified}
+                  undone={e.undone}
+                  onUndo={() => void undo(i, e.verified?.revert_token ?? "")}
+                  onFix={() => onHandOff(e.you)}
+                  t={t}
+                />
+              ) : null}
+              {e.done ? <TurnReceipt done={e.done} t={t} /> : null}
+            </div>
+          ))}
         </div>
       </div>
       {/* Only while there is something to miss: reading back through a finished answer should not
@@ -871,7 +1014,9 @@ export function Conversation({
             from one that was dropped, and the user would retype it — which is two sends, not one. */}
         {queued ? (
           <div className="mb-1.5 flex items-start gap-2 rounded-chip border border-hairline bg-surface-2 px-2 py-1.5">
-            <span className="shrink-0 text-xs text-muted-foreground">{t("composer.queued")}</span>
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {t("composer.queued")}
+            </span>
             <span className="min-w-0 flex-1 truncate text-xs">{queued}</span>
             <button
               type="button"
@@ -941,12 +1086,16 @@ export function Conversation({
             itself; a file that arrived by clipboard has no button to stand beside, and silence
             would leave someone waiting for a screenshot that was never uploaded. */}
         {uploadFailed ? (
-          <p className="text-xs text-bad">{t("code.attach.failed", { name: uploadFailed })}</p>
+          <p className="text-xs text-bad">
+            {t("code.attach.failed", { name: uploadFailed })}
+          </p>
         ) : null}
         <div className="flex flex-wrap items-center gap-2">
           <AttachButton onAdded={(a) => setAttached((prev) => [...prev, a])} />
           <DictateButton
-            onText={(text) => setDraft((prev) => (prev ? `${prev} ${text}` : text))}
+            onText={(text) =>
+              setDraft((prev) => (prev ? `${prev} ${text}` : text))
+            }
           />
           {/* Fusion is a per-turn choice, next to the box you type in — and it turns OFF the
               agent's ability to act, which the tooltip says before the click and `fusedAnswer` says
@@ -960,6 +1109,11 @@ export function Conversation({
           >
             <Network className="h-4 w-4" /> {t("composer.fuse")}
           </Button>
+          {/* Only while fusion is armed. Who plays each part is a real decision — three models, six
+              calls — and it is noise on every turn that is not fused. */}
+          {fuse ? (
+            <FusionCast value={cast} onChange={setCast} disabled={busy} />
+          ) : null}
           {/* What this turn may COST, next to what it may DO. Both are per-turn choices, and this
               one is the only limit in the app that can end a turn on its own — so it belongs where
               the decision is made rather than in a settings screen visited once. */}
@@ -969,14 +1123,23 @@ export function Conversation({
               <Square className="h-4 w-4" /> {t("code.chat.stop")}
             </Button>
           ) : (
-            <Button size="sm" disabled={!draft.trim() || busyElsewhere} onClick={() => send()}>
+            <Button
+              size="sm"
+              disabled={!draft.trim() || busyElsewhere}
+              onClick={() => send()}
+            >
               <Send className="h-4 w-4" /> {t("code.chat.send")}
             </Button>
           )}
           {/* Three warnings, at three moments, because each catches a different person: the tooltip
               before the click, this while the toggle is armed and the message is being typed, and
               the mark on the answer for whoever was not reading either. */}
-          <span className={cn("ml-auto text-xs", fuse ? "text-warn" : "text-muted-foreground")}>
+          <span
+            className={cn(
+              "ml-auto text-xs",
+              fuse ? "text-warn" : "text-muted-foreground",
+            )}
+          >
             {fuse ? t("composer.fuseOn") : t("code.chat.hint")}
           </span>
         </div>

--- a/apps/desktop/src/components/code/FusionCast.test.tsx
+++ b/apps/desktop/src/components/code/FusionCast.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Choosing who fuses — and being told, before paying, when the choice is not independent.
+ *
+ * The engine has taken `panel` / `judge` / `synthesizer` per instance since it was written; nothing
+ * in the app could set them, so the only cast anyone ran was the shipped one. These tests cover the
+ * two things this dialog has to do that a plain multi-select would not: state the cost of the SHAPE
+ * (a four-model panel is six calls, which is invisible until the receipt), and state when the panel
+ * is not independent — the judge grading its own answer, or judge and panelist from the same lab.
+ *
+ * Neither warning refuses the choice. A user holding one provider key cannot avoid the overlap, and
+ * a refusal they cannot act on removes the feature instead of the problem.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import {
+  CastDialog,
+  EMPTY_CAST,
+  type Cast,
+} from "@/components/code/FusionCast";
+import { getConfig, getModels, patchConfig } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getConfig: vi.fn(),
+    getModels: vi.fn(),
+    patchConfig: vi.fn(async () => ({ updated: ["CHIMERA_FUSION_PANEL"] })),
+  };
+});
+
+const mockConfig = vi.mocked(getConfig);
+const mockModels = vi.mocked(getModels);
+const mockPatch = vi.mocked(patchConfig);
+
+function model(slug: string, label = slug) {
+  return {
+    slug,
+    label,
+    vendor: slug.split("/")[1] ?? "",
+    source: "catalog",
+    free: false,
+    input_per_m: 1,
+    output_per_m: 2,
+    context_k: 128,
+    recommended: false,
+    tools: true,
+    vision: false,
+  };
+}
+
+const ANTHROPIC = "openrouter/anthropic/claude-opus-5";
+const HAIKU = "openrouter/anthropic/haiku";
+const OPENAI = "openrouter/openai/gpt-5.5";
+const DEEPSEEK = "openrouter/deepseek/deepseek-r1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConfig.mockResolvedValue({
+    fusion: {
+      panel: [ANTHROPIC, OPENAI],
+      judge: DEEPSEEK,
+      synthesizer: ANTHROPIC,
+      mode: "selective",
+      kinship: {
+        judge_is_panelist: false,
+        judge_shares_vendor_with: [],
+        independent: true,
+      },
+    },
+  } as unknown as Awaited<ReturnType<typeof getConfig>>);
+  mockModels.mockResolvedValue({
+    models: [model(ANTHROPIC), model(OPENAI), model(DEEPSEEK), model(HAIKU)],
+    reason: "",
+  } as unknown as Awaited<ReturnType<typeof getModels>>);
+});
+
+function open(value: Cast = EMPTY_CAST, onChange = vi.fn()) {
+  renderWithProviders(
+    <CastDialog
+      open
+      onOpenChange={() => {}}
+      value={value}
+      onChange={onChange}
+    />,
+  );
+  return onChange;
+}
+
+describe("choosing who fuses", () => {
+  it("starts from the configured cast rather than from three empty roles", async () => {
+    // Someone who only wants to swap the judge should not have to rebuild the panel to say "the
+    // usual, but with a different judge".
+    open();
+    expect(await screen.findByText(/2 models/)).toBeInTheDocument();
+    expect(screen.getByText("deepseek-r1")).toBeInTheDocument();
+  });
+
+  it("says how many calls the shape costs, not just which models were picked", async () => {
+    // Two panelists + judge + synthesizer. The arithmetic is the part people miss, and it is
+    // invisible until the receipt arrives.
+    open();
+    expect(await screen.findByText(/4 calls per turn/)).toBeInTheDocument();
+  });
+
+  it("warns when the judge sits on the panel it grades", async () => {
+    open({ panel: [ANTHROPIC, OPENAI], judge: ANTHROPIC, synthesizer: OPENAI });
+    expect(await screen.findByText(/grade its own answer/)).toBeInTheDocument();
+  });
+
+  it("warns when judge and panelist come from the same lab", async () => {
+    // The degree that a slug does not reveal: not the same model, and not two independent answers.
+    open({ panel: [ANTHROPIC, OPENAI], judge: HAIKU, synthesizer: OPENAI });
+    expect(
+      await screen.findByText(/not two independent answers/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not refuse either overlap — it reports them", async () => {
+    // A one-key user cannot avoid the overlap. Refusing would remove the feature, not the problem.
+    open({ panel: [ANTHROPIC, OPENAI], judge: ANTHROPIC, synthesizer: OPENAI });
+    await screen.findByText(/grade its own answer/);
+    expect(
+      screen.getByRole("button", { name: /make it the default/i }),
+    ).toBeEnabled();
+  });
+
+  it("refuses a panel of one, because that is not fusion", async () => {
+    open({ panel: [ANTHROPIC], judge: DEEPSEEK, synthesizer: ANTHROPIC });
+    expect(await screen.findByText(/at least two models/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /make it the default/i }),
+    ).toBeDisabled();
+  });
+
+  it("adds and removes panelists, and replaces a single-role pick", async () => {
+    const user = userEvent.setup();
+    const onChange = open();
+    await screen.findByRole("checkbox", { name: /gpt-5\.5/ });
+
+    // The panel is a set: clicking an unselected model adds it.
+    await user.click(screen.getByRole("checkbox", { name: /haiku/ }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ panel: [ANTHROPIC, OPENAI, HAIKU] }),
+    );
+  });
+
+  it("saves all three roles together when made the default", async () => {
+    const user = userEvent.setup();
+    open();
+    await screen.findByText(/2 models/);
+
+    await user.click(
+      screen.getByRole("button", { name: /make it the default/i }),
+    );
+
+    await waitFor(() =>
+      expect(mockPatch).toHaveBeenCalledWith({
+        CHIMERA_FUSION_PANEL: `${ANTHROPIC},${OPENAI}`,
+        CHIMERA_FUSION_JUDGE: DEEPSEEK,
+        CHIMERA_FUSION_SYNTHESIZER: ANTHROPIC,
+      }),
+    );
+  });
+
+  it("can hand the conversation back to the configured cast", async () => {
+    const user = userEvent.setup();
+    const onChange = open({
+      panel: [HAIKU, OPENAI],
+      judge: DEEPSEEK,
+      synthesizer: HAIKU,
+    });
+    await screen.findByText(/2 models/);
+
+    await user.click(
+      screen.getByRole("button", { name: /use the configured one/i }),
+    );
+
+    expect(onChange).toHaveBeenLastCalledWith(EMPTY_CAST);
+  });
+});

--- a/apps/desktop/src/components/code/FusionCast.tsx
+++ b/apps/desktop/src/components/code/FusionCast.tsx
@@ -1,0 +1,380 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Search, Users } from "lucide-react";
+
+import { getConfig, getModels, patchConfig } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Dialog } from "@/components/ui/dialog";
+import { focusRing } from "@/components/ui/focus";
+import { cn } from "@/lib/utils";
+import { useT, type TFunc } from "@/lib/i18n";
+import type { ModelOption } from "@/lib/types";
+
+/** Who plays each part in a fused turn. `null` for a role means "whatever this install is set to". */
+export interface Cast {
+  panel: string[];
+  judge: string;
+  synthesizer: string;
+}
+
+export const EMPTY_CAST: Cast = { panel: [], judge: "", synthesizer: "" };
+
+/** Same cut as the model list: sixty rows is more than fits on screen, and it says what it holds. */
+const MAX_ROWS = 60;
+
+/** A panel is at least two answers. One model plus a judge and a synthesiser is not fusion — it is
+ *  one opinion, graded and rewritten, at three times the price. The server refuses it too. */
+const MIN_PANEL = 2;
+
+function shortName(slug: string): string {
+  return slug.split("/").pop() ?? slug;
+}
+
+/** The lab a slug comes from: `openrouter/anthropic/claude-opus-5` → `anthropic`.
+ *
+ *  Mirrors `_vendor_of` in the engine, and only for the WARNING — the authoritative answer is
+ *  `config.fusion.kinship`, computed by the engine itself. This exists because the warning has to
+ *  react to a choice that has not been saved yet, and there is no round trip to ask about a cast
+ *  that only exists in this dialog. */
+function vendorOf(slug: string): string {
+  const parts = slug.split("/");
+  return parts.length >= 2 ? parts[parts.length - 2] : slug;
+}
+
+/**
+ * Who answers, who grades, and who writes — chosen per conversation.
+ *
+ * Fusion's whole claim is an INDEPENDENT signal: several models answer the same question without
+ * seeing each other, a judge that is not one of them says where they agree and where they contradict,
+ * and a synthesiser writes the answer from that analysis. The engine has taken those three roles
+ * per instance since it was written and the config has carried all three — but nothing between the
+ * engine and a person could set them, so the only cast anyone could run was the one that shipped.
+ * That is a strange place for a product to have no control: the shipped judge was once
+ * `panel[0]` verbatim, and it graded its own answer for as long as nobody noticed.
+ *
+ * So the two things this dialog does that a plain multi-select would not:
+ *
+ * 1. **It says the cost of the shape, not just of the models.** A four-model panel is six calls —
+ *    four answers, a judge, a synthesiser — and that arithmetic is invisible until the receipt.
+ * 2. **It says when the panel is not independent**, at the moment of choosing rather than after
+ *    paying. Two degrees: the judge sitting on its own panel, and the judge coming from the same lab
+ *    as a panelist. Neither is refused — a user with one provider key has no way to avoid the
+ *    overlap, and a refusal they cannot act on just removes the feature.
+ */
+export function FusionCast({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: Cast;
+  onChange: (cast: Cast) => void;
+  disabled?: boolean;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+
+  const config = useQuery({ queryKey: ["config"], queryFn: getConfig });
+  const standing = config.data?.fusion;
+
+  const panel = value.panel.length ? value.panel : (standing?.panel ?? []);
+  const chosen = value.panel.length > 0 || !!value.judge || !!value.synthesizer;
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+        title={t("fusion.cast.hint")}
+        className={cn(
+          "flex items-center gap-1.5 rounded-chip border border-border px-2.5 py-1 text-xs",
+          "transition-colors duration-1 ease-out hover:bg-surface-hover disabled:opacity-50",
+          focusRing,
+        )}
+      >
+        <Users className="h-3.5 w-3.5 text-muted-foreground" />
+        <span className="text-muted-foreground">{t("fusion.cast.label")}</span>
+        <span className="font-mono">
+          {chosen
+            ? t("fusion.cast.n", { n: panel.length })
+            : t("fusion.cast.standing")}
+        </span>
+      </button>
+      <CastDialog
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onChange={onChange}
+      />
+    </>
+  );
+}
+
+export function CastDialog({
+  open,
+  onOpenChange,
+  value,
+  onChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: Cast;
+  onChange: (cast: Cast) => void;
+}) {
+  const t = useT();
+  const qc = useQueryClient();
+  const [query, setQuery] = useState("");
+  const [role, setRole] = useState<"panel" | "judge" | "synthesizer">("panel");
+
+  const config = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    enabled: open,
+  });
+  const listing = useQuery({
+    queryKey: ["models", ""],
+    queryFn: () => getModels(),
+    enabled: open,
+  });
+
+  const standing = config.data?.fusion;
+  // The dialog always edits a COMPLETE cast, seeded from the standing one — otherwise a user who
+  // only wants to swap the judge would be shown three empty roles and have to rebuild the panel to
+  // express "the usual, but with a different judge".
+  const cast: Cast = {
+    panel: value.panel.length ? value.panel : (standing?.panel ?? []),
+    judge: value.judge || (standing?.judge ?? ""),
+    synthesizer: value.synthesizer || (standing?.synthesizer ?? ""),
+  };
+
+  const models = listing.data?.models ?? [];
+  const term = query.trim().toLowerCase();
+  const matches = useMemo(
+    () =>
+      term
+        ? models.filter(
+            (m) =>
+              m.slug.toLowerCase().includes(term) ||
+              m.label.toLowerCase().includes(term) ||
+              (m.vendor ?? "").toLowerCase().includes(term),
+          )
+        : models,
+    [models, term],
+  );
+  const rows = matches.slice(0, MAX_ROWS);
+  const hidden = Math.max(0, matches.length - rows.length);
+
+  // The two degrees of kinship, on the cast being edited rather than the one on disk.
+  const judgeIsPanelist = !!cast.judge && cast.panel.includes(cast.judge);
+  const sameLab = cast.judge
+    ? cast.panel.filter(
+        (m) => m !== cast.judge && vendorOf(m) === vendorOf(cast.judge),
+      )
+    : [];
+
+  const calls = cast.panel.length + 2; // every panelist, then the judge, then the synthesiser
+  const tooSmall = cast.panel.length < MIN_PANEL;
+
+  const makeDefault = useMutation({
+    mutationFn: () =>
+      patchConfig({
+        CHIMERA_FUSION_PANEL: cast.panel.join(","),
+        CHIMERA_FUSION_JUDGE: cast.judge,
+        CHIMERA_FUSION_SYNTHESIZER: cast.synthesizer,
+      }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["config"] }),
+  });
+
+  const pick = (slug: string) => {
+    if (role === "panel") {
+      const next = cast.panel.includes(slug)
+        ? cast.panel.filter((m) => m !== slug)
+        : [...cast.panel, slug];
+      onChange({ ...cast, panel: next });
+      return;
+    }
+    onChange({ ...cast, [role]: cast[role] === slug ? "" : slug });
+  };
+
+  const selected = (slug: string) =>
+    role === "panel" ? cast.panel.includes(slug) : cast[role] === slug;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t("fusion.cast.title")}
+      description={t("fusion.cast.blurb")}
+      className="flex max-h-dialog flex-col"
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-3">
+        {/* The three roles as a pipeline, in the order they run, because the order is the mechanism:
+            the panel cannot see each other, the judge cannot answer, the synthesiser cannot grade. */}
+        <div className="flex flex-wrap gap-1.5">
+          {(["panel", "judge", "synthesizer"] as const).map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setRole(r)}
+              aria-pressed={role === r}
+              className={cn(
+                "flex flex-col items-start gap-0.5 rounded-xl2 border px-3 py-2 text-left",
+                "transition-colors duration-1 ease-out",
+                role === r
+                  ? "border-accent bg-accent/10"
+                  : "border-hairline hover:bg-surface-hover",
+                focusRing,
+              )}
+            >
+              <span className="text-xs font-semibold">
+                {t(`fusion.role.${r}`)}
+              </span>
+              <span className="font-mono text-xs text-muted-foreground">
+                {r === "panel"
+                  ? t("fusion.cast.n", { n: cast.panel.length })
+                  : shortName(cast[r]) || t("fusion.cast.unset")}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <label className="flex items-center gap-2">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="sr-only">{t("model.pick.search")}</span>
+          <input
+            className="field h-9 w-full px-3 text-sm"
+            autoFocus
+            placeholder={t("model.pick.search")}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </label>
+
+        {/* Said here, before the turn, rather than in the receipt after it. */}
+        <div className="flex flex-col gap-1 text-xs">
+          <p className="text-muted-foreground">
+            {t("fusion.cast.calls", { n: calls })}
+          </p>
+          {tooSmall ? (
+            <p className="flex items-start gap-1.5 text-warn-foreground">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {t("fusion.cast.tooSmall")}
+            </p>
+          ) : null}
+          {judgeIsPanelist ? (
+            <p className="flex items-start gap-1.5 text-warn-foreground">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {t("fusion.cast.judgeIsPanelist")}
+            </p>
+          ) : null}
+          {!judgeIsPanelist && sameLab.length ? (
+            <p className="flex items-start gap-1.5 text-warn-foreground">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              {t("fusion.cast.sameVendor", { vendor: vendorOf(cast.judge) })}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-1 overflow-y-auto">
+          {rows.map((model) => (
+            <ModelRow
+              key={model.slug}
+              model={model}
+              selected={selected(model.slug)}
+              multi={role === "panel"}
+              onPick={() => pick(model.slug)}
+              t={t}
+            />
+          ))}
+          {hidden > 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {t("model.pick.more", { n: hidden })}
+            </p>
+          ) : null}
+          {!listing.isLoading && rows.length === 0 ? (
+            <p className="px-2 py-2 text-xs text-muted-foreground">
+              {t("model.pick.empty")}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-t border-hairline pt-3">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={tooSmall || makeDefault.isPending}
+            onClick={() => makeDefault.mutate()}
+          >
+            {t("fusion.cast.makeDefault")}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => onChange(EMPTY_CAST)}
+          >
+            {t("fusion.cast.reset")}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {makeDefault.isSuccess
+              ? t("fusion.cast.madeDefault")
+              : t("fusion.cast.thisChat")}
+          </span>
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function ModelRow({
+  model,
+  selected,
+  multi,
+  onPick,
+  t,
+}: {
+  model: ModelOption;
+  selected: boolean;
+  multi: boolean;
+  onPick: () => void;
+  t: TFunc;
+}) {
+  const price = model.free
+    ? t("model.pick.free")
+    : model.input_per_m == null || model.output_per_m == null
+      ? t("model.pick.priceUnknown")
+      : t("model.pick.price", {
+          in: model.input_per_m.toFixed(2),
+          out: model.output_per_m.toFixed(2),
+        });
+
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      role={multi ? "checkbox" : "radio"}
+      aria-checked={selected}
+      className={cn(
+        "flex w-full items-start gap-2 rounded-xl2 px-2 py-1.5 text-left",
+        "transition-colors duration-1 ease-out hover:bg-surface-hover",
+        selected && "bg-accent/10",
+        focusRing,
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "mt-1 h-3.5 w-3.5 shrink-0 border",
+          multi ? "rounded-[3px]" : "rounded-full",
+          selected ? "border-accent bg-accent" : "border-border",
+        )}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm">{model.label}</span>
+        <span className="block truncate font-mono text-xs text-muted-foreground">
+          {model.slug}
+        </span>
+        <span className="block text-xs text-muted-foreground">{price}</span>
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -1957,6 +1957,12 @@ export interface components {
              * @default false
              */
             fuse: boolean;
+            /** Fusion Judge */
+            fusion_judge?: string | null;
+            /** Fusion Panel */
+            fusion_panel?: string[] | null;
+            /** Fusion Synthesizer */
+            fusion_synthesizer?: string | null;
             /**
              * Max Attempts
              * @default 3
@@ -2390,6 +2396,12 @@ export interface components {
              * @default false
              */
             fuse: boolean;
+            /** Fusion Judge */
+            fusion_judge?: string | null;
+            /** Fusion Panel */
+            fusion_panel?: string[] | null;
+            /** Fusion Synthesizer */
+            fusion_synthesizer?: string | null;
             /** Max Steps */
             max_steps?: number | null;
             /** Max Usd */
@@ -2489,6 +2501,7 @@ export interface components {
             autonomy: components["schemas"]["AutonomyCfgOut"];
             browser?: components["schemas"]["BrowserCfgOut"];
             cache: components["schemas"]["CacheCfgOut"];
+            fusion?: components["schemas"]["FusionCfgOut"];
             guard: components["schemas"]["GuardCfgOut"];
             mcp: components["schemas"]["McpCfgOut"];
             memory: components["schemas"]["MemoryCfgOut"];
@@ -2805,6 +2818,54 @@ export interface components {
             path: string;
             /** Workspace */
             workspace: string;
+        };
+        /**
+         * FusionCfgOut
+         * @description Who plays each part when a turn is fused: the panel answers, the judge grades, the
+         *     synthesizer writes. Editable, because the shipped default was the only cast anyone could run —
+         *     and a default that cannot be changed is not a choice.
+         */
+        FusionCfgOut: {
+            /**
+             * Judge
+             * @default
+             */
+            judge: string;
+            kinship?: components["schemas"]["FusionKinshipOut"];
+            /**
+             * Mode
+             * @default selective
+             */
+            mode: string;
+            /** Panel */
+            panel?: string[];
+            /**
+             * Synthesizer
+             * @default
+             */
+            synthesizer: string;
+        };
+        /**
+         * FusionKinshipOut
+         * @description How independent the judge is from the panel it grades — reported, never enforced.
+         *
+         *     Two degrees, and the second is the one a slug does not reveal: ``judge_is_panelist`` is the judge
+         *     grading its own answer, and ``judge_shares_vendor_with`` is the judge and a panelist coming from
+         *     the same lab — not the same model, and not two independent votes either.
+         */
+        FusionKinshipOut: {
+            /**
+             * Independent
+             * @default true
+             */
+            independent: boolean;
+            /**
+             * Judge Is Panelist
+             * @default false
+             */
+            judge_is_panelist: boolean;
+            /** Judge Shares Vendor With */
+            judge_shares_vendor_with?: string[];
         };
         /** GitCommitOut */
         GitCommitOut: {
@@ -3824,6 +3885,12 @@ export interface components {
              * @default false
              */
             fuse: boolean;
+            /** Fusion Judge */
+            fusion_judge?: string | null;
+            /** Fusion Panel */
+            fusion_panel?: string[] | null;
+            /** Fusion Synthesizer */
+            fusion_synthesizer?: string | null;
             /**
              * Max Attempts
              * @default 3

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -515,6 +515,30 @@ const en: Dict = {
   "model.pick.blurb":
     "Applies to this conversation. The default stays whatever Settings says, unless you make this one the default below.",
   "model.pick.search": "Search by name, vendor or slug",
+  "fusion.cast.label": "cast",
+  "fusion.cast.standing": "as configured",
+  "fusion.cast.n": "{n} models",
+  "fusion.cast.unset": "as configured",
+  "fusion.cast.hint":
+    "Choose which models answer, which one grades them, and which one writes the final answer.",
+  "fusion.cast.title": "Who fuses",
+  "fusion.cast.blurb":
+    "The panel answers independently, the judge says where they agree and where they contradict, and the synthesizer writes the answer from that. Applies to this conversation unless you make it the default.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Judge",
+  "fusion.role.synthesizer": "Synthesizer",
+  "fusion.cast.calls":
+    "{n} calls per turn: every panelist, then the judge, then the synthesizer.",
+  "fusion.cast.tooSmall":
+    "A panel needs at least two models — one answer graded and rewritten is not fusion.",
+  "fusion.cast.judgeIsPanelist":
+    "The judge is on the panel, so it will grade its own answer.",
+  "fusion.cast.sameVendor":
+    "The judge and a panelist both come from {vendor} — not the same model, but not two independent answers either.",
+  "fusion.cast.makeDefault": "Make it the default",
+  "fusion.cast.madeDefault": "Saved. New conversations start with this cast.",
+  "fusion.cast.thisChat": "Without that, the cast lasts for this conversation.",
+  "fusion.cast.reset": "Use the configured one",
   "model.pick.empty": "No model matches that search.",
   "model.pick.failed": "The model list could not be loaded.",
   "model.pick.more": "{n} more — narrow the search to see them",
@@ -1467,6 +1491,31 @@ const pt: Dict = {
   "model.pick.blurb":
     "Vale para esta conversa. O padrão continua sendo o das Configurações, a não ser que você torne este o padrão aqui embaixo.",
   "model.pick.search": "Buscar por nome, fornecedor ou slug",
+  "fusion.cast.label": "elenco",
+  "fusion.cast.standing": "o configurado",
+  "fusion.cast.n": "{n} modelos",
+  "fusion.cast.unset": "o configurado",
+  "fusion.cast.hint":
+    "Escolha quais modelos respondem, qual avalia as respostas e qual escreve a resposta final.",
+  "fusion.cast.title": "Quem funde",
+  "fusion.cast.blurb":
+    "O painel responde de forma independente, o juiz diz onde eles concordam e onde se contradizem, e o sintetizador escreve a resposta a partir disso. Vale para esta conversa, a não ser que você torne isto o padrão.",
+  "fusion.role.panel": "Painel",
+  "fusion.role.judge": "Juiz",
+  "fusion.role.synthesizer": "Sintetizador",
+  "fusion.cast.calls":
+    "{n} chamadas por turno: cada modelo do painel, depois o juiz, depois o sintetizador.",
+  "fusion.cast.tooSmall":
+    "Um painel precisa de pelo menos dois modelos — uma resposta avaliada e reescrita não é fusão.",
+  "fusion.cast.judgeIsPanelist":
+    "O juiz está no painel, então vai avaliar a própria resposta.",
+  "fusion.cast.sameVendor":
+    "O juiz e um modelo do painel vêm ambos de {vendor} — não é o mesmo modelo, mas também não são duas respostas independentes.",
+  "fusion.cast.makeDefault": "Tornar padrão",
+  "fusion.cast.madeDefault":
+    "Salvo. As próximas conversas começam com este elenco.",
+  "fusion.cast.thisChat": "Sem isso, o elenco vale só para esta conversa.",
+  "fusion.cast.reset": "Usar o configurado",
   "model.pick.empty": "Nenhum modelo corresponde a essa busca.",
   "model.pick.failed": "Não deu para carregar a lista de modelos.",
   "model.pick.more": "mais {n} — refine a busca para vê-los",
@@ -2432,6 +2481,31 @@ const es: Dict = {
   "model.pick.blurb":
     "Se aplica a esta conversación. El predeterminado sigue siendo el de Ajustes, salvo que hagas de este el predeterminado aquí abajo.",
   "model.pick.search": "Buscar por nombre, proveedor o slug",
+  "fusion.cast.label": "elenco",
+  "fusion.cast.standing": "el configurado",
+  "fusion.cast.n": "{n} modelos",
+  "fusion.cast.unset": "el configurado",
+  "fusion.cast.hint":
+    "Elige qué modelos responden, cuál los evalúa y cuál escribe la respuesta final.",
+  "fusion.cast.title": "Quién fusiona",
+  "fusion.cast.blurb":
+    "El panel responde de forma independiente, el juez dice dónde coinciden y dónde se contradicen, y el sintetizador escribe la respuesta a partir de eso. Se aplica a esta conversación, salvo que lo hagas predeterminado.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Juez",
+  "fusion.role.synthesizer": "Sintetizador",
+  "fusion.cast.calls":
+    "{n} llamadas por turno: cada modelo del panel, luego el juez, luego el sintetizador.",
+  "fusion.cast.tooSmall":
+    "Un panel necesita al menos dos modelos — una respuesta evaluada y reescrita no es fusión.",
+  "fusion.cast.judgeIsPanelist":
+    "El juez está en el panel, así que evaluará su propia respuesta.",
+  "fusion.cast.sameVendor":
+    "El juez y un modelo del panel vienen ambos de {vendor} — no es el mismo modelo, pero tampoco son dos respuestas independientes.",
+  "fusion.cast.makeDefault": "Hacerlo predeterminado",
+  "fusion.cast.madeDefault":
+    "Guardado. Las conversaciones nuevas empiezan con este elenco.",
+  "fusion.cast.thisChat": "Si no, el elenco vale solo para esta conversación.",
+  "fusion.cast.reset": "Usar el configurado",
   "model.pick.empty": "Ningún modelo coincide con esa búsqueda.",
   "model.pick.failed": "No se pudo cargar la lista de modelos.",
   "model.pick.more": "{n} más — afina la búsqueda para verlos",
@@ -3406,6 +3480,32 @@ const fr: Dict = {
   "model.pick.blurb":
     "Vaut pour cette conversation. Le modèle par défaut reste celui des Réglages, sauf si vous en faites le défaut ci-dessous.",
   "model.pick.search": "Chercher par nom, fournisseur ou slug",
+  "fusion.cast.label": "casting",
+  "fusion.cast.standing": "tel que configuré",
+  "fusion.cast.n": "{n} modèles",
+  "fusion.cast.unset": "tel que configuré",
+  "fusion.cast.hint":
+    "Choisissez quels modèles répondent, lequel les évalue et lequel écrit la réponse finale.",
+  "fusion.cast.title": "Qui fusionne",
+  "fusion.cast.blurb":
+    "Le panel répond indépendamment, le juge dit où ils s'accordent et où ils se contredisent, et le synthétiseur écrit la réponse à partir de là. Vaut pour cette conversation, sauf si vous en faites le casting par défaut.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Juge",
+  "fusion.role.synthesizer": "Synthétiseur",
+  "fusion.cast.calls":
+    "{n} appels par tour : chaque modèle du panel, puis le juge, puis le synthétiseur.",
+  "fusion.cast.tooSmall":
+    "Un panel a besoin d'au moins deux modèles — une seule réponse évaluée puis réécrite, ce n'est pas de la fusion.",
+  "fusion.cast.judgeIsPanelist":
+    "Le juge est dans le panel : il évaluera donc sa propre réponse.",
+  "fusion.cast.sameVendor":
+    "Le juge et un modèle du panel viennent tous les deux de {vendor} — pas le même modèle, mais pas deux réponses indépendantes non plus.",
+  "fusion.cast.makeDefault": "En faire le casting par défaut",
+  "fusion.cast.madeDefault":
+    "Enregistré. Les nouvelles conversations démarrent avec ce casting.",
+  "fusion.cast.thisChat":
+    "Sinon, le casting ne vaut que pour cette conversation.",
+  "fusion.cast.reset": "Utiliser celui configuré",
   "model.pick.empty": "Aucun modèle ne correspond à cette recherche.",
   "model.pick.failed": "Impossible de charger la liste des modèles.",
   "model.pick.more": "{n} de plus — affinez la recherche pour les voir",
@@ -4386,6 +4486,31 @@ const de: Dict = {
   "model.pick.blurb":
     "Gilt für dieses Gespräch. Der Standard bleibt der aus den Einstellungen, außer du machst dieses hier unten zum Standard.",
   "model.pick.search": "Nach Name, Anbieter oder Slug suchen",
+  "fusion.cast.label": "Besetzung",
+  "fusion.cast.standing": "wie konfiguriert",
+  "fusion.cast.n": "{n} Modelle",
+  "fusion.cast.unset": "wie konfiguriert",
+  "fusion.cast.hint":
+    "Wähle, welche Modelle antworten, welches sie bewertet und welches die endgültige Antwort schreibt.",
+  "fusion.cast.title": "Wer fusioniert",
+  "fusion.cast.blurb":
+    "Das Panel antwortet unabhängig, der Judge sagt, wo sie übereinstimmen und wo sie sich widersprechen, und der Synthesizer schreibt daraus die Antwort. Gilt für dieses Gespräch, außer du machst es zum Standard.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Judge",
+  "fusion.role.synthesizer": "Synthesizer",
+  "fusion.cast.calls":
+    "{n} Aufrufe pro Zug: jedes Modell im Panel, dann der Judge, dann der Synthesizer.",
+  "fusion.cast.tooSmall":
+    "Ein Panel braucht mindestens zwei Modelle — eine Antwort bewerten und umschreiben ist keine Fusion.",
+  "fusion.cast.judgeIsPanelist":
+    "Der Judge sitzt im Panel und bewertet damit seine eigene Antwort.",
+  "fusion.cast.sameVendor":
+    "Judge und ein Modell im Panel kommen beide von {vendor} — nicht dasselbe Modell, aber auch keine zwei unabhängigen Antworten.",
+  "fusion.cast.makeDefault": "Als Standard setzen",
+  "fusion.cast.madeDefault":
+    "Gespeichert. Neue Gespräche starten mit dieser Besetzung.",
+  "fusion.cast.thisChat": "Sonst gilt die Besetzung nur für dieses Gespräch.",
+  "fusion.cast.reset": "Die konfigurierte nehmen",
   "model.pick.empty": "Kein Modell passt zu dieser Suche.",
   "model.pick.failed": "Die Modellliste konnte nicht geladen werden.",
   "model.pick.more": "{n} weitere — Suche eingrenzen, um sie zu sehen",
@@ -5323,6 +5448,28 @@ const zh: Dict = {
   "model.pick.blurb":
     "只对当前这段对话生效。默认模型仍以设置页为准，除非你在下面把它设为默认。",
   "model.pick.search": "按名称、厂商或 slug 搜索",
+  "fusion.cast.label": "阵容",
+  "fusion.cast.standing": "按配置",
+  "fusion.cast.n": "{n} 个模型",
+  "fusion.cast.unset": "按配置",
+  "fusion.cast.hint": "选择哪些模型作答、哪个来评判它们、哪个写出最终答案。",
+  "fusion.cast.title": "谁来融合",
+  "fusion.cast.blurb":
+    "评审组各自独立作答，评判指出它们在哪里一致、在哪里互相矛盾，综合者据此写出答案。只对当前这段对话生效，除非你把它设为默认。",
+  "fusion.role.panel": "评审组",
+  "fusion.role.judge": "评判",
+  "fusion.role.synthesizer": "综合者",
+  "fusion.cast.calls":
+    "每轮 {n} 次调用：评审组的每个模型，然后是评判，然后是综合者。",
+  "fusion.cast.tooSmall":
+    "评审组至少要有两个模型——一份答案被评判再重写，那不是融合。",
+  "fusion.cast.judgeIsPanelist": "评判也在评审组里，所以它会评判自己的答案。",
+  "fusion.cast.sameVendor":
+    "评判和评审组里的一个模型都来自 {vendor}——不是同一个模型，但也不是两份独立的答案。",
+  "fusion.cast.makeDefault": "设为默认",
+  "fusion.cast.madeDefault": "已保存。新对话都用这个阵容开始。",
+  "fusion.cast.thisChat": "不设的话，这个阵容只在本段对话有效。",
+  "fusion.cast.reset": "用配置里的",
   "model.pick.empty": "没有模型符合该搜索。",
   "model.pick.failed": "无法加载模型列表。",
   "model.pick.more": "还有 {n} 个 — 缩小搜索范围才能看到",
@@ -6256,6 +6403,30 @@ const ja: Dict = {
   "model.pick.blurb":
     "この会話にだけ効きます。下で既定にしない限り、既定は設定画面のままです。",
   "model.pick.search": "名前・提供元・slug で検索",
+  "fusion.cast.label": "配役",
+  "fusion.cast.standing": "設定どおり",
+  "fusion.cast.n": "モデル {n} 件",
+  "fusion.cast.unset": "設定どおり",
+  "fusion.cast.hint":
+    "どのモデルが答え、どれが採点し、どれが最終的な答えを書くかを選びます。",
+  "fusion.cast.title": "誰が融合するか",
+  "fusion.cast.blurb":
+    "パネルはそれぞれ独立に答え、ジャッジはどこが一致しどこが矛盾するかを示し、統合役がそこから答えを書きます。既定にしない限り、この会話にだけ効きます。",
+  "fusion.role.panel": "パネル",
+  "fusion.role.judge": "ジャッジ",
+  "fusion.role.synthesizer": "統合役",
+  "fusion.cast.calls":
+    "1ターンあたり {n} 回の呼び出し：パネルの各モデル、次にジャッジ、次に統合役。",
+  "fusion.cast.tooSmall":
+    "パネルにはモデルが最低2つ必要です — 1つの答えを採点して書き直すのは融合ではありません。",
+  "fusion.cast.judgeIsPanelist":
+    "ジャッジがパネルに入っているので、自分の答えを自分で採点します。",
+  "fusion.cast.sameVendor":
+    "ジャッジとパネルの1モデルがどちらも {vendor} 由来です — 同じモデルではありませんが、独立した2つの答えでもありません。",
+  "fusion.cast.makeDefault": "既定にする",
+  "fusion.cast.madeDefault": "保存しました。新しい会話はこの配役で始まります。",
+  "fusion.cast.thisChat": "しなければ、この配役はこの会話だけです。",
+  "fusion.cast.reset": "設定のものを使う",
   "model.pick.empty": "その検索に合うモデルはありません。",
   "model.pick.failed": "モデル一覧を読み込めませんでした。",
   "model.pick.more": "他に {n} 件 — 検索を絞ると出ます",
@@ -7223,6 +7394,32 @@ const it: Dict = {
   "model.pick.blurb":
     "Vale per questa conversazione. Il predefinito resta quello delle Impostazioni, a meno che tu non renda predefinito questo qui sotto.",
   "model.pick.search": "Cerca per nome, fornitore o slug",
+  "fusion.cast.label": "cast",
+  "fusion.cast.standing": "come configurato",
+  "fusion.cast.n": "{n} modelli",
+  "fusion.cast.unset": "come configurato",
+  "fusion.cast.hint":
+    "Scegli quali modelli rispondono, quale li valuta e quale scrive la risposta finale.",
+  "fusion.cast.title": "Chi fonde",
+  "fusion.cast.blurb":
+    "Il panel risponde in modo indipendente, il giudice dice dove concordano e dove si contraddicono, e il sintetizzatore scrive la risposta a partire da lì. Vale per questa conversazione, a meno che tu non lo renda predefinito.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Giudice",
+  "fusion.role.synthesizer": "Sintetizzatore",
+  "fusion.cast.calls":
+    "{n} chiamate per turno: ogni modello del panel, poi il giudice, poi il sintetizzatore.",
+  "fusion.cast.tooSmall":
+    "Un panel ha bisogno di almeno due modelli — una risposta valutata e riscritta non è fusione.",
+  "fusion.cast.judgeIsPanelist":
+    "Il giudice è nel panel, quindi valuterà la propria risposta.",
+  "fusion.cast.sameVendor":
+    "Il giudice e un modello del panel vengono entrambi da {vendor} — non è lo stesso modello, ma non sono nemmeno due risposte indipendenti.",
+  "fusion.cast.makeDefault": "Rendilo predefinito",
+  "fusion.cast.madeDefault":
+    "Salvato. Le nuove conversazioni partono con questo cast.",
+  "fusion.cast.thisChat":
+    "Altrimenti il cast vale solo per questa conversazione.",
+  "fusion.cast.reset": "Usa quello configurato",
   "model.pick.empty": "Nessun modello corrisponde a questa ricerca.",
   "model.pick.failed": "Non è stato possibile caricare l'elenco dei modelli.",
   "model.pick.more": "altri {n} — restringi la ricerca per vederli",
@@ -8192,6 +8389,31 @@ const pl: Dict = {
   "model.pick.blurb":
     "Dotyczy tej rozmowy. Domyślny nadal pochodzi z Ustawień, chyba że ustawisz ten poniżej jako domyślny.",
   "model.pick.search": "Szukaj po nazwie, dostawcy lub slugu",
+  "fusion.cast.label": "obsada",
+  "fusion.cast.standing": "jak skonfigurowano",
+  "fusion.cast.n": "modele: {n}",
+  "fusion.cast.unset": "jak skonfigurowano",
+  "fusion.cast.hint":
+    "Wybierz, które modele odpowiadają, który je ocenia i który pisze końcową odpowiedź.",
+  "fusion.cast.title": "Kto łączy",
+  "fusion.cast.blurb":
+    "Panel odpowiada niezależnie, sędzia mówi, gdzie modele się zgadzają, a gdzie sobie przeczą, a syntetyzator pisze z tego odpowiedź. Dotyczy tej rozmowy, chyba że ustawisz ją jako domyślną.",
+  "fusion.role.panel": "Panel",
+  "fusion.role.judge": "Sędzia",
+  "fusion.role.synthesizer": "Syntetyzator",
+  "fusion.cast.calls":
+    "Wywołań na turę: {n} — każdy model z panelu, potem sędzia, potem syntetyzator.",
+  "fusion.cast.tooSmall":
+    "Panel potrzebuje co najmniej dwóch modeli — jedna odpowiedź oceniona i przepisana to nie fuzja.",
+  "fusion.cast.judgeIsPanelist":
+    "Sędzia jest w panelu, więc oceni własną odpowiedź.",
+  "fusion.cast.sameVendor":
+    "Sędzia i jeden z modeli w panelu pochodzą od {vendor} — to nie ten sam model, ale też nie dwie niezależne odpowiedzi.",
+  "fusion.cast.makeDefault": "Ustaw jako domyślną",
+  "fusion.cast.madeDefault":
+    "Zapisano. Nowe rozmowy zaczynają się z tą obsadą.",
+  "fusion.cast.thisChat": "Inaczej obsada obowiązuje tylko w tej rozmowie.",
+  "fusion.cast.reset": "Użyj skonfigurowanej",
   "model.pick.empty": "Żaden model nie pasuje do tego wyszukiwania.",
   "model.pick.failed": "Nie udało się wczytać listy modeli.",
   "model.pick.more": "jeszcze {n} — zawęź wyszukiwanie, aby je zobaczyć",
@@ -9161,6 +9383,31 @@ const ru: Dict = {
   "model.pick.blurb":
     "Действует в этом разговоре. По умолчанию остаётся то, что указано в настройках, если не сделать эту моделью по умолчанию ниже.",
   "model.pick.search": "Поиск по имени, поставщику или slug",
+  "fusion.cast.label": "состав",
+  "fusion.cast.standing": "как настроено",
+  "fusion.cast.n": "моделей: {n}",
+  "fusion.cast.unset": "как настроено",
+  "fusion.cast.hint":
+    "Выберите, какие модели отвечают, какая их оценивает и какая пишет итоговый ответ.",
+  "fusion.cast.title": "Кто участвует в слиянии",
+  "fusion.cast.blurb":
+    "Панель отвечает независимо, судья говорит, где модели сходятся, а где противоречат друг другу, и синтезатор пишет из этого ответ. Действует в этом разговоре, если не сделать его составом по умолчанию.",
+  "fusion.role.panel": "Панель",
+  "fusion.role.judge": "Судья",
+  "fusion.role.synthesizer": "Синтезатор",
+  "fusion.cast.calls":
+    "Вызовов за ход: {n} — каждая модель панели, затем судья, затем синтезатор.",
+  "fusion.cast.tooSmall":
+    "Панели нужно хотя бы две модели — один ответ, оценённый и переписанный, это не слияние.",
+  "fusion.cast.judgeIsPanelist":
+    "Судья входит в панель, значит будет оценивать собственный ответ.",
+  "fusion.cast.sameVendor":
+    "Судья и одна из моделей панели — обе от {vendor}. Не одна и та же модель, но и не два независимых ответа.",
+  "fusion.cast.makeDefault": "Сделать по умолчанию",
+  "fusion.cast.madeDefault":
+    "Сохранено. Новые разговоры начинаются с этим составом.",
+  "fusion.cast.thisChat": "Иначе состав действует только в этом разговоре.",
+  "fusion.cast.reset": "Использовать настроенный",
   "model.pick.empty": "Ни одна модель не подходит под этот запрос.",
   "model.pick.failed": "Не удалось загрузить список моделей.",
   "model.pick.more": "ещё {n} — уточните поиск, чтобы увидеть их",

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -173,6 +173,26 @@ class CodeSeams(BaseModel):
     deciding for the user. What is NOT optional is that the turn says so, which ``done.fused`` does.
     """
 
+    fusion_panel: list[str] | None = None
+    """Which models answer this fused turn, overriding the configured panel.
+
+    ``None`` means the install's default, which is what every caller sent before this existed. The
+    override is per-conversation on purpose: "which three models should argue about THIS question"
+    is a property of the question, not of the installation. Ignored when ``fuse`` is false — a field
+    that quietly changed a non-fused turn would be a second, invisible way to pick a model.
+    """
+
+    fusion_judge: str | None = None
+    """Which model reads the panel's answers and writes the analysis. See ``fusion_panel``.
+
+    Nothing here refuses a judge that also sits on the panel. It is reported instead — ``kinship``
+    in the config, and a warning where the choice is made — because a user holding one provider key
+    cannot avoid the overlap, and a refusal they cannot act on just removes the feature.
+    """
+
+    fusion_synthesizer: str | None = None
+    """Which model writes the final answer from the judge's analysis. See ``fusion_panel``."""
+
     provider: str | None = None
     """Run this turn through an EXTERNAL coding agent instead of Chimera's own loop.
 
@@ -235,6 +255,41 @@ _ACTIONABLE = (
     "tool_use",
     "function calling",
 )
+
+
+def _cast_for_turn(backend: Any, req: CodeSeams) -> Any:
+    """The fusion engine this turn should use — the shared one, or a copy with a different cast.
+
+    The engine takes its roles from a ``FusionConfig`` it holds, so a per-turn choice is a new engine
+    over the SAME gateway rather than anything reentrant: no shared state is mutated, the swap in the
+    caller still restores the original, and an install with no override keeps the exact object it had
+    before. A panel of one is not a panel, so a single-model override is refused back to the default
+    rather than silently running fusion over one opinion.
+    """
+    panel = [m.strip() for m in (req.fusion_panel or []) if m and m.strip()]
+    judge = (req.fusion_judge or "").strip()
+    synth = (req.fusion_synthesizer or "").strip()
+    if not (panel or judge or synth):
+        return backend
+
+    config = getattr(backend, "config", None)
+    gateway = getattr(backend, "backend", None)
+    if config is None or gateway is None:  # not a FusionEngine — nothing to re-cast
+        return backend
+
+    from dataclasses import replace
+
+    from chimera.fusion.engine import FusionEngine
+
+    return FusionEngine(
+        gateway,
+        replace(
+            config,
+            panel=panel if len(panel) >= 2 else list(config.panel),
+            judge=judge or config.judge,
+            synthesizer=synth or config.synthesizer,
+        ),
+    )
 
 
 def _native_failure(exc: Exception) -> str:
@@ -771,7 +826,7 @@ def register_code_api(
                 fused = bool(req.fuse) and fuse_backend is not None
                 original_backend = getattr(agent, "backend", None) if fused else None
                 if fused:
-                    agent.backend = fuse_backend  # type: ignore[assignment]
+                    agent.backend = _cast_for_turn(fuse_backend, req)  # type: ignore[assignment]
 
                 external = (req.provider or "").strip().lower()
                 if external:

--- a/chimera/api/config_api.py
+++ b/chimera/api/config_api.py
@@ -87,6 +87,13 @@ _EDITABLE_SETTINGS = {
     "CHIMERA_APPROVAL",
     "CHIMERA_HOST_EXEC",
     "CHIMERA_TOOL_DENYLIST",
+    # Who plays each part in a fused turn. The engine has taken these three per instance since it
+    # existed; only the wire to a user was missing, so the panel a person could actually change was
+    # whichever one shipped — including the judge, whose independence from the panel is the whole
+    # claim fusion makes.
+    "CHIMERA_FUSION_PANEL",
+    "CHIMERA_FUSION_JUDGE",
+    "CHIMERA_FUSION_SYNTHESIZER",
 }
 ALLOWED_KEYS = _SECRET_KEYS | _EDITABLE_SETTINGS
 
@@ -133,6 +140,20 @@ APPLIES_WHEN: dict[str, str] = {
     "CHIMERA_APP_CRON": NEXT_LAUNCH,
     "CHIMERA_MCP_AUTOLOAD": NEXT_LAUNCH,
 }
+
+
+def _fusion_kinship(panel: list[str], judge: str) -> dict[str, Any]:
+    """How independent the judge is from the panel it grades — the engine's own answer.
+
+    Delegated to ``FusionConfig.role_kinship`` rather than reimplemented, because the interesting
+    half of it is the one nobody reimplements: not "is the judge a panelist" (obvious) but "is the
+    judge from the same lab as one" — which is not the same model and is not a second independent
+    vote either. Two copies of that rule would drift, and the copy on screen would be the one people
+    believe.
+    """
+    from chimera.fusion.engine import FusionConfig
+
+    return dict(FusionConfig(panel=list(panel), judge=judge, synthesizer=judge).role_kinship())
 
 
 def _hint(value: str | None) -> str:
@@ -274,6 +295,18 @@ def read_config(settings: Settings) -> dict[str, Any]:
             "tiers": {"weak": ladder.weak, "mid": ladder.mid, "top": ladder.top},
             "ollama_base_url": settings.ollama_base_url,
             "complete_model": settings.complete_model,
+        },
+        # Panel -> judge -> synthesizer, and how independent the judge actually is from the panel it
+        # grades. `role_kinship` is reported rather than enforced: a user with one provider key has
+        # no way to avoid overlap, and a labelled receipt beats a refusal they cannot act on.
+        "fusion": {
+            "panel": list(settings.fusion_panel),
+            "judge": settings.fusion_judge,
+            "synthesizer": settings.fusion_synthesizer,
+            "mode": settings.fusion_mode,
+            "kinship": _fusion_kinship(
+                list(settings.fusion_panel), settings.fusion_judge
+            ),
         },
         "memory": {
             "backend": settings.memory_backend,

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -230,6 +230,31 @@ class SandboxCfgOut(BaseModel):
     image: str
 
 
+class FusionKinshipOut(BaseModel):
+    """How independent the judge is from the panel it grades — reported, never enforced.
+
+    Two degrees, and the second is the one a slug does not reveal: ``judge_is_panelist`` is the judge
+    grading its own answer, and ``judge_shares_vendor_with`` is the judge and a panelist coming from
+    the same lab — not the same model, and not two independent votes either.
+    """
+
+    judge_is_panelist: bool = False
+    judge_shares_vendor_with: list[str] = Field(default_factory=list)
+    independent: bool = True
+
+
+class FusionCfgOut(BaseModel):
+    """Who plays each part when a turn is fused: the panel answers, the judge grades, the
+    synthesizer writes. Editable, because the shipped default was the only cast anyone could run —
+    and a default that cannot be changed is not a choice."""
+
+    panel: list[str] = Field(default_factory=list)
+    judge: str = ""
+    synthesizer: str = ""
+    mode: str = "selective"
+    kinship: FusionKinshipOut = Field(default_factory=FusionKinshipOut)
+
+
 class AutonomyCfgOut(BaseModel):
     """How much the agent may do — the three controls that decide it, in one place.
 
@@ -340,6 +365,7 @@ class BrowserCfgOut(BaseModel):
 
 class ConfigOut(BaseModel):
     models: ModelsCfgOut
+    fusion: FusionCfgOut = Field(default_factory=FusionCfgOut)
     memory: MemoryCfgOut
     cache: CacheCfgOut
     sandbox: SandboxCfgOut

--- a/tests/test_fusion_cast_is_a_choice.py
+++ b/tests/test_fusion_cast_is_a_choice.py
@@ -1,0 +1,157 @@
+"""Who plays each part in a fused turn, chosen by the person paying for it.
+
+The engine has taken ``panel`` / ``judge`` / ``synthesizer`` per instance since it was written, and
+the config has carried all three since then — but nothing between the engine and a user could set
+them. The only panel anyone could actually run was whichever one shipped, which put the product's
+central claim (several INDEPENDENT models answering, graded by a model that is not one of them) at
+the mercy of a default nobody could change without hand-editing an env file.
+
+Two seams, and they are deliberately different:
+
+* the **config** is the standing default, and writing it needs the three keys to be editable;
+* the **turn** is a per-conversation override, because "which models should argue about THIS
+  question" is a property of the question, not of the installation.
+
+Neither seam refuses a judge that also sits on the panel. That is reported — never enforced — and
+the reason is in ``role_kinship``'s own docstring: a user with one provider key cannot avoid the
+overlap, and refusing a configuration they have no way to fix would just remove the feature.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.api.code_api import CodeTurnRequest, _cast_for_turn
+from chimera.api.config_api import _fusion_kinship, is_editable
+from chimera.fusion.engine import FusionConfig, FusionEngine
+
+
+class _Gateway:
+    """Stands in for the LLM gateway: the per-turn engine must reuse it, not build another."""
+
+
+def _engine(panel: list[str] | None = None, judge: str = "j", synth: str = "s") -> FusionEngine:
+    return FusionEngine(
+        _Gateway(),
+        FusionConfig(panel=list(panel or ["a", "b", "c"]), judge=judge, synthesizer=synth),
+    )
+
+
+def _turn(**kwargs: Any) -> CodeTurnRequest:
+    return CodeTurnRequest(message="does this design hold up?", fuse=True, **kwargs)
+
+
+# --- the standing default ------------------------------------------------------------------------
+
+
+def test_the_three_roles_are_writable_from_the_app() -> None:
+    # Until this landed, `chimera/api/config_api.py` listed 25 editable settings and none of them was
+    # the fusion cast — so the app could show a fused turn's receipt and never let anyone change who
+    # produced it.
+    assert is_editable("CHIMERA_FUSION_PANEL")
+    assert is_editable("CHIMERA_FUSION_JUDGE")
+    assert is_editable("CHIMERA_FUSION_SYNTHESIZER")
+
+
+def test_the_config_reports_how_independent_the_judge_is() -> None:
+    """The two degrees, and the second is the one that gets missed."""
+    clean = _fusion_kinship(["vendor_a/one", "vendor_b/two"], "vendor_c/three")
+    assert clean["independent"] is True
+
+    grading_itself = _fusion_kinship(["vendor_a/one", "vendor_b/two"], "vendor_a/one")
+    assert grading_itself["judge_is_panelist"] is True
+    assert grading_itself["independent"] is False
+
+    # Not the same model — the same lab. Two answers from one vendor are not two votes, and this is
+    # the case a user would never notice from the slugs alone.
+    same_lab = _fusion_kinship(["openrouter/anthropic/claude-opus-5"], "openrouter/anthropic/haiku")
+    assert same_lab["judge_is_panelist"] is False
+    assert same_lab["judge_shares_vendor_with"] == ["openrouter/anthropic/claude-opus-5"]
+    assert same_lab["independent"] is False
+
+
+def test_the_kinship_shown_is_the_engine_s_own_answer() -> None:
+    # Reimplementing the vendor comparison in the API layer would give two rules that drift, and the
+    # copy on screen would be the one people believe. This asserts they are one rule.
+    panel, judge = ["openrouter/anthropic/opus", "openrouter/openai/gpt"], "openrouter/anthropic/haiku"
+    engine_says = FusionConfig(panel=panel, judge=judge, synthesizer=judge).role_kinship()
+    assert _fusion_kinship(panel, judge) == dict(engine_says)
+
+
+# --- the per-conversation override ---------------------------------------------------------------
+
+
+def test_a_turn_with_no_choice_keeps_the_object_it_already_had() -> None:
+    # The shared engine is handed to every turn. A turn that expresses no preference must get that
+    # exact instance back — not an equal copy — so nothing about the default path changes shape.
+    shared = _engine()
+    assert _cast_for_turn(shared, _turn()) is shared
+
+
+def test_a_chosen_cast_runs_on_the_same_gateway() -> None:
+    shared = _engine(panel=["a", "b"], judge="j", synth="s")
+    turn = _cast_for_turn(
+        shared, _turn(fusion_panel=["x", "y"], fusion_judge="jx", fusion_synthesizer="sx")
+    )
+
+    assert turn is not shared
+    assert turn.config.panel == ["x", "y"]
+    assert turn.config.judge == "jx"
+    assert turn.config.synthesizer == "sx"
+    # The point of `replace` over a fresh config: one gateway, one credential pool, one cache.
+    assert turn.backend is shared.backend
+
+
+def test_choosing_one_role_leaves_the_others_alone() -> None:
+    shared = _engine(panel=["a", "b"], judge="j", synth="s")
+    turn = _cast_for_turn(shared, _turn(fusion_judge="jx"))
+
+    assert turn.config.judge == "jx"
+    assert turn.config.panel == ["a", "b"]
+    assert turn.config.synthesizer == "s"
+
+
+def test_the_shared_engine_is_never_mutated() -> None:
+    """The swap in the caller restores `agent.backend` afterwards — but only the reference. If the
+    override edited the config in place, every later turn in every other conversation would inherit
+    a cast nobody chose there."""
+    shared = _engine(panel=["a", "b"], judge="j", synth="s")
+
+    _cast_for_turn(shared, _turn(fusion_panel=["x", "y"], fusion_judge="jx"))
+
+    assert shared.config.panel == ["a", "b"]
+    assert shared.config.judge == "j"
+    assert shared.config.synthesizer == "s"
+
+
+def test_a_panel_of_one_is_refused_back_to_the_default() -> None:
+    # Fusion over a single opinion is not fusion; it is one model plus the cost of a judge and a
+    # synthesizer. Refused rather than run, and refused back to something that works.
+    shared = _engine(panel=["a", "b", "c"])
+    assert _cast_for_turn(shared, _turn(fusion_panel=["only-me"])).config.panel == ["a", "b", "c"]
+
+
+def test_blank_and_whitespace_choices_are_not_choices() -> None:
+    shared = _engine(panel=["a", "b"], judge="j")
+    assert _cast_for_turn(shared, _turn(fusion_judge="   ")) is shared
+    assert _cast_for_turn(shared, _turn(fusion_panel=["", "  "])) is shared
+
+
+def test_a_judge_on_its_own_panel_is_allowed_and_visible() -> None:
+    """Allowed, because a one-key user has no alternative. Visible, because it is the case where the
+    independent signal fusion sells is not independent."""
+    shared = _engine(panel=["a", "b"])
+    turn = _cast_for_turn(shared, _turn(fusion_panel=["a", "b"], fusion_judge="a"))
+
+    assert turn.config.judge == "a"
+    assert turn.config.role_kinship()["judge_is_panelist"] is True
+
+
+def test_a_backend_that_is_not_a_fusion_engine_is_passed_through() -> None:
+    # `fuse_backend` is injected, and a deployment can hand something else in. Reading `.config` off
+    # whatever arrives would turn a wrong assumption into an AttributeError mid-turn.
+    class NotAnEngine:
+        pass
+
+    other = NotAnEngine()
+    assert _cast_for_turn(other, _turn(fusion_panel=["x", "y"])) is other


### PR DESCRIPTION
The fusion engine has taken `panel` / `judge` / `synthesizer` per instance since it was written, and `Settings` has carried all three the whole time. Nothing between the engine and a person could set them — so the only cast anyone could run was whichever one shipped. That is a strange place for a product to have no control: the shipped judge was once `panel[0]` verbatim and graded its own answer for as long as nobody noticed.

### Three seams, deliberately different

| | |
|---|---|
| **`/api/config`** | Reports the cast plus the engine's own `role_kinship`, and the three keys became editable. "Who fuses" stops being an env file you hand-edit. |
| **`/api/code/turn`** | Optional `fusion_panel` / `fusion_judge` / `fusion_synthesizer`. Which models should argue about *this* question is a property of the question — same reason the model picker and the spend ceiling sit next to the composer. |
| **The dialog** | Panel in multi-select, judge and synthesizer single, seeded from the standing cast so "the usual, but a different judge" takes one click. |

A chosen cast becomes `FusionEngine(same gateway, replace(config, …))` — no shared state is mutated, so one conversation cannot leak its cast into another, and an install that chooses nothing gets back the exact object it had before.

### What the dialog says that a multi-select would not

1. **The cost of the shape.** A four-model panel is six calls — four answers, a judge, a synthesizer. That arithmetic is invisible until the receipt.
2. **When the panel is not independent**, at the moment of choosing rather than after paying. Two degrees: the judge sitting on its own panel, and the judge coming from the same lab as a panelist — which no slug reveals.

Neither is refused. A user with one provider key cannot avoid the overlap, and a refusal they cannot act on removes the feature instead of the problem. A panel of one **is** refused, on both sides, because one opinion graded and rewritten is not fusion — it is three times the price for one answer.

`kinship` on screen is the engine's answer, not a second implementation. Two copies of that rule would drift, and the copy on screen is the one people would believe.

### Verification

- 11 new Python tests + 9 new desktop tests · **3513 Python**, **594 desktop**, `ruff`/`mypy`/`tsc` clean
- Driven in a live browser against a real backend: panel of 3 with judge and synthesizer named, "5 calls per turn", 60 models scrolling, and picking a judge that is already on the panel raises the warning without blocking the save
- Translated into all ten languages, placeholders verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)