### PR TITLE
fix(release): o push travava em vez de falhar, e o gh era checado tarde demais

### DIFF
--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -54,9 +56,15 @@ class Stop(SystemExit):
         super().__init__(f"\n  {message}\n")
 
 
-def run(*args: str, capture: bool = True) -> str:
+def run(*args: str, capture: bool = True, env: dict[str, str] | None = None) -> str:
     result = subprocess.run(
-        args, cwd=ROOT, capture_output=capture, text=True, check=False, encoding="utf-8"
+        args,
+        cwd=ROOT,
+        capture_output=capture,
+        text=True,
+        check=False,
+        encoding="utf-8",
+        env={**os.environ, **env} if env else None,
     )
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
@@ -214,12 +222,53 @@ def check_only_expected_files_changed(version: str) -> list[str]:
     return changed
 
 
+def preflight() -> None:
+    """Everything this needs, checked before anything is written.
+
+    `gh` is not optional here — the pull request is the whole point, and `main` is protected so
+    there is no fallback path. Checking late means bumping six files, regenerating three snapshots
+    and only then finding out the release cannot be opened. Which is what happened the first time
+    this ran under WSL, where `gh` is simply not installed.
+    """
+    if shutil.which("gh") is None:
+        raise Stop(
+            "`gh` is not on PATH. This opens the pull request with it, and `main` is protected, "
+            "so there is no way to finish without it.\n"
+            "  If you are in WSL and gh is installed on the Windows side, run this from there."
+        )
+    if subprocess.run(["gh", "auth", "status"], capture_output=True, check=False).returncode != 0:
+        raise Stop("`gh` is installed but not logged in. Run `gh auth login` first.")
+
+
+def push_branch(branch: str) -> None:
+    """Push using gh's own credential helper, and never wait on a prompt.
+
+    Git on a machine with no credential helper does not fail — it BLOCKS, asking for a username on
+    a stdin nobody is watching, and a release script that hangs looks like a slow release. Two
+    changes: `gh auth git-credential` lends the token this script is already authenticated with
+    (passed as a helper, so it never appears in a command line or a process list), and
+    `GIT_TERMINAL_PROMPT=0` turns anything still unauthenticated into an error you can read.
+    """
+    run(
+        "git",
+        "-c",
+        "credential.helper=",  # drop whatever is configured, so the next one is the only one
+        "-c",
+        "credential.helper=!gh auth git-credential",
+        "push",
+        "-u",
+        "origin",
+        branch,
+        env={"GIT_TERMINAL_PROMPT": "0"},
+    )
+
+
 def open_pull_request(version: str, changed: list[str]) -> str:
     branch = f"release/{version}"
     run("git", "checkout", "-b", branch)
     run("git", "add", *changed)
     run("git", "commit", "-m", f"chore(release): {version}")
-    run("git", "push", "-u", "origin", branch)
+    push_branch(branch)
 
     body = (
         f"Version bump to `{version}` (`{semver(version)}` for the desktop shell).\n\n"
@@ -262,6 +311,7 @@ def main() -> None:
 
     version = args.version.strip()
     semver(version)  # validate before touching anything
+    preflight()
     check_clean_and_on_main()
 
     previous = current_version()

--- a/tests/test_cut_release.py
+++ b/tests/test_cut_release.py
@@ -138,3 +138,38 @@ def test_scratch_files_do_not_block_a_release(monkeypatch) -> None:
     assert "--untracked-files=no" in status, (
         "the guard must ignore untracked files, or it refuses on every real checkout"
     )
+
+
+def test_the_push_lends_gh_its_credentials_and_never_waits_on_a_prompt(monkeypatch) -> None:
+    """Git without a credential helper does not fail — it BLOCKS.
+
+    It asks for a username on a stdin nobody is watching, and a release script that hangs looks
+    like a slow release. That is exactly how the first two real cuts ended: the commit was made,
+    the push sat there, and the branch had to be pushed by hand from another shell.
+    """
+    calls: list[tuple[tuple[str, ...], dict]] = []
+
+    def fake_run(*args: str, capture: bool = True, env: dict | None = None) -> str:
+        calls.append((args, {"env": env}))
+        return ""
+
+    monkeypatch.setattr(cut_release, "run", fake_run)
+    cut_release.push_branch("release/0.48.0rc10")
+
+    args, extra = calls[0]
+    # Passed as a helper, so the token is never a command-line argument or a line in `ps`.
+    assert "credential.helper=!gh auth git-credential" in args
+    # And anything still unauthenticated becomes an error you can read instead of a wait.
+    assert extra["env"] == {"GIT_TERMINAL_PROMPT": "0"}
+    assert args[-1] == "release/0.48.0rc10"
+
+
+def test_it_checks_for_gh_before_writing_anything(monkeypatch) -> None:
+    monkeypatch.setattr(cut_release.shutil, "which", lambda _name: None)
+
+    with pytest.raises(SystemExit) as refused:
+        cut_release.preflight()
+
+    # Checking late means bumping six files and regenerating three snapshots before finding out
+    # the release cannot be opened at all — which is what the first WSL run did.
+    assert "gh" in str(refused.value)


### PR DESCRIPTION
Os dois cortes reais terminaram igual: o commit era feito, o `git push` ficava pendurado, e a branch tinha que ir na mão de outro shell.

Git numa máquina sem helper de credencial **não falha — ele bloqueia**, pedindo usuário num stdin que ninguém está olhando. E um script de release que trava parece um release lento.

**Duas mudanças, e a segunda importa mais.**

O push agora empresta o `gh auth git-credential` — o helper que o próprio gh traz para isso — então autentica com o mesmo token que o script já usa para abrir o PR. Passado como *helper*, então o token nunca é argumento de linha de comando nem linha no `ps`. E o `GIT_TERMINAL_PROMPT=0` transforma qualquer coisa ainda não autenticada em erro legível em vez de espera.

E o `gh` passou a ser checado **antes de escrever qualquer coisa**. Ele não é opcional aqui: o PR é o objetivo, o `main` é protegido, e não existe caminho que termine sem ele. Checar tarde significava bumpar seis arquivos e regerar três snapshots para só então descobrir que o release não podia ser aberto — que é o que a primeira execução no WSL fez, onde o gh nem está instalado. Agora para na primeira linha, dizendo para rodar do lado que tem gh.

**Verificado nos dois sentidos:** o helper empurra de verdade (branch descartável, depois apagada) e o preflight para de verdade no WSL, antes de tocar em arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)