### PR TITLE
fix(identity): an agent configured in Portuguese answered in English on two screens

### DIFF
--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -480,6 +480,26 @@ def _preview_dict(plan: Any, *, sources: int, plan_id: str) -> dict[str, Any]:
     }
 
 
+def _owner_instructions(home: object) -> str:
+    """The owner's rendered instructions, or "" if they set none or the file cannot be read.
+
+    Every other surface that answers a person loads these — Code, Runs, chat, the bots. This one
+    did not, and because the same rendered block carries the "always answer in {language}" line,
+    an owner running the app in Portuguese got English out of the Orchestration tab.
+
+    Best-effort by design: a malformed identity file must not take an orchestration run down.
+    """
+    from pathlib import Path as _Path
+
+    try:
+        from chimera.core.instructions import load as load_identity
+        from chimera.core.instructions import render as render_identity
+
+        return render_identity(load_identity(_Path(str(home))))
+    except Exception:  # noqa: BLE001 -- see the docstring
+        return ""
+
+
 def register_orchestration_api(
     app: FastAPI,
     guard: params.Depends,
@@ -550,6 +570,7 @@ def register_orchestration_api(
                 fuse_final=fuse,
                 effort=EffortPolicy(complex_budget=req.budget or live.delegation_budget),
             ),
+            identity=_owner_instructions(live.home),
             evolution=build_evolution_context(
                 live, gateway, None, home=live.home,
                 evolve_skills=False, include_memory=True,
@@ -753,6 +774,7 @@ def register_orchestration_api(
                     max_workers=max(1, min(_MAX_WORKERS, req.max_workers)),
                     on_event=on_event,
                     should_stop=stop.is_set,
+                    identity=_owner_instructions(live.home),
                 )
                 crew.run(req.task, ws, verify=req.verify, timeout=live.batch_timeout)
             except Exception as exc:  # noqa: BLE001 -- surfaced to the client as an error frame

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1778,6 +1778,8 @@ def _start_cron_daemon(
 
     from chimera.api.usage import UsageRecord, append_usage, spent_today
     from chimera.core import Agent, AgentConfig
+    from chimera.core.instructions import load as load_identity
+    from chimera.core.instructions import render as render_identity
     from chimera.orchestration.budget import BudgetExceeded
     from chimera.scheduler import CronDaemon, CronJob, Scheduler, make_agent_dispatch
     from chimera.tools import default_registry
@@ -1827,6 +1829,12 @@ def _start_cron_daemon(
                 # LEAST able to be told the conventions any other way — nobody is at a terminal to
                 # restate them — and it was the one reading none.
                 project_root=workspace,
+                # And the owner's own instructions, which every other surface that answers a
+                # person already loads. A cron job reports to a person too — into Discord, into a
+                # log, into the app — and this was the second surface answering in English to an
+                # owner who had configured Portuguese, because the same rendered block carries the
+                # "always answer in {language}" line.
+                instructions=render_identity(load_identity(settings.home)),
                 # The path that runs the most was the one with no step-level record at all. Without
                 # it there is no success-versus-context curve, no replay of a job that went wrong,
                 # and no reliability bench for the 24/7 loop — every one of those reads this file.

--- a/chimera/orchestration/crew.py
+++ b/chimera/orchestration/crew.py
@@ -177,9 +177,13 @@ class IsolatedCrew:
         max_workers: int = 4,
         on_event: OrchEventSink | None = None,
         should_stop: Callable[[], bool] | None = None,
+        identity: str = "",
     ) -> None:
         self.backend = backend
         self.workers = workers
+        # The owner's rendered instructions, handed to every worker. Keyword-only with an empty
+        # default so no existing caller changes.
+        self.identity = identity
         self.supervisor = supervisor
         self.max_workers = max_workers
         # Same seam, same contract, same reasons as the hierarchy's — see
@@ -245,6 +249,10 @@ class IsolatedCrew:
                         worker.backend or self.backend,
                         tools=worker.tools(ws),
                         max_steps=worker.max_steps,
+                        identity=self.identity,
+                        # The worktree, not the original: a worker reads the conventions of the
+                        # checkout it is actually editing.
+                        project_root=ws,
                     )
                     answer = agent_answer = agent.act(task)
                 except Exception as exc:  # noqa: BLE001 -- one worker crashing is its own failure

--- a/chimera/orchestration/hierarchy.py
+++ b/chimera/orchestration/hierarchy.py
@@ -48,7 +48,7 @@ from chimera.orchestration.receipts import (
 )
 from chimera.orchestration.roles import Role, RoleAgent
 from chimera.orchestration.spec import EffortBudget, ResultEnvelope, TaskSpec
-from chimera.providers.gateway import CompletionResult, Message, SupportsComplete
+from chimera.providers.gateway import CompletionResult, Message, MessageLike, SupportsComplete
 from chimera.telemetry import get_logger
 
 _log = get_logger("orchestration.hierarchy")
@@ -239,8 +239,22 @@ class HierarchicalOrchestrator:
         on_event: OrchEventSink | None = None,
         should_stop: Callable[[], bool] | None = None,
         worker_tools: Callable[[], Any] | None = None,
+        identity: str = "",
     ) -> None:
         self.gateway = gateway
+        # The owner's rendered instructions. Keyword-only with an empty default, so every existing
+        # caller and test is untouched.
+        #
+        # It reaches the two stages that answer a PERSON — the synthesizer and the single-agent
+        # fallback — and deliberately not the decomposer or the sub-workers. The decomposer must
+        # emit only a JSON array, and "always answer in Portuguese" against "reply with ONLY a JSON
+        # array" is a conflict, not a preference. The workers answer the synthesizer rather than
+        # the user, and `WORKER_SYSTEM` already dictates their form; the owner's line about how to
+        # answer would fight it, on N calls per run, for text nobody reads directly.
+        #
+        # Without this, an owner who set the app to Portuguese got English out of this screen: the
+        # same `render()` that carries the persona carries the "always answer in {language}" line.
+        self.identity = identity
         # Both keyword-only with a None default, so every existing caller and test is untouched.
         # On the constructor rather than on run(): `run_prepared`, `_dispatch` and `_run_one` all
         # need them, and threading a pair of parameters through four private signatures is a wider
@@ -803,15 +817,16 @@ class HierarchicalOrchestrator:
             "synthesizing", text=f"{len(envelopes)} summaries",
             envelopes=len(envelopes), fused=use_fusion,
         )
