### PR TITLE
fix(memory): two Settings toggles that fired nothing from the app

### DIFF
--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -264,7 +264,13 @@ const STOP_REASONS: Record<string, string> = {
   cancelled: "code.chat.stopped.cancelled",
 };
 
-function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
+/** The badges under a finished turn.
+ *
+ *  Exported for its own test rather than reached through `Conversation`: every badge here encodes a
+ *  distinction that is invisible if it renders wrong — "0 facts recalled" against "we did not look",
+ *  a saved memory against none, an unknown cost against a free one. Those are exactly the claims
+ *  this file exists to keep honest, so they are worth asserting directly. */
+export function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
   // `stopped_reason` arrives on every `done` frame and, outside types and mocks, nothing read it.
   // So a turn that hit the step ceiling and stopped mid-task was pixel-for-pixel identical to one
   // that finished the work — the receipt drew nine badges and not the one that says whether to
@@ -326,6 +332,16 @@ function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
             n: done.memory_facts_used,
             layer: done.memory_layer ?? "",
           })}
+        </Badge>
+      ) : null}
+      {/* A durable fact was written. Shown because it outlives this conversation: it will be
+          recalled into every future one, and a change with that reach should not happen in
+          silence. The fact itself is in the title, not the badge — memory can hold a paragraph. */}
+      {done.memory_saved ? (
+        <Badge tone="ok" title={done.memory_saved}>
+          {done.memory_consolidated
+            ? t("code.chat.rememberedTidied", { n: done.memory_consolidated })
+            : t("code.chat.remembered")}
         </Badge>
       ) : null}
       {done.tainted ? (

--- a/apps/desktop/src/components/code/TurnReceipt.test.tsx
+++ b/apps/desktop/src/components/code/TurnReceipt.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { TurnReceipt } from "@/components/code/Conversation";
+import type { CodeTurnDone } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+/**
+ * What a finished turn says it did — and, more to the point, what it must not say.
+ *
+ * Two Settings toggles used to fire nothing at all from this app: an explicit "remember that…" went
+ * to a route no screen calls, and "Tidy memory" was read only inside the CLI's own REPL loop. Now
+ * both happen on the coding turn, which means a conversation can silently change what the agent
+ * knows in every FUTURE conversation. A change with that reach gets a badge.
+ */
+const BASE: CodeTurnDone = {
+  answer: "ok",
+  steps: 1,
+  stopped_reason: "final",
+  tool_names: [],
+  model: "m",
+  prompt_tokens: 10,
+  completion_tokens: 5,
+  usd: 0.001,
+  route_meta: null,
+  context_peak_tokens: 0,
+};
+
+function receipt(extra: Partial<CodeTurnDone>) {
+  renderWithProviders(<TurnReceipt done={{ ...BASE, ...extra }} t={(k) => k} />);
+}
+
+describe("the turn receipt", () => {
+  it("says a durable fact was saved", () => {
+    receipt({ memory_saved: "meu voo é dia 12" });
+
+    expect(screen.getByText("code.chat.remembered")).toBeInTheDocument();
+  });
+
+  it("carries the fact itself, because memory can hold a sentence a chip cannot", () => {
+    receipt({ memory_saved: "meu voo é dia 12" });
+
+    expect(screen.getByTitle("meu voo é dia 12")).toBeInTheDocument();
+  });
+
+  it("says how many were merged when tidying ran", () => {
+    receipt({ memory_saved: "x", memory_consolidated: 3 });
+
+    expect(screen.getByText("code.chat.rememberedTidied")).toBeInTheDocument();
+    expect(screen.queryByText("code.chat.remembered")).not.toBeInTheDocument();
+  });
+
+  it("stays quiet on a turn that saved nothing", () => {
+    // The failure worth guarding: a badge that always renders would tell a user their words are
+    // being written down on every turn, which is the one thing this narrow write is not doing.
+    receipt({ memory_consolidated: 0 });
+
+    expect(screen.queryByText("code.chat.remembered")).not.toBeInTheDocument();
+    expect(screen.queryByText("code.chat.rememberedTidied")).not.toBeInTheDocument();
+  });
+
+  it("does not report a count as a save", () => {
+    receipt({ memory_saved: null, memory_consolidated: 4 });
+
+    expect(screen.queryByText("code.chat.rememberedTidied")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/ui/panel.tsx
+++ b/apps/desktop/src/components/ui/panel.tsx
@@ -55,9 +55,23 @@ const tones: Record<Tone, string> = {
   accent: "bg-accent/15 text-accent ring-1 ring-accent/25",
 };
 
-export function Badge({ tone = "muted", children }: { tone?: Tone; children: ReactNode }) {
+export function Badge({
+  tone = "muted",
+  title,
+  children,
+}: {
+  tone?: Tone;
+  /** The long form of what the badge names — a saved fact, a full model slug. A badge is a chip and
+   *  the thing it stands for is often a sentence; without this the only way to read it is to go and
+   *  find it somewhere else. */
+  title?: string;
+  children: ReactNode;
+}) {
   return (
-    <span className={cn("rounded-chip px-2 py-0.5 text-xs font-medium", tones[tone])}>
+    <span
+      className={cn("rounded-chip px-2 py-0.5 text-xs font-medium", tones[tone])}
+      title={title}
+    >
       {children}
     </span>
   );

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -851,6 +851,13 @@ export interface CodeTurnDone {
    *  Never guessed: a layer that returned nothing is not named. */
   memory_facts_used?: number;
   memory_layer?: string | null;
+  /** The durable fact this turn SAVED, from an explicit "remember that…" the user typed, or null.
+   *  Reported rather than silent: a fact saved without a word changes every future conversation,
+   *  and the person who caused it never saw it happen. */
+  memory_saved?: string | null;
+  /** Redundant facts merged away after that write, when "Tidy memory" is on. Zero while memory is
+   *  under its budget — which is most of the time, and costs no model call to establish. */
+  memory_consolidated?: number;
   /** This turn went through the fusion panel and therefore could NOT use tools — it answered from
    *  the prompt alone. Zero tool calls is the same number a turn that needed none reports, so
    *  without this flag the two are indistinguishable. */

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -295,7 +295,7 @@ const en: Dict = {
   "settings.hint.fallbackModels": "tried in order when the primary errors",
   "settings.row.autoConsolidate": "Tidy memory",
   "settings.hint.autoConsolidate":
-    "merge near-duplicate facts at the end of a session",
+    "after a fact is saved, merge near-duplicates once memory outgrows its budget",
   "settings.row.skillCards": "Use what it learned",
   "settings.hint.skillCards":
     "a learned skill is read back when it matches the task — off, the agent writes skills it never reads",
@@ -313,7 +313,7 @@ const en: Dict = {
   "settings.hint.embedModel": "what makes semantic recall work at all",
   "settings.row.rememberChat": "Remember from chat",
   "settings.hint.rememberChat":
-    'an explicit "remember that…" saves a durable fact',
+    "an explicit \"remember that…\" in a conversation saves a durable fact",
   "settings.card.messaging": "Messaging",
   "settings.row.botToken": "{platform} bot token",
   "settings.hint.botToken": "so the agent can reach you on {platform}",
@@ -351,7 +351,7 @@ const en: Dict = {
   "memory.layers.semanticOff":
     "Semantic embeddings layer is off (opt-in) — these are per-kind fact counts, not a vector index.",
   "memory.layers.empty":
-    'Memory fills from a manual "Add Fact", from the CLI (solve / consolidation) sharing this home, or — with "Remember from chat" on in Settings — from an explicit "remember that…" in a conversation.',
+    "Memory fills from a manual \"Add Fact\", from the CLI (solve / consolidation) sharing this home, or — with \"Remember from chat\" on in Settings — from an explicit \"remember that…\" in a conversation.",
   "skills.title": "Skills",
   "catalog.title": "Skills you can install",
   "catalog.subtitle": "{n} available · {installed} installed here",
@@ -747,6 +747,8 @@ const en: Dict = {
   "code.chat.unknownCost": "price unknown",
   "code.chat.recalled": "{n} recalled ({layer})",
   "code.chat.tainted": "read untrusted content",
+  "code.chat.remembered": "saved to memory",
+  "code.chat.rememberedTidied": "saved to memory · {n} merged",
   "code.chat.verdict.passed": "Checked with `{{cmd}}` ({{src}}): passed.",
   "code.batch.proposal":
     "This reads as {n} separate jobs. Run them at the same time, each in its own git worktree?",
@@ -1407,7 +1409,7 @@ const pt: Dict = {
   "settings.hint.fallbackModels": "tentados em ordem quando o primário falha",
   "settings.row.autoConsolidate": "Arrumar a memória",
   "settings.hint.autoConsolidate":
-    "funde fatos quase duplicados ao fim de uma sessão",
+    "depois de guardar um fato, funde quase duplicados quando a memória passa do orçamento",
   "settings.row.skillCards": "Usar o que aprendeu",
   "settings.hint.skillCards":
     "uma skill aprendida volta a ser lida quando casa com a tarefa — desligado, o agente escreve skills que nunca lê",
@@ -1425,7 +1427,7 @@ const pt: Dict = {
   "settings.hint.embedModel": "é ele que faz o recall semântico funcionar",
   "settings.row.rememberChat": "Lembrar do chat",
   "settings.hint.rememberChat":
-    'um "lembre que…" explícito grava um fato duradouro',
+    "um \"lembre que…\" explícito numa conversa guarda um fato durável",
   "settings.card.messaging": "Mensageria",
   "settings.row.botToken": "Token do bot do {platform}",
   "settings.hint.botToken": "para o agente te alcançar no {platform}",
@@ -1464,7 +1466,7 @@ const pt: Dict = {
   "memory.layers.semanticOff":
     "Camada de embeddings semânticos desativada (opt-in) — os números são por tipo de fato, não um índice vetorial.",
   "memory.layers.empty":
-    'A memória é preenchida por um "Adicionar um fato" manual, pela CLI (solve / consolidação) que compartilha este home, ou — com "Lembrar do chat" ativo nas Configurações — por um "lembre que…" explícito numa conversa.',
+    "A memória se enche por um \"Adicionar fato\" manual, pela CLI (solve / consolidação) compartilhando este home, ou — com \"Lembrar do chat\" ligado em Configurações — por um \"lembre que…\" explícito numa conversa.",
   "skills.title": "Habilidades",
   "catalog.title": "Habilidades que você pode instalar",
   "catalog.subtitle": "{n} disponíveis · {installed} instaladas aqui",
@@ -1866,6 +1868,8 @@ const pt: Dict = {
   "code.chat.unknownCost": "preço desconhecido",
   "code.chat.recalled": "{n} lembrados ({layer})",
   "code.chat.tainted": "leu conteúdo não confiável",
+  "code.chat.remembered": "guardado na memória",
+  "code.chat.rememberedTidied": "guardado na memória · {n} fundidos",
   "code.chat.verdict.passed": "Verificado com `{{cmd}}` ({{src}}): passou.",
   "code.batch.proposal":
     "Isto se lê como {n} trabalhos separados. Rodar ao mesmo tempo, cada um no seu worktree do git?",
@@ -2298,7 +2302,7 @@ const es: Dict = {
     "No ha vuelto por sí solo. Cierra Chimera y ábrelo otra vez: lo último que dijo el backend queda en un informe dentro de la carpeta de datos de la aplicación.",
   "settings.row.rememberChat": "Recordar desde el chat",
   "settings.hint.rememberChat":
-    'un "recuerda que…" explícito guarda un hecho duradero',
+    "un \"recuerda que…\" explícito en una conversación guarda un dato duradero",
   "settings.card.messaging": "Mensajería",
   "settings.row.botToken": "Token del bot de {platform}",
   "settings.hint.botToken":
@@ -2560,7 +2564,7 @@ const es: Dict = {
     "se prueban en orden cuando el principal falla",
   "settings.row.autoConsolidate": "Ordenar la memoria",
   "settings.hint.autoConsolidate":
-    "fusiona hechos casi duplicados al final de una sesión",
+    "tras guardar un dato, fusiona casi duplicados cuando la memoria supera su presupuesto",
   "settings.row.skillCards": "Usar lo aprendido",
   "settings.hint.skillCards":
     "una habilidad aprendida se relee cuando encaja con la tarea — apagado, el agente escribe habilidades que nunca lee",
@@ -2607,7 +2611,7 @@ const es: Dict = {
   "memory.layers.semanticOff":
     "La capa de embeddings semánticos está desactivada (opcional) — son recuentos por tipo de hecho, no un índice vectorial.",
   "memory.layers.empty":
-    'La memoria se llena con un "Añadir un hecho" manual o desde la CLI (solve / consolidación) que comparten este home — el chat de escritorio en sí no escribe memoria duradera.',
+    "La memoria se llena con un \"Añadir dato\" manual, desde la CLI (solve / consolidación) que comparte este home, o —con \"Recordar del chat\" activado en Ajustes— con un \"recuerda que…\" explícito en una conversación.",
   "skills.title": "Habilidades",
   "catalog.title": "Habilidades que puedes instalar",
   "catalog.subtitle": "{n} disponibles · {installed} instaladas aquí",
@@ -2997,6 +3001,8 @@ const es: Dict = {
   "code.chat.unknownCost": "precio desconocido",
   "code.chat.recalled": "{n} recordados ({layer})",
   "code.chat.tainted": "leyó contenido no confiable",
+  "code.chat.remembered": "guardado en la memoria",
+  "code.chat.rememberedTidied": "guardado en la memoria · {n} fusionados",
   "code.chat.verdict.passed": "Comprobado con `{{cmd}}` ({{src}}): pasó.",
   "code.batch.proposal":
     "Esto se lee como {n} trabajos separados. ¿Ejecutarlos a la vez, cada uno en su propio worktree de git?",
@@ -3433,7 +3439,7 @@ const fr: Dict = {
     "Il n'est pas revenu tout seul. Fermez Chimera puis rouvrez-le — ce que le backend a dit en dernier est consigné dans un rapport, dans le dossier de données de l'application.",
   "settings.row.rememberChat": "Mémoriser depuis le chat",
   "settings.hint.rememberChat":
-    "un « retiens que… » explicite enregistre un fait durable",
+    "un « retiens que… » explicite dans une conversation enregistre un fait durable",
   "settings.card.messaging": "Messagerie",
   "settings.row.botToken": "Jeton du bot {platform}",
   "settings.hint.botToken":
@@ -3698,7 +3704,7 @@ const fr: Dict = {
     "essayés dans l'ordre quand le principal échoue",
   "settings.row.autoConsolidate": "Ranger la mémoire",
   "settings.hint.autoConsolidate":
-    "fusionne les faits quasi identiques en fin de session",
+    "après l'enregistrement d'un fait, fusionne les quasi-doublons dès que la mémoire dépasse son budget",
   "settings.row.skillCards": "Utiliser ce qu'il a appris",
   "settings.hint.skillCards":
     "une compétence apprise est relue quand elle correspond à la tâche — désactivé, l'agent écrit des compétences qu'il ne lit jamais",
@@ -3746,7 +3752,7 @@ const fr: Dict = {
   "memory.layers.semanticOff":
     "La couche d'embeddings sémantiques est désactivée (optionnelle) — ce sont des comptes par type de fait, pas un index vectoriel.",
   "memory.layers.empty":
-    "La mémoire se remplit via un « Ajouter un fait » manuel ou depuis la CLI (solve / consolidation) qui partagent ce home — le chat de bureau lui-même n'écrit pas de mémoire durable.",
+    "La mémoire se remplit par un « Ajouter un fait » manuel, par la CLI (solve / consolidation) partageant ce dossier, ou — avec « Retenir depuis le chat » activé dans les Réglages — par un « retiens que… » explicite dans une conversation.",
   "skills.title": "Compétences",
   "catalog.title": "Compétences que vous pouvez installer",
   "catalog.subtitle": "{n} disponibles · {installed} installées ici",
@@ -4142,6 +4148,8 @@ const fr: Dict = {
   "code.chat.unknownCost": "prix inconnu",
   "code.chat.recalled": "{n} rappelés ({layer})",
   "code.chat.tainted": "a lu du contenu non fiable",
+  "code.chat.remembered": "gardé en mémoire",
+  "code.chat.rememberedTidied": "gardé en mémoire · {n} fusionnés",
   "code.chat.verdict.passed": "Vérifié avec `{{cmd}}` ({{src}}) : réussi.",
   "code.batch.proposal":
     "Cela se lit comme {n} travaux distincts. Les lancer en même temps, chacun dans son propre worktree git ?",
@@ -4581,7 +4589,7 @@ const de: Dict = {
     "Es ist nicht von selbst zurückgekommen. Schließen Sie Chimera und öffnen Sie es erneut — was das Backend zuletzt gesagt hat, steht in einem Bericht im Datenordner der App.",
   "settings.row.rememberChat": "Aus dem Chat merken",
   "settings.hint.rememberChat":
-    'ein ausdrückliches "merk dir, dass…" speichert einen dauerhaften Fakt',
+    "ein ausdrückliches „merke dir, dass …“ im Gespräch speichert einen dauerhaften Fakt",
   "settings.card.messaging": "Messaging",
   "settings.row.botToken": "{platform}-Bot-Token",
   "settings.hint.botToken":
@@ -4845,7 +4853,7 @@ const de: Dict = {
     "der Reihe nach versucht, wenn das primäre fehlschlägt",
   "settings.row.autoConsolidate": "Gedächtnis aufräumen",
   "settings.hint.autoConsolidate":
-    "führt fast doppelte Fakten am Sitzungsende zusammen",
+    "nach dem Speichern eines Fakts Beinahe-Duplikate zusammenführen, sobald das Gedächtnis sein Budget übersteigt",
   "settings.row.skillCards": "Gelerntes nutzen",
   "settings.hint.skillCards":
     "eine gelernte Fähigkeit wird wieder gelesen, wenn sie zur Aufgabe passt — aus schreibt der Agent Fähigkeiten, die er nie liest",
@@ -4893,7 +4901,7 @@ const de: Dict = {
   "memory.layers.semanticOff":
     "Die semantische Embedding-Ebene ist aus (optional) — dies sind Faktenzahlen pro Typ, kein Vektorindex.",
   "memory.layers.empty":
-    "Der Speicher füllt sich über ein manuelles „Fakt hinzufügen“ oder über die CLI (solve / Konsolidierung), die dasselbe Home teilen — der Desktop-Chat selbst schreibt keinen dauerhaften Speicher.",
+    "Das Gedächtnis füllt sich durch ein manuelles „Fakt hinzufügen“, über die CLI (solve / Konsolidierung) im selben Home oder — mit aktiviertem „Aus dem Chat merken“ in den Einstellungen — durch ein ausdrückliches „merke dir, dass …“ im Gespräch.",
   "skills.title": "Fähigkeiten",
   "catalog.title": "Fähigkeiten zum Installieren",
   "catalog.subtitle": "{n} verfügbar · {installed} hier installiert",
@@ -5286,6 +5294,8 @@ const de: Dict = {
   "code.chat.unknownCost": "Preis unbekannt",
   "code.chat.recalled": "{n} erinnert ({layer})",
   "code.chat.tainted": "las nicht vertrauenswürdige Inhalte",
+  "code.chat.remembered": "im Gedächtnis gespeichert",
+  "code.chat.rememberedTidied": "im Gedächtnis gespeichert · {n} zusammengeführt",
   "code.chat.verdict.passed": "Geprüft mit `{{cmd}}` ({{src}}): bestanden.",
   "code.batch.proposal":
     "Das liest sich wie {n} getrennte Aufgaben. Gleichzeitig ausführen, jede in ihrem eigenen Git-Worktree?",
@@ -5723,7 +5733,8 @@ const zh: Dict = {
   "app.backendStillDown":
     "它没有自行恢复。请关闭 Chimera 再重新打开——后端最后说的话会写入应用数据文件夹里的一份报告。",
   "settings.row.rememberChat": "从聊天中记住",
-  "settings.hint.rememberChat": "明确说出“记住……”会保存一条持久事实",
+  "settings.hint.rememberChat":
+    "在对话里明确说“记住……”会保存一条长期记忆",
   "settings.card.messaging": "消息平台",
   "settings.row.botToken": "{platform} 机器人令牌",
   "settings.hint.botToken": "这样智能体就能在 {platform} 上找到你",
@@ -5962,7 +5973,8 @@ const zh: Dict = {
   "settings.row.fallbackModels": "备用模型",
   "settings.hint.fallbackModels": "主模型出错时按顺序尝试",
   "settings.row.autoConsolidate": "整理记忆",
-  "settings.hint.autoConsolidate": "会话结束时合并近乎重复的事实",
+  "settings.hint.autoConsolidate":
+    "保存一条记忆后，若记忆超出预算就合并近似重复项",
   "settings.row.skillCards": "用上学到的东西",
   "settings.hint.skillCards":
     "学到的技能在与任务匹配时会被重新读取——关闭时，智能体只写技能、从不回读",
@@ -6007,7 +6019,7 @@ const zh: Dict = {
   "memory.layers.semanticOff":
     "语义嵌入层已关闭（需手动开启）——这些是按类型统计的事实数量，而非向量索引。",
   "memory.layers.empty":
-    "记忆通过手动“添加事实”或共享同一 home 的 CLI（solve／整合）填充——桌面聊天本身不会写入持久记忆。",
+    "记忆可以来自手动“添加事实”、来自共用同一 home 的命令行（solve / 合并），或者在设置里打开“从对话中记忆”后，来自对话里明确的“记住……”。",
   "skills.title": "技能",
   "catalog.title": "可以安装的技能",
   "catalog.subtitle": "{n} 个可用 · 本机已安装 {installed} 个",
@@ -6371,6 +6383,8 @@ const zh: Dict = {
   "code.chat.unknownCost": "价格未知",
   "code.chat.recalled": "回忆 {n} 条（{layer}）",
   "code.chat.tainted": "读取了不可信内容",
+  "code.chat.remembered": "已存入记忆",
+  "code.chat.rememberedTidied": "已存入记忆 · 合并 {n} 条",
   "code.chat.verdict.passed": "用 `{{cmd}}`（{{src}}）检查：通过。",
   "code.batch.proposal":
     "这看起来是 {n} 件独立的活。要同时跑吗？每件各用一个 git worktree。",
@@ -6789,7 +6803,7 @@ const ja: Dict = {
     "自力では戻りませんでした。Chimera を閉じて開き直してください。バックエンドが最後に残した言葉は、アプリのデータフォルダー内のレポートに書かれています。",
   "settings.row.rememberChat": "チャットから記憶する",
   "settings.hint.rememberChat":
-    "明示的な「〜を覚えて」で永続的な事実を保存します",
+    "会話のなかで明示的に「覚えておいて…」と言うと永続的な事実として保存します",
   "settings.card.messaging": "メッセージング",
   "settings.row.botToken": "{platform} ボットトークン",
   "settings.hint.botToken":
@@ -7048,7 +7062,7 @@ const ja: Dict = {
   "settings.hint.fallbackModels": "主モデルが失敗したら順に試します",
   "settings.row.autoConsolidate": "記憶を整理",
   "settings.hint.autoConsolidate":
-    "セッション終了時にほぼ重複した事実をまとめます",
+    "事実を保存したあと、記憶が予算を超えたら重複に近いものを統合します",
   "settings.row.skillCards": "学んだことを使う",
   "settings.hint.skillCards":
     "学習したスキルはタスクに合えば読み戻されます — オフだと、書くだけで一度も読みません",
@@ -7094,7 +7108,7 @@ const ja: Dict = {
   "memory.layers.semanticOff":
     "セマンティック埋め込みレイヤーは無効です（オプトイン）— これは種類別の事実数であり、ベクトルインデックスではありません。",
   "memory.layers.empty":
-    "メモリは手動の「事実を追加」または同じ home を共有する CLI（solve／統合）から満たされます — デスクトップのチャット自体は永続的なメモリを書き込みません。",
+    "記憶は手動の「事実を追加」、同じ home を共有する CLI（solve / 統合）、または設定で「会話から記憶する」を有効にしたうえでの会話中の明示的な「覚えておいて…」から増えます。",
   "skills.title": "スキル",
   "catalog.title": "インストールできるスキル",
   "catalog.subtitle": "{n} 件が利用可能 · このマシンに {installed} 件",
@@ -7481,6 +7495,8 @@ const ja: Dict = {
   "code.chat.unknownCost": "価格不明",
   "code.chat.recalled": "{n} 件を想起（{layer}）",
   "code.chat.tainted": "信頼できない内容を読みました",
+  "code.chat.remembered": "記憶に保存しました",
+  "code.chat.rememberedTidied": "記憶に保存しました · {n} 件を統合",
   "code.chat.verdict.passed": "`{{cmd}}`（{{src}}）で検証：合格。",
   "code.batch.proposal":
     "これは {n} 件の別々の仕事に読めます。それぞれ自前の git worktree で同時に走らせますか？",
@@ -8152,7 +8168,7 @@ const it: Dict = {
     "provati in ordine quando il primario fallisce",
   "settings.row.autoConsolidate": "Riordina la memoria",
   "settings.hint.autoConsolidate":
-    "unisce fatti quasi duplicati a fine sessione",
+    "dopo aver salvato un fatto, unisce i quasi-duplicati quando la memoria supera il suo budget",
   "settings.row.skillCards": "Usa ciò che ha imparato",
   "settings.hint.skillCards":
     "una skill appresa viene riletta quando combacia con il compito — spento, l'agente scrive skill che non legge mai",
@@ -8170,7 +8186,7 @@ const it: Dict = {
   "settings.hint.embedModel": "è ciò che fa funzionare il richiamo semantico",
   "settings.row.rememberChat": "Ricorda dalla chat",
   "settings.hint.rememberChat":
-    'un esplicito "ricorda che…" salva un fatto duraturo',
+    "un \"ricorda che…\" esplicito in una conversazione salva un fatto duraturo",
   "settings.card.messaging": "Messaggistica",
   "settings.row.botToken": "Token del bot {platform}",
   "settings.hint.botToken": "così l'agente può raggiungerti su {platform}",
@@ -8210,7 +8226,7 @@ const it: Dict = {
   "memory.layers.semanticOff":
     "Il livello degli embedding semantici è spento (opt-in) — questi sono conteggi di fatti per tipo, non un indice vettoriale.",
   "memory.layers.empty":
-    'La memoria si riempie da un "Aggiungi fatto" manuale, dalla CLI (solve / consolidamento) che condivide questa home, oppure — con "Ricorda dalla chat" attivo nelle Impostazioni — da un esplicito "ricorda che…" in una conversazione.',
+    "La memoria si riempie con un \"Aggiungi fatto\" manuale, dalla CLI (solve / consolidamento) che condivide questa home, oppure — con \"Ricorda dalla chat\" attivo nelle Impostazioni — da un \"ricorda che…\" esplicito in una conversazione.",
   "skills.title": "Skill",
   "catalog.title": "Abilità che puoi installare",
   "catalog.subtitle": "{n} disponibili · {installed} installate qui",
@@ -8616,6 +8632,8 @@ const it: Dict = {
   "code.chat.unknownCost": "prezzo sconosciuto",
   "code.chat.recalled": "{n} richiamati ({layer})",
   "code.chat.tainted": "ha letto contenuti non attendibili",
+  "code.chat.remembered": "salvato in memoria",
+  "code.chat.rememberedTidied": "salvato in memoria · {n} uniti",
   "code.chat.verdict.passed": "Verificato con `{{cmd}}` ({{src}}): passato.",
   "code.batch.proposal":
     "Questo si legge come {n} lavori separati. Eseguirli insieme, ciascuno nel proprio worktree git?",
@@ -9290,7 +9308,7 @@ const pl: Dict = {
   "settings.hint.fallbackModels": "próbowane po kolei, gdy główny zawiedzie",
   "settings.row.autoConsolidate": "Uporządkuj pamięć",
   "settings.hint.autoConsolidate":
-    "scala niemal identyczne fakty na koniec sesji",
+    "po zapisaniu faktu scala niemal duplikaty, gdy pamięć przekroczy swój budżet",
   "settings.row.skillCards": "Korzystaj z tego, czego się nauczył",
   "settings.hint.skillCards":
     "wyuczona umiejętność jest odczytywana, gdy pasuje do zadania — wyłączone, agent pisze umiejętności, których nigdy nie czyta",
@@ -9309,7 +9327,7 @@ const pl: Dict = {
     "to od niego zależy, czy wyszukiwanie semantyczne działa",
   "settings.row.rememberChat": "Zapamiętuj z czatu",
   "settings.hint.rememberChat":
-    'wyraźne „zapamiętaj, że…" zapisuje trwały fakt',
+    "wyraźne „zapamiętaj, że…” w rozmowie zapisuje trwały fakt",
   "settings.card.messaging": "Komunikatory",
   "settings.row.botToken": "Token bota {platform}",
   "settings.hint.botToken":
@@ -9349,7 +9367,7 @@ const pl: Dict = {
   "memory.layers.semanticOff":
     "Warstwa embeddingów semantycznych jest wyłączona (opcjonalna) — to są liczby faktów według rodzaju, a nie indeks wektorowy.",
   "memory.layers.empty":
-    'Pamięć zapełnia się z ręcznego „Dodaj fakt", z CLI (solve / konsolidacja) dzielącego ten sam katalog domowy, albo — przy włączonym „Zapamiętuj z czatu" w Ustawieniach — z wyraźnego „zapamiętaj, że…" w rozmowie.',
+    "Pamięć zapełnia się przez ręczne „Dodaj fakt”, przez CLI (solve / konsolidacja) w tym samym katalogu domowym albo — przy włączonym „Zapamiętuj z czatu” w Ustawieniach — przez wyraźne „zapamiętaj, że…” w rozmowie.",
   "skills.title": "Umiejętności",
   "catalog.title": "Umiejętności, które możesz zainstalować",
   "catalog.subtitle": "{n} dostępnych · {installed} zainstalowanych tutaj",
@@ -9750,6 +9768,8 @@ const pl: Dict = {
   "code.chat.unknownCost": "cena nieznana",
   "code.chat.recalled": "{n} przypomnianych ({layer})",
   "code.chat.tainted": "przeczytał niezaufaną treść",
+  "code.chat.remembered": "zapisane w pamięci",
+  "code.chat.rememberedTidied": "zapisane w pamięci · scalono {n}",
   "code.chat.verdict.passed": "Sprawdzone przez `{{cmd}}` ({{src}}): zdane.",
   "code.batch.proposal":
     "To czyta się jak {n} osobnych zadań. Uruchomić je naraz, każde w swoim worktree gita?",
@@ -10425,7 +10445,7 @@ const ru: Dict = {
     "пробуются по порядку, когда основная даёт ошибку",
   "settings.row.autoConsolidate": "Прибирать память",
   "settings.hint.autoConsolidate":
-    "объединять почти одинаковые факты в конце сессии",
+    "после сохранения факта объединяет почти-дубликаты, когда память выходит за бюджет",
   "settings.row.skillCards": "Использовать усвоенное",
   "settings.hint.skillCards":
     "усвоенный навык считывается обратно, когда подходит к задаче — при выключенном агент пишет навыки, которые никогда не читает",
@@ -10444,7 +10464,7 @@ const ru: Dict = {
   "settings.hint.embedModel": "то, без чего смысловой поиск вообще не работает",
   "settings.row.rememberChat": "Запоминать из чата",
   "settings.hint.rememberChat":
-    "явное «запомни, что…» сохраняет долговременный факт",
+    "явное «запомни, что…» в разговоре сохраняет долговременный факт",
   "settings.card.messaging": "Мессенджеры",
   "settings.row.botToken": "Токен бота {platform}",
   "settings.hint.botToken": "чтобы агент мог связаться с вами в {platform}",
@@ -10482,7 +10502,7 @@ const ru: Dict = {
   "memory.layers.semanticOff":
     "Слой смысловых векторов выключен (включается по желанию) — это количество фактов по видам, а не векторный индекс.",
   "memory.layers.empty":
-    "Память наполняется вручную через «Добавить факт», из командной строки (solve / консолидация), использующей тот же каталог, или — при включённом «Запоминать из чата» в настройках — из явного «запомни, что…» в разговоре.",
+    "Память наполняется вручную через «Добавить факт», из CLI (solve / консолидация) с тем же домашним каталогом или — при включённом «Запоминать из чата» в настройках — из явного «запомни, что…» в разговоре.",
   "skills.title": "Навыки",
   "catalog.title": "Навыки, которые можно установить",
   "catalog.subtitle": "{n} доступно · {installed} установлено здесь",
@@ -10885,6 +10905,8 @@ const ru: Dict = {
   "code.chat.unknownCost": "цена неизвестна",
   "code.chat.recalled": "вспомнено: {n} ({layer})",
   "code.chat.tainted": "прочитано недоверенное содержимое",
+  "code.chat.remembered": "сохранено в память",
+  "code.chat.rememberedTidied": "сохранено в память · объединено: {n}",
   "code.chat.verdict.passed":
     "Проверено командой `{{cmd}}` ({{src}}): пройдено.",
   "code.batch.proposal":

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -602,6 +602,56 @@ def _log_usage(payload: dict[str, Any], session_id: str, settings: Settings) -> 
         _log.debug("usage logging skipped: %s", exc)
 
 
+def _remember_and_tidy(message: str, memory: Any, settings: Settings) -> tuple[str | None, int]:
+    """Honour an explicit "remember that…" from the user's own message, then tidy if asked.
+
+    Two Settings toggles fired nothing from the app before this. "Remember from chat" was real and
+    correctly gated — but reachable only from ``/api/chat/stream``, and the desktop's ``streamChat``
+    has no callers: every conversation in the app goes through ``/api/code/turn``. "Tidy memory" was
+    read only inside the CLI REPL's own loop, so it did nothing unless the same person also ran
+    ``chimera chat`` against the same home.
+
+    They belong together and they belong here. Memory only grows when something is written, so the
+    moment after a write is exactly when tidying is worth checking — and ``autoconsolidate`` returns
+    0 without calling a model while memory is under budget, so the check is free until it is not.
+    That also keeps ``features.py``'s rule intact: the token-spending path stays off the read-only
+    feature routes and lives on the streaming turn, like every other call that can cost money.
+
+    Best-effort throughout: neither toggle may take a turn down. The answer is the product.
+    """
+    if not getattr(settings, "remember_from_chat", False) or memory is None:
+        return None, 0
+    write = getattr(memory, "remember", None)
+    if not callable(write):
+        return None, 0
+    try:
+        from chimera.memory.capture import parse_remember_request
+
+        fact = parse_remember_request(message)
+        if fact is None:
+            return None, 0
+        write(fact, source="chat")  # deduped by the manager; provenance is clean — the user typed it
+    except Exception as exc:  # noqa: BLE001 -- see the docstring
+        _log.debug("remember-from-chat skipped: %s", exc)
+        return None, 0
+
+    if not getattr(settings, "auto_consolidate", False):
+        return fact, 0
+    try:
+        from chimera.memory.consolidate import model_summarizer
+        from chimera.providers import LLMGateway
+
+        removed = int(
+            memory.autoconsolidate(
+                model_summarizer(LLMGateway()), max_items=settings.memory_budget
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 -- see the docstring
+        _log.debug("auto-consolidate skipped: %s", exc)
+        return fact, 0
+    return fact, removed
+
+
 def register_code_api(
     app: FastAPI,
     guard: params.Depends,
@@ -615,12 +665,22 @@ def register_code_api(
 ) -> None:
     """Mount ``POST /api/code/turn`` — a conversational coding turn, streamed.
 
-    ``memory``/``graph`` are READ from, never written to. Reading is safe in a way writing is not: a
+    ``memory``/``graph`` are READ from, and written to in exactly ONE case: an explicit
+    "remember that…" in the message the USER typed.
+
+    The asymmetry that made this one-way is about what the AGENT or the WORKSPACE produced. A
     recalled fact learned from untrusted content carries its ``[unverified]`` label into the prompt
     and the admission gate still rejects injection patterns, so the worst case is a wasted line of
-    context. Writing is the opposite — with the workspace trusted by default, a poisoned README would
-    enter memory looking clean, and a memory item has no project scope, so it would be recalled into
-    every other project too. That asymmetry is the whole reason this is one-way.
+    context. Writing derived text is the opposite — with the workspace trusted by default, a poisoned
+    README would enter memory looking clean, and a memory item has no project scope, so it would be
+    recalled into every other project too.
+
+    None of that describes the user's own sentence. ``parse_remember_request`` reads the typed
+    message and nothing else, anchored to the start so an incidental "I can't remember where I put
+    my keys" is not a command; it never touches tool output, the answer, or a file. Keeping this
+    write out was not a decision anyone made about it — it was the general rule catching a case it
+    does not cover, and the cost was that the toggle in Settings did nothing from the app at all
+    while the empty Memory screen advertised it as the way to fill memory.
     """
     from chimera.core.code_session import CodeSession, CodeSessionStore
     from chimera.core.events import tool as tool_event
@@ -838,6 +898,11 @@ def register_code_api(
                     fill up is worse than an absent one: it reports zero spend as a fact.
                     """
                     _log_usage(payload, session_id, live())
+                    # Here rather than in either branch: both go through this function, and an
+                    # external agent's turn is still a turn the user typed "remember that…" into.
+                    saved, tidied = _remember_and_tidy(req.message, memory, live())
+                    payload["memory_saved"] = saved
+                    payload["memory_consolidated"] = tidied
                     if edited:
                         from chimera.api.app import resolve_verify
                         from chimera.core.verify import CommandVerifier

--- a/tests/test_code_turn_memory.py
+++ b/tests/test_code_turn_memory.py
@@ -1,0 +1,133 @@
+"""The two Settings toggles that fired nothing from the app.
+
+"Remember from chat" was real, correctly gated, and reachable only from ``/api/chat/stream`` — a
+route with no callers in the desktop, whose every conversation goes through ``/api/code/turn``.
+"Tidy memory" was read only inside the CLI REPL's own loop, so it did nothing unless the same person
+also ran ``chimera chat`` against the same home. The empty Memory screen meanwhile advertised the
+first one as the way to fill memory.
+
+The write is narrow on purpose, and the tests below are mostly about the edges of that narrowness:
+the user's own typed sentence is written, and nothing derived from the agent, the tools or a file
+ever is.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.api.code_api import _remember_and_tidy
+
+
+class _Settings:
+    def __init__(
+        self, *, remember: bool = True, tidy: bool = False, budget: int = 100
+    ) -> None:
+        self.remember_from_chat = remember
+        self.auto_consolidate = tidy
+        self.memory_budget = budget
+
+
+class _Memory:
+    """Duck-typed like MemoryManager for the two methods this path touches."""
+
+    def __init__(self, *, removes: int = 0, writable: bool = True) -> None:
+        self.written: list[tuple[str, str]] = []
+        self.consolidations = 0
+        self._removes = removes
+        if not writable:
+            # An attribute, not a method: `_remember_and_tidy` duck-types on callable(), which is
+            # what a search-only backend actually looks like.
+            self.remember = None  # type: ignore[assignment]
+
+    def remember(self, fact: str, *, source: str = "") -> None:
+        self.written.append((fact, source))
+
+    def autoconsolidate(self, _summarizer: Any, *, max_items: int) -> int:
+        self.consolidations += 1
+        return self._removes
+
+
+def test_an_explicit_remember_from_the_users_own_message_is_saved() -> None:
+    memory = _Memory()
+
+    saved, tidied = _remember_and_tidy("lembre que meu voo é dia 12", memory, _Settings())
+
+    assert saved == "meu voo é dia 12"
+    assert memory.written == [("meu voo é dia 12", "chat")]
+    assert tidied == 0, "tidying is off in this configuration"
+
+
+def test_an_ordinary_message_writes_nothing() -> None:
+    """The trigger is anchored to the start of the message, and this is the reason why.
+
+    Automatic extraction is what pollutes memory: a fact has no project scope, so anything written
+    here is recalled into every other conversation forever.
+    """
+    memory = _Memory()
+
+    saved, _ = _remember_and_tidy("I can't remember where I put the config file", memory, _Settings())
+
+    assert saved is None
+    assert memory.written == []
+
+
+def test_the_toggle_being_off_means_off() -> None:
+    memory = _Memory()
+
+    saved, _ = _remember_and_tidy("remember that I use tabs", memory, _Settings(remember=False))
+
+    assert saved is None and memory.written == []
+
+
+def test_tidying_runs_after_a_write_and_only_after_one() -> None:
+    """Memory only grows when something is written, so the moment after a write is the moment to
+    check — and `autoconsolidate` returns 0 without calling a model while memory is under budget."""
+    wrote = _Memory(removes=3)
+    saved, tidied = _remember_and_tidy(
+        "remember that I use tabs", wrote, _Settings(tidy=True)
+    )
+    assert saved == "I use tabs" and tidied == 3 and wrote.consolidations == 1
+
+    quiet = _Memory(removes=3)
+    _remember_and_tidy("just a normal question", quiet, _Settings(tidy=True))
+    assert quiet.consolidations == 0, "nothing was written, so nothing can have outgrown anything"
+
+
+def test_tidying_off_leaves_the_write_alone() -> None:
+    memory = _Memory(removes=3)
+
+    saved, tidied = _remember_and_tidy("remember that I use tabs", memory, _Settings(tidy=False))
+
+    assert saved == "I use tabs" and tidied == 0 and memory.consolidations == 0
+
+
+def test_a_memory_that_cannot_write_is_skipped_not_crashed() -> None:
+    """A search-only backend has no `remember`. Duck-typed, as the CLI path already was."""
+    assert _remember_and_tidy("remember that x", _Memory(writable=False), _Settings()) == (None, 0)
+    assert _remember_and_tidy("remember that x", None, _Settings()) == (None, 0)
+
+
+def test_a_failing_write_never_takes_the_turn_down() -> None:
+    """The answer is the product. A memory backend with a full disk must not lose it."""
+
+    class _Broken(_Memory):
+        def remember(self, fact: str, *, source: str = "") -> None:
+            raise OSError("disk full")
+
+    assert _remember_and_tidy("remember that x", _Broken(), _Settings()) == (None, 0)
+
+
+def test_a_failing_consolidation_still_reports_the_fact_that_was_saved() -> None:
+    """Consolidation calls a model, so it can fail for reasons the write cannot — no key, no
+    network, a rate limit. Losing the confirmation of a write that DID happen would tell the user
+    their fact was not saved when it was."""
+
+    class _BadTidy(_Memory):
+        def autoconsolidate(self, _summarizer: Any, *, max_items: int) -> int:
+            raise RuntimeError("no api key")
+
+    saved, tidied = _remember_and_tidy(
+        "remember that I use tabs", _BadTidy(), _Settings(tidy=True)
+    )
+
+    assert saved == "I use tabs" and tidied == 0


### PR DESCRIPTION
## Os dois interruptores

**"Lembrar do chat"** era real e corretamente protegido. `_maybe_remember` só é chamado de `send_verbose`, que é alcançável por `/api/chat/stream`, pelo compat OpenAI e pela TUI — e o desktop não chama nenhum. `streamChat` está definido no `api.ts` e tem **zero consumidores**; toda conversa do app passa por `/api/code/turn`. Pior: a tela de Memória vazia anunciava esse caminho morto como sendo a forma de preenchê-la.

**"Arrumar memória"** era lida em exatamente dois lugares: um display só-leitura, e `_maybe_autoconsolidate`, cujos únicos chamadores estão dentro dos laços `console.input()` do `chimera chat` e `chimera assist`. Não fazia nada a menos que a mesma pessoa também rodasse o REPL contra o mesmo home.

## Por que a recusa não cobria este caso

`/api/code/turn` se recusava a escrever memória por design, e esse design está **certo sobre o que ele mirava** — a saída do *agente* e o conteúdo do *workspace*. Com o workspace confiável por padrão, um README envenenado entraria na memória parecendo limpo, e um item de memória não tem escopo de projeto: seria recuperado em todos os outros também.

Nada disso descreve **a frase que o usuário digitou**. O `parse_remember_request` lê a mensagem e mais nada, ancorado no início para que *"não lembro onde deixei as chaves"* não vire comando, e nunca toca em saída de ferramenta, na resposta ou num arquivo.

> Esta escrita não foi uma decisão que alguém tomou sobre ela — foi a regra geral pegando um caso que ela não cobre.

## A arrumação vai junto porque é o lugar dela

Memória só cresce quando algo é escrito, e `autoconsolidate` devolve 0 **sem chamar modelo** enquanto a memória está abaixo do orçamento. A checagem é grátis até deixar de ser. Isso também mantém intacta a regra do próprio `features.py`: o caminho que gasta token fica fora das rotas de leitura.

Acontece em `_verify_and_finish`, por onde **os dois ramos** passam: um turno de agente externo também é um turno em que o usuário digitou "lembre que…".

## E a tela

Um fato durável sobrevive à conversa que o criou — vai ser recuperado em toda conversa futura. Uma mudança com esse alcance ganha um badge, com o fato no `title`. **Três strings que descreviam o que não acontecia** foram corrigidas nos dez idiomas.

## Verificação

Backend **3.650 passed** · frontend **666 passed** em 88 arquivos · mypy limpo · ruff limpo · typecheck limpo.

Um dos testes prende o caso que importa mais: **um turno que não guardou nada não mostra badge nenhum** — um badge que sempre aparecesse diria ao usuário que suas palavras estão sendo anotadas a cada turno, que é justamente o que esta escrita estreita não faz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)