### PR TITLE
fix(cost): a stopped run reported "nothing was spent", and Cost counted one path

### DIFF
--- a/apps/desktop/src/components/orchestration/HierarchyRun.tsx
+++ b/apps/desktop/src/components/orchestration/HierarchyRun.tsx
@@ -4,8 +4,13 @@ import { Loader2, Square } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cancelOrchestration, streamHierarchy, type HierarchyRunInput } from "@/lib/api";
-import { useT } from "@/lib/i18n";
-import { applyFrame, EMPTY_RUN, isRunning } from "@/lib/orchestration-run";
+import { useT, type TFunc } from "@/lib/i18n";
+import {
+  applyFrame,
+  EMPTY_RUN,
+  isRunning,
+  type OrchestrationState,
+} from "@/lib/orchestration-run";
 
 import { FellBackNote } from "./FellBackNote";
 import { RunStepper } from "./RunStepper";
@@ -113,8 +118,16 @@ export function HierarchyRun({
         </p>
       ) : null}
 
+      {/* A stopped run has a bill. The server sends `total_tokens` on cancel, the reducer stores
+          it, and it used to live only inside the `state.answer` branch — which is empty on
+          cancel, so the number arrived and was never rendered. The sentence above it said
+          "nothing was spent", while the Stop button's own tooltip two lines up said the
+          opposite and said it correctly. */}
       {state.cancelled ? (
-        <p className="text-sm text-muted-foreground">{t("orch.cancelled")}</p>
+        <section className="surface p-4">
+          <p className="text-sm text-muted-foreground">{t("orch.cancelled")}</p>
+          <Totals totals={state.totals} t={t} />
+        </section>
       ) : null}
 
       {state.answer ? (
@@ -122,19 +135,25 @@ export function HierarchyRun({
           <div className="prose-chimera text-sm">
             <Markdown>{state.answer}</Markdown>
           </div>
-          {state.totals ? (
-            <p className="mt-3 border-t border-hairline pt-3 text-xs tabular-nums text-muted-foreground">
-              {t("orch.tokens", { n: state.totals.tokens ?? 0 })}
-              {/* Only when there IS one. A counterfactual is an ESTIMATE of what one inline agent
-                  would have spent, and the word matters: printing a saving without it would read
-                  as a measurement of two runs that never both happened. */}
-              {state.totals.counterfactual
-                ? ` · ${t("orch.counterfactual", { n: state.totals.counterfactual })}`
-                : ""}
-            </p>
-          ) : null}
+          <Totals totals={state.totals} t={t} />
         </section>
       ) : null}
     </div>
+  );
+}
+
+/** What the run cost, under the answer or under the notice that there will not be one. */
+function Totals({ totals, t }: { totals: OrchestrationState["totals"]; t: TFunc }) {
+  if (!totals) return null;
+  return (
+    <p className="mt-3 border-t border-hairline pt-3 text-xs tabular-nums text-muted-foreground">
+      {t("orch.tokens", { n: totals.tokens ?? 0 })}
+      {/* Only when there IS one. A counterfactual is an ESTIMATE of what one inline agent would
+          have spent, and the word matters: printing a saving without it would read as a
+          measurement of two runs that never both happened. */}
+      {totals.counterfactual
+        ? ` · ${t("orch.counterfactual", { n: totals.counterfactual })}`
+        : ""}
+    </p>
   );
 }

--- a/apps/desktop/src/components/orchestration/Orchestration.stream.test.tsx
+++ b/apps/desktop/src/components/orchestration/Orchestration.stream.test.tsx
@@ -158,6 +158,34 @@ describe("watching a fan-out", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /stopping/i })).toBeInTheDocument());
   });
 
