### PR TITLE
fix(kanban): a card in the solve lane ran outside the owner's governance

### DIFF
--- a/chimera/kanban/lanes.py
+++ b/chimera/kanban/lanes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from chimera.kanban.dispatch import LaneResult
 from chimera.kanban.models import KanbanCard
@@ -26,6 +26,22 @@ from chimera.kanban.models import KanbanCard
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from chimera.core.registry import AgentDef
     from chimera.kanban.dispatch import LaneRunner
+
+
+def _refusals(approvals: Any) -> str:
+    """A line naming what governance refused, or "" when it refused nothing.
+
+    Read defensively: this runs on an unattended path, and a lane that crashed while reporting what
+    it had been denied would be worse than one that reported nothing at all.
+    """
+    try:
+        denied = [e for e in approvals.entries() if getattr(e, "decision", "") == "deny"]
+    except Exception:  # noqa: BLE001 -- see the docstring
+        return ""
+    if not denied:
+        return ""
+    names = sorted({str(getattr(e, "tool", "") or "?") for e in denied})
+    return f"[governance refused {len(denied)} call(s): {', '.join(names)}]"
 
 
 class SolveLane:
@@ -60,14 +76,32 @@ class SolveLane:
         )
         from chimera.core.verify import CommandVerifier
         from chimera.evolution import build_evolution_context
+        from chimera.governance.profile import governed_profile
         from chimera.providers import LLMGateway
         from chimera.tools import default_registry
 
         gateway = LLMGateway()
         settings = get_settings()
+        # Through the deployment's governance, like every other autonomous surface. It was not, and
+        # the build gate that exists to make this structural reported green anyway: three classes in
+        # this file have a method called `run`, the gate's key carried only function names, and so
+        # the single exemption written for `AgentLane.run` — which really does restrict its registry
+        # — silently covered this line too. A card in the `solve` lane therefore ran a full
+        # autonomous loop with shell, file writes, code execution and network, outside any
+        # allowlist, denylist, trust kernel or taint ledger, reachable from the Tasks screen. An
+        # owner's `CHIMERA_TOOL_DENYLIST` did not reach it.
+        #
+        # Its own surface name, not the CLI's: the audit log has to be able to say which entrance a
+        # run came through, and a board dispatch is not a person typing `chimera solve`.
+        registry, approvals = governed_profile(
+            default_registry(self.workspace),
+            settings=settings,
+            home=settings.home,
+            surface="kanban-solve",
+        )
         worker = Agent(
             gateway,
-            default_registry(self.workspace),
+            registry,
             # The card's workspace, in both arguments: it roots the tools and it carries the
             # project's conventions. A lane is an autonomous path, so nobody is there to
             # restate them.
@@ -90,7 +124,13 @@ class SolveLane:
             config=AutonomousConfig(max_attempts=self.max_attempts),
         )
         result = auto.run(card.action)
-        return LaneResult(success=result.success, answer=result.answer)
+        # The refusals travel with the answer. `governed_profile` says in its own docstring
+        # that a caller who throws the approvals away cannot tell "the job did its work" from
+        # "the job was not allowed to" — and on a board nobody is watching, that difference is
+        # the whole report.
+        refused = _refusals(approvals)
+        answer = result.answer + ("\n\n" + refused if refused else "")
+        return LaneResult(success=result.success, answer=answer)
 
 
 class CrewLane:

--- a/tests/test_governed_surfaces.py
+++ b/tests/test_governed_surfaces.py
@@ -161,7 +161,9 @@ EXEMPT: dict[str, str] = {
         "tests/test_governance_on_the_api_path.py, because an exemption is prose and prose "
         "goes stale"
     ),
-    "chimera/kanban/lanes.py:run": "restrict_registry from the card's own role (fail-closed)",
+    "chimera/kanban/lanes.py:AgentLane.run": (
+        "restrict_registry from the card's own role (fail-closed)"
+    ),
     # --- not an agent surface at all ---
     "chimera/api/app.py:build_api_app.tools_endpoint": "lists tool schemas; nothing is invoked",
     "chimera/cli/main.py:tools": "prints the tool table",
