### PR TITLE
fix(code): the undo existed on one branch of four, and overstated what it did

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -7502,7 +7502,7 @@
     },
     "/api/code/revert/{token}": {
       "post": {
-        "description": "Undo an editing turn whose verification failed, if the user takes the offer.\n\nA token is single-use and dies with the process. An unknown one is ``{ok: false}`` rather\nthan a 404 \u2014 that is the state a second click hits, and a stale offer is not an error.",
+        "description": "Undo an editing turn, if the user takes the offer.\n\nAny editing turn, not only one whose verification failed. A check answers \"does this still\nbuild\"; the button answers \"do I want this\", and only the person reading the diff can.\n\nA token is single-use and dies with the process. An unknown one is ``{ok: false}`` rather\nthan a 404 \u2014 that is the state a second click hits, and a stale offer is not an error.",
         "operationId": "revert_turn_api_code_revert__token__post",
         "parameters": [
           {

--- a/apps/desktop/src/components/Code.verdict.test.tsx
+++ b/apps/desktop/src/components/Code.verdict.test.tsx
@@ -76,6 +76,90 @@ describe("Code — the verdict on what a turn wrote", () => {
     await screen.findByText(/Edits undone/i);
   });
 
+  it("offers the undo on a turn that PASSED, because a pass is not consent", async () => {
+    // The token used to be minted only for `state === "failed"`, so three of the four verdicts —
+    // passed, abstained, and no command at all — took a snapshot and let it die with the request.
+    // Meanwhile the Posture note promised outright: "What is guaranteed is the snapshot and the
+    // undo, not the limits."
+    //
+    // The check answers "does this still build". The button answers "do I want this", and only the
+    // person reading the diff can.
+    vi.mocked(revertCodeTurn).mockResolvedValue({ ok: true, restored: 1 });
+    const user = await turnWith({
+      command: "python -m pytest -q",
+      source: "inferred:tests/",
+      state: "passed",
+      revert_token: "tok",
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Undo these edits/i }));
+    await waitFor(() => expect(revertCodeTurn).toHaveBeenCalledWith("tok"));
+  });
+
+  it("offers the undo when there was no command to check with at all", async () => {
+    // The case where it matters most: a project with no test command never reaches the failed
+    // branch, so under the old rule the snapshot was taken and dropped on EVERY editing turn.
+    vi.mocked(revertCodeTurn).mockResolvedValue({ ok: true, restored: 2 });
+    const user = await turnWith({
+      command: null,
+      source: "none",
+      state: "none",
+      revert_token: "tok",
+    });
+
+    await screen.findByText(/no verification command/i);
+    await user.click(screen.getByRole("button", { name: /Undo these edits/i }));
+    await waitFor(() => expect(revertCodeTurn).toHaveBeenCalledWith("tok"));
+  });
+
+  it("offers no undo on a turn that wrote nothing", async () => {
+    // Or the two tests above would pass against a version that showed the button unconditionally,
+    // inviting someone to roll back a snapshot of work they did by hand.
+    await turnWith({ command: "python -m pytest -q", source: "inferred:tests/", state: "passed" });
+
+    await screen.findByText(/passed/i);
+    expect(screen.queryByRole("button", { name: /Undo these edits/i })).not.toBeInTheDocument();
+  });
+
+  it("does not call new files removed when they are still there", async () => {
+    // Inside a git repository the delete-new pass is skipped unconditionally — deliberately, after
+    // a path bug once let a revert wipe a repo — so a turn that CREATED a file leaves it behind.
+    // "Edits undone." over that describes a state the workspace is not in, and it is the one
+    // sentence a reader would act on without checking.
+    vi.mocked(revertCodeTurn).mockResolvedValue({
+      ok: true,
+      restored: 1,
+      left_new_files: true,
+    });
+    const user = await turnWith({
+      command: "python -m pytest -q",
+      source: "inferred:tests/",
+      state: "failed",
+      revert_token: "tok",
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Undo these edits/i }));
+    await screen.findByText(/files this turn created are still there/i);
+  });
+
+  it("still says plainly undone when it really was", async () => {
+    // Or the test above would pass against a version that had started hedging on every undo.
+    vi.mocked(revertCodeTurn).mockResolvedValue({
+      ok: true,
+      restored: 1,
+      left_new_files: false,
+    });
+    const user = await turnWith({
+      command: "python -m pytest -q",
+      source: "inferred:tests/",
+      state: "failed",
+      revert_token: "tok",
+    });
+
+    await user.click(await screen.findByRole("button", { name: /Undo these edits/i }));
+    await screen.findByText(/^Edits undone\.$/i);
+  });
+
   it("reports a refused undo as edits still present, not as success", async () => {
     // The failure mode this guards is the worst kind of lie the screen could tell: saying the files
     // were restored when they were not.

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -96,7 +96,7 @@ interface Exchange {
   /** The verdict on what this turn WROTE. Absent when the turn wrote nothing. */
   verified?: CodeVerified;
   /** Set once the offered undo was taken (or refused by the server) — the offer is single-use. */
-  undone?: "ok" | "gone";
+  undone?: "ok" | "partial" | "gone";
   /** Stopped by the Stop button. Distinct from `failed`: nothing went wrong, the user changed
    *  their mind — and distinct from a finished turn, which has a `done`. */
   abandoned?: boolean;
@@ -122,25 +122,59 @@ function Verdict({
   t,
 }: {
   v: CodeVerified;
-  undone?: "ok" | "gone";
+  undone?: "ok" | "partial" | "gone";
   onUndo: () => void;
   onFix: () => void;
   t: TFunc;
 }) {
-  if (v.state === "none")
-    return <p className="text-xs text-warn">{t("code.chat.verdict.none")}</p>;
   const cmd = v.command ?? "";
   const args = { cmd, src: v.source };
-  if (v.state === "abstained")
-    return (
-      <p className="text-xs text-warn">
-        {t("code.chat.verdict.abstained", args)}
+  // The undo offer belongs to "this turn edited files", not to "the check disliked them". It used
+  // to render only inside the failed branch, so a turn that passed, abstained, or ran in a project
+  // with no test command at all — which for many projects is every turn — had its snapshot taken
+  // and then dropped. A check answers "does this still build"; the button answers "do I want this",
+  // and only the person reading the diff can.
+  const undo =
+    undone ? (
+      <p
+        className={cn(
+          "text-xs",
+          undone === "ok" ? "text-ok" : undone === "partial" ? "text-warn" : "text-bad",
+        )}
+      >
+        {t(
+          undone === "ok"
+            ? "code.chat.verdict.reverted"
+            : undone === "partial"
+              ? "code.chat.verdict.revertedPartly"
+              : "code.chat.verdict.revertFailed",
+        )}
       </p>
-    );
-  if (v.state === "passed")
+    ) : v.revert_token ? (
+      <Button size="sm" variant="ghost" onClick={onUndo}>
+        <Undo2 className="h-3.5 w-3.5" /> {t("code.chat.verdict.revert")}
+      </Button>
+    ) : null;
+
+  if (v.state !== "failed")
     return (
-      <p className="text-xs text-ok">{t("code.chat.verdict.passed", args)}</p>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <p
+          className={cn(
+            "text-xs",
+            v.state === "passed" ? "text-ok" : "text-warn",
+          )}
+        >
+          {v.state === "none"
+            ? t("code.chat.verdict.none")
+            : v.state === "abstained"
+              ? t("code.chat.verdict.abstained", args)
+              : t("code.chat.verdict.passed", args)}
+        </p>
+        {undo}
+      </div>
     );
+
   return (
     <div className="space-y-1.5 rounded-chip border border-bad/40 p-2">
       <p className="text-xs text-bad">{t("code.chat.verdict.failed", args)}</p>
@@ -150,20 +184,10 @@ function Verdict({
         </pre>
       ) : null}
       {undone ? (
-        <p className={cn("text-xs", undone === "ok" ? "text-ok" : "text-bad")}>
-          {t(
-            undone === "ok"
-              ? "code.chat.verdict.reverted"
-              : "code.chat.verdict.revertFailed",
-          )}
-        </p>
+        undo
       ) : (
         <div className="flex flex-wrap gap-2">
-          {v.revert_token ? (
-            <Button size="sm" variant="ghost" onClick={onUndo}>
-              <Undo2 className="h-3.5 w-3.5" /> {t("code.chat.verdict.revert")}
-            </Button>
-          ) : null}
+          {undo}
           <Button size="sm" variant="ghost" onClick={onFix}>
             <ShieldCheck className="h-3.5 w-3.5" /> {t("code.chat.verdict.fix")}
           </Button>
@@ -807,9 +831,14 @@ export function Conversation({
   }
 
   async function undo(index: number, token: string) {
-    let outcome: "ok" | "gone" = "gone";
+    // Three outcomes, not two. "partial" is a restore that put the captured content back and left
+    // the files this turn CREATED where they are — which is what happens inside a git repository,
+    // and therefore what happens in most projects someone opens here. Reporting that as "Edits
+    // undone." describes a state the workspace is not in.
+    let outcome: "ok" | "partial" | "gone" = "gone";
     try {
-      outcome = (await revertCodeTurn(token)).ok ? "ok" : "gone";
+      const result = await revertCodeTurn(token);
+      outcome = !result.ok ? "gone" : result.left_new_files ? "partial" : "ok";
     } catch {
       // A failed call and a refused token mean the same thing to the user: the edits are still
       // there. Saying "gone" is the honest read of both, and it is the one that does not imply the
@@ -818,7 +847,7 @@ export function Conversation({
     setExchanges((prev) =>
       prev.map((e, j) => (j === index ? { ...e, undone: outcome } : e)),
     );
-    if (outcome === "ok") {
+    if (outcome !== "gone") {
       void qc.invalidateQueries({ queryKey: ["fs-file"] });
       void qc.invalidateQueries({ queryKey: ["git-status"] });
       onEdited();

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -184,7 +184,10 @@ export interface paths {
         put?: never;
         /**
          * Revert Turn
-         * @description Undo an editing turn whose verification failed, if the user takes the offer.
+         * @description Undo an editing turn, if the user takes the offer.
+         *
+         *     Any editing turn, not only one whose verification failed. A check answers "does this still
+         *     build"; the button answers "do I want this", and only the person reading the diff can.
          *
          *     A token is single-use and dies with the process. An unknown one is ``{ok: false}`` rather
          *     than a 404 — that is the state a second click hits, and a stale offer is not an error.

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -977,8 +977,17 @@ export async function transcribe(audio: Blob): Promise<Transcript> {
 
 /** Undo the edits of a turn whose verification failed. Single-use: the token is consumed by the
  *  server, so a second press cannot restore a snapshot the user has since typed on top of. */
-export async function revertCodeTurn(token: string): Promise<{ ok: boolean; restored: number }> {
-  return json<{ ok: boolean; restored: number }>(`/api/code/revert/${token}`, { method: "POST" });
+export async function revertCodeTurn(
+  token: string,
+): Promise<{ ok: boolean; restored: number; left_new_files?: boolean }> {
+  // `left_new_files`: the restore put the captured content back but did NOT remove files the turn
+  // created. Inside a git repository that pass is skipped unconditionally — deliberately, after a
+  // path bug once let a revert wipe a repo — which is most workspaces someone opens in this app.
+  // Optional so an older server, which sends neither field, is not read as `false`.
+  return json<{ ok: boolean; restored: number; left_new_files?: boolean }>(
+    `/api/code/revert/${token}`,
+    { method: "POST" },
+  );
 }
 
 /** Send one turn of a coding conversation and stream it. Mirrors {@link streamRun}: the SSE lives

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -527,7 +527,7 @@ const en: Dict = {
     "Pause for my approval if the run reads untrusted content",
   "runs.pausedTitle": "Waiting for you",
   "runs.pausedNote":
-    "This run read untrusted content and stopped before finalizing. Nothing is saved until you decide.",
+    "This run read untrusted content and stopped before finalizing. Nothing is written to memory, no skill is learned and no receipt is filed until you decide — but the files the run already wrote are on disk.",
   "runs.pausedAnswer": "What it would finalize",
   "runs.accept": "Accept",
   "runs.editAnswer": "Accept an edited answer",
@@ -762,6 +762,8 @@ const en: Dict = {
     "Nothing checked these edits — this project has no verification command.",
   "code.chat.verdict.revert": "Undo these edits",
   "code.chat.verdict.reverted": "Edits undone.",
+  "code.chat.verdict.revertedPartly":
+    "Edits undone. Files this turn created are still there — inside a git repository nothing is deleted on an undo, so remove them yourself if you want them gone.",
   "code.chat.verdict.revertFailed": "Could not undo — that snapshot is gone.",
   "code.chat.verdict.fix": "Let the agent try to fix it",
   "code.posture.title": "Reach & approval",
@@ -1656,7 +1658,7 @@ const pt: Dict = {
     "Pausar para minha aprovação se a execução ler conteúdo não confiável",
   "runs.pausedTitle": "Esperando por você",
   "runs.pausedNote":
-    "Esta execução leu conteúdo não confiável e parou antes de finalizar. Nada é salvo até você decidir.",
+    "Esta execução leu conteúdo não confiável e parou antes de finalizar. Nada vai para a memória, nenhuma skill é aprendida e nenhum recibo é registrado até você decidir — mas os arquivos que a execução já escreveu estão em disco.",
   "runs.pausedAnswer": "O que ela finalizaria",
   "runs.accept": "Aceitar",
   "runs.editAnswer": "Aceitar uma resposta editada",
@@ -1894,6 +1896,8 @@ const pt: Dict = {
     "Nada verificou estas edições — este projeto não tem comando de verificação.",
   "code.chat.verdict.revert": "Desfazer estas edições",
   "code.chat.verdict.reverted": "Edições desfeitas.",
+  "code.chat.verdict.revertedPartly":
+    "Edições desfeitas. Os arquivos que este turno criou continuam aí — dentro de um repositório git nada é apagado ao desfazer, então remova você mesmo se quiser.",
   "code.chat.verdict.revertFailed":
     "Não deu para desfazer — aquele instantâneo já não existe.",
   "code.chat.verdict.fix": "Deixar o agente tentar corrigir",
@@ -2799,7 +2803,7 @@ const es: Dict = {
     "Pausar para mi aprobación si la ejecución lee contenido no confiable",
   "runs.pausedTitle": "Esperándote",
   "runs.pausedNote":
-    "Esta ejecución leyó contenido no confiable y se detuvo antes de finalizar. Nada se guarda hasta que decidas.",
+    "Esta ejecución leyó contenido no fiable y se detuvo antes de finalizar. Nada se escribe en la memoria, no se aprende ninguna habilidad y no se archiva ningún recibo hasta que decidas, pero los archivos que la ejecución ya escribió están en disco.",
   "runs.pausedAnswer": "Lo que finalizaría",
   "runs.accept": "Aceptar",
   "runs.editAnswer": "Aceptar una respuesta editada",
@@ -3037,6 +3041,8 @@ const es: Dict = {
     "Nada comprobó estas ediciones: este proyecto no tiene comando de verificación.",
   "code.chat.verdict.revert": "Deshacer estas ediciones",
   "code.chat.verdict.reverted": "Ediciones deshechas.",
+  "code.chat.verdict.revertedPartly":
+    "Ediciones deshechas. Los archivos que este turno creó siguen ahí: dentro de un repositorio git no se borra nada al deshacer, así que elimínalos tú si los quieres fuera.",
   "code.chat.verdict.revertFailed":
     "No se pudo deshacer: esa instantánea ya no existe.",
   "code.chat.verdict.fix": "Dejar que el agente intente arreglarlo",
@@ -3951,7 +3957,7 @@ const fr: Dict = {
     "Mettre en pause pour mon approbation si l'exécution lit du contenu non fiable",
   "runs.pausedTitle": "En attente de vous",
   "runs.pausedNote":
-    "Cette exécution a lu du contenu non fiable et s'est arrêtée avant de finaliser. Rien n'est enregistré tant que vous n'avez pas décidé.",
+    "Cette exécution a lu du contenu non fiable et s'est arrêtée avant de finaliser. Rien n'est écrit en mémoire, aucune compétence n'est apprise et aucun reçu n'est enregistré avant votre décision — mais les fichiers déjà écrits sont sur le disque.",
   "runs.pausedAnswer": "Ce qu'elle finaliserait",
   "runs.accept": "Accepter",
   "runs.editAnswer": "Accepter une réponse modifiée",
@@ -4194,6 +4200,8 @@ const fr: Dict = {
     "Rien n'a vérifié ces modifications — ce projet n'a pas de commande de vérification.",
   "code.chat.verdict.revert": "Annuler ces modifications",
   "code.chat.verdict.reverted": "Modifications annulées.",
+  "code.chat.verdict.revertedPartly":
+    "Modifications annulées. Les fichiers créés par ce tour sont toujours là — dans un dépôt git, rien n'est supprimé lors d'une annulation ; retirez-les vous-même si vous le souhaitez.",
   "code.chat.verdict.revertFailed":
     "Impossible d'annuler — cet instantané n'existe plus.",
   "code.chat.verdict.fix": "Laisser l'agent essayer de corriger",
@@ -5109,7 +5117,7 @@ const de: Dict = {
     "Für meine Freigabe pausieren, wenn der Lauf nicht vertrauenswürdige Inhalte liest",
   "runs.pausedTitle": "Wartet auf dich",
   "runs.pausedNote":
-    "Dieser Lauf hat nicht vertrauenswürdige Inhalte gelesen und vor dem Abschluss angehalten. Bis zu deiner Entscheidung wird nichts gespeichert.",
+    "Dieser Lauf hat nicht vertrauenswürdige Inhalte gelesen und vor dem Abschluss angehalten. Nichts wird ins Gedächtnis geschrieben, keine Fähigkeit gelernt und kein Beleg abgelegt, bis Sie entscheiden — die Dateien, die der Lauf bereits geschrieben hat, liegen aber auf der Platte.",
   "runs.pausedAnswer": "Was er abschließen würde",
   "runs.accept": "Annehmen",
   "runs.editAnswer": "Bearbeitete Antwort annehmen",
@@ -5351,6 +5359,8 @@ const de: Dict = {
     "Nichts hat diese Änderungen geprüft — dieses Projekt hat keinen Prüfbefehl.",
   "code.chat.verdict.revert": "Diese Änderungen zurücknehmen",
   "code.chat.verdict.reverted": "Änderungen zurückgenommen.",
+  "code.chat.verdict.revertedPartly":
+    "Änderungen zurückgenommen. Dateien, die dieser Zug angelegt hat, sind noch da — in einem Git-Repository wird beim Rückgängigmachen nichts gelöscht; entfernen Sie sie selbst, wenn Sie sie loswerden wollen.",
   "code.chat.verdict.revertFailed":
     "Zurücknehmen nicht möglich — dieser Schnappschuss ist weg.",
   "code.chat.verdict.fix": "Den Agenten es reparieren lassen",
@@ -6228,7 +6238,7 @@ const zh: Dict = {
   "runs.pauseOnTaint": "若运行读取了不可信内容，暂停并等待我批准",
   "runs.pausedTitle": "等待你的决定",
   "runs.pausedNote":
-    "本次运行读取了不可信内容，已在完成前停止。在你决定之前不会保存任何内容。",
+    "这次运行读到了不可信的内容，在收尾之前停住了。在你做出决定之前，不会写入记忆、不会学到技能、也不会归档任何凭据 —— 但这次运行已经写下的文件就在磁盘上。",
   "runs.pausedAnswer": "它将要提交的结果",
   "runs.accept": "接受",
   "runs.editAnswer": "接受修改后的回答",
@@ -6448,6 +6458,8 @@ const zh: Dict = {
     "没有任何东西检查过这些改动——这个项目没有验证命令。",
   "code.chat.verdict.revert": "撤销这些改动",
   "code.chat.verdict.reverted": "改动已撤销。",
+  "code.chat.verdict.revertedPartly":
+    "改动已撤销。这一轮新建的文件仍然在 —— 在 git 仓库里撤销不会删除任何东西，想清掉请自己删。",
   "code.chat.verdict.revertFailed": "无法撤销——那份快照已经没有了。",
   "code.chat.verdict.fix": "让智能体试着修好",
   "code.posture.title": "触及范围与批准",
@@ -7335,7 +7347,7 @@ const ja: Dict = {
   "runs.pauseOnTaint": "信頼できない内容を読んだ場合は承認のために一時停止する",
   "runs.pausedTitle": "あなたの判断待ち",
   "runs.pausedNote":
-    "この実行は信頼できない内容を読み、確定する前に停止しました。判断するまで何も保存されません。",
+    "この実行は信頼できない内容を読み、仕上げの前で止まりました。あなたが決めるまで、記憶には何も書かれず、スキルも学ばれず、レシートも残りません — ただし実行がすでに書いたファイルはディスク上にあります。",
   "runs.pausedAnswer": "確定される内容",
   "runs.accept": "承認",
   "runs.editAnswer": "修正した回答を承認",
@@ -7571,6 +7583,8 @@ const ja: Dict = {
     "この編集は何にも検証されていません — このプロジェクトに検証コマンドがありません。",
   "code.chat.verdict.revert": "この編集を取り消す",
   "code.chat.verdict.reverted": "編集を取り消しました。",
+  "code.chat.verdict.revertedPartly":
+    "編集を取り消しました。このターンが作成したファイルはそのまま残っています — git リポジトリの中では取り消しで何も削除しないので、消したい場合はご自分でどうぞ。",
   "code.chat.verdict.revertFailed":
     "取り消せません — そのスナップショットはもうありません。",
   "code.chat.verdict.fix": "エージェントに直させる",
@@ -8479,7 +8493,7 @@ const it: Dict = {
     "Metti in pausa per la mia approvazione se l'esecuzione legge contenuti non fidati",
   "runs.pausedTitle": "In attesa di te",
   "runs.pausedNote":
-    "Questa esecuzione ha letto contenuti non fidati e si è fermata prima di finalizzare. Nulla viene salvato finché non decidi.",
+    "Questa esecuzione ha letto contenuto non affidabile e si è fermata prima di finalizzare. Nulla viene scritto in memoria, nessuna abilità viene appresa e nessuna ricevuta viene archiviata finché non decidi — ma i file che l'esecuzione ha già scritto sono su disco.",
   "runs.pausedAnswer": "Cosa finalizzerebbe",
   "runs.accept": "Accetta",
   "runs.editAnswer": "Accetta una risposta modificata",
@@ -8718,6 +8732,8 @@ const it: Dict = {
     "Nulla ha verificato queste modifiche — questo progetto non ha un comando di verifica.",
   "code.chat.verdict.revert": "Annulla queste modifiche",
   "code.chat.verdict.reverted": "Modifiche annullate.",
+  "code.chat.verdict.revertedPartly":
+    "Modifiche annullate. I file creati da questo turno sono ancora lì: dentro un repository git nulla viene cancellato con un annulla, quindi rimuovili tu se li vuoi via.",
   "code.chat.verdict.revertFailed":
     "Non è stato possibile annullare — quello snapshot non c'è più.",
   "code.chat.verdict.fix": "Lascia che l'agente provi a correggere",
@@ -9626,7 +9642,7 @@ const pl: Dict = {
     "Wstrzymaj do mojej zgody, jeśli przebieg przeczyta niezaufaną treść",
   "runs.pausedTitle": "Czeka na ciebie",
   "runs.pausedNote":
-    "Ten przebieg przeczytał niezaufaną treść i zatrzymał się przed zatwierdzeniem. Nic nie zostanie zapisane, dopóki nie zdecydujesz.",
+    "Ten przebieg przeczytał niezaufaną treść i zatrzymał się przed sfinalizowaniem. Nic nie trafia do pamięci, żadna umiejętność nie jest uczona i żaden rachunek nie jest zapisywany, dopóki nie zdecydujesz — ale pliki, które przebieg już zapisał, są na dysku.",
   "runs.pausedAnswer": "Co by zatwierdził",
   "runs.accept": "Akceptuj",
   "runs.editAnswer": "Akceptuj poprawioną odpowiedź",
@@ -9864,6 +9880,8 @@ const pl: Dict = {
     "Nic nie sprawdziło tych zmian — ten projekt nie ma polecenia weryfikującego.",
   "code.chat.verdict.revert": "Cofnij te zmiany",
   "code.chat.verdict.reverted": "Zmiany cofnięte.",
+  "code.chat.verdict.revertedPartly":
+    "Zmiany cofnięte. Pliki utworzone w tej turze nadal tam są — w repozytorium git cofnięcie niczego nie usuwa, więc skasuj je sam, jeśli mają zniknąć.",
   "code.chat.verdict.revertFailed":
     "Nie udało się cofnąć — tamtego zrzutu już nie ma.",
   "code.chat.verdict.fix": "Niech agent spróbuje to naprawić",
@@ -10774,7 +10792,7 @@ const ru: Dict = {
     "Приостановить и спросить меня, если запуск прочитает недоверенное содержимое",
   "runs.pausedTitle": "Ждёт вас",
   "runs.pausedNote":
-    "Этот запуск прочитал недоверенное содержимое и остановился, не завершив работу. Ничего не сохраняется, пока вы не решите.",
+    "Этот запуск прочитал недоверенное содержимое и остановился, не завершившись. Пока вы не решите, ничего не пишется в память, навык не выучивается и квитанция не заводится — но файлы, которые запуск уже записал, лежат на диске.",
   "runs.pausedAnswer": "Что он собирается зафиксировать",
   "runs.accept": "Принять",
   "runs.editAnswer": "Принять изменённый ответ",
@@ -11013,6 +11031,8 @@ const ru: Dict = {
     "Эти правки никто не проверил — в проекте нет команды проверки.",
   "code.chat.verdict.revert": "Отменить эти правки",
   "code.chat.verdict.reverted": "Правки отменены.",
+  "code.chat.verdict.revertedPartly":
+    "Правки отменены. Файлы, созданные этим ходом, остались — внутри git-репозитория отмена ничего не удаляет, так что уберите их сами, если они не нужны.",
   "code.chat.verdict.revertFailed":
     "Не удалось отменить — этого снимка больше нет.",
   "code.chat.verdict.fix": "Дать агенту попробовать это починить",

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -915,9 +915,26 @@ def register_code_api(
                         from chimera.api.app import resolve_verify
                         from chimera.core.verify import CommandVerifier
 
+                        # Minted for every turn that EDITED, not only for one whose verification
+                        # failed. The snapshot was already taken above and the Posture note promises
+                        # outright: "What is guaranteed is the snapshot and the undo, not the
+                        # limits." It was guaranteed on one branch of four. Verification that
+                        # passed, abstained, or was never configured — which for a project with no
+                        # test command is ALWAYS — left the snapshot to die with the request.
+                        #
+                        # A pass is not consent. The check answers "does this still build", and the
+                        # question the button answers is "do I want this", which nothing else on the
+                        # screen can answer for the person reading the diff.
+                        token = uuid.uuid4().hex
+                        _pending_reverts[token] = (guard, before)
+                        while len(_pending_reverts) > _MAX_PENDING_REVERTS:
+                            _pending_reverts.pop(next(iter(_pending_reverts)))
                         command, source = resolve_verify(None, ws)
                         if command is None:
-                            emit("verified", {"command": None, "source": source, "state": "none"})
+                            emit("verified", {
+                                "command": None, "source": source, "state": "none",
+                                "revert_token": token,
+                            })
                         else:
                             outcome = CommandVerifier(command, ws).verify()
                             state = (
@@ -925,12 +942,6 @@ def register_code_api(
                                 else "passed" if outcome.passed
                                 else "failed"
                             )
-                            token = ""
-                            if state == "failed":
-                                token = uuid.uuid4().hex
-                                _pending_reverts[token] = (guard, before)
-                                while len(_pending_reverts) > _MAX_PENDING_REVERTS:
-                                    _pending_reverts.pop(next(iter(_pending_reverts)))
                             emit("verified", {
                                 "command": command, "source": source, "state": state,
                                 "output": outcome.output[:4000], "revert_token": token,
@@ -1253,7 +1264,10 @@ def register_code_api(
 
     @app.post("/api/code/revert/{token}", dependencies=[guard])
     def revert_turn(token: str) -> dict[str, Any]:
-        """Undo an editing turn whose verification failed, if the user takes the offer.
+        """Undo an editing turn, if the user takes the offer.
+
+        Any editing turn, not only one whose verification failed. A check answers "does this still
+        build"; the button answers "do I want this", and only the person reading the diff can.
 
         A token is single-use and dies with the process. An unknown one is ``{ok: false}`` rather
         than a 404 — that is the state a second click hits, and a stale offer is not an error.
@@ -1262,7 +1276,15 @@ def register_code_api(
         if pending is None:
             return {"ok": False, "restored": 0}
         workspace_guard, snapshot = pending
-        return {"ok": True, "restored": workspace_guard.restore(snapshot)}
+        # Whether files this turn CREATED go away with it. Inside a git repository the delete pass
+        # is skipped unconditionally — deliberately, since a path bug once let a revert wipe a repo
+        # — so "Edits undone." over surviving new files reported something that did not happen.
+        left_new = not workspace_guard.deletes_new_files(snapshot)
+        return {
+            "ok": True,
+            "restored": workspace_guard.restore(snapshot),
+            "left_new_files": left_new,
+        }
 
     @app.delete("/api/code/sessions/{session_id}", dependencies=[guard])
     def delete_code_session(session_id: str) -> dict[str, bool]:

--- a/chimera/core/checkpoint.py
+++ b/chimera/core/checkpoint.py
@@ -88,6 +88,23 @@ class WorkspaceGuard:
                 break
         return snap
 
+    def _skip_reasons(self, snapshot: FileSnapshot) -> tuple[bool, bool]:
+        """(truncated, in_git_repo) — the two conditions that disable the delete-new pass."""
+        return (
+            len(snapshot.present) >= self.max_files,
+            any((parent / ".git").exists() for parent in (self.workspace, *self.workspace.parents)),
+        )
+
+    def deletes_new_files(self, snapshot: FileSnapshot) -> bool:
+        """Would a restore remove files created since ``snapshot``?
+
+        Asked by callers that TELL somebody the turn was undone. It usually will not — a workspace
+        inside a git repository never runs the delete pass, which is most workspaces a person opens
+        in the app — and "Edits undone." over surviving new files is a report of something that did
+        not happen. The behaviour is deliberate and stays; only the claim about it changes.
+        """
+        return not any(self._skip_reasons(snapshot))
+
     def restore(self, snapshot: FileSnapshot) -> int:
         """Restore the workspace to ``snapshot``. Returns the number of changes."""
         changes = 0
@@ -104,10 +121,7 @@ class WorkspaceGuard:
         #     untracked work and — if the snapshot predates them — committed files, so a revert could
         #     wipe the repo. It has (bench harness, 2026-07-17). Refuse to delete anywhere inside a repo,
         #     unconditionally — checking ancestors too, not just the immediate directory.
-        truncated = len(snapshot.present) >= self.max_files
-        in_git_repo = any(
-            (parent / ".git").exists() for parent in (self.workspace, *self.workspace.parents)
-        )
+        truncated, in_git_repo = self._skip_reasons(snapshot)
         if truncated:
             _log.warning(
                 "snapshot truncated at %d files; skipping delete-new pass on restore to avoid "

--- a/tests/test_code_api.py
+++ b/tests/test_code_api.py
@@ -12,6 +12,7 @@ reimplemented, because a second copy of that registry order is one waiting to dr
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -287,7 +288,12 @@ def test_a_project_with_no_verify_command_says_so_rather_than_staying_quiet(
     # check. Silence here reads as approval.
     client, _ = _editing_client(tmp_path, monkeypatch)
     verdict = _verdict(client.post("/api/code/turn", json={"message": "edit a.py"}))
-    assert verdict == {"command": None, "source": "none", "state": "none"}
+    assert verdict["command"] is None and verdict["source"] == "none"
+    assert verdict["state"] == "none"
+    # And the undo is still on the table. This is the case where it matters most — a project with
+    # no test command never reaches the "failed" branch, so under the old rule the snapshot was
+    # taken on every editing turn and thrown away on every editing turn.
+    assert verdict["revert_token"]
 
 
 def test_a_failing_verification_offers_an_undo_and_does_not_take_it(
@@ -306,6 +312,63 @@ def test_a_failing_verification_offers_an_undo_and_does_not_take_it(
 
     assert client.post(f"/api/code/revert/{verdict['revert_token']}").json()["ok"] is True
     assert not (ws / "a.py").exists()  # the snapshot predates the file
+
+
+def test_a_passing_verification_still_offers_the_undo(tmp_path: Path, monkeypatch: Any) -> None:
+    """A pass is not consent.
+
+    The Posture note promises outright: "What is guaranteed is the snapshot and the undo, not the
+    limits." The token was minted only when `state == "failed"`, so three of the four verdicts —
+    passed, abstained, and no command at all — took a snapshot and let it die with the request.
+
+    The check answers "does this still build". The button answers "do I want this", and only the
+    person reading the diff can.
+    """
+    client, ws = _editing_client(tmp_path, monkeypatch)
+    (ws / "tests").mkdir()
+    (ws / "tests" / "test_it.py").write_text(
+        "def test_it():\n    assert True\n", encoding="utf-8"
+    )
+
+    verdict = _verdict(client.post("/api/code/turn", json={"message": "edit a.py"}))
+
+    assert verdict["state"] == "passed"
+    assert verdict["revert_token"]
+    assert client.post(f"/api/code/revert/{verdict['revert_token']}").json()["ok"] is True
+    assert not (ws / "a.py").exists()
+
+
+def test_a_turn_that_edited_nothing_offers_no_undo(tmp_path: Path, monkeypatch: Any) -> None:
+    """Or the tests above would pass against a version that handed out a token on every turn.
+
+    A conversation that answered a question has nothing to undo, and an undo button over it would
+    invite someone to roll back a snapshot of work they did by hand.
+    """
+    from chimera.api import build_api_app
+
+    class _Answering(_ScriptedAgent):
+        """Same shape, but it never calls `on_edit` — a question, not a change."""
+
+        def run(self, task: str, **kw: Any) -> AgentResult:
+            kw.pop("on_edit", None)
+            return super().run(task, on_edit=None, **kw)
+
+    ws = tmp_path / "ws"
+    ws.mkdir(exist_ok=True)
+    import chimera.core
+
+    monkeypatch.setattr(chimera.core, "Agent", lambda *_a, **_k: _Answering(), raising=True)
+    client = TestClient(
+        build_api_app(
+            lambda: ChatSession(_ScriptedAgent()),
+            workspace=ws,
+            settings=Settings(CHIMERA_HOME=str(tmp_path / "home")),
+        )
+    )
+
+    frames = _frames(client.post("/api/code/turn", json={"message": "what does this do?"}))
+
+    assert not [payload for event, payload in frames if event == "verified"]
 
 
 def test_a_revert_token_is_single_use(tmp_path: Path, monkeypatch: Any) -> None:
@@ -466,3 +529,35 @@ def test_an_unpriced_turn_is_counted_but_never_priced_at_zero(
     # "unpriced" is the truth, and the summary keeps them apart.
     assert totals["usd"] == 0.0
     assert totals["unpriced_turns"] == 1
+
+
+def test_a_revert_says_whether_it_actually_removed_what_the_turn_created(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Inside a git repository, an undo puts content back and deletes nothing.
+
+    That is deliberate — a path bug once let a revert wipe a repo, so the delete-new pass refuses to
+    run anywhere inside one. But the screen said "Edits undone." over files that were still on
+    disk, which is the one sentence a reader acts on without checking.
+    """
+    client, ws = _editing_client(tmp_path, monkeypatch)
+    subprocess.run(["git", "init"], cwd=ws, capture_output=True, check=True)
+
+    token = _verdict(client.post("/api/code/turn", json={"message": "edit a.py"}))["revert_token"]
+    result = client.post(f"/api/code/revert/{token}").json()
+
+    assert result["ok"] is True
+    assert result["left_new_files"] is True
+    # And the created file really is still there, which is what makes the flag worth sending.
+    assert (ws / "a.py").exists()
+
+
+def test_outside_a_repo_the_undo_is_complete_and_says_so(tmp_path: Path, monkeypatch: Any) -> None:
+    """Or the test above would pass against a version that always hedged."""
+    client, ws = _editing_client(tmp_path, monkeypatch)
+
+    token = _verdict(client.post("/api/code/turn", json={"message": "edit a.py"}))["revert_token"]
+    result = client.post(f"/api/code/revert/{token}").json()
+
+    assert result["left_new_files"] is False
+    assert not (ws / "a.py").exists()


### PR DESCRIPTION
## 1 · Só era oferecido quando a verificação **falhava**

O token de reversão era criado dentro de `if state == "failed"`. Então um turno que **passou**, que **se absteve**, ou que rodou num projeto **sem comando de teste** — que para muitos projetos é todo turno — tirava o snapshot ali em cima e deixava morrer com a requisição.

Enquanto isso a nota de Postura promete, em dez idiomas: *"O que é garantido é o snapshot e o desfazer, não os limites."*

> Passar não é consentir. A checagem responde "isso ainda compila"; o botão responde "eu quero isso", e só quem está lendo o diff responde.

O token passa a ser criado para **todo turno que editou**, e o botão aparece em todo ramo de veredito que tenha um. Um turno que não editou nada continua **sem** oferecer desfazer — e há teste para isso: o botão sobre um turno sem edição convidaria alguém a reverter um snapshot de trabalho feito à mão.

## 2 · "Edições desfeitas." não era verdade dentro de um repositório git

`WorkspaceGuard.restore` pula a passada de apagar-novos **incondicionalmente** em qualquer lugar dentro de um repo — de propósito, depois que um bug de caminho quase varreu um. Então arquivos que o turno **criou** sobrevivem ao desfazer.

O comportamento fica; **a afirmação sobre ele muda.** `deletes_new_files` faz as mesmas duas perguntas num lugar só, `/api/code/revert` reporta `left_new_files`, e a tela passa a ter **três** desfechos em vez de dois. O campo é opcional no cliente, para que um servidor antigo — que não manda nem um nem outro — não seja lido como `false`.

## 3 · "Nada é salvo até você decidir" era três quartos verdade

Numa execução pausada por taint a **finalização** realmente está segurada — sem recibo, sem fato de memória, sem skill card — e isso valia dizer. Mas os arquivos da tentativa **bem-sucedida**, uma linha de `experience` e uma de `trajectory` já estão gravadas quando a pausa acontece.

A frase agora diz o que está segurado e admite o que não está.

## Verificação

Backend **3.672 passed** · frontend **673 passed** · mypy limpo · ruff limpo · typecheck limpo.

Os testes do token foram rodados contra o código pré-conserto e ficam vermelhos; um par de testes prende que uma reversão completa **continua** dizendo "Edições desfeitas." sem hedge, senão o conserto viraria hedge em todo desfazer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)