+  it("shows what a stopped run cost, instead of saying nothing was spent", async () => {
+    const { handlers } = await startRun();
+
+    // The server sends the real spend on cancel and the reducer stores it. The totals used to be
+    // rendered only inside the `state.answer` branch — which is empty on a cancel — so the number
+    // arrived and was thrown away, under a sentence claiming nothing had been spent. The Stop
+    // button's own tooltip, two lines above it in the same component, said the opposite.
+    send(
+      handlers(),
+      frame(6, "worker_verified", { stage: "criteria", tokens: 900 }, "a"),
+      frame(7, "done", { answer: "", cancelled: true, total_tokens: 1700 }),
+    );
+
+    expect(screen.getByText(/1700 tokens/i)).toBeInTheDocument();
+    expect(screen.getByText(/were charged/i)).toBeInTheDocument();
+  });
+
+  it("does not claim a stopped run produced an answer", async () => {
+    const { handlers } = await startRun();
+
+    send(handlers(), frame(6, "done", { answer: "", cancelled: true, total_tokens: 0 }));
+
+    // Zero is a real number here: it means the stop landed before anything ran. Rendering it is
+    // not the same as rendering the answer section, which must stay absent.
+    expect(screen.getByText(/0 tokens/i)).toBeInTheDocument();
+    expect(screen.queryByText(/would have cost about/i)).toBeNull();
+  });
+
   it("renders the answer and prices it against the counterfactual", async () => {
     const { handlers } = await startRun();
 

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1101,7 +1101,8 @@ const en: Dict = {
   "orch.stop": "Stop",
   "orch.stopping": "Stopping",
   "orch.stopHint": "Stops before the next model call; calls already in flight finish and are charged.",
-  "orch.cancelled": "Stopped. The answer was never synthesised, so nothing was spent on it.",
+  "orch.cancelled":
+    "Stopped before the answer was synthesised. The workers that had already started were charged — what that came to is below.",
   "orch.tokens": "{n} tokens",
   "orch.counterfactual": "one agent would have cost about {n}",
   "orch.fellback.buildCrew": "Build a crew",
@@ -2238,7 +2239,8 @@ const pt: Dict = {
   "orch.stop": "Parar",
   "orch.stopping": "Parando",
   "orch.stopHint": "Para antes da próxima chamada ao modelo; as que já estão em voo terminam e são cobradas.",
-  "orch.cancelled": "Parado. A resposta não chegou a ser sintetizada, então nada foi gasto nela.",
+  "orch.cancelled":
+    "Parado antes de a resposta ser sintetizada. Os trabalhadores que já tinham começado foram cobrados — o total está abaixo.",
   "orch.tokens": "{n} tokens",
   "orch.counterfactual": "um agente só teria custado cerca de {n}",
   "orch.fellback.buildCrew": "Montar um time",
@@ -3385,7 +3387,8 @@ const es: Dict = {
   "orch.stop": "Detener",
   "orch.stopping": "Deteniendo",
   "orch.stopHint": "Se detiene antes de la próxima llamada al modelo; las que ya están en vuelo terminan y se cobran.",
-  "orch.cancelled": "Detenido. La respuesta nunca se sintetizó, así que no se gastó nada en ella.",
+  "orch.cancelled":
+    "Detenido antes de sintetizar la respuesta. Los trabajadores que ya habían empezado se cobraron: el total está abajo.",
   "orch.tokens": "{n} tokens",
   "orch.counterfactual": "un solo agente habría costado unos {n}",
   "orch.fellback.buildCrew": "Formar un equipo",
@@ -4545,7 +4548,8 @@ const fr: Dict = {
   "orch.stop": "Arrêter",
   "orch.stopping": "Arrêt",
   "orch.stopHint": "S'arrête avant le prochain appel au modèle ; ceux déjà en vol se terminent et sont facturés.",
-  "orch.cancelled": "Arrêté. La réponse n'a jamais été synthétisée, donc rien n'a été dépensé pour elle.",
+  "orch.cancelled":
+    "Arrêté avant la synthèse de la réponse. Les travailleurs déjà lancés ont été facturés — le total est ci-dessous.",
   "orch.tokens": "{n} jetons",
   "orch.counterfactual": "un seul agent aurait coûté environ {n}",
   "orch.fellback.buildCrew": "Constituer une équipe",
@@ -5702,7 +5706,8 @@ const de: Dict = {
   "orch.stop": "Stopp",
   "orch.stopping": "Stoppt",
   "orch.stopHint": "Hält vor dem nächsten Modellaufruf; bereits laufende Aufrufe enden und werden berechnet.",
-  "orch.cancelled": "Gestoppt. Die Antwort wurde nie zusammengefasst, dafür wurde also nichts ausgegeben.",
+  "orch.cancelled":
+    "Gestoppt, bevor die Antwort zusammengeführt wurde. Die bereits gestarteten Arbeiter wurden berechnet — die Summe steht unten.",
   "orch.tokens": "{n} Token",
   "orch.counterfactual": "ein einzelner Agent hätte etwa {n} gekostet",
   "orch.fellback.buildCrew": "Team zusammenstellen",
@@ -6778,7 +6783,8 @@ const zh: Dict = {
   "orch.stop": "停止",
   "orch.stopping": "正在停止",
   "orch.stopHint": "在下一次模型调用前停止；已经发出的调用会跑完并照常计费。",
-  "orch.cancelled": "已停止。答案从未被汇总，因此这一步没有产生花费。",
+  "orch.cancelled":
+    "在答案被综合之前就停止了。已经开始的工作者仍会计费 —— 总数在下面。",
   "orch.tokens": "{n} 词元",
   "orch.counterfactual": "单个智能体大约要花 {n}",
   "orch.fellback.buildCrew": "组建团队",
@@ -7916,7 +7922,8 @@ const ja: Dict = {
   "orch.stop": "停止",
   "orch.stopping": "停止中",
   "orch.stopHint": "次のモデル呼び出しの前で止まります。実行中の呼び出しは最後まで走り、課金されます。",
-  "orch.cancelled": "停止しました。回答は統合されなかったので、その分の費用は発生していません。",
+  "orch.cancelled":
+    "答えがまとめられる前に停止しました。すでに動き出していたワーカーの分は請求されます — 合計は下にあります。",
   "orch.tokens": "{n} トークン",
   "orch.counterfactual": "単独のエージェントなら約 {n} かかったはずです",
   "orch.fellback.buildCrew": "チームを組む",
@@ -9068,7 +9075,8 @@ const it: Dict = {
   "orch.stop": "Ferma",
   "orch.stopping": "In arresto",
   "orch.stopHint": "Si ferma prima della prossima chiamata al modello; quelle già in volo finiscono e vengono addebitate.",
-  "orch.cancelled": "Fermato. La risposta non è mai stata sintetizzata, quindi non è stato speso nulla per essa.",
+  "orch.cancelled":
+    "Fermato prima che la risposta fosse sintetizzata. I lavoratori già avviati sono stati addebitati: il totale è qui sotto.",
   "orch.tokens": "{n} token",
   "orch.counterfactual": "un solo agente sarebbe costato circa {n}",
   "orch.fellback.buildCrew": "Forma una squadra",
@@ -10212,7 +10220,8 @@ const pl: Dict = {
   "orch.stop": "Zatrzymaj",
   "orch.stopping": "Zatrzymywanie",
   "orch.stopHint": "Zatrzymuje przed kolejnym wywołaniem modelu; te już w locie kończą się i są naliczane.",
-  "orch.cancelled": "Zatrzymane. Odpowiedź nigdy nie została scalona, więc nic na nią nie wydano.",
+  "orch.cancelled":
+    "Zatrzymano, zanim odpowiedź została złożona. Pracownicy, którzy już ruszyli, zostali policzeni — suma jest poniżej.",
   "orch.tokens": "tokeny: {n}",
   "orch.counterfactual": "jeden agent kosztowałby około {n}",
   "orch.fellback.buildCrew": "Zbuduj zespół",
@@ -11362,7 +11371,8 @@ const ru: Dict = {
   "orch.stop": "Остановить",
   "orch.stopping": "Останавливается",
   "orch.stopHint": "Останавливает до следующего вызова модели; уже начатые вызовы дойдут до конца и будут оплачены.",
-  "orch.cancelled": "Остановлено. Ответ не сводился, поэтому на него ничего не потрачено.",
+  "orch.cancelled":
+    "Остановлено до того, как ответ был собран. Работники, которые уже начали, оплачены — итог ниже.",
   "orch.tokens": "токенов: {n}",
   "orch.counterfactual": "один агент обошёлся бы примерно в {n}",
   "orch.fellback.buildCrew": "Собрать команду",

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -1027,6 +1027,10 @@ def build_api_app(
                     max_workers=max_workers,
                     timeout=live_settings().batch_timeout,
                 )
+                # On the Cost screen too. This endpoint runs N full agent loops with tools and
+                # wrote nothing to the usage log, so the one screen that answers "what has this
+                # cost me" reported a number that left out every batch the user had ever run.
+                _record_batch_spend(live_settings().home, batch_id, batch)
                 emit("batch_done", _agents_batch_dict(req, ws, batch))
             except Exception as exc:  # noqa: BLE001 — surfaced to the client as an error event
                 _log.warning("agents batch failed: %s", exc)
@@ -1940,6 +1944,37 @@ def _append_usage(report: Any, session_id: str, settings: Settings) -> None:
         append_usage(settings.home / "usage.jsonl", record)
     except Exception as exc:  # noqa: BLE001 — usage logging is best-effort, never fatal to a turn
         _log.debug("usage logging skipped: %s", exc)
+
+
+def _record_batch_spend(home: Path, batch_id: str, batch: Any) -> None:
+    """Put an agents batch on the Cost screen — every task, summed, under one session id.
+
+    Per batch rather than per task: the Cost screen groups by session, and N rows for one click
+    would read as N separate pieces of work the user did not do.
+    """
+    from chimera.api.usage import record_spend
+
+    # `.value` is the AgentResult; the IsolatedResult around it carries only the unit's fate.
+    # A task that crashed has `value is None` and no accounting to contribute.
+    results = [
+        r.value for r in (getattr(batch, "results", None) or []) if getattr(r, "value", None)
+    ]
+    priced = [r.usd for r in results if getattr(r, "usd", None) is not None]
+    if not results:
+        return
+    record_spend(
+        home,
+        session_id=f"agents:{batch_id}",
+        model=str(getattr(results[0], "model", "") or ""),
+        prompt_tokens=sum(int(getattr(r, "prompt_tokens", 0) or 0) for r in results),
+        completion_tokens=sum(int(getattr(r, "completion_tokens", 0) or 0) for r in results),
+        cache_read_tokens=sum(int(getattr(r, "cache_read_tokens", 0) or 0) for r in results),
+        cache_write_tokens=sum(int(getattr(r, "cache_write_tokens", 0) or 0) for r in results),
+        # None when ANY task could not be priced. A partial sum shown as the total is the failure
+        # this accounting exists to avoid.
+        usd=round(sum(priced), 6) if len(priced) == len(results) else None,
+        tools=sum(len(getattr(r, "tool_names", ()) or ()) for r in results),
+    )
 
 
 def _report_dict(report: Any, session_id: str, *, fused: bool = False) -> dict[str, Any]:

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -500,6 +500,34 @@ def _owner_instructions(home: object) -> str:
         return ""
 
 
+def _record_run_spend(home: object, run_id: str, outcome: object) -> None:
+    """Put an orchestration run on the Cost screen, cancelled or not.
+
+    The receipts already carry per-delegation tokens and dollars; nothing ever moved them into the
+    usage log, so the one screen that answers "what has this cost me" was blind to the most
+    expensive thing the app can start.
+    """
+    from pathlib import Path as _Path
+
+    from chimera.api.usage import record_spend
+
+    receipts = list(getattr(outcome, "receipts", None) or [])
+    if not receipts:
+        return
+    priced = [r.usd for r in receipts if getattr(r, "usd", None) is not None]
+    record_spend(
+        _Path(str(home)),
+        session_id=f"orchestration:{run_id}",
+        model=str(getattr(receipts[0], "model", "") or ""),
+        prompt_tokens=sum(int(getattr(r, "prompt_tokens", 0) or 0) for r in receipts),
+        completion_tokens=sum(int(getattr(r, "completion_tokens", 0) or 0) for r in receipts),
+        # None when ANY delegation could not be priced: a partial sum presented as the total is the
+        # failure this whole accounting path exists to avoid.
+        usd=round(sum(priced), 6) if len(priced) == len(receipts) else None,
+        route_kind="hierarchy",
+    )
+
+
 def register_orchestration_api(
     app: FastAPI,
     guard: params.Depends,
@@ -664,11 +692,18 @@ def register_orchestration_api(
                     # The decomposition a person looked at and said yes to. Popped rather than
                     # read: a plan is consumed by its run, and leaving it behind would let a
                     # second run silently reuse a split that was approved for the first.
-                    orchestrator.run_prepared(req.task, approved.specs, shape=approved.shape)
+                    outcome = orchestrator.run_prepared(
+                        req.task, approved.specs, shape=approved.shape
+                    )
                 else:
                     # No id, or an id this process no longer has — decompose afresh. That is
                     # exactly the old behaviour, so a restart costs a model call, never an error.
-                    orchestrator.run(req.task)
+                    outcome = orchestrator.run(req.task)
+                # On the Cost screen, not only in the SSE stream that vanishes when the tab closes.
+                # This path spends a top-model decompose plus N workers plus a synthesis and wrote
+                # nothing to the usage log, so a screen reporting "the spend" left it out entirely —
+                # including for a run the user cancelled, which is charged all the same.
+                _record_run_spend(read_settings().home, run_id, outcome)
             except Exception as exc:  # noqa: BLE001 -- surfaced to the client as an error frame
                 _log.warning("hierarchy run failed: %s", exc)
                 emit("error", {"message": "the run failed"})

--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -42,6 +42,52 @@ def append_usage(path: Path, record: UsageRecord) -> None:
         handle.write(record.model_dump_json() + "\n")
 
 
+def record_spend(
+    home: Path,
+    *,
+    session_id: str,
+    model: str = "",
+    prompt_tokens: int | None = 0,
+    completion_tokens: int | None = 0,
+    cache_read_tokens: int | None = 0,
+    cache_write_tokens: int | None = 0,
+    usd: float | None = None,
+    tools: int = 0,
+    route_kind: str | None = None,
+) -> None:
+    """Log one spending call from anywhere, best-effort.
+
+    The Cost screen reads this file and reports what it finds as *the* spend. It was written by two
+    paths out of the many that call models — and one of those two, ``/api/chat/stream``, is a route
+    no screen in the app calls. So the dashboard reported one path's spending as the whole bill,
+    which is worse than an absent dashboard: an absent one is not consulted, and this one answered
+    a question with a number that was confidently too low.
+
+    Best-effort in the same way every other logging call here is: failing to record what a run cost
+    must never be the reason the run fails. The answer is the product.
+    """
+    from datetime import UTC, datetime
+
+    try:
+        append_usage(
+            Path(home) / "usage.jsonl",
+            UsageRecord(
+                ts=datetime.now(UTC).isoformat(),
+                session_id=session_id,
+                model=model or "",
+                prompt_tokens=prompt_tokens or 0,
+                completion_tokens=completion_tokens or 0,
+                cache_read_tokens=cache_read_tokens or 0,
+                cache_write_tokens=cache_write_tokens or 0,
+                usd=usd,
+                tools=tools,
+                route_kind=route_kind,
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 -- see the docstring
+        _log.debug("usage logging skipped: %s", exc)
+
+
 def load_usage(path: Path) -> list[UsageRecord]:
     """Load persisted usage records; malformed lines are skipped."""
     path = Path(path)

--- a/tests/test_usage_covers_what_spends.py
+++ b/tests/test_usage_covers_what_spends.py
@@ -1,0 +1,143 @@
+"""What the Cost screen counts, and what it used to leave out.
+
+The screen reads `usage.jsonl` and reports what it finds as *the* spend. Two paths wrote to it —
+and one of those two, `/api/chat/stream`, is a route no screen in the app calls (`streamChat` is
+defined in api.ts and has zero consumers). So a dashboard that answers "what has this cost me"
+was answering from one path, with a number confidently too low.
+
+That is worse than an absent dashboard. An absent one is not consulted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.api.usage import load_usage, record_spend
+
+
+class _Receipt:
+    def __init__(self, model: str, prompt: int, completion: int, usd: float | None) -> None:
+        self.model = model
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.usd = usd
+
+
+class _Result:
+    def __init__(self, usd: float | None, prompt: int = 100, completion: int = 50) -> None:
+        self.model = "m/model"
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.usd = usd
+        self.tool_names = ["read_file"]
+
+
+class _Unit:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+def test_record_spend_writes_a_row_the_cost_screen_can_read(tmp_path: Path) -> None:
+    record_spend(
+        tmp_path,
+        session_id="orchestration:run_7",
+        model="t/model",
+        prompt_tokens=1000,
+        completion_tokens=400,
+        usd=0.0123,
+        route_kind="hierarchy",
+    )
+
+    rows = load_usage(tmp_path / "usage.jsonl")
+    assert len(rows) == 1
+    assert rows[0].session_id == "orchestration:run_7"
+    assert rows[0].prompt_tokens == 1000 and rows[0].usd == 0.0123
+    assert rows[0].ts, "a row with no timestamp cannot be placed on a spend-over-time chart"
+
+
+def test_a_failure_to_log_never_takes_the_run_down(tmp_path: Path) -> None:
+    """The answer is the product. A full disk must not lose a run that already cost money."""
+    blocked = tmp_path / "usage.jsonl"
+    blocked.mkdir()  # a directory where the log wants a file: append will raise
+
+    record_spend(blocked.parent, session_id="x")  # must not raise
+
+    assert blocked.is_dir()
+
+
+def test_an_orchestration_run_lands_on_the_cost_screen(tmp_path: Path) -> None:
+    from chimera.api.orchestration_api import _record_run_spend
+
+    class _Outcome:
+        receipts = [
+            _Receipt("t/model", 1000, 200, 0.01),
+            _Receipt("m/model", 500, 300, 0.002),
+        ]
+
+    _record_run_spend(tmp_path, "run_7", _Outcome())
+
+    rows = load_usage(tmp_path / "usage.jsonl")
+    assert len(rows) == 1
+    assert rows[0].prompt_tokens == 1500 and rows[0].completion_tokens == 500
+    assert rows[0].usd == 0.012
+    assert rows[0].route_kind == "hierarchy"
+
+
+def test_one_unpriced_delegation_makes_the_total_unknown_not_smaller(tmp_path: Path) -> None:
+    """A partial sum presented as the total is the failure this accounting exists to avoid.
+
+    Same rule the spend ceiling follows, and the same one `FusionReceipt.total_usd` follows: a
+    missing number never masquerades as a smaller one.
+    """
+    from chimera.api.orchestration_api import _record_run_spend
+
+    class _Outcome:
+        receipts = [_Receipt("t/model", 1000, 200, 0.01), _Receipt("who/knows", 500, 300, None)]
+
+    _record_run_spend(tmp_path, "run_8", _Outcome())
+
+    row = load_usage(tmp_path / "usage.jsonl")[0]
+    assert row.usd is None
+    # The tokens ARE measured, so they are still reported. Only the dollars are unknown.
+    assert row.prompt_tokens == 1500
+
+
+def test_a_run_that_delegated_nothing_writes_no_row(tmp_path: Path) -> None:
+    from chimera.api.orchestration_api import _record_run_spend
+
+    class _Outcome:
+        receipts: list[Any] = []
+
+    _record_run_spend(tmp_path, "run_9", _Outcome())
+
+    assert load_usage(tmp_path / "usage.jsonl") == []
+
+
+def test_an_agents_batch_is_one_row_not_one_per_task(tmp_path: Path) -> None:
+    """The Cost screen groups by session, and N rows for one click would read as N pieces of work."""
+    from chimera.api.app import _record_batch_spend
+
+    class _Batch:
+        results = [_Unit(_Result(0.01)), _Unit(_Result(0.02)), _Unit(None)]
+
+    _record_batch_spend(tmp_path, "batch_3", _Batch())
+
+    rows = load_usage(tmp_path / "usage.jsonl")
+    assert len(rows) == 1
+    # Two tasks reported; the third crashed with no result and contributes nothing rather than zero.
+    assert rows[0].prompt_tokens == 200 and rows[0].usd == 0.03
+    assert rows[0].session_id == "agents:batch_3"
+
+
+def test_a_batch_where_nothing_ran_writes_no_row(tmp_path: Path) -> None:
+    from chimera.api.app import _record_batch_spend
+
+    class _Batch:
+        results = [_Unit(None)]
+
+    _record_batch_spend(tmp_path, "batch_4", _Batch())
+
+    assert load_usage(tmp_path / "usage.jsonl") == []


### PR DESCRIPTION
## 1 · O run parado

`hierarchy.py` devolve o `total_tokens` real no cancelamento, e o `orchestration-run.ts` guarda. Só que era renderizado **dentro do ramo `state.answer`** — e `answer` é `""` num cancelamento. O número chegava e era jogado fora, embaixo de uma frase dizendo *"nada foi gasto nela"*.

O tooltip do próprio botão Parar, **duas linhas acima, no mesmo componente**, já dizia a coisa certa: as chamadas em voo terminam e são cobradas.

Os totais viraram componente próprio e aparecem tanto sob o aviso de cancelamento quanto sob a resposta. `orch.cancelled` reescrita nos dez idiomas. Zero é um número real aqui — significa que o Parar chegou antes de qualquer coisa rodar — então é renderizado, não escondido, e há teste de que um run parado continua **sem** seção de resposta.

## 2 · A tela de Custo

Ela lê o `usage.jsonl` e reporta o que acha como sendo **o** gasto. Dois caminhos escreviam ali, e um dos dois é `/api/chat/stream` — rota que **nenhuma tela do app chama** (o `streamChat` está definido no `api.ts` com zero consumidores). Então o painel respondia "quanto isso me custou" a partir de, na prática, um caminho.

> Isso é pior que painel ausente. Ausente ninguém consulta.

`record_spend` é o escritor compartilhado e best-effort; `/api/orchestration/hierarchy` e `/api/agents` passam a usar.

Os dois **agregam por run/batch**, não por delegação ou por tarefa, porque a tela agrupa por sessão e N linhas para um clique leriam como N trabalhos que o usuário não fez.

E os dois seguem a regra que o teto de gasto e o `FusionReceipt.total_usd` já seguem: se **qualquer** delegação não pôde ser precificada, o total em dólar é `None`, não um número menor. Os tokens são medidos de qualquer jeito, então continuam reportados.

## O que ficou de fora, de propósito

**O crew.** `IsolatedCrewResult` não carrega contabilidade de token nenhuma — `RoleAgent.act` devolve um `str` puro — então não há o que registrar até isso existir. Registrar um zero seria a mesma mentira num lugar novo.

## Verificação

Backend **3.671 passed** · frontend **663 passed** · mypy limpo · ruff limpo · typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)