### PR TITLE
test(bench): prove the suite discriminates before spending on it

### DIFF
--- a/bench/learning_lift/run_learning.py
+++ b/bench/learning_lift/run_learning.py
@@ -51,6 +51,8 @@ sys.path.insert(0, str(LIFT))
 sys.path.insert(0, str(HERE.parent.parent))
 from tasks import TASKS  # noqa: E402
 
+from chimera.eval.selftest import TaskCheck, assert_discriminating  # noqa: E402
+
 _MODEL = os.environ.get("BENCH_MODEL", "openrouter/mistralai/mistral-small-3.2-24b-instruct")
 _TIMEOUT = int(os.environ.get("BENCH_TIMEOUT", "240"))
 _OUT = Path(os.environ.get("BENCH_OUT", str(HERE / "results")))
@@ -301,6 +303,22 @@ def main() -> None:
 
     root = Path(tempfile.mkdtemp(prefix="chimlearn-ws-"))
     homes_root = Path(tempfile.mkdtemp(prefix="chimlearn-home-"))
+
+    # Before a single model call: does every task's committed test actually FAIL against the buggy
+    # source it ships with? `tasks_recurring` states that requirement in prose and validates it by
+    # hand; this runs it. A task where the test already passes hands both arms a free hit, and this
+    # suite's whole difficulty is that the control has never dropped below 88% — an unfalsifiable
+    # ceiling is exactly where a vacuous task would hide.
+    assert_discriminating(
+        [
+            TaskCheck(
+                task_id=str(task["id"]),
+                setup=lambda task=task: _fresh_workspace(task, root / "_selftest"),
+                verify=f'"{sys.executable}" -m pytest -q {task["test"]}',
+            )
+            for task in SUITE
+        ]
+    )
     tampered: set[str] = set()
     accum: list[dict[str, object]] = []
     timings: list[dict[str, object]] = []

--- a/bench/local_lift/run_ab.py
+++ b/bench/local_lift/run_ab.py
@@ -21,12 +21,15 @@ import shutil
 import subprocess
 import sys
 import time
+from importlib.metadata import version
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 REPO_ROOT = HERE.parent.parent
 sys.path.insert(0, str(HERE))
 from tasks import TASKS  # noqa: E402
+
+from chimera.eval.selftest import TaskCheck, assert_discriminating  # noqa: E402
 
 
 def _load_dotenv() -> dict[str, str]:
@@ -46,7 +49,13 @@ _DOTENV = _load_dotenv()
 
 RESULTS = HERE / "results"
 DETAILS = RESULTS / "details.jsonl"
-_HYGIENE = ["--no-remember", "--no-collect", "--no-evolve-skills"]
+# What neither arm may carry in from a previous run. `--no-skill-cards` is here for the same reason
+# as the other three and was missing: reading learned cards back is a per-run flag whose default
+# follows `settings.skill_cards`, and `_load_dotenv` below hands this process's `.env` to BOTH
+# subprocesses — so an install that turned cards on would silently give the BASELINE the thing the
+# experiment is supposed to be measuring. It is not contaminated today; it is one env var away, and
+# nothing in the recorded rows would have shown it.
+_HYGIENE = ["--no-remember", "--no-collect", "--no-evolve-skills", "--no-skill-cards"]
 # The honest product A/B, clearly labelled:
 #   baseline = the raw cheap model, ONE shot, no scaffold (no plan / no manager / 1 attempt).
 #   chimera  = the full Chimera solve loop: plan + verify-or-revert (3 attempts) + the M14 scaffolding.
@@ -131,6 +140,28 @@ def main() -> None:
     model = os.environ.get("CHIMERA_DEFAULT_MODEL", "?")
     print(f"model={model}  tasks={len(TASKS)}  arms={list(ARMS)}  (done cells: {len(done)})")
 
+    # Prove the apparatus before paying for the phenomenon. Every task claims its test fails on the
+    # untouched workspace; a task where it does not scores a hit for an arm that did nothing, and
+    # nothing downstream would ever say so. Costs no model call and aborts before the first one.
+    assert_discriminating(
+        [
+            TaskCheck(
+                task_id=str(task["id"]),
+                setup=lambda task=task: _setup_workspace(task, work_root / "_selftest"),
+                verify=f'"{_PY}" -m pytest -q {task["test"]}',
+            )
+            for task in TASKS
+        ]
+    )
+
+    # Stamped on every row below. Read once, so a run that spans an hour reports the version it
+    # STARTED with rather than whatever a mid-run upgrade left behind.
+    provenance = {
+        "chimera_version": version("chimera-agent"),
+        "model": model,
+        "hygiene": " ".join(_HYGIENE),
+    }
+
     for task in TASKS:
         for arm, flags in ARMS.items():
             if (task["id"], arm) in done:
@@ -144,6 +175,12 @@ def main() -> None:
             rec = {
                 "task": task["id"], "arm": arm, "passed": passed,
                 "solve_exit": code, "seconds": round(dt, 1),
+                # Provenance, so two files from two dates are comparable — or explicitly are not.
+                # Without it a row says a task passed and nothing else: not which Chimera, not which
+                # model, not which flags. Every number this suite has ever produced was, strictly,
+                # unfalsifiable after the fact.
+                **provenance,
+                "arm_flags": " ".join(flags),
             }
             with DETAILS.open("a", encoding="utf-8") as fh:
                 fh.write(json.dumps(rec) + "\n")

--- a/chimera/eval/selftest.py
+++ b/chimera/eval/selftest.py
@@ -1,0 +1,169 @@
+"""Prove the apparatus discriminates, before spending a cent on the phenomenon.
+
+A benchmark task is a claim: *this test fails now, and passes once the work is done*. The second half
+is measured on every run. The first half — that the test fails **before** anyone touches anything —
+is assumed, and an assumption is exactly the shape of the failure this repository has already paid
+for twice.
+
+A task whose test passes against the starting workspace measures nothing. It scores a hit for every
+arm, including a baseline that did nothing, and it does it silently: the run completes, the numbers
+look plausible, and the suite's pass rate quietly carries a task that could never have failed. Three
+of this project's own learning-lift runs closed with a control above 88%, and a check like this one
+would have named the reason before the spend rather than after it.
+
+The rule is stated in `bench/learning_lift/tasks_recurring.py`, in
+`skills/chimera-prove-the-test-discriminates/`, and in the card about writing the check before the
+code. It was never in the execution path. That is the whole point of this module: a guard that lives
+in prose guards nothing, which is the lesson from the Bee pre-training — the assertion was written,
+committed, and never called.
+
+Two failures, kept apart on purpose:
+
+* **not discriminating** — the verify command SUCCEEDS on the untouched workspace. The task is
+  vacuous and the suite is measuring air.
+* **not runnable** — the command could not be executed at all: no pytest, a timeout, a broken
+  interpreter. That is an environment problem, not a vacuous task, and calling it the same thing
+  would train everyone to ignore both.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["TaskCheck", "Verdict", "check_discriminates", "run_selftest", "assert_discriminating"]
+
+#: Long enough for a pytest collect + a slow import; short enough that a hung task does not stall a
+#: guard whose entire selling point is being cheap. A task that needs longer than this to FAIL is
+#: reporting something worth knowing on its own.
+DEFAULT_TIMEOUT = 120
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """What the untouched workspace did when the task's own verify command ran against it."""
+
+    task_id: str
+    discriminates: bool
+    """True when the command failed, which is the only healthy answer before any work is done."""
+
+    runnable: bool = True
+    """False when the command could not be executed at all — a different problem, said differently."""
+
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.discriminates and self.runnable
+
+
+@dataclass(frozen=True)
+class TaskCheck:
+    """One task to prove: how to build its starting workspace, and how it is verified.
+
+    ``setup`` is a callable rather than a path because every runner already has its own
+    workspace-building function, and re-deriving it here would be a second copy of the thing under
+    test — the copy that drifts.
+    """
+
+    task_id: str
+    setup: Callable[[], Path]
+    verify: str
+
+
+def check_discriminates(check: TaskCheck, *, timeout: int = DEFAULT_TIMEOUT) -> Verdict:
+    """Run one task's verify command against its untouched workspace and report what happened."""
+    try:
+        workspace = check.setup()
+    except Exception as exc:  # a workspace that cannot be built is not a vacuous task either
+        return Verdict(check.task_id, discriminates=False, runnable=False, detail=f"setup failed: {exc}")
+
+    try:
+        done = subprocess.run(
+            check.verify,
+            shell=True,
+            cwd=str(workspace),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return Verdict(
+            check.task_id,
+            discriminates=False,
+            runnable=False,
+            detail=f"verify command did not finish in {timeout}s",
+        )
+    except OSError as exc:
+        return Verdict(check.task_id, discriminates=False, runnable=False, detail=str(exc))
+
+    # A command that never ran exits non-zero too, and non-zero is the answer this guard calls
+    # healthy — so without this, an environment with no pytest would report every task as
+    # discriminating and the guard would certify an apparatus that measured nothing. That is the
+    # exact failure it exists to prevent, one level up. 127 is "command not found", 126 is "found
+    # and not executable", and the module case is the one that actually happens: a workspace whose
+    # interpreter has no pytest.
+    if done.returncode in (126, 127) or "No module named" in (done.stderr or ""):
+        return Verdict(
+            check.task_id,
+            discriminates=False,
+            runnable=False,
+            detail=(
+                f"verify command could not run (exit {done.returncode}): "
+                f"{(done.stderr or done.stdout or '').strip()[:200]}"
+            ),
+        )
+
+    if done.returncode == 0:
+        # The one that matters. Say what was run and where, because the fix is always in the task.
+        return Verdict(
+            check.task_id,
+            discriminates=False,
+            detail=(
+                "the test PASSES against the untouched workspace — this task scores a hit for an arm "
+                "that does nothing, so it measures nothing"
+            ),
+        )
+
+    # A non-zero exit is the healthy case: the test fails, so there is something for the work to fix.
+    return Verdict(check.task_id, discriminates=True, detail=f"exit {done.returncode}")
+
+
+def run_selftest(checks: Iterable[TaskCheck], *, timeout: int = DEFAULT_TIMEOUT) -> list[Verdict]:
+    """Every task, in order. Nothing is short-circuited: one vacuous task rarely travels alone, and a
+    run that aborts on the first would hide the other four behind a second and third rerun."""
+    return [check_discriminates(check, timeout=timeout) for check in checks]
+
+
+def assert_discriminating(
+    checks: Iterable[TaskCheck],
+    *,
+    timeout: int = DEFAULT_TIMEOUT,
+    report: Callable[[str], None] = print,
+) -> list[Verdict]:
+    """Prove the suite before spending on it, or refuse to run.
+
+    Raises ``SystemExit`` rather than returning a flag, and that is the design: a guard whose result
+    the caller may ignore is the guard this project already wrote three times and never called. The
+    exception carries the offending task ids, because "some task is broken" is not actionable.
+    """
+    verdicts = run_selftest(checks, timeout=timeout)
+    vacuous = [v for v in verdicts if v.runnable and not v.discriminates]
+    unrunnable = [v for v in verdicts if not v.runnable]
+
+    if not vacuous and not unrunnable:
+        report(f"[selftest] {len(verdicts)} tasks discriminate — the suite can measure something")
+        return verdicts
+
+    for verdict in vacuous:
+        report(f"[selftest] VACUOUS  {verdict.task_id}: {verdict.detail}")
+    for verdict in unrunnable:
+        report(f"[selftest] BROKEN   {verdict.task_id}: {verdict.detail}")
+
+    raise SystemExit(
+        f"selftest failed before any model was called: "
+        f"{len(vacuous)} vacuous, {len(unrunnable)} unrunnable, of {len(verdicts)} tasks. "
+        "A task whose test passes on the untouched workspace scores a hit for every arm."
+    )

--- a/chimera/eval/selftest.py
+++ b/chimera/eval/selftest.py
@@ -28,6 +28,9 @@ Two failures, kept apart on purpose:
 
 from __future__ import annotations
 
+import os
+import shlex
+import shutil
 import subprocess
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
@@ -73,12 +76,40 @@ class TaskCheck:
     verify: str
 
 
+def _executable_missing(command: str) -> str:
+    """The command's own program, when it is not on PATH — else "".
+
+    Asked BEFORE running, because after running it is unanswerable: a POSIX shell reports a missing
+    command as exit 127, but `cmd.exe` reports it as exit 1 with a message in the system's language,
+    and exit 1 is exactly what a failing test looks like. A guard that cannot tell "the test failed"
+    from "nothing ran" on Windows is a guard that passes an empty apparatus, which is what this whole
+    module exists to refuse.
+    """
+    try:
+        parts = shlex.split(command, posix=os.name != "nt")
+    except ValueError:  # unbalanced quotes — let the shell report it in its own words
+        return ""
+    if not parts:
+        return ""
+    program = parts[0].strip('"')
+    return "" if shutil.which(program) else program
+
+
 def check_discriminates(check: TaskCheck, *, timeout: int = DEFAULT_TIMEOUT) -> Verdict:
     """Run one task's verify command against its untouched workspace and report what happened."""
     try:
         workspace = check.setup()
     except Exception as exc:  # a workspace that cannot be built is not a vacuous task either
         return Verdict(check.task_id, discriminates=False, runnable=False, detail=f"setup failed: {exc}")
+
+    missing = _executable_missing(check.verify)
+    if missing:
+        return Verdict(
+            check.task_id,
+            discriminates=False,
+            runnable=False,
+            detail=f"verify command not found on PATH: {missing}",
+        )
 
     try:
         done = subprocess.run(
@@ -100,11 +131,13 @@ def check_discriminates(check: TaskCheck, *, timeout: int = DEFAULT_TIMEOUT) -> 
         return Verdict(check.task_id, discriminates=False, runnable=False, detail=str(exc))
 
     # A command that never ran exits non-zero too, and non-zero is the answer this guard calls
-    # healthy — so without this, an environment with no pytest would report every task as
-    # discriminating and the guard would certify an apparatus that measured nothing. That is the
-    # exact failure it exists to prevent, one level up. 127 is "command not found", 126 is "found
-    # and not executable", and the module case is the one that actually happens: a workspace whose
-    # interpreter has no pytest.
+    # healthy — so an environment with no pytest would otherwise report every task as discriminating
+    # and certify an apparatus that measured nothing: the exact failure this exists to prevent, one
+    # level up. The exit codes below are POSIX shells (127 not found, 126 not executable) and cost
+    # nothing to keep; Windows is why they are not the only check, because `cmd` answers a missing
+    # command with plain exit 1 — indistinguishable from a failing test — and says so in the system
+    # language, which is why `_executable_missing` runs first. "No module named" comes from Python
+    # itself and is English on every platform, and it is the case that actually happens.
     if done.returncode in (126, 127) or "No module named" in (done.stderr or ""):
         return Verdict(
             check.task_id,

--- a/tests/test_selftest_guards_the_apparatus.py
+++ b/tests/test_selftest_guards_the_apparatus.py
@@ -1,0 +1,200 @@
+"""The guard that runs before the spend, and the two failures it refuses to confuse.
+
+A benchmark task claims two things. That its test passes once the work is done is measured on every
+run; that the test FAILS before anyone touches anything is assumed — and that assumption is how a
+suite ends up carrying tasks that score a hit for an arm that did nothing.
+
+These tests use a real subprocess and a real temporary workspace, because the whole value of this
+guard is that it executes. A mocked `subprocess.run` here would test that the module calls a function
+this project already trusts, and would have passed just as happily against the version of this rule
+that lived only in prose.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from chimera.eval.selftest import (
+    TaskCheck,
+    assert_discriminating,
+    check_discriminates,
+    run_selftest,
+)
+
+PY = f'"{sys.executable}"'
+
+
+def _workspace(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    ws = tmp_path / name
+    ws.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        target = ws / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return ws
+
+
+def _check(tmp_path: Path, name: str, files: dict[str, str], test: str = "test_it.py") -> TaskCheck:
+    return TaskCheck(
+        task_id=name,
+        setup=lambda: _workspace(tmp_path, name, files),
+        verify=f"{PY} -m pytest -q {test}",
+    )
+
+
+# --- the healthy case ----------------------------------------------------------------------------
+
+
+def test_a_task_whose_test_fails_first_is_the_healthy_one(tmp_path: Path) -> None:
+    # Nothing implements `add` yet, so collection fails — which is exactly what a task should look
+    # like before the work starts.
+    verdict = check_discriminates(
+        _check(tmp_path, "missing_impl", {"test_it.py": "from impl import add\n\ndef test_add():\n    assert add(1, 2) == 3\n"})
+    )
+
+    assert verdict.discriminates is True
+    assert verdict.runnable is True
+    assert verdict.ok is True
+
+
+def test_a_buggy_source_that_the_test_catches_discriminates(tmp_path: Path) -> None:
+    # The other shape: the file exists and is WRONG. This is the case the rule was written for —
+    # `bench/learning_lift` ships buggy sources and asserts the committed test catches them.
+    verdict = check_discriminates(
+        _check(
+            tmp_path,
+            "off_by_one",
+            {
+                "impl.py": "def add(a, b):\n    return a + b + 1\n",
+                "test_it.py": "from impl import add\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+            },
+        )
+    )
+
+    assert verdict.ok is True
+
+
+# --- the failure this exists to catch --------------------------------------------------------------
+
+
+def test_a_test_that_already_passes_is_named_vacuous(tmp_path: Path) -> None:
+    """The task that measures nothing: it scores a hit for every arm, including one that did nothing,
+    and it does it silently."""
+    verdict = check_discriminates(
+        _check(
+            tmp_path,
+            "already_done",
+            {
+                "impl.py": "def add(a, b):\n    return a + b\n",
+                "test_it.py": "from impl import add\n\ndef test_add():\n    assert add(1, 2) == 3\n",
+            },
+        )
+    )
+
+    assert verdict.discriminates is False
+    assert verdict.runnable is True  # it ran fine — that is the problem
+    assert "PASSES" in verdict.detail
+
+
+def test_a_vacuous_task_stops_the_run_before_any_model_is_called(tmp_path: Path) -> None:
+    lines: list[str] = []
+    checks = [
+        _check(tmp_path, "good", {"test_it.py": "def test_x():\n    assert False\n"}),
+        _check(tmp_path, "vacuous", {"test_it.py": "def test_x():\n    assert True\n"}),
+    ]
+
+    with pytest.raises(SystemExit) as raised:
+        assert_discriminating(checks, report=lines.append)
+
+    # The ids, not just a count: "some task is broken" is not actionable.
+    assert "vacuous" in "\n".join(lines)
+    assert "1 vacuous" in str(raised.value)
+
+
+def test_every_task_is_checked_rather_than_stopping_at_the_first(tmp_path: Path) -> None:
+    # One vacuous task rarely travels alone, and aborting at the first hides the rest behind two more
+    # reruns of a suite that costs money to run.
+    checks = [
+        _check(tmp_path, "vacuous_a", {"test_it.py": "def test_x():\n    assert True\n"}),
+        _check(tmp_path, "vacuous_b", {"test_it.py": "def test_y():\n    assert True\n"}),
+    ]
+
+    verdicts = run_selftest(checks)
+
+    assert [v.task_id for v in verdicts] == ["vacuous_a", "vacuous_b"]
+    assert all(not v.discriminates for v in verdicts)
+
+
+# --- the failure that is NOT the same failure ------------------------------------------------------
+
+
+def test_an_unrunnable_command_is_reported_as_broken_not_vacuous(tmp_path: Path) -> None:
+    """No pytest, a bad interpreter, a timeout — an environment problem. Calling it "vacuous" would
+    train everyone to ignore both messages."""
+    check = TaskCheck(
+        task_id="no_such_binary",
+        setup=lambda: _workspace(tmp_path, "no_such_binary", {}),
+        verify="definitely-not-a-real-command-9d3f --version",
+    )
+
+    verdict = check_discriminates(check)
+
+    # Written expecting `ok is False` and it came back True: a missing command exits 127, and
+    # non-zero is the answer this guard calls healthy. Left as the assertion that caught it, because
+    # the consequence is the guard's own failure mode — an environment with no pytest would have
+    # every task "discriminate" and the suite would be certified having measured nothing.
+    assert verdict.runnable is False
+    assert verdict.discriminates is False
+    assert "could not run" in verdict.detail
+
+
+def test_a_workspace_that_cannot_be_built_is_broken_not_vacuous(tmp_path: Path) -> None:
+    def explode() -> Path:
+        raise RuntimeError("disk full")
+
+    verdict = check_discriminates(TaskCheck(task_id="bad_setup", setup=explode, verify="true"))
+
+    assert verdict.runnable is False
+    assert verdict.discriminates is False
+    assert "disk full" in verdict.detail
+
+
+def test_a_hanging_verify_times_out_instead_of_stalling_the_guard(tmp_path: Path) -> None:
+    check = TaskCheck(
+        task_id="hangs",
+        setup=lambda: _workspace(tmp_path, "hangs", {}),
+        verify=f"{PY} -c \"import time; time.sleep(30)\"",
+    )
+
+    verdict = check_discriminates(check, timeout=2)
+
+    assert verdict.runnable is False
+    assert "did not finish" in verdict.detail
+
+
+def test_a_broken_environment_also_stops_the_run(tmp_path: Path) -> None:
+    lines: list[str] = []
+
+    with pytest.raises(SystemExit) as raised:
+        assert_discriminating(
+            [TaskCheck(task_id="bad", setup=lambda: (_ for _ in ()).throw(OSError("nope")), verify="true")],
+            report=lines.append,
+        )
+
+    assert "BROKEN" in "\n".join(lines)
+    assert "1 unrunnable" in str(raised.value)
+
+
+def test_a_clean_suite_says_so_and_returns(tmp_path: Path) -> None:
+    lines: list[str] = []
+
+    verdicts = assert_discriminating(
+        [_check(tmp_path, "good", {"test_it.py": "def test_x():\n    assert False\n"})],
+        report=lines.append,
+    )
+
+    assert [v.ok for v in verdicts] == [True]
+    assert "1 tasks discriminate" in "\n".join(lines)

--- a/tests/test_selftest_guards_the_apparatus.py
+++ b/tests/test_selftest_guards_the_apparatus.py
@@ -148,7 +148,10 @@ def test_an_unrunnable_command_is_reported_as_broken_not_vacuous(tmp_path: Path)
     # every task "discriminate" and the suite would be certified having measured nothing.
     assert verdict.runnable is False
     assert verdict.discriminates is False
-    assert "could not run" in verdict.detail
+    # Either wording is the same verdict: caught before running (not on PATH) or after (exit 126/127,
+    # or Python saying the module is missing). Windows only ever reaches the first — see
+    # `_executable_missing`.
+    assert "not found" in verdict.detail or "could not run" in verdict.detail
 
 
 def test_a_workspace_that_cannot_be_built_is_broken_not_vacuous(tmp_path: Path) -> None:


### PR DESCRIPTION
Every benchmark task claims two things: its test **passes** once the work is done, and its test **fails** before anyone touches anything. The first is measured on every run. The second was assumed — and a task where it is false scores a hit for an arm that did nothing, silently, while the run completes and the numbers look plausible.

The rule was already written three times in this repo: in `tasks_recurring.py`'s docstring, in `skills/chimera-prove-the-test-discriminates/`, and in the card about writing the check before the code. It was never in the execution path — `grep -rniE "selftest"` over `chimera/`, `bench/` and `tests/` returned **zero lines**. That is the Bee pre-training lesson exactly: the guard was written, committed, and never called.

### The guard

`chimera/eval/selftest.py` runs each task's own verify command against its untouched workspace and refuses to continue unless every one fails. No model call, and it aborts before the first.

It keeps **two failures apart**, because collapsing them would train everyone to ignore both:

- **vacuous** — the command *succeeded*. The task measures nothing.
- **unrunnable** — the command could not run at all: no pytest, a timeout, a broken setup. An environment problem, said differently.

That distinction is not cosmetic, and the test suite proved it. The first version treated any non-zero exit as healthy — but a missing command exits 127, so an environment without pytest would have reported all 190 tasks as discriminating and certified an apparatus that had measured nothing. **The guard had the exact failure mode it exists to prevent, one level up.** The assertion that caught it is kept in the file, with the reason.

### What it found

| suite | tasks | discriminate | vacuous |
|---|---:|---:|---:|
| `local_lift` | 100 | 100 | 0 |
| `learning_lift` recurring | 25 | 25 | 0 |
| `learning_lift` recurring_hard | 25 | 25 | 0 |
| `learning_lift` hard_fix | 40 | 40 | 0 |

**Nothing.** Which is itself a result worth having: this suite's ceiling — a control that has never dropped below 88% across seven pre-registered runs — is *not* explained by tasks that could not fail. One hypothesis eliminated for the price of some CPU.

### And the A/B's two open holes

- **`--no-skill-cards` joins `_HYGIENE`.** Reading learned cards back is a per-run flag whose default follows `settings.skill_cards`, and `_load_dotenv` hands this process's `.env` to *both* subprocesses — so an install with cards on would have given the **baseline** the thing the experiment measures. Not contaminated today; one env var away, with nothing in the recorded rows to show it.
- **Every row now carries provenance** — Chimera version, model, arm flags. Before this a row said a task passed and nothing else: two result files from two dates were not comparable even in principle.

### Verification

`ruff` clean · `mypy` clean on 310 files · **3523 Python tests** (10 new, all exercising a real subprocess against a real workspace — a mocked `subprocess.run` here would have passed against the prose version of this rule too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)