@@ -201,7 +203,13 @@ def _bare_registry_calls(tree: ast.Module, module: str) -> list[tuple[str, int]]
     found: list[tuple[str, int]] = []
 
     def walk(node: ast.AST, chain: list[str]) -> None:
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        # ClassDef belongs in the chain, and leaving it out was not cosmetic. `lanes.py` holds
+        # three classes with a method called `run`; without the class name all three collapsed
+        # onto the key `chimera/kanban/lanes.py:run`, so the single exemption written for
+        # `AgentLane.run` — which really does restrict the registry — silently covered
+        # `SolveLane.run`, which builds a bare one. A gate whose key cannot tell two call sites
+        # apart exempts the wrong one and stays green about it.
+        if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
             chain = [*chain, node.name]
         if (
             isinstance(node, ast.Call)

--- a/tests/test_kanban.py
+++ b/tests/test_kanban.py
@@ -102,3 +102,57 @@ def test_dispatch_respects_limit(tmp_path: Path) -> None:
     outcomes = dispatch(board, {"solve": FakeRunner(True)}, limit=2)
     assert len(outcomes) == 2
     assert len(board.cards("backlog")) == 1
+
+
+def test_the_solve_lane_runs_under_the_owners_governance(tmp_path: Path, monkeypatch) -> None:
+    """A card in the `solve` lane is an autonomous loop nobody is watching — so it is governed.
+
+    It was not. `SolveLane.run` built a bare registry, which handed a card shell, file writes, code
+    execution and network outside any allowlist, denylist, trust kernel or taint ledger — reachable
+    from the Tasks screen, and the structural gate reported green because three classes in that file
+    have a method called `run` and its key carried only the function name. This test asks the
+    question a user would: I denied a tool; is it gone here too?
+    """
+    import chimera.core as core
+    import chimera.evolution as evolution
+    import chimera.providers as providers
+    from chimera.config import get_settings
+    from chimera.kanban.lanes import SolveLane
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CHIMERA_TOOL_DENYLIST", "run_shell,execute_code")
+    get_settings.cache_clear()
+    monkeypatch.setattr(providers, "LLMGateway", lambda *a, **k: object())
+
+    seen: dict[str, object] = {}
+
+    class _Agent:
+        def __init__(self, _gateway, registry, _config):
+            seen["registry"] = registry
+
+    class _Auto:
+        def __init__(self, *_a, **_k) -> None:
+            pass
+
+        def run(self, _task: str):
+            return LaneResult(success=True, answer="done")
+
+    monkeypatch.setattr(core, "Agent", _Agent)
+    monkeypatch.setattr(core, "AutonomousAgent", _Auto)
+    monkeypatch.setattr(core, "Planner", lambda *a, **k: None)
+    monkeypatch.setattr(core, "Manager", lambda *a, **k: None)
+    monkeypatch.setattr(evolution, "build_evolution_context", lambda *a, **k: _Evo())
+
+    result = SolveLane(workspace=tmp_path).run(KanbanCard(id="c1", title="x", action="do"))
+
+    assert result.success is True
+    names = {t.name for t in seen["registry"].tools()}  # type: ignore[attr-defined]
+    assert "run_shell" not in names and "execute_code" not in names
+    # And something is still there — a test that passes because the registry came back empty would
+    # pass just as well against a lane that had stopped working at all.
+    assert "read_file" in names
+
+
+class _Evo:
+    def apply_to(self) -> dict[str, object]:
+        return {}


### PR DESCRIPTION
## O buraco

`SolveLane.run` construía `default_registry(self.workspace)` — sem allowlist, sem denylist, sem trust kernel, sem taint ledger, `write_region=None`.

Um card largado na lane `solve` recebia então um loop autônomo completo com `run_shell`, `write_file`, `edit_file`, `apply_patch`, `execute_code` e `http_get`, **alcançável pela tela de Tarefas** (`features.py:163`, `:542`, `:626`). Um dono que tinha configurado `CHIMERA_TOOL_DENYLIST` não via a configuração valer ali.

## Por que o portão não viu

`tests/test_governed_surfaces.py` existe exatamente para tornar isso estrutural. Ele reportou verde o tempo todo.

A chave dele era montada só com nomes de função, e três classes deste arquivo têm um método chamado `run` — `SolveLane`, `CrewLane`, `AgentLane`. As três colapsavam em `chimera/kanban/lanes.py:run`, e a única isenção escrita para `AgentLane.run` (que de fato restringe seu registry) cobria `SolveLane.run` em silêncio.

O portão foi consertado **primeiro**, de propósito: enquanto a chave colide, qualquer conserto pode regredir sem ninguém ver. Com `ClassDef` no `walk`, ele ficou vermelho imediatamente nos dois sites e na chave de isenção agora obsoleta.

> Um portão cuja chave não distingue dois sites isenta justamente o que você não queria isentar.

## O conserto

`governed_profile(..., surface="kanban-solve")` — nome de superfície próprio, porque o log de auditoria precisa poder dizer por qual entrada o run veio, e um dispatch de board não é uma pessoa digitando `chimera solve`.

As recusas voltam junto com a resposta. Num board que ninguém está olhando, "o trabalho foi feito" e "o trabalho não foi permitido" são, de outra forma, o mesmo resultado vazio.

## Verificação

- `tests/test_governed_surfaces.py` — 25 passed
- Suíte completa — **3637 passed**, 13 skipped
- `mypy chimera/` — 316 arquivos, limpo
- O teste novo foi rodado **contra o código pré-conserto** e falha (`assert 'run_shell' not in {...}`) — ele discrimina, não passa vazio

🤖 Generated with [Claude Code](https://claude.com/claude-code)