### PR TITLE
fix(orchestration): both Stop buttons latched permanently on a failed cancel

### DIFF
--- a/apps/desktop/src/components/orchestration/CrewRun.tsx
+++ b/apps/desktop/src/components/orchestration/CrewRun.tsx
@@ -1,12 +1,14 @@
-import { useEffect, useReducer, useState } from "react";
-import { AlertTriangle, Check, FolderGit2, Loader2, Square, X } from "lucide-react";
+import { useEffect, useReducer } from "react";
+import { AlertTriangle, Check, FolderGit2, Loader2, X } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/panel";
-import { cancelOrchestration, streamCrew, type CrewRunInput } from "@/lib/api";
+import { streamCrew, type CrewRunInput } from "@/lib/api";
 import { useT } from "@/lib/i18n";
 import { applyCrewFrame, EMPTY_CREW, isCrewRunning, type CrewWorkerState } from "@/lib/orchestration-run";
 import { cn } from "@/lib/utils";
+
+import { StopButton } from "./StopButton";
+import { useStop } from "./use-stop";
 
 const rails: Record<CrewWorkerState["status"], string> = {
   queued: "bg-muted",
@@ -154,7 +156,6 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
 export function CrewRun({ request }: { request: CrewRunInput }) {
   const t = useT();
   const [state, dispatch] = useReducer(applyCrewFrame, EMPTY_CREW);
-  const [stopping, setStopping] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -177,6 +178,7 @@ export function CrewRun({ request }: { request: CrewRunInput }) {
   }, []);
 
   const running = isCrewRunning(state);
+  const stop = useStop(state.runId ?? "", running);
 
   return (
     <div className="space-y-4">
@@ -189,19 +191,7 @@ export function CrewRun({ request }: { request: CrewRunInput }) {
               : t("crew.working", { n: state.workers.length })}
         </div>
         {running && state.runId ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            disabled={stopping}
-            onClick={() => {
-              setStopping(true);
-              void cancelOrchestration(state.runId as string).catch(() => undefined);
-            }}
-            title={t("crew.stopHint")}
-          >
-            {stopping ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-4 w-4" />}
-            {stopping ? t("orch.stopping") : t("orch.stop")}
-          </Button>
+          <StopButton stop={stop} hint={t("crew.stopHint")} />
         ) : null}
       </div>
 

--- a/apps/desktop/src/components/orchestration/HierarchyRun.tsx
+++ b/apps/desktop/src/components/orchestration/HierarchyRun.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer } from "react";
 import Markdown from "react-markdown";
-import { Loader2, Square } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { cancelOrchestration, streamHierarchy, type HierarchyRunInput } from "@/lib/api";
+import { streamHierarchy, type HierarchyRunInput } from "@/lib/api";
 import { useT, type TFunc } from "@/lib/i18n";
 import {
   applyFrame,
@@ -13,6 +11,8 @@ import {
 } from "@/lib/orchestration-run";
 
 import { FellBackNote } from "./FellBackNote";
+import { StopButton } from "./StopButton";
+import { useStop } from "./use-stop";
 import { RunStepper } from "./RunStepper";
 import { WorkerCard } from "./WorkerCard";
 
@@ -32,7 +32,6 @@ export function HierarchyRun({
 }) {
   const t = useT();
   const [state, dispatch] = useReducer(applyFrame, EMPTY_RUN);
-  const [stopping, setStopping] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -59,34 +58,15 @@ export function HierarchyRun({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  async function stop() {
-    const id = state.runId;
-    if (!id) return;
-    setStopping(true);
-    try {
-      await cancelOrchestration(id);
-    } catch {
-      // The stream is the source of truth about whether it stopped, not this response.
-    }
-  }
-
   const running = isRunning(state);
+  const stop = useStop(state.runId ?? "", running);
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <RunStepper state={state} />
         {running ? (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => void stop()}
-            disabled={stopping || !state.runId}
-            title={t("orch.stopHint")}
-          >
-            {stopping ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-4 w-4" />}
-            {stopping ? t("orch.stopping") : t("orch.stop")}
-          </Button>
+          <StopButton stop={stop} disabled={!state.runId} hint={t("orch.stopHint")} />
         ) : null}
       </div>
 

--- a/apps/desktop/src/components/orchestration/Orchestration.stream.test.tsx
+++ b/apps/desktop/src/components/orchestration/Orchestration.stream.test.tsx
@@ -158,6 +158,32 @@ describe("watching a fan-out", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /stopping/i })).toBeInTheDocument());
   });
 
