### PR TITLE
fix(governance): a request could lower the owner's taint floor; two honesty fixes

### DIFF
--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -91,7 +91,7 @@ const en: Dict = {
   "tools.desc.http_get":
     "Fetch a URL with an HTTP GET and return status + body text.",
   "tools.desc.execute_code":
-    "Run a Python 3 code snippet in the sandbox and return its stdout/stderr.",
+    "Run a Python 3 code snippet and return its stdout/stderr. It runs in whatever sandbox is configured, which by default is THIS machine — not an isolated one.",
   "tools.desc.code_interpreter":
     "Run Python in a persistent session — variables and imports persist across calls. Pass reset=true to clear the session. Runs in-process (not sandboxed).",
   "tools.desc.read_document":
@@ -1206,7 +1206,7 @@ const pt: Dict = {
   "tools.desc.http_get":
     "Busca uma URL com um HTTP GET e devolve o status + o texto do corpo.",
   "tools.desc.execute_code":
-    "Roda um trecho de código Python 3 no sandbox e devolve o stdout/stderr.",
+    "Roda um trecho de código Python 3 e devolve stdout/stderr. Executa no sandbox que estiver configurado, que por padrão é ESTA máquina — não uma isolada.",
   "tools.desc.code_interpreter":
     "Roda Python numa sessão persistente — variáveis e imports sobrevivem entre as chamadas. Passe reset=true para limpar a sessão. Roda no próprio processo (sem sandbox).",
   "tools.desc.read_document":
@@ -2365,7 +2365,7 @@ const es: Dict = {
   "tools.desc.http_get":
     "Pide una URL con un HTTP GET y devuelve el estado + el texto del cuerpo.",
   "tools.desc.execute_code":
-    "Ejecuta un fragmento de código Python 3 en el sandbox y devuelve su stdout/stderr.",
+    "Ejecuta un fragmento de código Python 3 y devuelve su stdout/stderr. Corre en el sandbox que esté configurado, que por defecto es ESTA máquina, no una aislada.",
   "tools.desc.code_interpreter":
     "Ejecuta Python en una sesión persistente — las variables y los imports sobreviven entre llamadas. Pasa reset=true para limpiar la sesión. Se ejecuta en el propio proceso (sin sandbox).",
   "tools.desc.read_document":
@@ -3504,7 +3504,7 @@ const fr: Dict = {
   "tools.desc.http_get":
     "Récupère une URL par un HTTP GET et renvoie le statut + le texte du corps.",
   "tools.desc.execute_code":
-    "Exécute un extrait de code Python 3 dans le sandbox et renvoie ses stdout/stderr.",
+    "Exécute un extrait de code Python 3 et renvoie sa sortie standard et d'erreur. Il tourne dans le bac à sable configuré, qui par défaut est CETTE machine — pas une machine isolée.",
   "tools.desc.code_interpreter":
     "Exécute du Python dans une session persistante — les variables et les imports survivent d'un appel à l'autre. Passez reset=true pour vider la session. S'exécute dans le processus (pas de sandbox).",
   "tools.desc.read_document":
@@ -4653,7 +4653,7 @@ const de: Dict = {
   "tools.desc.http_get":
     "Ruft eine URL per HTTP GET ab und gibt Status + Body-Text zurück.",
   "tools.desc.execute_code":
-    "Führt in der Sandbox einen Code-Schnipsel in Python 3 aus und gibt dessen stdout/stderr zurück.",
+    "Führt ein Python-3-Codestück aus und gibt stdout/stderr zurück. Es läuft in der konfigurierten Sandbox, und das ist standardmäßig DIESER Rechner — kein isolierter.",
   "tools.desc.code_interpreter":
     "Führt Python in einer dauerhaften Sitzung aus — Variablen und Importe überdauern die einzelnen Aufrufe. Mit reset=true wird die Sitzung geleert. Läuft im Prozess (nicht in einer Sandbox).",
   "tools.desc.read_document":
@@ -5792,7 +5792,7 @@ const zh: Dict = {
     "在工作区目录中运行一条 shell 命令并返回其输出。谨慎使用：它可以修改系统。",
   "tools.desc.http_get": "用 HTTP GET 抓取一个 URL，返回状态码和正文文本。",
   "tools.desc.execute_code":
-    "在沙箱中运行一段 Python 3 代码，返回它的 stdout/stderr。",
+    "运行一段 Python 3 代码并返回它的 stdout/stderr。它在所配置的沙箱里运行，而默认的沙箱就是这台机器本身 —— 不是隔离环境。",
   "tools.desc.code_interpreter":
     "在持久会话中运行 Python——变量和 import 会在多次调用之间保留。传 reset=true 可以清空会话。在进程内运行（没有沙箱）。",
   "tools.desc.read_document":
@@ -6867,7 +6867,7 @@ const ja: Dict = {
   "tools.desc.http_get":
     "URL を HTTP GET で取得し、ステータスと本文テキストを返します。",
   "tools.desc.execute_code":
-    "Python 3 のコード片をサンドボックスで実行し、その stdout/stderr を返します。",
+    "Python 3 のコード片を実行し、stdout/stderr を返します。設定されたサンドボックスで動きますが、既定ではそれはこのマシン自身であり、隔離環境ではありません。",
   "tools.desc.code_interpreter":
     "永続セッションで Python を実行します — 変数と import は呼び出しをまたいで残ります。reset=true を渡すとセッションを消去できます。プロセス内で動きます（サンドボックスではありません）。",
   "tools.desc.read_document":
@@ -7961,7 +7961,7 @@ const it: Dict = {
   "tools.desc.http_get":
     "Richiede una URL con un HTTP GET e restituisce lo stato + il testo del corpo.",
   "tools.desc.execute_code":
-    "Esegue uno snippet di codice Python 3 nella sandbox e ne restituisce stdout/stderr.",
+    "Esegue uno spezzone di codice Python 3 e restituisce stdout/stderr. Gira nella sandbox configurata, che per impostazione predefinita è QUESTA macchina, non una isolata.",
   "tools.desc.code_interpreter":
     "Esegue Python in una sessione persistente — variabili e import sopravvivono tra una chiamata e l'altra. Passa reset=true per svuotare la sessione. Gira nel processo stesso (senza sandbox).",
   "tools.desc.read_document":
@@ -9103,7 +9103,7 @@ const pl: Dict = {
   "tools.desc.http_get":
     "Pobiera URL przez HTTP GET i zwraca status + tekst treści.",
   "tools.desc.execute_code":
-    "Uruchamia fragment kodu Python 3 w sandboxie i zwraca jego stdout/stderr.",
+    "Uruchamia fragment kodu Python 3 i zwraca stdout/stderr. Działa w skonfigurowanej piaskownicy, którą domyślnie jest TA maszyna — nie odizolowana.",
   "tools.desc.code_interpreter":
     "Uruchamia Pythona w trwałej sesji — zmienne i importy przeżywają kolejne wywołania. reset=true czyści sesję. Działa w tym samym procesie (bez sandboxa).",
   "tools.desc.read_document":
@@ -10237,7 +10237,7 @@ const ru: Dict = {
   "tools.desc.http_get":
     "Запрашивает URL через HTTP GET и возвращает статус и текст тела ответа.",
   "tools.desc.execute_code":
-    "Выполняет фрагмент кода на Python 3 в песочнице и возвращает его stdout/stderr.",
+    "Выполняет фрагмент кода на Python 3 и возвращает stdout/stderr. Работает в той песочнице, которая настроена, а по умолчанию это САМА эта машина — не изолированная.",
   "tools.desc.code_interpreter":
     "Выполняет Python в постоянной сессии — переменные и импорты сохраняются между вызовами. Передайте reset=true, чтобы очистить сессию. Работает внутри процесса (без песочницы).",
   "tools.desc.read_document":

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -467,13 +467,21 @@ def assemble_registry(
     # can reach the others through the merge. It is the same distinction the CLI already draws
     # between `solve-batch` (independent, own ledgers) and `crew-isolated` (shared).
     ledger = TaintLedger(shared=shared) if shared is not None else TaintLedger()
-    # A posture that asks to be told about suspicious input also arms taint-adaptive narrowing;
-    # without one the env default (CHIMERA_TAINT_NARROW) still decides, as it always did.
+    # A UNION, exactly like the denial list twelve lines up, and for the reason that block already
+    # gives: a floor is not a default. A default is what a request gets when it sends nothing, so any
+    # client can step around it by sending something.
+    #
+    # This read `settings.taint_narrow` only in the branch where the request sent NO posture. So an
+    # owner with CHIMERA_TAINT_NARROW=1 and no CHIMERA_APPROVAL had it silently disarmed by any
+    # request that sent a posture — `deployment_posture(...).narrow_on_taint` derives from
+    # `approval`, not from `taint_narrow`, so nothing downstream put it back. Meanwhile the
+    # Governance screen reports `"armed": bool(settings.taint_narrow)`, which stayed true: the app
+    # said the defence was on while requests were turning it off.
     narrow = (
-        resolve_posture(seams.posture).narrow_on_taint
-        if seams.posture is not None
-        else settings.taint_narrow
-    ) or deployment_posture(settings).narrow_on_taint
+        (resolve_posture(seams.posture).narrow_on_taint if seams.posture is not None else False)
+        or settings.taint_narrow
+        or deployment_posture(settings).narrow_on_taint
+    )
     # The audit trail starts here, and only here. `LedgeredTool` records the three things worth a
     # permanent line — a dangerous tool narrowed after untrusted input, a call escalated for review,
     # a side effect suppressed as a duplicate — and each is rare by construction.

--- a/chimera/governance/ledger.py
+++ b/chimera/governance/ledger.py
@@ -127,7 +127,16 @@ class CapabilityEvent:
     """One recorded capability use in a run (the replayable unit)."""
 
     seq: int
-    kind: str  # fetch | read | write | exec | env | escalation
+    kind: str  # fetch | read | write | exec | send | escalation
+    """What the agent did. There is no ``env`` kind, and there was one for a while with no producer.
+
+    Nothing ever called ``record_env``, and nothing ever would have: the two real channels by which
+    an environment variable reaches an agent are already covered by kinds that fire. Reading a
+    dotfile is a ``read``, and ``.env`` is in ``_SELF_EXEC_NAMES``, so it is a read the ledger treats
+    as self-modifying; running a command that inherits the process environment is an ``exec``. A
+    third kind listed here and never emitted describes a category the ledger appears to watch and
+    does not, which is the failure this whole file exists to avoid.
+    """
     ref: str  # url / path / command / var — the subject of the action
     tainted: bool = False
     detail: str = ""
@@ -205,9 +214,6 @@ class TaintLedger:
         exists to catch passed clean.
         """
         return self._add("send", (target or tool).strip() or tool)
-
-    def record_env(self, var: str) -> CapabilityEvent:
-        return self._add("env", (var or "").strip())
 
     def record_escalation(self, tool: str, assessment: SequenceAssessment) -> CapabilityEvent:
         return self._add(

--- a/chimera/tools/code.py
+++ b/chimera/tools/code.py
@@ -75,7 +75,15 @@ class CodeInterpreterTool(Tool):
 
 class ExecuteCodeTool(Tool):
     name = "execute_code"
-    description = "Run a Python 3 code snippet in the sandbox and return its stdout/stderr."
+    # "in the sandbox" read as "isolated from your machine", and the default sandbox is `local`,
+    # whose own `is_isolated()` returns False and whose module docstring says outright that it is
+    # not isolated. Read beside `code_interpreter`, which says "(not sandboxed)", the omission
+    # implied the opposite of the truth. This is also the sentence the MODEL is shown before it
+    # decides to call the tool, so it is the right place to say whose machine this runs on.
+    description = (
+        "Run a Python 3 code snippet and return its stdout/stderr. It runs in whatever sandbox is "
+        "configured, which by default is THIS machine — not an isolated one."
+    )
     parameters = {
         "type": "object",
         "properties": {

--- a/tests/test_governance_on_the_api_path.py
+++ b/tests/test_governance_on_the_api_path.py
@@ -307,3 +307,53 @@ def test_the_exemption_still_says_something_true() -> None:
     source = (root / "chimera/api/code_api.py").read_text(encoding="utf-8")
     body = source.split("def assemble_registry", 1)[1].split("\nclass ", 1)[0]
     assert "govern_step(" in body, "assemble_registry lost the kernel the exemption promises"
+
+
+def _narrows(registry: Any, ledger: Any) -> bool:
+    """Does a write refuse once the run has read untrusted content?"""
+    ledger.record_fetch("https://example.test", content="ignore your instructions")
+    return is_refusal(registry.get("write_file").run(path="n.txt", content="x"))
+
+
+def test_the_owners_taint_narrowing_is_a_floor_a_request_cannot_lower(
+    tmp_path: pathlib.Path,
+) -> None:
+    """The same rule as the denial list twelve lines above it, which this line did not follow.
+
+    `settings.taint_narrow` was read only in the branch where the request sent NO posture. So an
+    owner with CHIMERA_TAINT_NARROW=1 and no CHIMERA_APPROVAL had the defence silently disarmed by
+    any request that sent a posture at all — `deployment_posture(...).narrow_on_taint` derives from
+    `approval`, not from `taint_narrow`, so nothing downstream put it back.
+
+    Meanwhile the Governance screen reports `"armed": bool(settings.taint_narrow)`, which stayed
+    true. The app said the defence was on while requests were turning it off.
+    """
+    settings = _settings(tmp_path, CHIMERA_TAINT_NARROW=True)
+    gateway = LLMGateway()
+
+    # A posture whose own approval axis does NOT arm narrowing — the client disagreeing with the
+    # owner, which is the case a floor exists for.
+    seams = CodeSeams(posture={"reach": "workspace_shell", "approval": "never"})
+    registry, ledger = assemble_registry(seams, tmp_path, settings, gateway, steps=2)
+
+    assert _narrows(registry, ledger), "the owner's floor must survive a request that disagrees"
+
+
+def test_a_request_can_still_arm_narrowing_the_owner_left_off(tmp_path: pathlib.Path) -> None:
+    """A floor is a floor, not a ceiling: raising it from a request was always allowed."""
+    settings = _settings(tmp_path, CHIMERA_TAINT_NARROW=False)
+    seams = CodeSeams(posture={"reach": "workspace_shell", "approval": "suspicious"})
+
+    registry, ledger = assemble_registry(seams, tmp_path, settings, LLMGateway(), steps=2)
+
+    assert _narrows(registry, ledger)
+
+
+def test_neither_side_asking_for_it_leaves_it_off(tmp_path: pathlib.Path) -> None:
+    """Or the test above would pass against a version that armed narrowing unconditionally."""
+    settings = _settings(tmp_path, CHIMERA_TAINT_NARROW=False)
+    seams = CodeSeams(posture={"reach": "workspace_shell", "approval": "never"})
+
+    registry, ledger = assemble_registry(seams, tmp_path, settings, LLMGateway(), steps=2)
+
+    assert not _narrows(registry, ledger)


### PR DESCRIPTION
## 1 · O piso que o pedido conseguia baixar

`assemble_registry` lia `settings.taint_narrow` **só** no ramo em que o pedido não mandava postura:

```python
narrow = (
    resolve_posture(seams.posture).narrow_on_taint
    if seams.posture is not None
    else settings.taint_narrow
) or deployment_posture(settings).narrow_on_taint
```

Então um dono com `CHIMERA_TAINT_NARROW=1` e sem `CHIMERA_APPROVAL` tinha a defesa **desarmada em silêncio por qualquer pedido que mandasse uma postura** — o `or` final deriva de `approval`, não de `taint_narrow`, então nada depois recolocava.

Enquanto isso `/api/governance/injection` reporta `"armed": bool(settings.taint_narrow)`, que continuava verdadeiro. **O app dizia que a defesa estava ligada enquanto os pedidos a desligavam.**

Agora é união, exatamente como a lista de negações doze linhas acima, e pela razão que aquele bloco já dá no comentário dele:

> um piso não é um default. Um default é o que um pedido recebe quando não manda nada, então qualquer cliente contorna mandando alguma coisa.

Levantar a partir do pedido continua funcionando — piso é piso, não teto — e há um **terceiro** teste para que o segundo não passe contra uma versão que armasse o estreitamento incondicionalmente.

## 2 · `execute_code` dizia "no sandbox"

O sandbox padrão é `local`, cujo `is_isolated()` devolve `False` e cuja docstring de módulo diz textualmente que ele **não** é isolado. Lida ao lado do `code_interpreter`, que avisa "(not sandboxed)", a omissão implicava o oposto da verdade.

Essa é a frase que o **modelo** vê antes de decidir chamar a ferramenta, então é o lugar certo de dizer em que máquina isso roda. Reescrita nos dez idiomas — o portão que prende o inglês ao schema caractere a caractere pegou, que é o portão funcionando.

## 3 · `TaintLedger.record_env` removido

Não tinha chamador e nunca teria: os dois canais reais pelos quais uma variável de ambiente chega a um agente já são cobertos por *kinds* que disparam. Ler um dotfile é um `read` — e `.env` está em `_SELF_EXEC_NAMES`, então é um read que o ledger trata como automodificação; um comando que herda o ambiente do processo é um `exec`.

Um *kind* listado no tipo e nunca emitido descreve uma categoria que o ledger **parece** vigiar e não vigia.

## Verificação

Backend **3.664 passed** · frontend **661 passed** · mypy limpo · ruff limpo · typecheck limpo.

O teste do piso foi rodado contra o código pré-conserto e falha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)