+        synth_system = self._owned(_SYNTH_SYSTEM)
         if fusion is not None:
             _log.debug("envelopes conflict — engaging fusion for the final synthesis")
             result = fusion.complete(
-                [Message(role="system", content=_SYNTH_SYSTEM),
+                [Message(role="system", content=synth_system),
                  Message(role="user", content=prompt)]
             )
         else:
             result = self.gateway.complete(
-                [Message(role="system", content=_SYNTH_SYSTEM),
+                [Message(role="system", content=synth_system),
                  Message(role="user", content=prompt)],
                 model=self.top_model,
             )
@@ -835,9 +850,12 @@ class HierarchicalOrchestrator:
         # Emitted from the single site every fallback passes through, so no route out of the
         # hierarchy can forget to say it happened.
         self._emit("fell_back", text=reason, shape=shape, reason=code)
-        result = self.gateway.complete(
-            [Message(role="user", content=task)], model=self.top_model
-        )
+        # This path answers the user directly, so the owner's instructions belong here even more
+        # plainly than at synthesis — and it was sending no system message at all.
+        messages: list[MessageLike] = [Message(role="user", content=task)]
+        if self.identity:
+            messages.insert(0, Message(role="system", content=self.identity))
+        result = self.gateway.complete(messages, model=self.top_model)
         tokens = (result.prompt_tokens or 0) + (result.completion_tokens or 0)
         estimated = tokens == 0
         if estimated:
@@ -921,6 +939,14 @@ class HierarchicalOrchestrator:
         accrues telemetry only (the honest gate)."""
         if self.evolution is not None:
             self.evolution.record_external(task, answer, success=bool(answer and answer.strip()))
+
+    def _owned(self, system: str) -> str:
+        """``system`` with the owner's instructions in front of it, or unchanged when there are none.
+
+        In front rather than appended: the stage prompt is the more specific instruction, and the
+        convention everywhere else in the stack is that the closer-to-the-task text comes last.
+        """
+        return f"{self.identity}\n\n{system}" if self.identity else system
 
     def _complete_top(self, system: str, user: str) -> CompletionResult:
         return self.gateway.complete(

--- a/chimera/orchestration/roles.py
+++ b/chimera/orchestration/roles.py
@@ -13,6 +13,7 @@ mix talkers and doers transparently.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 from chimera.providers.gateway import Message, SupportsComplete
 from chimera.tools.registry import ToolRegistry
@@ -53,11 +54,22 @@ class RoleAgent:
         *,
         tools: ToolRegistry | None = None,
         max_steps: int = 6,
+        identity: str = "",
+        project_root: Path | None = None,
     ) -> None:
         self.role = role
         self.backend = backend
         self.tools = tools
         self.max_steps = max_steps
+        # A crew worker's answer lands in front of the user, so the owner's instructions apply to
+        # it exactly as they do to the coding agent. This built `AgentConfig` without them, and
+        # since the same rendered block carries the "always answer in {language}" line, an owner
+        # who set the app to Portuguese got English out of the crew.
+        self.identity = identity
+        # And the project's own conventions, for the same reason: `project_root` is what makes an
+        # agent read AGENTS.md, and a crew worker editing a repo was the one worker in the stack
+        # not reading it.
+        self.project_root = project_root
 
     @property
     def name(self) -> str:
@@ -82,12 +94,19 @@ class RoleAgent:
                     max_steps=self.max_steps,
                     temperature=temperature,
                     system_prompt=self.role.system_prompt,
+                    instructions=self.identity,
+                    project_root=self.project_root,
                 ),
             )
             return agent.run(user).answer
+        system = self.role.system_prompt
+        if self.identity:
+            # In front of the role, matching the agent loop's own order: the role is the more
+            # specific instruction and reads closer to the task.
+            system = f"{self.identity}\n\n{system}"
         return self.backend.complete(
             [
-                Message(role="system", content=self.role.system_prompt),
+                Message(role="system", content=system),
                 Message(role="user", content=user),
             ],
             model=self.role.model,

--- a/tests/test_orchestration_identity.py
+++ b/tests/test_orchestration_identity.py
@@ -1,0 +1,217 @@
+"""The owner's instructions on the two surfaces that were not getting them.
+
+Settings says these are "applied to every turn, on every surface". They were applied on Code, on
+Runs and in chat — not in Orchestration, and not in Automation. Because the same rendered block
+carries the "always answer in {language}" line, the visible symptom was not a missing persona: an
+owner who had configured the app in Portuguese got English answers out of those two screens, in an
+app whose entire interface is translated into ten languages.
+
+The tests below pin where the block goes and, just as deliberately, where it must not.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from chimera.core.instructions import AgentIdentity, render
+from chimera.orchestration.artifacts import ArtifactStore
+from chimera.orchestration.envelope_verify import EnvelopeVerifier
+from chimera.orchestration.hierarchy import HierarchicalOrchestrator
+from chimera.orchestration.roles import Role, RoleAgent
+from chimera.providers.gateway import CompletionResult, Message, MessageLike
+
+WEAK, MID, TOP = "w/model:free", "m/model", "t/model"
+
+IDENTITY = render(
+    AgentIdentity(name="Quimera", language="português", instructions="Prefira respostas curtas.")
+)
+
+_DECOMPOSITION = json.dumps(
+    [
+        {"objective": "Summarize doc A", "output_format": "3 bullets", "boundaries": "doc A only"},
+        {"objective": "Summarize doc B", "output_format": "3 bullets", "boundaries": "doc B only"},
+    ]
+)
+
+_READ_TASK = (
+    "Research and compare the release notes in doc A and doc B, extract the breaking "
+    "changes from each, and summarize what upgrading requires; list the risks as well."
+)
+
+
+class _Backend:
+    """Records the system prompt of every call, which is the whole assertion surface here."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def complete(
+        self, messages: list[MessageLike], *, model: str | None = None, **kwargs: Any
+    ) -> CompletionResult:
+        first = messages[0]
+        data = first.as_dict() if isinstance(first, Message) else first
+        system = str(data.get("content", "")) if data.get("role") == "system" else ""
+        self.calls.append({"model": model, "system": system, "roles": len(messages)})
+        if "Split the user's task" in system:
+            content = _DECOMPOSITION
+        elif "Synthesize ONE final answer" in system:
+            content = "Resposta final."
+        elif "focused sub-worker" in system:
+            content = "Findings: tudo certo.\n\nGaps\n(none)"
+        else:
+            content = "resposta de agente único"
+        return CompletionResult(
+            content=content, model=model or "?", prompt_tokens=100, completion_tokens=50
+        )
+
+
+def _orchestrator(backend: _Backend, tmp_path: Path, *, identity: str) -> HierarchicalOrchestrator:
+    store = ArtifactStore(tmp_path / "artifacts")
+    return HierarchicalOrchestrator(
+        backend,
+        weak_model=WEAK,
+        mid_model=MID,
+        top_model=TOP,
+        store=store,
+        verifier=EnvelopeVerifier(store=store, backend=None, spot_rate=0.0),
+        receipts_path=tmp_path / "delegations.jsonl",
+        identity=identity,
+    )
+
+
+def _system_of(backend: _Backend, needle: str) -> str:
+    return next(c["system"] for c in backend.calls if needle in c["system"])
+
+
+# --- the hierarchy --------------------------------------------------------------------------------
+
+
+def test_the_stage_that_answers_a_person_carries_the_owners_instructions(tmp_path: Path) -> None:
+    backend = _Backend()
+
+    _orchestrator(backend, tmp_path, identity=IDENTITY).run(_READ_TASK)
+
+    synth = _system_of(backend, "Synthesize ONE final answer")
+    assert "português" in synth, "the language line is the visible half of this"
+    assert "Prefira respostas curtas." in synth
+    # In front of the stage prompt: the stage instruction is the more specific one, and the
+    # convention everywhere else in the stack is that closer-to-the-task text comes last.
+    assert synth.index("Quimera") < synth.index("Synthesize ONE final answer")
+
+
+def test_the_decomposer_is_deliberately_left_alone(tmp_path: Path) -> None:
+    """It must emit ONLY a JSON array.
+
+    "Always answer in Portuguese" against "reply with ONLY a JSON array" is a conflict, not a
+    preference, and the decomposer's output is parsed by code — no person ever reads it.
+    """
+    backend = _Backend()
+
+    _orchestrator(backend, tmp_path, identity=IDENTITY).run(_READ_TASK)
+
+    assert "português" not in _system_of(backend, "Split the user's task")
+
+
+def test_sub_workers_are_left_alone_too(tmp_path: Path) -> None:
+    """They answer the synthesizer, not the user, and `WORKER_SYSTEM` already dictates their form.
+
+    It is also byte-identical across workers on purpose — an identical prefix is a shared provider
+    cache prefix — and the owner's line about *how to answer* would fight the stage's own.
+    """
+    backend = _Backend()
+
+    _orchestrator(backend, tmp_path, identity=IDENTITY).run(_READ_TASK)
+
+    worker_calls = [c for c in backend.calls if "focused sub-worker" in c["system"]]
+    assert worker_calls, "this task must actually fan out, or the test asserts nothing"
+    assert all("português" not in c["system"] for c in worker_calls)
+
+
+def test_the_single_agent_fallback_carries_them_too(tmp_path: Path) -> None:
+    """The path that answers the user most directly was sending no system message at all."""
+    backend = _Backend()
+
+    # `simple` shape: short and single-source, so it never fans out.
+    _orchestrator(backend, tmp_path, identity=IDENTITY).run("What is the capital of France?")
+
+    assert any("português" in c["system"] for c in backend.calls)
+
+
+def test_without_an_identity_nothing_changes(tmp_path: Path) -> None:
+    """The default is "" and the behaviour on it must be byte-identical to before.
+
+    Twenty existing tests construct this orchestrator without the argument; a default that quietly
+    altered a prompt would have moved them all without anyone deciding to.
+    """
+    backend = _Backend()
+
+    _orchestrator(backend, tmp_path, identity="").run(_READ_TASK)
+
+    synth = _system_of(backend, "Synthesize ONE final answer")
+    assert synth.startswith("You are the lead orchestrator.")
+
+
+# --- the crew -------------------------------------------------------------------------------------
+
+
+def test_a_crew_role_carries_the_owners_instructions() -> None:
+    """A crew worker's answer lands in front of the user, so the same rule applies to it."""
+    backend = _Backend()
+
+    RoleAgent(Role("writer", "You write the final answer."), backend, identity=IDENTITY).act("faça")
+
+    system = backend.calls[0]["system"]
+    assert "português" in system
+    assert system.index("Quimera") < system.index("You write the final answer.")
+
+
+def test_a_crew_role_without_an_identity_sends_only_its_role() -> None:
+    backend = _Backend()
+
+    RoleAgent(Role("writer", "You write the final answer."), backend).act("faça")
+
+    assert backend.calls[0]["system"] == "You write the final answer."
+
+
+def test_a_tool_using_crew_role_carries_them_through_AgentConfig() -> None:
+    """The path the real crew takes.
+
+    `IsolatedCrew` always passes `tools=`, so a role with no tools is not the configuration that
+    ships. Asserting only on the tool-free branch let a sabotaged `AgentConfig(instructions=...)`
+    pass this file — which is how this test came to exist.
+    """
+    from chimera.tools.registry import ToolRegistry
+
+    backend = _Backend()
+
+    RoleAgent(
+        Role("writer", "You write the final answer."),
+        backend,
+        tools=ToolRegistry(),
+        identity=IDENTITY,
+    ).act("faça")
+
+    assert any("português" in c["system"] for c in backend.calls)
+
+
+def test_a_tool_using_crew_role_reads_the_projects_conventions(tmp_path: Path) -> None:
+    """`project_root` is what makes an agent read AGENTS.md, and this was the one worker without it.
+
+    Invisible until a screen put a crew in front of a real repository: the workers that edit files
+    were the only ones in the stack ignoring the file that says how this repository wants edits.
+    """
+    from chimera.tools.registry import ToolRegistry
+
+    (tmp_path / "AGENTS.md").write_text("Sempre use aspas simples.", encoding="utf-8")
+    backend = _Backend()
+
+    RoleAgent(
+        Role("writer", "You write the final answer."),
+        backend,
+        tools=ToolRegistry(),
+        project_root=tmp_path,
+    ).act("faça")
+
+    assert any("aspas simples" in c["system"] for c in backend.calls)


### PR DESCRIPTION
## O sintoma

Configurações promete que as instruções do dono são "aplicadas a todo turno, **em toda superfície**". Chegavam em Código, Runs e chat. **Não chegavam em Orquestração nem em Automação** — as duas no rail de navegação.

E o sintoma visível não era persona faltando. O `render()` põe a linha *"sempre responda em {idioma}, seja qual for o idioma da pergunta, do código, dos logs ou das mensagens de erro"* dentro do **mesmo bloco**. Então essas duas telas respondiam em inglês para um dono rodando um app cuja interface inteira está traduzida em dez idiomas.

## Onde passa a ir — e onde deliberadamente não vai

| vai | por quê |
|---|---|
| sintetizador da hierarquia | é o estágio que responde a uma **pessoa** |
| fallback de agente único | responde ainda mais diretamente — e não mandava system message nenhuma |
| todo papel de crew | a resposta do worker aparece na frente do usuário |
| job de cron | também reporta a uma pessoa: Discord, log, app |

| **não** vai | por quê |
|---|---|
| decompositor | tem de emitir **só** um array JSON. "Sempre responda em português" contra "responda APENAS com um array JSON" é conflito, não preferência — e ninguém lê a saída dele |
| sub-workers | respondem ao sintetizador, o `WORKER_SYSTEM` já dita a forma deles, e aquele prompt é **byte-idêntico** entre workers de propósito: prefixo idêntico = prefixo de cache compartilhado no provedor |

## Junto no mesmo conserto

`project_root` vai para os papéis de crew, pela mesma razão: é o que faz um agente ler o AGENTS.md, e **os workers que de fato editam um repositório eram os únicos do stack ignorando o arquivo que diz como aquele repositório quer as edições.** Cada um recebe o próprio worktree, não o original.

## Compatibilidade

Todo parâmetro novo é keyword-only com default vazio, então os vinte testes de hierarquia existentes ficam intocados — e **um dos testes novos prende exatamente isso**.

Dois dos testes existem porque a primeira rodada de sabotagem só deixou um vermelho: a asserção do crew estava cobrindo o ramo **sem** ferramentas, que não é a configuração que o `IsolatedCrew` usa.

Suíte: **3.646 passed** · mypy limpo · ruff limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)