+  it("comes back out of Stopping when the ask could not be delivered", async () => {
+    // `stopping` was set on click and never cleared. A cancel that could not land — a dropped
+    // request, or a run id the server no longer has — left a disabled spinner beside a run that was
+    // still going, and nothing else cleared it either: the run stays running until a terminal frame
+    // arrives and no such frame was coming. Reloading was the only way out.
+    const { user } = await startRun();
+    mockCancel.mockRejectedValue(new Error("network"));
+
+    await user.click(screen.getByRole("button", { name: /^stop$/i }));
+
+    await screen.findByText(/could not tell/i);
+    // Re-armed, because being able to ask again is the only honest offer left.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^stop$/i })).not.toBeDisabled(),
+    );
+  });
+
+  it("treats a run the server no longer knows as unknown, not as stopped", async () => {
+    const { user } = await startRun();
+    mockCancel.mockResolvedValue({ ok: false, cancelled: false });
+
+    await user.click(screen.getByRole("button", { name: /^stop$/i }));
+
+    await screen.findByText(/could not tell/i);
+  });
+
   it("shows what a stopped run cost, instead of saying nothing was spent", async () => {
     const { handlers } = await startRun();
 

--- a/apps/desktop/src/components/orchestration/StopButton.tsx
+++ b/apps/desktop/src/components/orchestration/StopButton.tsx
@@ -1,0 +1,50 @@
+import { Loader2, Square } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useT } from "@/lib/i18n";
+
+import type { useStop } from "./use-stop";
+
+/** Stop, with a way back out of "Stopping…".
+ *
+ *  The button used to latch: `stopping` was set on click and never cleared, so a cancel that could
+ *  not be delivered — a dropped request, a run id the server no longer has — left a disabled
+ *  spinner beside a run that was still going. Nothing else cleared it either, since the run stays
+ *  running until a terminal frame arrives and no such frame is coming. Reloading was the only exit.
+ *
+ *  Now a failed ask says so and re-arms. Being able to press it again is the only honest offer
+ *  available when we could not find out what happened.
+ */
+export function StopButton({
+  stop,
+  disabled = false,
+  hint,
+}: {
+  stop: ReturnType<typeof useStop>;
+  disabled?: boolean;
+  hint: string;
+}) {
+  const t = useT();
+  const busy = stop.state === "stopping";
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={() => void stop.stop()}
+        disabled={busy || disabled}
+        title={hint}
+      >
+        {busy ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Square className="h-4 w-4" />
+        )}
+        {busy ? t("orch.stopping") : t("orch.stop")}
+      </Button>
+      {stop.state === "unknown" ? (
+        <span className="text-xs text-warn-foreground">{t("orch.stopUnknown")}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/orchestration/use-stop.ts
+++ b/apps/desktop/src/components/orchestration/use-stop.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+
+import { cancelOrchestration } from "@/lib/api";
+
+/** The Stop button's state, shared by the hierarchy and the crew.
+ *
+ *  Both set `stopping` to true and never set it back. A cancel that failed — the network dropped,
+ *  the server no longer knows the run id, the process restarted — left a permanently disabled
+ *  button spinning next to a run that was still going, because nothing else clears it either: the
+ *  run stays `running` until a terminal frame arrives, and if the cancel never landed, one never
+ *  will. The user's only way out was to reload.
+ *
+ *  Three states, because they mean three different things to whoever is watching:
+ *  - `idle` — press it.
+ *  - `stopping` — the request landed; the server stops before its next model call.
+ *  - `unknown` — we asked and could not tell. The run may already be finished, or the request may
+ *    have been lost. Either way the button comes back, because being able to ask again is the only
+ *    honest offer we have.
+ */
+export type StopState = "idle" | "stopping" | "unknown";
+
+export function useStop(runId: string, running: boolean) {
+  const [state, setState] = useState<StopState>("idle");
+
+  // A run that ended for any reason — stopped, finished, failed — leaves nothing to stop. Without
+  // this the label would still read "Stopping…" over a finished run whose Stop button is gone.
+  useEffect(() => {
+    if (!running) setState("idle");
+  }, [running]);
+
+  async function stop() {
+    if (!runId) return;
+    setState("stopping");
+    try {
+      // `ok: false` is the server saying it has no such run in flight — a stale click on a run that
+      // already ended, which is not an error and is also not a stop we performed.
+      setState((await cancelOrchestration(runId)).ok ? "stopping" : "unknown");
+    } catch {
+      setState("unknown");
+    }
+  }
+
+  return { state, stop };
+}

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1100,6 +1100,8 @@ const en: Dict = {
   "orch.stateOnly": "Workers report state changes, not live text.",
   "orch.stop": "Stop",
   "orch.stopping": "Stopping",
+  "orch.stopUnknown":
+    "We asked and could not tell — it may already be finished. Press again to ask once more.",
   "orch.stopHint": "Stops before the next model call; calls already in flight finish and are charged.",
   "orch.cancelled":
     "Stopped before the answer was synthesised. The workers that had already started were charged — what that came to is below.",
@@ -2238,6 +2240,8 @@ const pt: Dict = {
   "orch.stateOnly": "Os trabalhadores relatam mudanças de estado, não texto ao vivo.",
   "orch.stop": "Parar",
   "orch.stopping": "Parando",
+  "orch.stopUnknown":
+    "Pedimos e não deu para saber — pode já ter terminado. Aperte de novo para pedir mais uma vez.",
   "orch.stopHint": "Para antes da próxima chamada ao modelo; as que já estão em voo terminam e são cobradas.",
   "orch.cancelled":
     "Parado antes de a resposta ser sintetizada. Os trabalhadores que já tinham começado foram cobrados — o total está abaixo.",
@@ -3386,6 +3390,8 @@ const es: Dict = {
   "orch.stateOnly": "Los trabajadores informan cambios de estado, no texto en vivo.",
   "orch.stop": "Detener",
   "orch.stopping": "Deteniendo",
+  "orch.stopUnknown":
+    "Lo pedimos y no pudimos saberlo: puede que ya haya terminado. Pulsa de nuevo para pedirlo otra vez.",
   "orch.stopHint": "Se detiene antes de la próxima llamada al modelo; las que ya están en vuelo terminan y se cobran.",
   "orch.cancelled":
     "Detenido antes de sintetizar la respuesta. Los trabajadores que ya habían empezado se cobraron: el total está abajo.",
@@ -4547,6 +4553,8 @@ const fr: Dict = {
   "orch.stateOnly": "Les travailleurs signalent des changements d'état, pas du texte en direct.",
   "orch.stop": "Arrêter",
   "orch.stopping": "Arrêt",
+  "orch.stopUnknown":
+    "Nous avons demandé sans pouvoir le savoir — c'est peut-être déjà terminé. Appuyez encore pour redemander.",
   "orch.stopHint": "S'arrête avant le prochain appel au modèle ; ceux déjà en vol se terminent et sont facturés.",
   "orch.cancelled":
     "Arrêté avant la synthèse de la réponse. Les travailleurs déjà lancés ont été facturés — le total est ci-dessous.",
@@ -5705,6 +5713,8 @@ const de: Dict = {
   "orch.stateOnly": "Worker melden Zustandswechsel, keinen laufenden Text.",
   "orch.stop": "Stopp",
   "orch.stopping": "Stoppt",
+  "orch.stopUnknown":
+    "Wir haben gefragt und konnten es nicht feststellen — vielleicht ist es schon fertig. Nochmals drücken, um erneut zu fragen.",
   "orch.stopHint": "Hält vor dem nächsten Modellaufruf; bereits laufende Aufrufe enden und werden berechnet.",
   "orch.cancelled":
     "Gestoppt, bevor die Antwort zusammengeführt wurde. Die bereits gestarteten Arbeiter wurden berechnet — die Summe steht unten.",
@@ -6782,6 +6792,8 @@ const zh: Dict = {
   "orch.stateOnly": "工作者只报告状态变化，不提供实时文字。",
   "orch.stop": "停止",
   "orch.stopping": "正在停止",
+  "orch.stopUnknown":
+    "我们发出了请求但无法确认 —— 也可能它已经结束了。再按一次可以重新请求。",
   "orch.stopHint": "在下一次模型调用前停止；已经发出的调用会跑完并照常计费。",
   "orch.cancelled":
     "在答案被综合之前就停止了。已经开始的工作者仍会计费 —— 总数在下面。",
@@ -7921,6 +7933,8 @@ const ja: Dict = {
   "orch.stateOnly": "ワーカーが伝えるのは状態の変化で、逐次のテキストではありません。",
   "orch.stop": "停止",
   "orch.stopping": "停止中",
+  "orch.stopUnknown":
+    "停止を頼みましたが結果を確認できませんでした — すでに終わっているかもしれません。もう一度押すと再度頼めます。",
   "orch.stopHint": "次のモデル呼び出しの前で止まります。実行中の呼び出しは最後まで走り、課金されます。",
   "orch.cancelled":
     "答えがまとめられる前に停止しました。すでに動き出していたワーカーの分は請求されます — 合計は下にあります。",
@@ -9074,6 +9088,8 @@ const it: Dict = {
   "orch.stateOnly": "I lavoratori segnalano cambi di stato, non testo dal vivo.",
   "orch.stop": "Ferma",
   "orch.stopping": "In arresto",
+  "orch.stopUnknown":
+    "Abbiamo chiesto e non siamo riusciti a saperlo: potrebbe essere già finito. Premi di nuovo per richiedere.",
   "orch.stopHint": "Si ferma prima della prossima chiamata al modello; quelle già in volo finiscono e vengono addebitate.",
   "orch.cancelled":
     "Fermato prima che la risposta fosse sintetizzata. I lavoratori già avviati sono stati addebitati: il totale è qui sotto.",
@@ -10219,6 +10235,8 @@ const pl: Dict = {
   "orch.stateOnly": "Pracownicy zgłaszają zmiany stanu, nie tekst na żywo.",
   "orch.stop": "Zatrzymaj",
   "orch.stopping": "Zatrzymywanie",
+  "orch.stopUnknown":
+    "Poprosiliśmy i nie udało się ustalić — może już się skończyło. Naciśnij ponownie, żeby zapytać jeszcze raz.",
   "orch.stopHint": "Zatrzymuje przed kolejnym wywołaniem modelu; te już w locie kończą się i są naliczane.",
   "orch.cancelled":
     "Zatrzymano, zanim odpowiedź została złożona. Pracownicy, którzy już ruszyli, zostali policzeni — suma jest poniżej.",
@@ -11370,6 +11388,8 @@ const ru: Dict = {
   "orch.stateOnly": "Работники сообщают смену состояний, а не текст в реальном времени.",
   "orch.stop": "Остановить",
   "orch.stopping": "Останавливается",
+  "orch.stopUnknown":
+    "Мы попросили и не смогли выяснить — возможно, всё уже закончилось. Нажмите ещё раз, чтобы попросить снова.",
   "orch.stopHint": "Останавливает до следующего вызова модели; уже начатые вызовы дойдут до конца и будут оплачены.",
   "orch.cancelled":
     "Остановлено до того, как ответ был собран. Работники, которые уже начали, оплачены — итог ниже.",


### PR DESCRIPTION
`stopping` era posto no clique e **nunca voltava**. Um cancelamento que não conseguia ser entregue — requisição perdida, ou um id de run que o servidor não tem mais — deixava um spinner desabilitado ao lado de um run que continuava rodando.

E nada mais limpava: o run fica `running` até chegar um frame terminal, e se o cancelamento nunca chegou, esse frame nunca vem. **Recarregar era a única saída.**

`ok: false` tinha o mesmo efeito, e nem é uma falha: é o servidor dizendo que não tem esse run em voo, que é o que um clique tardio num run já terminado recebe.

## Três estados

| estado | o que significa para quem está olhando |
|---|---|
| `idle` | pode apertar |
| `stopping` | o pedido chegou; o servidor para antes da próxima chamada de modelo |
| `unknown` | perguntamos e não deu para saber — pode já ter acabado, ou o pedido se perdeu |

`unknown` **rearma o botão e diz isso**, porque poder perguntar de novo é a única oferta honesta que sobra quando não foi possível descobrir o que aconteceu.

Um efeito também limpa o estado quando o run para por qualquer motivo, então um run terminado nunca fica rotulado "Parando…".

## Extraído, não consertado duas vezes

A hierarquia e o crew tinham **o mesmo bug na mesma forma** — e a segunda cópia é como a primeira volta.

## Verificação

Frontend **674 passed** em 89 arquivos · typecheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
