### PR TITLE
fix(release): a guarda recusava por arquivo não rastreado

### DIFF
--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -94,8 +94,11 @@ def installed_version() -> str:
 
 
 def check_clean_and_on_main() -> None:
-    if run("git", "status", "--porcelain"):
-        raise Stop("the working tree has changes. Commit or stash them first.")
+    # TRACKED changes only. Untracked files are not part of any commit — the release adds its six
+    # files by name — and every real checkout has some: scratch scripts, bench output, a venv. The
+    # first run of this script on a real machine was refused by its own guard for exactly that.
+    if run("git", "status", "--porcelain", "--untracked-files=no"):
+        raise Stop("the working tree has uncommitted changes. Commit or stash them first.")
     branch = run("git", "rev-parse", "--abbrev-ref", "HEAD")
     if branch != "main":
         raise Stop(f"on branch {branch!r}. Cut releases from main.")

--- a/tests/test_cut_release.py
+++ b/tests/test_cut_release.py
@@ -93,3 +93,31 @@ def test_a_stale_install_stops_the_release_rather_than_stamping_the_old_version(
     # a commit that looks complete, passes locally, and is wrong. The message says what to run.
     assert "0.48.0rc9" in str(refused.value)
     assert "pip install -e ." in str(refused.value)
+
+
+def test_scratch_files_do_not_block_a_release(monkeypatch) -> None:
+    """Untracked files are not a reason to refuse. Tracked modifications are.
+
+    The first real run of this script was refused by its own guard, on a checkout whose only
+    "changes" were bench output and a helper script nobody tracks. A precondition that no real
+    machine can satisfy is not a precondition, it is a bug with a polite message.
+    """
+    seen: list[tuple[str, ...]] = []
+
+    def fake_run(*args: str, capture: bool = True) -> str:
+        seen.append(args)
+        if args[:2] == ("git", "status"):
+            return ""  # nothing tracked has changed
+        if args[:2] == ("git", "rev-parse"):
+            return "main"
+        if args[:2] == ("git", "rev-list"):
+            return "0"
+        return ""
+
+    monkeypatch.setattr(cut_release, "run", fake_run)
+    cut_release.check_clean_and_on_main()
+
+    status = next(args for args in seen if args[:2] == ("git", "status"))
+    assert "--untracked-files=no" in status, (
+        "the guard must ignore untracked files, or it refuses on every real checkout"
+    )


### PR DESCRIPTION
O primeiro uso real do script foi recusado pela própria guarda, numa árvore cuja única "mudança" eram resultados de bench e um helper que ninguém rastreia.

`git status --porcelain` conta arquivo não rastreado. Toda máquina de trabalho tem alguns — script de rascunho, saída de bench, um venv. Uma pré-condição que máquina nenhuma satisfaz não é pré-condição, é bug com mensagem educada.

Modificação **rastreada** continua barrando, que é o caso que importa: ou entraria no commit de release, ou significa que a árvore não é o que parece. Não rastreado não alcança nada — o release adiciona os seis arquivos pelo nome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)