### PR TITLE
fix(crew): a check that never ran was picking the winner, and Stop was skippable

### DIFF
--- a/apps/desktop/src/components/orchestration/Crew.test.tsx
+++ b/apps/desktop/src/components/orchestration/Crew.test.tsx
@@ -283,6 +283,45 @@ describe("the crew", () => {
     expect(cancelOrchestration).toHaveBeenCalledWith("c1");
   });
 
+  it("does not present a merge as approved when the check decided nothing", async () => {
+    const user = await openCrewForm();
+    const handlers = await runCrew(user);
+
+    // `pytest` that is not installed exits 127, and `VerificationResult` reports that as
+    // `passed=True` on purpose — the work is not punished for our inability to check it. Reading
+    // only `passed` turned "the command does not exist" into "the command approved this", on a
+    // screen whose entire premise is that the test picks the winner.
+    send(
+      handlers(),
+      frame(1, "run", { run_id: "c1" }),
+      frame(2, "crew_worker_started", {}, "conservador"),
+      frame(
+        3,
+        "crew_worker_verified",
+        { verified_by: "", abstained: true, detail: "pytest: command not found" },
+        "conservador",
+      ),
+    );
+
+    expect(screen.getByText(/reached no verdict/i)).toBeInTheDocument();
+    expect(screen.getByText(/nothing approved it/i)).toBeInTheDocument();
+  });
+
+  it("still says a real pass is a pass", async () => {
+    // Or the test above would pass against a version that had stopped trusting any check at all.
+    const user = await openCrewForm();
+    const handlers = await runCrew(user);
+
+    send(
+      handlers(),
+      frame(1, "run", { run_id: "c1" }),
+      frame(2, "crew_worker_started", {}, "conservador"),
+      frame(3, "crew_worker_verified", { verified_by: "pytest -q" }, "conservador"),
+    );
+
+    expect(screen.queryByText(/reached no verdict/i)).toBeNull();
+  });
+
   it("tells a check that could not run apart from one that failed", async () => {
     const user = await openCrewForm();
     const handlers = await runCrew(user);

--- a/apps/desktop/src/components/orchestration/CrewRun.tsx
+++ b/apps/desktop/src/components/orchestration/CrewRun.tsx
@@ -52,8 +52,10 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
           <span className="text-sm font-medium text-foreground">{label}</span>
           <Badge
             tone={
-              worker.status === "verified" ? "ok" : worker.status === "running" ? "accent"
-                : worker.status === "queued" ? "muted" : "bad"
+              worker.status === "verified"
+                ? worker.abstained ? "warn" : "ok"
+                : worker.status === "running" ? "accent"
+                  : worker.status === "queued" ? "muted" : "bad"
             }
           >
             {t(`crew.status.${worker.status}`)}
@@ -70,6 +72,25 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
             <FolderGit2 className="mt-0.5 h-3 w-3 shrink-0" />
             <span className="min-w-0 break-all">{worker.workspace}</span>
           </p>
+        ) : null}
+
+        {/* A merge with nothing behind it. The crew is justified entirely by "N attempts, the
+            test picks the winner", so a run where the test never executed has to say so — the card
+            used to read "verified by pytest -q" for a pytest that is not installed. */}
+        {worker.status === "verified" && worker.abstained ? (
+          <div className="space-y-1">
+            <p className="text-xs text-warn-foreground">{t("crew.verified.abstained")}</p>
+            {worker.detail ? (
+              <details className="text-xs">
+                <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                  {t("crew.rejected.output")}
+                </summary>
+                <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded-chip bg-surface-2 p-2 font-mono text-muted-foreground">
+                  {worker.detail}
+                </pre>
+              </details>
+            ) : null}
+          </div>
         ) : null}
 
         {worker.status === "rejected" ? (

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1145,6 +1145,8 @@ const en: Dict = {
   "crew.rejected.couldNotRun": "`{command}` could not run here — the command or the folder, not your code.",
   "crew.rejected.cancelled": "Stopped before it finished.",
   "crew.rejected.output": "what the check printed",
+  "crew.verified.abstained":
+    "The check ran and reached no verdict — it found nothing to run, or is not installed here. This merged as if you had set no check at all; nothing approved it.",
   "crew.rejected.discarded": "Its changes were thrown away — nothing from this worker reached your files.",
   "crew.conflicts.title": "contested files: {n}",
   "crew.conflicts.explain": "Two workers changed each of these, so NEITHER version was kept. The files are as they were.",
@@ -2282,6 +2284,8 @@ const pt: Dict = {
   "crew.rejected.couldNotRun": "`{command}` não pôde rodar aqui — o problema é o comando ou a pasta, não o seu código.",
   "crew.rejected.cancelled": "Parado antes de terminar.",
   "crew.rejected.output": "o que a verificação imprimiu",
+  "crew.verified.abstained":
+    "A checagem rodou e não chegou a veredito — não achou o que rodar, ou não está instalada aqui. Isto entrou como se você não tivesse posto checagem nenhuma; nada aprovou.",
   "crew.rejected.discarded": "As mudanças dele foram jogadas fora — nada deste trabalhador chegou aos seus arquivos.",
   "crew.conflicts.title": "arquivos disputados: {n}",
   "crew.conflicts.explain": "Dois trabalhadores mudaram cada um destes, então NENHUMA versão foi mantida. Os arquivos estão como estavam.",
@@ -3429,6 +3433,8 @@ const es: Dict = {
   "crew.rejected.couldNotRun": "`{command}` no pudo ejecutarse aquí — es el comando o la carpeta, no tu código.",
   "crew.rejected.cancelled": "Detenido antes de terminar.",
   "crew.rejected.output": "lo que imprimió la comprobación",
+  "crew.verified.abstained":
+    "La comprobación se ejecutó y no llegó a un veredicto: no encontró qué ejecutar, o no está instalada aquí. Esto se fusionó como si no hubieras puesto ninguna comprobación; nada lo aprobó.",
   "crew.rejected.discarded": "Sus cambios se descartaron — nada de este trabajador llegó a tus archivos.",
   "crew.conflicts.title": "archivos en disputa: {n}",
   "crew.conflicts.explain": "Dos trabajadores cambiaron cada uno de estos, así que NINGUNA versión se guardó. Los archivos están como estaban.",
@@ -4589,6 +4595,8 @@ const fr: Dict = {
   "crew.rejected.couldNotRun": "`{command}` n'a pas pu s'exécuter ici — c'est la commande ou le dossier, pas votre code.",
   "crew.rejected.cancelled": "Arrêté avant la fin.",
   "crew.rejected.output": "ce qu'a affiché la vérification",
+  "crew.verified.abstained":
+    "La vérification s'est lancée sans rendre de verdict — elle n'a rien trouvé à exécuter, ou n'est pas installée ici. Ceci a été fusionné comme si vous n'aviez mis aucune vérification ; rien ne l'a approuvé.",
   "crew.rejected.discarded": "Ses modifications ont été jetées — rien de ce travailleur n'a atteint vos fichiers.",
   "crew.conflicts.title": "fichiers disputés : {n}",
   "crew.conflicts.explain": "Deux travailleurs ont modifié chacun de ces fichiers, donc AUCUNE version n'a été gardée. Ils sont restés tels quels.",
@@ -5746,6 +5754,8 @@ const de: Dict = {
   "crew.rejected.couldNotRun": "`{command}` konnte hier nicht laufen — es liegt am Befehl oder am Ordner, nicht an Ihrem Code.",
   "crew.rejected.cancelled": "Vor dem Ende gestoppt.",
   "crew.rejected.output": "was die Prüfung ausgab",
+  "crew.verified.abstained":
+    "Die Prüfung lief und kam zu keinem Urteil — sie fand nichts auszuführen oder ist hier nicht installiert. Das wurde zusammengeführt, als hätten Sie gar keine Prüfung gesetzt; nichts hat es freigegeben.",
   "crew.rejected.discarded": "Seine Änderungen wurden verworfen — nichts von diesem Worker hat Ihre Dateien erreicht.",
   "crew.conflicts.title": "umstrittene Dateien: {n}",
   "crew.conflicts.explain": "Zwei Worker haben jede dieser Dateien geändert, also wurde KEINE Version behalten. Die Dateien sind unverändert.",
@@ -6822,6 +6832,8 @@ const zh: Dict = {
   "crew.rejected.couldNotRun": "`{command}` 在这里无法运行——问题出在命令或文件夹，不是你的代码。",
   "crew.rejected.cancelled": "在完成前被停止。",
   "crew.rejected.output": "校验输出了什么",
+  "crew.verified.abstained":
+    "检查跑了，但没有给出结论 —— 它没找到可运行的东西，或者这里根本没装。这次合并等同于你没有设置任何检查；没有任何东西批准过它。",
   "crew.rejected.discarded": "它的改动被丢弃了——这个工作者的内容没有进入你的文件。",
   "crew.conflicts.title": "冲突文件：{n}",
   "crew.conflicts.explain": "这些文件都被两个工作者改动过，因此两个版本都没有保留。文件保持原样。",
@@ -7960,6 +7972,8 @@ const ja: Dict = {
   "crew.rejected.couldNotRun": "`{command}` はここで実行できませんでした。原因はコマンドかフォルダで、コードではありません。",
   "crew.rejected.cancelled": "完了前に停止されました。",
   "crew.rejected.output": "チェックの出力",
+  "crew.verified.abstained":
+    "チェックは走りましたが判定に至りませんでした — 実行するものが見つからないか、ここには入っていません。これはチェックを設定しなかった場合と同じように取り込まれました。承認したものは何もありません。",
   "crew.rejected.discarded": "その変更は破棄されました。このワーカーのものは一切ファイルに入っていません。",
   "crew.conflicts.title": "競合したファイル: {n}",
   "crew.conflicts.explain": "これらはいずれも二人のワーカーが変更したため、どちらの版も採用されていません。ファイルは元のままです。",
@@ -9112,6 +9126,8 @@ const it: Dict = {
   "crew.rejected.couldNotRun": "`{command}` non ha potuto essere eseguito qui — è il comando o la cartella, non il tuo codice.",
   "crew.rejected.cancelled": "Fermato prima di finire.",
   "crew.rejected.output": "cosa ha stampato la verifica",
+  "crew.verified.abstained":
+    "Il controllo è partito e non ha dato un verdetto: non ha trovato nulla da eseguire, oppure qui non è installato. Questo è stato unito come se non avessi impostato alcun controllo; nulla lo ha approvato.",
   "crew.rejected.discarded": "Le sue modifiche sono state scartate — nulla di questo lavoratore è arrivato ai tuoi file.",
   "crew.conflicts.title": "file contesi: {n}",
   "crew.conflicts.explain": "Due lavoratori hanno modificato ciascuno di questi, quindi NESSUNA versione è stata tenuta. I file sono come erano.",
@@ -10256,6 +10272,8 @@ const pl: Dict = {
   "crew.rejected.couldNotRun": "`{command}` nie mogło się tu uruchomić — chodzi o polecenie lub folder, nie o twój kod.",
   "crew.rejected.cancelled": "Zatrzymany przed końcem.",
   "crew.rejected.output": "co wypisało sprawdzenie",
+  "crew.verified.abstained":
+    "Sprawdzenie uruchomiło się i nie wydało werdyktu — nie znalazło nic do uruchomienia albo nie jest tu zainstalowane. Scalono to tak, jakbyś nie ustawił żadnego sprawdzenia; nic tego nie zatwierdziło.",
   "crew.rejected.discarded": "Jego zmiany odrzucono — nic od tego pracownika nie trafiło do twoich plików.",
   "crew.conflicts.title": "sporne pliki: {n}",
   "crew.conflicts.explain": "Każdy z tych plików zmieniło dwóch pracowników, więc NIE zachowano żadnej wersji. Pliki są jak były.",
@@ -11406,6 +11424,8 @@ const ru: Dict = {
   "crew.rejected.couldNotRun": "`{command}` не смогла запуститься здесь — дело в команде или папке, а не в вашем коде.",
   "crew.rejected.cancelled": "Остановлен до завершения.",
   "crew.rejected.output": "что вывела проверка",
+  "crew.verified.abstained":
+    "Проверка запустилась и не вынесла вердикта — ей нечего было запускать, либо она здесь не установлена. Это слилось так, как если бы вы вообще не задали проверку; ничто её не одобрило.",
   "crew.rejected.discarded": "Его правки отброшены — ничего от этого работника не попало в ваши файлы.",
   "crew.conflicts.title": "спорные файлы: {n}",
   "crew.conflicts.explain": "Каждый из этих файлов изменили двое, поэтому НИ ОДНА версия не сохранена. Файлы остались прежними.",

--- a/apps/desktop/src/lib/orchestration-run.ts
+++ b/apps/desktop/src/lib/orchestration-run.ts
@@ -266,8 +266,14 @@ export interface CrewWorkerState {
   /** The checkout this worker writes in. Empty until it starts. */
   workspace: string;
   instruction: string;
-  /** The check that passed, or the one that refused it. */
+  /** The check that passed, or the one that refused it. Empty when there was none, and empty when
+   *  there WAS one that reached no verdict — see `abstained`. */
   verify: string;
+  /** The check ran and decided nothing: pytest collected no tests (exit 5), or the binary is not
+   *  installed (exit 127). This worker merged, as it would with no check configured, and nothing
+   *  may say a check approved it. Kept apart from `verify` because "approved by pytest" and
+   *  "pytest is not installed here" send a reader to two different places. */
+  abstained: boolean;
   /** What the failing check printed — the only thing that says WHY this was discarded. */
   detail: string;
   reason: string;
@@ -322,6 +328,7 @@ function patchCrewWorker(
     workspace: "",
     instruction: "",
     verify: "",
+    abstained: false,
     detail: "",
     reason: "",
     answerChars: 0,
@@ -364,8 +371,14 @@ export function applyCrewFrame(state: CrewState, frame: OrchFrame): CrewState {
         ...state,
         seq,
         workers: patchCrewWorker(state.workers, frame.task_id, {
+          // "verified" is the merge decision. `abstained` is whether anything actually decided it:
+          // pytest that collected nothing, or a binary that is not installed, comes back
+          // `passed=True` so the work is not punished for our inability to check it — and reading
+          // only that turned a command which DOES NOT EXIST into an approval.
           status: "verified",
           verify: str(data.verified_by),
+          abstained: data.abstained === true,
+          detail: str(data.detail),
           answerChars: num(data.answer_chars),
         }),
       };

--- a/chimera/orchestration/crew.py
+++ b/chimera/orchestration/crew.py
@@ -140,6 +140,11 @@ class WorkerOutcome:
 
     answer: str
     verified: bool = True
+    #: The check ran and reached NO verdict — pytest collecting nothing (exit 5), a missing binary
+    #: (exit 127, or `program_missing` on Windows). Separate from ``verified`` because the two
+    #: answer different questions: this worker merges, as it would with no check configured, and
+    #: nobody may say a check approved it.
+    abstained: bool = False
 
 
 @dataclass
@@ -258,19 +263,38 @@ class IsolatedCrew:
                 except Exception as exc:  # noqa: BLE001 -- one worker crashing is its own failure
                     self._emit("worker_failed", task_id=name, text=str(exc)[:300])
                     raise
+                # BEFORE the no-verify branch, not after it. There were exactly two stop checks
+                # and the early return sat between them, so a crew run with the check left empty —
+                # a configuration the form presents as valid — ignored Stop entirely: the worker
+                # came back `verified=True` and MERGED, while the button's tooltip promised that a
+                # worker which stops is discarded and nothing half-written lands.
+                if self.should_stop is not None and self.should_stop():
+                    self._emit("worker_rejected", task_id=name, reason="cancelled",
+                               text="cancelled after it finished, before anything landed")
+                    return WorkerOutcome(answer=agent_answer, verified=False)
                 if not verify:
                     # No verify command: every worker that did not crash merges, subject to the
                     # one-file-one-owner conflict rule. Said out loud because it is the case where
                     # two workers editing the same file BOTH lose.
                     self._emit("worker_verified", task_id=name, verified_by="", answer_chars=len(answer))
                     return WorkerOutcome(answer=answer, verified=True)
-                if self.should_stop is not None and self.should_stop():
-                    self._emit("worker_rejected", task_id=name, reason="cancelled",
-                               text="cancelled before its check ran")
-                    return WorkerOutcome(answer=agent_answer, verified=False)
                 from chimera.core.verify import CommandVerifier
 
                 outcome = CommandVerifier(verify, ws).verify()
+                if outcome.abstained:
+                    # The check reached no verdict: pytest collected nothing, or the binary is not
+                    # there. `VerificationResult` sets `passed=True` in that case so the work is not
+                    # punished for our inability to check it — and reading only `passed` turned a
+                    # `pytest` that DOES NOT EXIST into an approval. The whole crew is justified by
+                    # "N attempts, the test picks the winner"; a test that never ran picking the
+                    # winner is that justification with the middle removed.
+                    #
+                    # It still merges, because that is what "as if no check were configured" means
+                    # and it is what the autonomous loop already does with an abstention. What
+                    # changes is that nothing claims a check approved it.
+                    self._emit("worker_verified", task_id=name, verified_by="", abstained=True,
+                               answer_chars=len(answer), detail=(outcome.output or "")[:2000])
+                    return WorkerOutcome(answer=answer, verified=True, abstained=True)
                 if outcome.passed:
                     self._emit("worker_verified", task_id=name, verified_by=verify,
                                answer_chars=len(answer))

--- a/tests/test_isolated_crew.py
+++ b/tests/test_isolated_crew.py
@@ -179,3 +179,89 @@ def test_a_worker_that_actually_landed_says_so(tmp_path: Path) -> None:
     produced = {e.task_id: e.data for e in seen if e.kind == "worker_produced"}
     assert produced["a"]["landed"] is True and produced["a"]["files"] == ["a.txt"]
     assert produced["a"]["lost"] == []
+
+
+def _events(crew_kwargs: dict[str, Any], tmp_path: Path, **run_kwargs: Any) -> list[Any]:
+    seen: list[Any] = []
+    crew = IsolatedCrew(
+        WritingBackend("_", "_"),
+        [_worker("solo", "out/solo.txt", "good")],
+        on_event=seen.append,
+        **crew_kwargs,
+    )
+    crew.run("go", tmp_path, **run_kwargs)
+    return seen
+
+
+def test_a_check_that_reached_no_verdict_does_not_get_reported_as_an_approval(
+    tmp_path: Path,
+) -> None:
+    """`pytest` that DOES NOT EXIST used to approve a worker.
+
+    `VerificationResult` sets `passed=True` for exit 5 (collected nothing) and exit 127 (no such
+    command), on purpose: the work is not punished for our inability to check it. `crew.py` read
+    only `passed`, so an abstention arrived as a pass and the card said "verified by pytest -q".
+
+    The crew's entire justification is "N attempts, the test picks the winner". A test that never
+    ran picking the winner is that justification with the middle removed.
+    """
+    _init_repo(tmp_path)
+    # Exit 127 is the shell saying the command is not there — the abstaining case, not a failure.
+    events = _events({}, tmp_path, verify="python -c \"import sys; sys.exit(127)\"")
+
+    verified = [e for e in events if e.kind == "worker_verified"]
+    assert len(verified) == 1
+    assert verified[0].data.get("abstained") is True
+    # And it must not name the command as the thing that approved it.
+    assert not verified[0].data.get("verified_by")
+
+
+def test_an_abstention_still_merges_because_that_is_what_no_check_means(tmp_path: Path) -> None:
+    """Not punishing the work is the point of abstaining; the autonomous loop already does this.
+
+    Refusing to merge would be claiming the work is bad, which we did not establish either.
+    """
+    _init_repo(tmp_path)
+    crew = IsolatedCrew(WritingBackend("_", "_"), [_worker("solo", "out/solo.txt", "good")])
+
+    res = crew.run("go", tmp_path, verify="python -c \"import sys; sys.exit(127)\"")
+
+    assert (tmp_path / "out" / "solo.txt").exists()
+    assert not res.rejected
+
+
+def test_a_real_pass_still_names_the_command_that_gave_it(tmp_path: Path) -> None:
+    """Or the test above would pass against a version that never named a command at all."""
+    _init_repo(tmp_path)
+    events = _events({}, tmp_path, verify="python -c \"import sys; sys.exit(0)\"")
+
+    verified = [e for e in events if e.kind == "worker_verified"]
+    assert verified[0].data.get("verified_by")
+    assert not verified[0].data.get("abstained")
+
+
+def test_stop_is_honoured_by_a_crew_with_no_check_configured(tmp_path: Path) -> None:
+    """The configuration the form presents as valid, and the one Stop used to be ignored in.
+
+    There were exactly two stop checks and the no-verify early return sat BETWEEN them, so leaving
+    "The check" empty and pressing Stop mid-work returned `verified=True` and merged — while the
+    button's own tooltip promised that a worker which stops is discarded and nothing half-written
+    lands.
+    """
+    _init_repo(tmp_path)
+    # Stops only AFTER the worker has done its work, which is the window the early return skipped.
+    calls: list[int] = []
+
+    def stop_after_the_work() -> bool:
+        calls.append(1)
+        return len(calls) > 1
+
+    crew = IsolatedCrew(
+        WritingBackend("_", "_"),
+        [_worker("solo", "out/solo.txt", "good")],
+        should_stop=stop_after_the_work,
+    )
+    res = crew.run("go", tmp_path)  # no verify — the case that had no second check
+
+    assert not (tmp_path / "out" / "solo.txt").exists(), "a stopped worker must not land its edit"
+    assert "solo" in res.rejected


### PR DESCRIPTION
Os dois defeitos atacam a mesma frase, que é a justificativa **inteira** da aba Crew: *N tentativas em worktrees separadas, e o teste escolhe o vencedor*.

## 1 · Uma checagem sem veredito contava como aprovação

`VerificationResult` devolve `passed=True, abstained=True` para exit 5 (pytest não coletou nada) e exit 127 (comando não existe), e no Windows para binário ausente. Isso é **deliberado** — o trabalho não é punido pela nossa incapacidade de conferir, e o loop autônomo já rebaixa uma abstenção para o caminho sem verificador.

`crew.py` lia **só** `outcome.passed`. Então um `pytest` **que não existe** chegava como aprovação e o card dizia *"verificado por pytest -q"*.

Continua fundindo — porque "como se não houvesse checagem configurada" é o que uma abstenção significa, e fundir é no que isso desaba; recusar afirmaria que o trabalho é ruim, e isso também não foi estabelecido. **O que muda é que nada diz que uma checagem aprovou:** o frame carrega `abstained`, o selo deixa de ser verde, e o card diz que a checagem não achou o que rodar ou não está instalada aqui.

## 2 · Stop era ignorado num crew sem checagem

Havia exatamente dois portões de parada, e o retorno antecipado do "sem verify" ficava **entre os dois**:

```
228:  if should_stop(): ...              # antes de começar
249:  answer = agent.act(task)           # o trabalho longo
253:  if not verify: return verified=True    # <-- sem portão aqui
259:  if should_stop(): ...              # antes de rodar a checagem
```

Então deixar "A checagem" vazia — configuração que o próprio formulário apresenta como válida — e apertar Parar no meio do trabalho devolvia `verified=True` e **fundia**, enquanto o tooltip do botão prometia que um worker que para é descartado e nada meio-escrito entra.

## Verificação

Os dois testes foram rodados contra o código pré-conserto e **ficam vermelhos**. Um terceiro prende que uma aprovação real continua nomeando o comando que a deu — senão o teste da abstenção passaria contra uma versão que tivesse deixado de confiar em qualquer checagem.

Backend **3.669 passed** · frontend **670 passed** · mypy limpo · ruff limpo · typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)