### PR TITLE
fix(desktop): the worker picker said which one is chosen only in colour

### DIFF
--- a/apps/desktop/src/components/code/ExternalAgent.test.tsx
+++ b/apps/desktop/src/components/code/ExternalAgent.test.tsx
@@ -65,14 +65,53 @@ describe("ProviderPicker", () => {
     expect(screen.getByRole("button", { name: "Chimera" })).toBeInTheDocument();
   });
 
-  it("shows an agent it cannot run, disabled, beside one it can", async () => {
-    // "Gemini needs npm i -g" is useful information standing next to a Claude Code you can press.
+  it("shows an agent it cannot run, unusable but reachable, beside one it can", async () => {
+    // "Gemini needs npm i -g" is useful information standing next to a Claude Code you can press —
+    // and it was only useful to a pointer. The reason lives in a tooltip, and a `disabled` button
+    // takes no focus, so nobody navigating by keyboard could ever land on it to hear why the
+    // option was greyed out. `aria-disabled` says the same thing to assistive tech while leaving
+    // the button in the tab order.
     vi.mocked(getDoctor).mockResolvedValue(
       doctor([CLAUDE, { ...CLAUDE, key: "gemini", label: "Gemini CLI", available: false }]) as never,
     );
     picker();
     expect(await screen.findByRole("button", { name: "Claude Code" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Gemini CLI" })).toBeDisabled();
+
+    const missing = screen.getByRole("button", { name: "Gemini CLI" });
+    expect(missing).toHaveAttribute("aria-disabled", "true");
+    // Still named for what it is: the reason belongs in the description, not in the name.
+    expect(missing).not.toHaveAttribute("disabled");
+  });
+
+  it("does not switch to an agent that is not installed, however it is pressed", async () => {
+    const onChange = vi.fn();
+    // With an installed agent beside it — on its own the picker hides entirely, which is the
+    // component refusing to offer a choice that has only one impossible option.
+    vi.mocked(getDoctor).mockResolvedValue(
+      doctor([CLAUDE, { ...CLAUDE, key: "gemini", label: "Gemini CLI", available: false }]) as never,
+    );
+    picker({ onChange });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Gemini CLI" }));
+
+    // Reachable is not the same as usable. Leaving it in the tab order must not make it work.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("says which worker is selected, not only which one is coloured", async () => {
+    vi.mocked(getDoctor).mockResolvedValue(doctor([CLAUDE]) as never);
+    picker({ value: "claude" });
+
+    // The choice used to be communicated by a background colour and nothing else, so a screen
+    // reader heard three buttons and no answer to "which one is active".
+    expect(await screen.findByRole("button", { name: "Claude Code" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Chimera" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
   });
 
   it("disappears entirely when nothing here can run", async () => {

--- a/apps/desktop/src/components/code/ProviderPicker.tsx
+++ b/apps/desktop/src/components/code/ProviderPicker.tsx
@@ -47,6 +47,10 @@ export function ProviderPicker({
       <div className="flex overflow-hidden rounded-chip border border-border">
         <button
           type="button"
+          // Which one is chosen was said in colour and nowhere else, so a screen reader heard
+          // three buttons and no answer to "which is active". This is a toggle group; pressed is
+          // the state it has.
+          aria-pressed={value === ""}
           disabled={disabled}
           onClick={() => onChange("")}
           className={cn(
@@ -66,11 +70,24 @@ export function ProviderPicker({
           >
             <button
               type="button"
-              disabled={disabled || !agent.available}
-              onClick={() => onChange(agent.key)}
+              aria-pressed={value === agent.key}
+              // `aria-disabled` rather than `disabled` for an agent that is merely missing.
+              //
+              // The tooltip beside this already carries the reason — "not installed here, run
+              // this to get it" — and a `disabled` button takes no focus, so that reason reached
+              // a pointer and nobody else. Marked this way the button is still reachable, still
+              // announces that it cannot be used, and the sentence explaining WHY is finally
+              // available to someone navigating by keyboard.
+              //
+              // `disabled` stays real for the other case: a turn in flight is not a missing
+              // install, and there is nothing to explain there.
+              aria-disabled={!agent.available || undefined}
+              disabled={disabled}
+              onClick={() => agent.available && onChange(agent.key)}
               className={cn(
                 "px-2.5 py-1 text-xs transition-colors duration-1 ease-out disabled:opacity-40",
                 focusRing,
+                !agent.available && "cursor-not-allowed opacity-40",
                 value === agent.key
                   ? "bg-accent/20 text-accent"
                   : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
Two findings from driving the Code screen — and the first one I reported wrong
before getting it right, which is worth writing down.

## The selection existed only as a background colour

No `aria-pressed` on any of the three buttons, so a screen reader heard three
buttons and no answer to *"which one is active"*. It is a toggle group; pressed is
the state it has.

## The reason an agent is greyed out reached a pointer and nobody else

My first report was "the button doesn't say why", and **that was wrong** — there is
a `Tooltip` carrying `code.provider.missing` with the install hint. Reading the code
found the real defect one layer down: the button was `disabled`, and **a disabled
button takes no focus**, so nobody navigating by keyboard could land on it to hear
that tooltip. The explanation existed and was unreachable.

`aria-disabled` instead, for the missing-install case only:

- the button stays in the tab order and still announces it cannot be used;
- the sentence explaining why is finally available without a mouse;
- the click handler refuses the change, so *reachable* does not become *usable*;
- real `disabled` stays for a turn in flight — that is not a missing install, and
  there is nothing to explain there.

**A worse fix went first and a test caught it.** Putting the reason into
`aria-label` replaced the button's NAME, so it stopped being called "Gemini CLI".
The reason is a description, not an identity.

## Also exercised on this screen, and working

Model picker (search, per-1M prices, vision filter) · **"Make default" is visible
and reachable with the full model list** — the rc3 defect stays fixed · spend cap
(named by its wrapping `<label>`) · duplicate conversation (two distinct ids in the
backend, content carried) · raw session JSON · rename project (alias stored per
path) · Activity panel (machine stats live; token counters show dashes because
there is no turn in flight, which is the honest reading rather than last turn's
numbers).

Three near-misses I checked before reporting, all mine: memory search filters on
submit not per keystroke; standing instructions persist to `/api/instructions`, not
the config blob; and a project group that "vanished" was the rename input replacing
its own heading.

## Verification

634 desktop tests, types clean. New: the picker announces which worker is selected,
an uninstalled agent is reachable but cannot be switched to, and it keeps its own
name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
