### PR TITLE
fix(release): o bump reformatava um arquivo que só devia bumpar

### DIFF
--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -285,7 +285,12 @@ def main() -> None:
         # putting a branch on the remote to prove it.
         print("  would commit:\n    " + "\n    ".join(changed), file=sys.stderr)
         run("git", "checkout", "--", ".")
-        print("  dry run — tree restored, nothing pushed", file=sys.stderr)
+        # The install too, not just the tree. Verifying the snapshot stamping means really
+        # refreshing the metadata, and a dry run that left the environment reporting a version
+        # the repository does not have is not dry — it made the next `pytest` fail on a
+        # snapshot that was perfectly correct.
+        refresh_install()
+        print("  dry run - tree and install restored, nothing pushed", file=sys.stderr)
         return
 
     url = open_pull_request(version, changed)

--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -127,9 +127,21 @@ def write_versions(version: str) -> None:
         raise Stop("could not find the version line in Cargo.toml")
     CARGO.write_text(text, encoding="utf-8")
 
-    data = json.loads(TAURI.read_text(encoding="utf-8"))
-    data["version"] = tauri_version
-    TAURI.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    # Substituted on the line, not parsed and re-dumped. `json.dumps` normalises formatting it
+    # was never asked to touch: the first real cut with this expanded a compact
+    # `"targets": ["nsis", "dmg", ...]` onto five lines, so a commit that promises to change one
+    # version number arrived with eleven lines of noise around it.
+    text = TAURI.read_text(encoding="utf-8")
+    text, count = re.subn(
+        r'^(\s*"version"\s*:\s*)"[^"]*"',
+        rf'\g<1>"{tauri_version}"',
+        text,
+        count=1,
+        flags=re.M,
+    )
+    if count != 1:
+        raise Stop("could not find the version line in tauri.conf.json")
+    TAURI.write_text(text, encoding="utf-8")
 
 
 def refresh_install() -> None:

--- a/tests/test_cut_release.py
+++ b/tests/test_cut_release.py
@@ -55,7 +55,20 @@ def test_the_bump_hits_the_version_line_and_nothing_else(tmp_path: Path, monkeyp
     cargo = tmp_path / "Cargo.toml"
     cargo.write_text('[package]\nname = "chimera"\nversion = "0.48.0-rc.9"\n', encoding="utf-8")
     tauri = tmp_path / "tauri.conf.json"
-    tauri.write_text(json.dumps({"version": "0.48.0-rc.9", "productName": "Chimera"}), encoding="utf-8")
+    # Pretty-printed with a compact array in it, like the real file. The shape matters: the first
+    # real release cut re-dumped this through `json.dumps` and expanded the array onto five lines,
+    # so a commit promising to change one number arrived with eleven lines of noise.
+    tauri.write_text(
+        """\n{
+  "productName": "Chimera",
+  "version": "0.48.0-rc.9",
+  "bundle": {
+    "targets": ["nsis", "dmg", "appimage", "deb"]
+  }
+}
+""",
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(cut_release, "PYPROJECT", pyproject)
     monkeypatch.setattr(cut_release, "CARGO", cargo)
@@ -72,8 +85,12 @@ def test_the_bump_hits_the_version_line_and_nothing_else(tmp_path: Path, monkeyp
 
     # And the desktop shell gets the OTHER spelling, which is the whole point.
     assert 'version = "0.48.0-rc.10"' in cargo.read_text(encoding="utf-8")
-    assert json.loads(tauri.read_text(encoding="utf-8"))["version"] == "0.48.0-rc.10"
-    assert json.loads(tauri.read_text(encoding="utf-8"))["productName"] == "Chimera"
+    after = tauri.read_text(encoding="utf-8")
+    assert json.loads(after)["version"] == "0.48.0-rc.10"
+    assert json.loads(after)["productName"] == "Chimera"
+    # And nothing else moved. A release commit that reformats a config file it was only supposed
+    # to bump has broken the promise the six-file check exists to make.
+    assert '"targets": ["nsis", "dmg", "appimage", "deb"]' in after
 
 
 def test_a_stale_install_stops_the_release_rather_than_stamping_the_old_version(monkeypatch) -> None:


### PR DESCRIPTION
O primeiro corte real com o script fez parse do `tauri.conf.json` e re-dumpou. O `json.dumps` normalizou formatação que ninguém pediu: um `"targets": ["nsis", "dmg", "appimage", "deb"]` compacto saiu em cinco linhas, e um commit que promete mudar **um número de versão** chegou com onze linhas de ruído em volta.

Agora é substituição por linha, como já era nos dois arquivos TOML.

A checagem de seis arquivos pega um release que toca os arquivos errados; isto é a mesma promessa um nível abaixo — o arquivo certo, e só aquilo que ele veio buscar.

A fixture do teste escrevia JSON de uma linha só, e é por isso que ela passava na asserção de versão enquanto o arquivo real era reflowado. Agora é pretty-printed com array compacto, e afirma que o array sobrevive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)