### PR TITLE
fix(docs): 174 instructions named a command that cannot do the thing, and a guard

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -323,13 +323,13 @@ Spalte „Braucht"). **Docker? Das offizielle Image enthält bereits alles unten
 | **Ein Team von Spezialisten-Agenten** | — | `chimera crew "deine Aufgabe" --mode supervisor` |
 | **Ein ganzes Projekt bis zum Ende führen** (pausiert vor riskanten Schritten) | — | `chimera project start spec.yaml -w .` |
 | **Bilder sehen** (Vision) | Schlüssel: Gemini oder OpenAI | `chimera run --image foto.jpg "was ist das?" --model gemini/gemini-2.0-flash` |
-| **Audio hören** (Sprache → Text) | `[stt]` + ffmpeg | `chimera run "transkribiere meeting.mp3"` |
+| **Audio hören** (Sprache → Text) | `[stt]` + ffmpeg | `chimera agent "transkribiere meeting.mp3"` |
 | **Sprechen** (Text → Sprache) | Schlüssel: ElevenLabs oder OpenAI | bitte eine Aufgabe „lies das laut nach speech.mp3 vor" |
-| **Dokumente lesen** (PDF, Word, Excel → Text) | `[documents]` | `chimera run "fasse bericht.pdf zusammen"` |
-| **Video/Audio herunterladen** (YouTube + 1000+ Seiten) | `[media-dl]` + ffmpeg | `chimera run "lade das Audio von <url> herunter"` |
-| **Daten analysieren & Diagramme erstellen** | `[data,viz]` | `chimera run "lade umsatz.csv und plotte den Monatsumsatz"` |
-| **Im Web suchen** | Schlüssel: Tavily | `chimera run "suche im Web: die neueste Python-Version"` |
-| **Echte Webseiten lesen & scrapen** (ein echter Browser) | — | `chimera run "öffne example.com und nenne die Überschrift"` |
+| **Dokumente lesen** (PDF, Word, Excel → Text) | `[documents]` | `chimera agent "fasse bericht.pdf zusammen"` |
+| **Video/Audio herunterladen** (YouTube + 1000+ Seiten) | `[media-dl]` + ffmpeg | `chimera agent "lade das Audio von <url> herunter"` |
+| **Daten analysieren & Diagramme erstellen** | `[data,viz]` | `chimera agent "lade umsatz.csv und plotte den Monatsumsatz"` |
+| **Im Web suchen** | Schlüssel: Tavily | `chimera agent "suche im Web: die neueste Python-Version"` |
+| **Echte Webseiten lesen & scrapen** (ein echter Browser) | — | `chimera agent "öffne example.com und nenne die Überschrift"` |
 | **Langzeitgedächtnis** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Wiederverwendbare Skills selbst lernen** | — | passiert während `chimera solve`; auflisten mit `chimera skills-stats` (`chimera skills` listet die eingebauten) |
 | **Eine kuratierte Skill-Karte nutzen** (23 Stück, 9 Sprachen) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.es.md
+++ b/README.es.md
@@ -318,13 +318,13 @@ quieras (mira la columna "Necesita"). **¿Usas Docker? La imagen oficial ya incl
 | **Un equipo de agentes especialistas** | — | `chimera crew "tu tarea" --mode supervisor` |
 | **Llevar un proyecto entero hasta el final** (pausa antes de pasos arriesgados) | — | `chimera project start spec.yaml -w .` |
 | **Ver imágenes** (visión) | clave: Gemini u OpenAI | `chimera run --image foto.jpg "¿qué hay aquí?" --model gemini/gemini-2.0-flash` |
-| **Oír audio** (voz → texto) | `[stt]` + ffmpeg | `chimera run "transcribe reunion.mp3"` |
+| **Oír audio** (voz → texto) | `[stt]` + ffmpeg | `chimera agent "transcribe reunion.mp3"` |
 | **Hablar** (texto → voz) | clave: ElevenLabs u OpenAI | pide a cualquier tarea "lee esto en voz alta a speech.mp3" |
-| **Leer documentos** (PDF, Word, Excel → texto) | `[documents]` | `chimera run "resume informe.pdf"` |
-| **Descargar vídeo/audio** (YouTube + 1000+ sitios) | `[media-dl]` + ffmpeg | `chimera run "descarga el audio de <url>"` |
-| **Analizar datos y hacer gráficos** | `[data,viz]` | `chimera run "carga ventas.csv y grafica los ingresos mensuales"` |
-| **Buscar en la web** | clave: Tavily | `chimera run "busca en la web: la última versión de Python"` |
-| **Leer y extraer páginas web reales** (un navegador de verdad) | — | `chimera run "abre example.com y dime el título"` |
+| **Leer documentos** (PDF, Word, Excel → texto) | `[documents]` | `chimera agent "resume informe.pdf"` |
+| **Descargar vídeo/audio** (YouTube + 1000+ sitios) | `[media-dl]` + ffmpeg | `chimera agent "descarga el audio de <url>"` |
+| **Analizar datos y hacer gráficos** | `[data,viz]` | `chimera agent "carga ventas.csv y grafica los ingresos mensuales"` |
+| **Buscar en la web** | clave: Tavily | `chimera agent "busca en la web: la última versión de Python"` |
+| **Leer y extraer páginas web reales** (un navegador de verdad) | — | `chimera agent "abre example.com y dime el título"` |
 | **Memoria a largo plazo** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Aprender skills reutilizables solo** | — | ocurre durante `chimera solve`; lista con `chimera skills-stats` (`chimera skills` lista las integradas) |
 | **Usar una tarjeta de skill curada** (23 de ellas, 9 idiomas) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.fr.md
+++ b/README.fr.md
@@ -322,13 +322,13 @@ extras voulus (voir la colonne « Requiert »). **Docker ? L'image officielle co
 | **Une équipe d'agents spécialistes** | — | `chimera crew "votre tâche" --mode supervisor` |
 | **Mener un projet entier jusqu'au bout** (pause avant les étapes risquées) | — | `chimera project start spec.yaml -w .` |
 | **Voir des images** (vision) | clé : Gemini ou OpenAI | `chimera run --image photo.jpg "qu'y a-t-il ?" --model gemini/gemini-2.0-flash` |
-| **Entendre l'audio** (voix → texte) | `[stt]` + ffmpeg | `chimera run "transcris reunion.mp3"` |
+| **Entendre l'audio** (voix → texte) | `[stt]` + ffmpeg | `chimera agent "transcris reunion.mp3"` |
 | **Parler** (texte → voix) | clé : ElevenLabs ou OpenAI | demandez à une tâche « lis ceci à voix haute dans speech.mp3 » |
-| **Lire des documents** (PDF, Word, Excel → texte) | `[documents]` | `chimera run "résume rapport.pdf"` |
-| **Télécharger vidéo/audio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera run "télécharge l'audio de <url>"` |
-| **Analyser des données et faire des graphiques** | `[data,viz]` | `chimera run "charge ventes.csv et trace le revenu mensuel"` |
-| **Chercher sur le web** | clé : Tavily | `chimera run "cherche sur le web : la dernière version de Python"` |
-| **Lire et extraire de vraies pages web** (un vrai navigateur) | — | `chimera run "ouvre example.com et donne-moi le titre"` |
+| **Lire des documents** (PDF, Word, Excel → texte) | `[documents]` | `chimera agent "résume rapport.pdf"` |
+| **Télécharger vidéo/audio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera agent "télécharge l'audio de <url>"` |
+| **Analyser des données et faire des graphiques** | `[data,viz]` | `chimera agent "charge ventes.csv et trace le revenu mensuel"` |
+| **Chercher sur le web** | clé : Tavily | `chimera agent "cherche sur le web : la dernière version de Python"` |
+| **Lire et extraire de vraies pages web** (un vrai navigateur) | — | `chimera agent "ouvre example.com et donne-moi le titre"` |
 | **Mémoire à long terme** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Apprendre des skills réutilisables tout seul** | — | pendant `chimera solve` ; liste avec `chimera skills-stats` (`chimera skills` liste celles intégrées) |
 | **Utiliser une skill card sélectionnée** (23 au total, 9 langues) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.it.md
+++ b/README.it.md
@@ -321,13 +321,13 @@ vuoi (vedi la colonna "Richiede"). **Usi Docker? L'immagine ufficiale ha già tu
 | **Una squadra di agenti specialisti** | — | `chimera crew "il tuo compito" --mode supervisor` |
 | **Porta a termine un intero progetto** (chiede prima dei passi rischiosi) | — | `chimera project start spec.yaml -w .` |
 | **Vedere immagini** (visione) | chiave: Gemini o OpenAI | `chimera run --image foto.jpg "cosa c'è qui?" --model gemini/gemini-2.0-flash` |
-| **Ascoltare audio** (voce → testo) | `[stt]` + ffmpeg | `chimera run "trascrivi riunione.mp3"` |
+| **Ascoltare audio** (voce → testo) | `[stt]` + ffmpeg | `chimera agent "trascrivi riunione.mp3"` |
 | **Parlare** (testo → voce) | chiave: ElevenLabs o OpenAI | chiedi a un compito di "leggi questo ad alta voce in speech.mp3" |
-| **Leggere documenti** (PDF, Word, Excel → testo) | `[documents]` | `chimera run "riassumi report.pdf"` |
-| **Scaricare video/audio** (YouTube + 1000+ siti) | `[media-dl]` + ffmpeg | `chimera run "scarica l'audio di <url>"` |
-| **Analizzare dati e fare grafici** | `[data,viz]` | `chimera run "carica vendite.csv e fai un grafico dei ricavi mensili"` |
-| **Cercare sul web** | chiave: Tavily | `chimera run "cerca sul web: l'ultima versione di Python"` |
-| **Leggere e raschiare pagine web reali** (un browser vero) | — | `chimera run "apri example.com e dimmi il titolo"` |
+| **Leggere documenti** (PDF, Word, Excel → testo) | `[documents]` | `chimera agent "riassumi report.pdf"` |
+| **Scaricare video/audio** (YouTube + 1000+ siti) | `[media-dl]` + ffmpeg | `chimera agent "scarica l'audio di <url>"` |
+| **Analizzare dati e fare grafici** | `[data,viz]` | `chimera agent "carica vendite.csv e fai un grafico dei ricavi mensili"` |
+| **Cercare sul web** | chiave: Tavily | `chimera agent "cerca sul web: l'ultima versione di Python"` |
+| **Leggere e raschiare pagine web reali** (un browser vero) | — | `chimera agent "apri example.com e dimmi il titolo"` |
 | **Memoria a lungo termine** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Imparare skill riutilizzabili da solo** | — | succede durante `chimera solve`; elencale con `chimera skills-stats` (`chimera skills` elenca quelle integrate) |
 | **Usare una scheda di skill curata** (23, in 9 lingue) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.ja.md
+++ b/README.ja.md
@@ -303,13 +303,13 @@ pip install 'chimera-agent[full]'     # 下記の非 GPU 機能すべてを 1 �
 | **専門エージェントのチーム** | — | `chimera crew "あなたのタスク" --mode supervisor` |
 | **プロジェクト全体を最後までやり切る**（危険な手順の前に確認で一時停止） | — | `chimera project start spec.yaml -w .` |
 | **画像を見る**（ビジョン） | キー：Gemini か OpenAI | `chimera run --image photo.jpg "これは何？" --model gemini/gemini-2.0-flash` |
-| **音声を聞く**（音声 → 文字） | `[stt]` + ffmpeg | `chimera run "meeting.mp3 を文字起こしして"` |
+| **音声を聞く**（音声 → 文字） | `[stt]` + ffmpeg | `chimera agent "meeting.mp3 を文字起こしして"` |
 | **話す**（文字 → 音声） | キー：ElevenLabs か OpenAI | 任意のタスクに「これを読み上げて speech.mp3 に保存して」 |
-| **ドキュメントを読む**（PDF・Word・Excel → 文字） | `[documents]` | `chimera run "report.pdf を要約して"` |
-| **動画/音声をダウンロード**（YouTube ほか 1000+ サイト） | `[media-dl]` + ffmpeg | `chimera run "<url> の音声をダウンロードして"` |
-| **データ分析とグラフ作成** | `[data,viz]` | `chimera run "sales.csv を読み込んで月次売上をグラフに"` |
-| **ウェブ検索** | キー：Tavily | `chimera run "ウェブ検索：最新の Python バージョン"` |
-| **実際のウェブページを読む・スクレイプ**（本物のブラウザ） | — | `chimera run "example.com を開いて見出しを教えて"` |
+| **ドキュメントを読む**（PDF・Word・Excel → 文字） | `[documents]` | `chimera agent "report.pdf を要約して"` |
+| **動画/音声をダウンロード**（YouTube ほか 1000+ サイト） | `[media-dl]` + ffmpeg | `chimera agent "<url> の音声をダウンロードして"` |
+| **データ分析とグラフ作成** | `[data,viz]` | `chimera agent "sales.csv を読み込んで月次売上をグラフに"` |
+| **ウェブ検索** | キー：Tavily | `chimera agent "ウェブ検索：最新の Python バージョン"` |
+| **実際のウェブページを読む・スクレイプ**（本物のブラウザ） | — | `chimera agent "example.com を開いて見出しを教えて"` |
 | **長期記憶** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **再利用可能なスキルを自分で学習** | — | `chimera solve` の実行中に起こる；`chimera skills-stats` で一覧（`chimera skills` は組み込みを一覧） |
 | **厳選されたスキルカードを使う**（23 枚、9 言語） | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ a long run stays useful, and most of it is invisible until it fails. Chimera mea
 ### 🚀 Run anywhere, safely
 - **Any model, one interface** — hosted models or your own local ones, with automatic fallback if one is down and rotation across multiple keys.
 - **One-command server deploy** — run it with Docker (or bare-metal) so it stays up and restarts on reboot. See **[docs/deploy.md](docs/deploy.md)**.
-- **Safety kernel** — a check on each action it is wired to (allow / warn / review / block), an **opt-in** network-isolated container for untrusted code (`CHIMERA_SANDBOX=docker`; the default local runner is *not* isolated), and a redacted audit log of what it did. **Where it runs, precisely:** `chimera run --guard` and `solve --guard`, the scheduler, the ACP endpoint, and — once `CHIMERA_GOVERNANCE` is `observe` or `enforce` — the API's run and turn endpoints. It does **not** yet reach the chat stream, the OpenAI-compatible endpoint, or the board and project endpoints; that gap is named here rather than left for you to discover, and it is open work. This bullet used to say "every action", which was not true of anything served over HTTP. Whether a `review` verdict stops to ask you or simply refuses is the approval mode (`CHIMERA_APPROVAL_MODE=ask|deny|allow`) — unattended, it denies rather than inventing consent, and over HTTP it never prompts on the server's own terminal, because whoever is looking at that console is not the person who made the request.
+- **Safety kernel** — a check on each action it is wired to (allow / warn / review / block), an **opt-in** network-isolated container for untrusted code (`CHIMERA_SANDBOX=docker`; the default local runner is *not* isolated), and a redacted audit log of what it did. **Where it runs, precisely:** `chimera agent --guard` and `solve --guard`, the scheduler, the ACP endpoint, and — once `CHIMERA_GOVERNANCE` is `observe` or `enforce` — the API's run and turn endpoints. It does **not** yet reach the chat stream, the OpenAI-compatible endpoint, or the board and project endpoints; that gap is named here rather than left for you to discover, and it is open work. This bullet used to say "every action", which was not true of anything served over HTTP. Whether a `review` verdict stops to ask you or simply refuses is the approval mode (`CHIMERA_APPROVAL_MODE=ask|deny|allow`) — unattended, it denies rather than inventing consent, and over HTTP it never prompts on the server's own terminal, because whoever is looking at that console is not the person who made the request.
 - **Stop before it commits, when it read something it shouldn't trust** (`--pause-on-taint`) — a run that consumed untrusted content parks itself instead of finalising, and waits for you. You can accept the result, accept a version you edited, send guidance and let it try again, or reject it outright — from the terminal *or* the desktop app. Nothing is saved and nothing is learned until you decide, and a pause is never reported as a failure: it hasn't reached a verdict, it's waiting on a person.
 - **A desktop app that pilots a run, not just launches one** — five destinations instead of a menu of fifteen, in ten languages. Start a run and walk away: the progress is still there when you come back, the status bar names what the agent is doing from every screen, and Stop works from all of them. Native installers for Windows / macOS / Linux on [Releases](https://github.com/brcampidelli/chimera-agent/releases).
 
@@ -303,13 +303,13 @@ Prefer a lean install? Keep `pip install chimera-agent` and add only the extras 
 | **A team of specialist agents** | — | `chimera crew "your task" --mode supervisor` |
 | **Run a whole project to completion** (asks you before risky steps) | — | `chimera project start spec.yaml -w .` |
 | **See images** (vision) | key: Gemini or OpenAI | `chimera run --image photo.jpg "what's in this?" --model gemini/gemini-2.0-flash` |
-| **Hear audio** (speech → text) | `[stt]` + ffmpeg | `chimera run "transcribe meeting.mp3"` |
+| **Hear audio** (speech → text) | `[stt]` + ffmpeg | `chimera agent "transcribe meeting.mp3"` |
 | **Speak** (text → speech) | key: ElevenLabs or OpenAI | ask any task to "read this out loud to speech.mp3" |
-| **Read documents** (PDF, Word, Excel → text) | `[documents]` | `chimera run "summarize report.pdf"` |
-| **Download video/audio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera run "download the audio of <url>"` |
-| **Analyze data & make charts** | `[data,viz]` | `chimera run "load sales.csv and chart monthly revenue"` |
-| **Search the web** | key: Tavily | `chimera run "search the web: the latest Python version"` |
-| **Read & scrape real web pages** (a real browser) | — | `chimera run "open example.com and tell me the heading"` |
+| **Read documents** (PDF, Word, Excel → text) | `[documents]` | `chimera agent "summarize report.pdf"` |
+| **Download video/audio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera agent "download the audio of <url>"` |
+| **Analyze data & make charts** | `[data,viz]` | `chimera agent "load sales.csv and chart monthly revenue"` |
+| **Search the web** | key: Tavily | `chimera agent "search the web: the latest Python version"` |
+| **Read & scrape real web pages** (a real browser) | — | `chimera agent "open example.com and tell me the heading"` |
 | **Long-term memory** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Learn reusable skills automatically** | — | happens during `chimera solve`; list what it learned with `chimera skills-stats` (`chimera skills` lists the built-in ones) |
 | **Use a curated skill card** (23 of them, 9 languages) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.pl.md
+++ b/README.pl.md
@@ -316,13 +316,13 @@ chcesz (zobacz kolumnę „Wymaga"). **Używasz Dockera? Oficjalny obraz ma już
 | **Zespół agentów-specjalistów** | — | `chimera crew "twoje zadanie" --mode supervisor` |
 | **Poprowadź cały projekt do końca** (pyta przed ryzykownymi krokami) | — | `chimera project start spec.yaml -w .` |
 | **Widzieć obrazy** (wizja) | klucz: Gemini albo OpenAI | `chimera run --image zdjecie.jpg "co tu jest?" --model gemini/gemini-2.0-flash` |
-| **Słyszeć audio** (mowa → tekst) | `[stt]` + ffmpeg | `chimera run "transkrybuj spotkanie.mp3"` |
+| **Słyszeć audio** (mowa → tekst) | `[stt]` + ffmpeg | `chimera agent "transkrybuj spotkanie.mp3"` |
 | **Mówić** (tekst → mowa) | klucz: ElevenLabs albo OpenAI | poproś dowolne zadanie o „przeczytaj to na głos do speech.mp3" |
-| **Czytać dokumenty** (PDF, Word, Excel → tekst) | `[documents]` | `chimera run "streść raport.pdf"` |
-| **Pobierać wideo/audio** (YouTube + 1000+ stron) | `[media-dl]` + ffmpeg | `chimera run "pobierz audio z <url>"` |
-| **Analizować dane i robić wykresy** | `[data,viz]` | `chimera run "wczytaj sprzedaz.csv i zrób wykres miesięcznych przychodów"` |
-| **Szukać w sieci** | klucz: Tavily | `chimera run "poszukaj w sieci: najnowsza wersja Pythona"` |
-| **Czytać i zbierać prawdziwe strony** (prawdziwa przeglądarka) | — | `chimera run "otwórz example.com i podaj mi nagłówek"` |
+| **Czytać dokumenty** (PDF, Word, Excel → tekst) | `[documents]` | `chimera agent "streść raport.pdf"` |
+| **Pobierać wideo/audio** (YouTube + 1000+ stron) | `[media-dl]` + ffmpeg | `chimera agent "pobierz audio z <url>"` |
+| **Analizować dane i robić wykresy** | `[data,viz]` | `chimera agent "wczytaj sprzedaz.csv i zrób wykres miesięcznych przychodów"` |
+| **Szukać w sieci** | klucz: Tavily | `chimera agent "poszukaj w sieci: najnowsza wersja Pythona"` |
+| **Czytać i zbierać prawdziwe strony** (prawdziwa przeglądarka) | — | `chimera agent "otwórz example.com i podaj mi nagłówek"` |
 | **Pamięć długoterminowa** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Uczyć się wielokrotnego użytku umiejętności samodzielnie** | — | dzieje się podczas `chimera solve`; wypisz przez `chimera skills-stats` (`chimera skills` pokazuje wbudowane) |
 | **Użyć kuratorowanej karty umiejętności** (jest ich 23, w 9 językach) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -313,13 +313,13 @@ Prefere instalação enxuta? Mantenha `pip install chimera-agent` e adicione só
 | **Um time de agentes especialistas** | — | `chimera crew "sua tarefa" --mode supervisor` |
 | **Tocar um projeto inteiro até o fim** (pausa antes de passos arriscados) | — | `chimera project start spec.yaml -w .` |
 | **Ver imagens** (visão) | chave: Gemini ou OpenAI | `chimera run --image foto.jpg "o que há aqui?" --model gemini/gemini-2.0-flash` |
-| **Ouvir áudio** (fala → texto) | `[stt]` + ffmpeg | `chimera run "transcreva reuniao.mp3"` |
+| **Ouvir áudio** (fala → texto) | `[stt]` + ffmpeg | `chimera agent "transcreva reuniao.mp3"` |
 | **Falar** (texto → fala) | chave: ElevenLabs ou OpenAI | peça a qualquer tarefa "leia isto em voz alta para speech.mp3" |
-| **Ler documentos** (PDF, Word, Excel → texto) | `[documents]` | `chimera run "resuma relatorio.pdf"` |
-| **Baixar vídeo/áudio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera run "baixe o áudio de <url>"` |
-| **Analisar dados e fazer gráficos** | `[data,viz]` | `chimera run "carregue vendas.csv e faça um gráfico da receita mensal"` |
-| **Buscar na web** | chave: Tavily | `chimera run "busque na web: a versão mais recente do Python"` |
-| **Ler e raspar páginas web reais** (um navegador de verdade) | — | `chimera run "abra example.com e me diga o título"` |
+| **Ler documentos** (PDF, Word, Excel → texto) | `[documents]` | `chimera agent "resuma relatorio.pdf"` |
+| **Baixar vídeo/áudio** (YouTube + 1000+ sites) | `[media-dl]` + ffmpeg | `chimera agent "baixe o áudio de <url>"` |
+| **Analisar dados e fazer gráficos** | `[data,viz]` | `chimera agent "carregue vendas.csv e faça um gráfico da receita mensal"` |
+| **Buscar na web** | chave: Tavily | `chimera agent "busque na web: a versão mais recente do Python"` |
+| **Ler e raspar páginas web reais** (um navegador de verdade) | — | `chimera agent "abra example.com e me diga o título"` |
 | **Memória de longo prazo** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Aprender skills reutilizáveis sozinho** | — | acontece durante o `chimera solve`; liste com `chimera skills-stats` (o `chimera skills` lista as embutidas) |
 | **Usar um skill card curado** (são 23, em 9 idiomas) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.ru.md
+++ b/README.ru.md
@@ -322,13 +322,13 @@ pip install 'chimera-agent[full]'     # все возможности ниже, 
 | **Команда агентов-специалистов** | — | `chimera crew "your task" --mode supervisor` |
 | **Довести целый проект до конца** (спрашивает перед рискованными шагами) | — | `chimera project start spec.yaml -w .` |
 | **Видеть изображения** (зрение) | key: Gemini или OpenAI | `chimera run --image photo.jpg "what's in this?" --model gemini/gemini-2.0-flash` |
-| **Слышать звук** (речь → текст) | `[stt]` + ffmpeg | `chimera run "transcribe meeting.mp3"` |
+| **Слышать звук** (речь → текст) | `[stt]` + ffmpeg | `chimera agent "transcribe meeting.mp3"` |
 | **Говорить** (текст → речь) | key: ElevenLabs или OpenAI | попросите любую задачу «прочитать это вслух в speech.mp3» |
-| **Читать документы** (PDF, Word, Excel → текст) | `[documents]` | `chimera run "summarize report.pdf"` |
-| **Скачивать видео и звук** (YouTube и 1000+ сайтов) | `[media-dl]` + ffmpeg | `chimera run "download the audio of <url>"` |
-| **Анализировать данные и строить графики** | `[data,viz]` | `chimera run "load sales.csv and chart monthly revenue"` |
-| **Искать в вебе** | key: Tavily | `chimera run "search the web: the latest Python version"` |
-| **Читать и собирать настоящие веб-страницы** (настоящий браузер) | — | `chimera run "open example.com and tell me the heading"` |
+| **Читать документы** (PDF, Word, Excel → текст) | `[documents]` | `chimera agent "summarize report.pdf"` |
+| **Скачивать видео и звук** (YouTube и 1000+ сайтов) | `[media-dl]` + ffmpeg | `chimera agent "download the audio of <url>"` |
+| **Анализировать данные и строить графики** | `[data,viz]` | `chimera agent "load sales.csv and chart monthly revenue"` |
+| **Искать в вебе** | key: Tavily | `chimera agent "search the web: the latest Python version"` |
+| **Читать и собирать настоящие веб-страницы** (настоящий браузер) | — | `chimera agent "open example.com and tell me the heading"` |
 | **Долговременная память** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **Автоматически усваивать переиспользуемые навыки** | — | происходит во время `chimera solve`; список — командой `chimera skills-stats` (`chimera skills` показывает встроенные) |
 | **Взять отобранную карточку навыка** (их 23, на 9 языках) | — | `chimera skills-import skills/verify-before-claiming` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -289,13 +289,13 @@ pip install 'chimera-agent[full]'     # 下面所有非 GPU 功能，一条命�
 | **一支专家智能体团队** | — | `chimera crew "你的任务" --mode supervisor` |
 | **把整个项目做到完成**（危险步骤前会暂停征询你） | — | `chimera project start spec.yaml -w .` |
 | **看图片**（视觉） | 密钥：Gemini 或 OpenAI | `chimera run --image photo.jpg "这是什么？" --model gemini/gemini-2.0-flash` |
-| **听音频**（语音 → 文字） | `[stt]` + ffmpeg | `chimera run "转写 meeting.mp3"` |
+| **听音频**（语音 → 文字） | `[stt]` + ffmpeg | `chimera agent "转写 meeting.mp3"` |
 | **说话**（文字 → 语音） | 密钥：ElevenLabs 或 OpenAI | 让任意任务“把这段读出来存到 speech.mp3” |
-| **读文档**（PDF、Word、Excel → 文字） | `[documents]` | `chimera run "总结 report.pdf"` |
-| **下载视频/音频**（YouTube 等 1000+ 网站） | `[media-dl]` + ffmpeg | `chimera run "下载 <url> 的音频"` |
-| **分析数据并画图** | `[data,viz]` | `chimera run "加载 sales.csv 并画月度收入图"` |
-| **网络搜索** | 密钥：Tavily | `chimera run "上网搜：最新的 Python 版本"` |
-| **读取并抓取真实网页**（真实浏览器） | — | `chimera run "打开 example.com 并告诉我标题"` |
+| **读文档**（PDF、Word、Excel → 文字） | `[documents]` | `chimera agent "总结 report.pdf"` |
+| **下载视频/音频**（YouTube 等 1000+ 网站） | `[media-dl]` + ffmpeg | `chimera agent "下载 <url> 的音频"` |
+| **分析数据并画图** | `[data,viz]` | `chimera agent "加载 sales.csv 并画月度收入图"` |
+| **网络搜索** | 密钥：Tavily | `chimera agent "上网搜：最新的 Python 版本"` |
+| **读取并抓取真实网页**（真实浏览器） | — | `chimera agent "打开 example.com 并告诉我标题"` |
 | **长期记忆** | — | `chimera memory add "..."` · `chimera memory search "..."` |
 | **自动学会可复用技能** | — | 在 `chimera solve` 过程中发生；用 `chimera skills-stats` 查看（`chimera skills` 列出内置的） |
 | **使用一张精选技能卡**（共 23 张，9 种语言） | — | `chimera skills-import skills/verify-before-claiming` |

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -950,9 +950,9 @@ const en: Dict = {
   "governance.injection.disarmed":
     "Switched OFF in this install (CHIMERA_TAINT_NARROW=0) — the defended column below describes a configuration you are not running.",
   "governance.injection.kernel":
-    "Nothing here measures the BLOCK/REVIEW policy rules. They run under `chimera run --guard`, `solve --guard`, and — when CHIMERA_GOVERNANCE is set — the run and turn endpoints. This score is about taint narrowing only.",
+    "Nothing here measures the BLOCK/REVIEW policy rules. They run under `chimera agent --guard`, `solve --guard`, and — when CHIMERA_GOVERNANCE is set — the run and turn endpoints. This score is about taint narrowing only.",
   "governance.audit.empty":
-    "No audit events — here that means nothing has been narrowed, escalated or suppressed, not that nothing is watching. The app records an entry whenever a defence fires; `chimera run --guard` and `solve --guard/--taint` also write their policy decisions.",
+    "No audit events — here that means nothing has been narrowed, escalated or suppressed, not that nothing is watching. The app records an entry whenever a defence fires; `chimera agent --guard` and `solve --guard/--taint` also write their policy decisions.",
   "nav.maturity": "Maturity",
   "maturity.title": "Maturity",
   "maturity.overall": "Overall",
@@ -2088,9 +2088,9 @@ const pt: Dict = {
   "governance.injection.disarmed":
     "Desligada nesta instalação (CHIMERA_TAINT_NARROW=0) — a coluna com defesa abaixo descreve uma configuração que você não está usando.",
   "governance.injection.kernel":
-    "Nada aqui mede as regras de política BLOCK/REVIEW. Elas rodam em `chimera run --guard`, `solve --guard` e — quando CHIMERA_GOVERNANCE está definido — nos endpoints de run e turn. Esta pontuação é só sobre taint narrowing.",
+    "Nada aqui mede as regras de política BLOCK/REVIEW. Elas rodam em `chimera agent --guard`, `solve --guard` e — quando CHIMERA_GOVERNANCE está definido — nos endpoints de run e turn. Esta pontuação é só sobre taint narrowing.",
   "governance.audit.empty":
-    "Nenhum evento de auditoria — aqui isso significa que nada foi estreitado, escalado ou suprimido, não que ninguém está observando. O aplicativo registra uma entrada sempre que uma defesa dispara; `chimera run --guard` e `solve --guard/--taint` também gravam suas decisões de política.",
+    "Nenhum evento de auditoria — aqui isso significa que nada foi estreitado, escalado ou suprimido, não que ninguém está observando. O aplicativo registra uma entrada sempre que uma defesa dispara; `chimera agent --guard` e `solve --guard/--taint` também gravam suas decisões de política.",
   "nav.maturity": "Maturidade",
   "maturity.title": "Maturidade",
   "maturity.overall": "Geral",
@@ -3237,9 +3237,9 @@ const es: Dict = {
   "governance.injection.disarmed":
     "Desactivada en esta instalación (CHIMERA_TAINT_NARROW=0) — la columna con defensa de abajo describe una configuración que no estás usando.",
   "governance.injection.kernel":
-    "Nada aquí mide las reglas de política BLOCK/REVIEW. Se ejecutan con `chimera run --guard`, `solve --guard` y — cuando CHIMERA_GOVERNANCE está definido — en los endpoints de run y turn. Esta puntuación trata solo del taint narrowing.",
+    "Nada aquí mide las reglas de política BLOCK/REVIEW. Se ejecutan con `chimera agent --guard`, `solve --guard` y — cuando CHIMERA_GOVERNANCE está definido — en los endpoints de run y turn. Esta puntuación trata solo del taint narrowing.",
   "governance.audit.empty":
-    "Ningún evento de auditoría — aquí eso significa que nada se ha restringido, escalado ni suprimido, no que nadie esté vigilando. La app registra una entrada cada vez que una defensa se activa; `chimera run --guard` y `solve --guard/--taint` también escriben sus decisiones de política.",
+    "Ningún evento de auditoría — aquí eso significa que nada se ha restringido, escalado ni suprimido, no que nadie esté vigilando. La app registra una entrada cada vez que una defensa se activa; `chimera agent --guard` y `solve --guard/--taint` también escriben sus decisiones de política.",
   "nav.maturity": "Madurez",
   "maturity.title": "Madurez",
   "maturity.overall": "General",
@@ -4398,9 +4398,9 @@ const fr: Dict = {
   "governance.injection.disarmed":
     "Désactivée sur cette installation (CHIMERA_TAINT_NARROW=0) — la colonne défendue ci-dessous décrit une configuration que vous n'utilisez pas.",
   "governance.injection.kernel":
-    "Rien ici ne mesure les règles de politique BLOCK/REVIEW. Elles tournent sous `chimera run --guard`, `solve --guard` et — quand CHIMERA_GOVERNANCE est défini — sur les endpoints run et turn. Ce score ne porte que sur le taint narrowing.",
+    "Rien ici ne mesure les règles de politique BLOCK/REVIEW. Elles tournent sous `chimera agent --guard`, `solve --guard` et — quand CHIMERA_GOVERNANCE est défini — sur les endpoints run et turn. Ce score ne porte que sur le taint narrowing.",
   "governance.audit.empty":
-    "Aucun événement d'audit — ici cela veut dire que rien n'a été restreint, escaladé ni supprimé, pas que personne ne surveille. L'app enregistre une entrée dès qu'une défense se déclenche ; `chimera run --guard` et `solve --guard/--taint` écrivent aussi leurs décisions de politique.",
+    "Aucun événement d'audit — ici cela veut dire que rien n'a été restreint, escaladé ni supprimé, pas que personne ne surveille. L'app enregistre une entrée dès qu'une défense se déclenche ; `chimera agent --guard` et `solve --guard/--taint` écrivent aussi leurs décisions de politique.",
   "nav.maturity": "Maturité",
   "maturity.title": "Maturité",
   "maturity.overall": "Global",
@@ -5558,9 +5558,9 @@ const de: Dict = {
   "governance.injection.disarmed":
     "In dieser Installation AUS (CHIMERA_TAINT_NARROW=0) — die Spalte „mit Abwehr“ unten beschreibt eine Konfiguration, die du nicht fährst.",
   "governance.injection.kernel":
-    "Hier misst nichts die BLOCK/REVIEW-Policy-Regeln. Sie laufen unter `chimera run --guard`, `solve --guard` und — wenn CHIMERA_GOVERNANCE gesetzt ist — auf den Run- und Turn-Endpunkten. Dieser Wert betrifft nur Taint-Narrowing.",
+    "Hier misst nichts die BLOCK/REVIEW-Policy-Regeln. Sie laufen unter `chimera agent --guard`, `solve --guard` und — wenn CHIMERA_GOVERNANCE gesetzt ist — auf den Run- und Turn-Endpunkten. Dieser Wert betrifft nur Taint-Narrowing.",
   "governance.audit.empty":
-    "Keine Audit-Ereignisse — das heißt hier, dass nichts eingeschränkt, eskaliert oder unterdrückt wurde, nicht dass niemand hinsieht. Die App schreibt einen Eintrag, sobald eine Abwehr greift; `chimera run --guard` und `solve --guard/--taint` schreiben zusätzlich ihre Policy-Entscheidungen.",
+    "Keine Audit-Ereignisse — das heißt hier, dass nichts eingeschränkt, eskaliert oder unterdrückt wurde, nicht dass niemand hinsieht. Die App schreibt einen Eintrag, sobald eine Abwehr greift; `chimera agent --guard` und `solve --guard/--taint` schreiben zusätzlich ihre Policy-Entscheidungen.",
   "nav.maturity": "Reife",
   "maturity.title": "Reife",
   "maturity.overall": "Gesamt",
@@ -6643,9 +6643,9 @@ const zh: Dict = {
   "governance.injection.disarmed":
     "本安装中已关闭（CHIMERA_TAINT_NARROW=0）——下方“有防御”一列描述的并不是你正在运行的配置。",
   "governance.injection.kernel":
-    "这里不衡量 BLOCK/REVIEW 策略规则。它们运行于 `chimera run --guard`、`solve --guard`，以及设置了 CHIMERA_GOVERNANCE 时的 run 与 turn 端点。此分数只关于 taint narrowing。",
+    "这里不衡量 BLOCK/REVIEW 策略规则。它们运行于 `chimera agent --guard`、`solve --guard`，以及设置了 CHIMERA_GOVERNANCE 时的 run 与 turn 端点。此分数只关于 taint narrowing。",
   "governance.audit.empty":
-    "没有审计事件——在这里这意味着没有任何调用被收紧、升级或抑制，而不是没人在看。防御一旦触发，应用就会记录一条；`chimera run --guard` 和 `solve --guard/--taint` 也会写入各自的策略决策。",
+    "没有审计事件——在这里这意味着没有任何调用被收紧、升级或抑制，而不是没人在看。防御一旦触发，应用就会记录一条；`chimera agent --guard` 和 `solve --guard/--taint` 也会写入各自的策略决策。",
   "nav.maturity": "成熟度",
   "maturity.title": "成熟度",
   "maturity.overall": "总体",
@@ -7780,9 +7780,9 @@ const ja: Dict = {
   "governance.injection.disarmed":
     "このインストールではオフです（CHIMERA_TAINT_NARROW=0）——下の「防御あり」の列は、あなたが動かしていない構成を示しています。",
   "governance.injection.kernel":
-    "ここでは BLOCK/REVIEW のポリシー規則を測定していません。これらは `chimera run --guard`、`solve --guard`、そして CHIMERA_GOVERNANCE が設定されている場合の run と turn のエンドポイントで動きます。このスコアは taint narrowing のみを対象としています。",
+    "ここでは BLOCK/REVIEW のポリシー規則を測定していません。これらは `chimera agent --guard`、`solve --guard`、そして CHIMERA_GOVERNANCE が設定されている場合の run と turn のエンドポイントで動きます。このスコアは taint narrowing のみを対象としています。",
   "governance.audit.empty":
-    "監査イベントはありません——ここではそれは、絞り込み・エスカレーション・抑止のいずれも起きていないという意味であり、誰も見ていないという意味ではありません。防御が働くたびにアプリが記録します。`chimera run --guard` と `solve --guard/--taint` もポリシー判断を書き込みます。",
+    "監査イベントはありません——ここではそれは、絞り込み・エスカレーション・抑止のいずれも起きていないという意味であり、誰も見ていないという意味ではありません。防御が働くたびにアプリが記録します。`chimera agent --guard` と `solve --guard/--taint` もポリシー判断を書き込みます。",
   "nav.maturity": "成熟度",
   "maturity.title": "成熟度",
   "maturity.overall": "全体",
@@ -8935,9 +8935,9 @@ const it: Dict = {
   "governance.injection.disarmed":
     "Disattivata in questa installazione (CHIMERA_TAINT_NARROW=0) — la colonna con difesa qui sotto descrive una configurazione che non stai usando.",
   "governance.injection.kernel":
-    "Qui nulla misura le regole di policy BLOCK/REVIEW. Girano con `chimera run --guard`, `solve --guard` e — quando CHIMERA_GOVERNANCE è impostato — sugli endpoint run e turn. Questo punteggio riguarda solo il taint narrowing.",
+    "Qui nulla misura le regole di policy BLOCK/REVIEW. Girano con `chimera agent --guard`, `solve --guard` e — quando CHIMERA_GOVERNANCE è impostato — sugli endpoint run e turn. Questo punteggio riguarda solo il taint narrowing.",
   "governance.audit.empty":
-    "Nessun evento di audit — qui significa che nulla è stato ristretto, escalato o soppresso, non che nessuno stia guardando. L'app registra una voce ogni volta che una difesa scatta; anche `chimera run --guard` e `solve --guard/--taint` scrivono le loro decisioni di policy.",
+    "Nessun evento di audit — qui significa che nulla è stato ristretto, escalato o soppresso, non che nessuno stia guardando. L'app registra una voce ogni volta che una difesa scatta; anche `chimera agent --guard` e `solve --guard/--taint` scrivono le loro decisioni di policy.",
   "nav.maturity": "Maturità",
   "maturity.title": "Maturità",
   "maturity.overall": "Complessivo",
@@ -10082,9 +10082,9 @@ const pl: Dict = {
   "governance.injection.disarmed":
     "Wyłączone w tej instalacji (CHIMERA_TAINT_NARROW=0) — kolumna z obroną poniżej opisuje konfigurację, której nie używasz.",
   "governance.injection.kernel":
-    "Nic tutaj nie mierzy reguł policy BLOCK/REVIEW. Działają pod `chimera run --guard`, `solve --guard` oraz — gdy ustawiono CHIMERA_GOVERNANCE — na endpointach run i turn. Ten wynik dotyczy wyłącznie taint narrowing.",
+    "Nic tutaj nie mierzy reguł policy BLOCK/REVIEW. Działają pod `chimera agent --guard`, `solve --guard` oraz — gdy ustawiono CHIMERA_GOVERNANCE — na endpointach run i turn. Ten wynik dotyczy wyłącznie taint narrowing.",
   "governance.audit.empty":
-    "Brak zdarzeń audytu — tutaj znaczy to, że nic nie zostało zawężone, eskalowane ani wstrzymane, a nie że nikt nie patrzy. Aplikacja zapisuje wpis za każdym razem, gdy zadziała zabezpieczenie; `chimera run --guard` i `solve --guard/--taint` zapisują też swoje decyzje policy.",
+    "Brak zdarzeń audytu — tutaj znaczy to, że nic nie zostało zawężone, eskalowane ani wstrzymane, a nie że nikt nie patrzy. Aplikacja zapisuje wpis za każdym razem, gdy zadziała zabezpieczenie; `chimera agent --guard` i `solve --guard/--taint` zapisują też swoje decyzje policy.",
   "nav.maturity": "Dojrzałość",
   "maturity.title": "Dojrzałość",
   "maturity.overall": "Ogółem",
@@ -11235,9 +11235,9 @@ const ru: Dict = {
   "governance.injection.disarmed":
     "В этой установке ВЫКЛЮЧЕНО (CHIMERA_TAINT_NARROW=0) — столбец «с защитой» ниже описывает конфигурацию, которая у вас не работает.",
   "governance.injection.kernel":
-    "Здесь ничто не измеряет правила политики BLOCK/REVIEW. Они работают в `chimera run --guard`, `solve --guard` и — когда задан CHIMERA_GOVERNANCE — на эндпоинтах run и turn. Эта оценка относится только к taint narrowing.",
+    "Здесь ничто не измеряет правила политики BLOCK/REVIEW. Они работают в `chimera agent --guard`, `solve --guard` и — когда задан CHIMERA_GOVERNANCE — на эндпоинтах run и turn. Эта оценка относится только к taint narrowing.",
   "governance.audit.empty":
-    "Событий аудита нет — здесь это значит, что ничего не сужалось, не повышалось и не подавлялось, а не что никто не наблюдает. Приложение делает запись всякий раз, когда срабатывает защита; `chimera run --guard` и `solve --guard/--taint` тоже записывают свои решения.",
+    "Событий аудита нет — здесь это значит, что ничего не сужалось, не повышалось и не подавлялось, а не что никто не наблюдает. Приложение делает запись всякий раз, когда срабатывает защита; `chimera agent --guard` и `solve --guard/--taint` тоже записывают свои решения.",
   "nav.maturity": "Зрелость",
   "maturity.title": "Зрелость",
   "maturity.overall": "В целом",

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -1835,6 +1835,57 @@
     },
     {
       "deprecated": false,
+      "help": "Search a repository by what code DOES, not by the string it contains.\n\n`chimera/rag/` has been in the tree since 0.44.0 \u2014 symbol-level chunking over Python's AST, one\nSQLite file with an FTS5 index, RRF fusion \u2014 measured, documented, and reachable from nothing.\nA library with no entrance is a library nobody has. This is the entrance.\n\nKeyword retrieval only, and that is stated rather than glossed: the semantic half needs an\nembedder, none is wired, and the pre-registered baseline in `bench/rag/` says exactly what the\nkeyword half is worth on this repository \u2014 recall@10 of 0.4925 over 400 probes. Half the\nanswers are not in the top ten. Printing that beside the results is the difference between a\ntool you can calibrate and one you learn to distrust.",
+      "hidden": false,
+      "name": "find",
+      "params": [
+        {
+          "help": "What you are looking for, in words.",
+          "kind": "argument",
+          "name": "query",
+          "opts": [
+            "query"
+          ],
+          "required": true,
+          "type": "str"
+        },
+        {
+          "default": "'.'",
+          "help": "Repository to search.",
+          "kind": "option",
+          "name": "path",
+          "opts": [
+            "--path"
+          ],
+          "required": false,
+          "type": "str"
+        },
+        {
+          "default": "8",
+          "help": "How many results.",
+          "kind": "option",
+          "name": "k",
+          "opts": [
+            "--k"
+          ],
+          "required": false,
+          "type": "int"
+        },
+        {
+          "help": "Rebuild the index before searching.",
+          "kind": "option",
+          "name": "reindex",
+          "opts": [
+            "--reindex"
+          ],
+          "required": false,
+          "type": "boolean"
+        }
+      ],
+      "path": "find"
+    },
+    {
+      "deprecated": false,
       "help": "Run a prompt through the LLM-Fusion engine (panel -> judge -> synthesizer).",
       "hidden": false,
       "name": "fuse",

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -6384,5 +6384,73 @@ def meta(
     console.print(table)
 
 
+@app.command("find")
+def find_command(
+    query: str = typer.Argument(..., help="What you are looking for, in words."),
+    path: str = typer.Option(".", "--path", help="Repository to search."),
+    k: int = typer.Option(8, "--k", help="How many results."),
+    reindex: bool = typer.Option(False, "--reindex", help="Rebuild the index before searching."),
+) -> None:
+    """Search a repository by what code DOES, not by the string it contains.
+
+    `chimera/rag/` has been in the tree since 0.44.0 — symbol-level chunking over Python's AST, one
+    SQLite file with an FTS5 index, RRF fusion — measured, documented, and reachable from nothing.
+    A library with no entrance is a library nobody has. This is the entrance.
+
+    Keyword retrieval only, and that is stated rather than glossed: the semantic half needs an
+    embedder, none is wired, and the pre-registered baseline in `bench/rag/` says exactly what the
+    keyword half is worth on this repository — recall@10 of 0.4925 over 400 probes. Half the
+    answers are not in the top ten. Printing that beside the results is the difference between a
+    tool you can calibrate and one you learn to distrust.
+    """
+    from chimera.rag import ChunkStore, default_index_path, walk
+
+    root = Path(path).expanduser().resolve()
+    if not root.is_dir():
+        console.print(f"[red]{root} is not a directory[/red]")
+        raise typer.Exit(code=1)
+
+    index = default_index_path(get_settings().home, root)
+    store = ChunkStore(index)
+    try:
+        if reindex or store.stats()["chunks"] == 0:
+            with console.status("indexing..."):
+                n = store.replace_all(walk(root))
+            console.print(f"[dim]indexed {n} chunks from {root}[/dim]")
+        hits = store.search_keyword(query, k=k)
+        stats = store.stats()
+    finally:
+        store.close()
+
+    if not hits:
+        # Named, because "no results" from a stale index and "no results" from a repository that
+        # really does not contain this are different problems with the same empty screen.
+        console.print(
+            f"[dim]nothing matched in {stats['chunks']} chunks from {stats['files']} files. "
+            f"If the code moved since the index was built, try --reindex.[/dim]"
+        )
+        return
+
+    table = Table(title=repr(query), show_header=True, title_style="bold")
+    table.add_column("where", style="cyan", no_wrap=True)
+    table.add_column("what")
+    table.add_column("score", justify="right")
+    for hit in hits:
+        chunk = hit.chunk
+        table.add_row(
+            f"{chunk.path}:{chunk.start_line}",
+            chunk.symbol or f"[dim]{chunk.kind}[/dim]",
+            f"{hit.score:.3f}",
+        )
+    console.print(table)
+    # The number, every time. Measured on this repository, pre-registered before any embedder
+    # existed so it could not be chosen after seeing what looked good.
+    console.print(
+        "[dim]keyword retrieval only (no embedder wired). Measured on this repository: "
+        "recall@10 of 0.4925 over 400 probes — about half of what you look for is NOT in the "
+        "top ten.[/dim]"
+    )
+
+
 if __name__ == "__main__":
     app()

--- a/docs/i18n/de/recipes.md
+++ b/docs/i18n/de/recipes.md
@@ -18,7 +18,7 @@ verweisen:
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 Das war's — kein `OPENROUTER_API_KEY`, keine Cloud. Das Credential-Gate erkennt `ollama/…` (und
@@ -155,8 +155,8 @@ nötig:
   genutzt wird, die ein Selektor nicht gefüllt hat.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Für ganze Websites gibt es zwei weitere Verben:
@@ -172,7 +172,7 @@ Für ganze Websites gibt es zwei weitere Verben:
   ab N+1 weitermacht (`resume=true` standardmäßig).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Alles ist data-fenced und kontaminiert den Lauf (es ist nicht vertrauenswürdiger Webinhalt),
@@ -190,7 +190,7 @@ OpenAI-Key):
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Eine Anmerkung zum Umfang, im ehrlichen Geist dieses Projekts: Chimera ist ein **Agent**, kein
@@ -211,7 +211,7 @@ Opt-in; Audio-Extraktion braucht außerdem `ffmpeg` im PATH:
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Passt natürlich zu `transcribe_audio` von oben: herunterladen → transkribieren →
@@ -227,7 +227,7 @@ ausführt.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Bildgenerierung (gehostet oder vollständig lokal)
@@ -240,7 +240,7 @@ OpenAI-Key vorhanden ist.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Derselbe ehrliche Umfang wie oben: Chimera *führt* hier ein Diffusionsmodell *aus*; es
@@ -262,7 +262,7 @@ Speichern-im-Workspace-Disziplin eingebacken.
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. Das `render_chart`-Tool — eine sichere, deklarative Vega-Lite-Spec.** Eine Vega-Lite-Spec
@@ -273,7 +273,7 @@ braucht kein Extra** (bettet die Spec + das Vega-CDN ein); PNG/SVG nutzen das op
 `viz-vega`-Extra (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/es/recipes.md
+++ b/docs/i18n/es/recipes.md
@@ -17,7 +17,7 @@ Instala [Ollama](https://ollama.com), descarga un modelo, y luego apunta Chimera
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 Eso es todo — sin `OPENROUTER_API_KEY`, sin nube. La barrera de credenciales reconoce
@@ -152,8 +152,8 @@ sin ningún extra que instalar:
   selector no llenó.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Para sitios completos hay dos verbos más:
@@ -169,7 +169,7 @@ Para sitios completos hay dos verbos más:
   ejecución (`resume=true` por defecto).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Todo queda cercado como datos y contamina (taint) la ejecución (es contenido web no confiable),
@@ -187,7 +187,7 @@ si no, la API alojada de OpenAI Whisper (necesita una clave de OpenAI):
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Una nota sobre el alcance, en el espíritu honesto de este proyecto: Chimera es un **agente**,
@@ -207,7 +207,7 @@ Opcional; la extracción de audio también necesita `ffmpeg` en el PATH:
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Combina naturalmente con `transcribe_audio` de arriba: descargar → transcribir → resumir, todo
@@ -222,7 +222,7 @@ luego ejecuta.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Generación de imágenes (alojada o totalmente local)
@@ -235,7 +235,7 @@ hay una clave de OpenAI presente.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Mismo alcance honesto que arriba: Chimera *ejecuta* un modelo de difusión aquí; no entrena
@@ -257,7 +257,7 @@ incorporadas.
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. La herramienta `render_chart` — una especificación Vega-Lite segura y declarativa.** Una
@@ -268,7 +268,7 @@ calor/facetado…). **La salida HTML no necesita ningún extra** (incrusta la es
 CDN de Vega); PNG/SVG usan el extra opcional `viz-vega` (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/fr/recipes.md
+++ b/docs/i18n/fr/recipes.md
@@ -18,7 +18,7 @@ dessus :
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 C'est tout — pas de `OPENROUTER_API_KEY`, pas de cloud. La barrière d'identifiants reconnaît
@@ -155,8 +155,8 @@ Deux outils intégrés transforment n'importe quelle page en données propres, p
   sélecteur n'a pas remplis.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Pour des sites entiers, il y a deux verbes supplémentaires :
@@ -172,7 +172,7 @@ Pour des sites entiers, il y a deux verbes supplémentaires :
   suivant (`resume=true` par défaut).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Tout est clôturé comme donnée et contamine le run (c'est du contenu web non fiable), donc
@@ -189,7 +189,7 @@ pas) : l'outil `transcribe_audio` utilise le **faster-whisper** local si vous in
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Une note sur le périmètre, dans l'esprit honnête de ce projet : Chimera est un **agent**, pas
@@ -210,7 +210,7 @@ pytube). Opt-in ; l'extraction audio nécessite aussi `ffmpeg` dans le PATH :
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Se combine naturellement avec `transcribe_audio` ci-dessus : télécharger → transcrire →
@@ -225,7 +225,7 @@ explorer → modéliser → évaluer) que l'agent exécute ensuite.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Génération d'images (hébergée ou entièrement locale)
@@ -238,7 +238,7 @@ clé OpenAI n'est présente.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Même périmètre honnête que ci-dessus : Chimera *exécute* un modèle de diffusion ici ; il n'en
@@ -262,7 +262,7 @@ workspace intégrées.
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. L'outil `render_chart` — une spec Vega-Lite sûre et déclarative.** Une spec Vega-Lite est
@@ -273,7 +273,7 @@ HTML ne nécessite aucun extra** (elle embarque la spec + le CDN Vega) ; le PNG/
 l'extra optionnel `viz-vega` (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/it/recipes.md
+++ b/docs/i18n/it/recipes.md
@@ -17,7 +17,7 @@ esso:
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 Tutto qui — niente `OPENROUTER_API_KEY`, niente cloud. Il gate delle credenziali riconosce
@@ -149,8 +149,8 @@ da installare:
   selettore non ha riempito.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Per interi siti ci sono altri due verbi:
@@ -166,7 +166,7 @@ Per interi siti ci sono altri due verbi:
   prossima esecuzione (`resume=true` per default).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Tutto è recintato come dato e contamina l'esecuzione (è contenuto web non fidato), quindi
@@ -184,7 +184,7 @@ immagini e text-to-speech. **Orchestra un modello Whisper** (non lo addestra): i
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Una nota sull'ambito, nello spirito onesto di questo progetto: Chimera è un **agente**, non un
@@ -204,7 +204,7 @@ l'estrazione audio richiede anche `ffmpeg` nel PATH:
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Si abbina naturalmente a `transcribe_audio` sopra: scaricare → trascrivere → riassumere, tutto
@@ -219,7 +219,7 @@ esegue.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Generazione immagini (ospitata o completamente locale)
@@ -232,7 +232,7 @@ alcuna chiave OpenAI.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Stesso ambito onesto di prima: Chimera qui *esegue* un modello di diffusione; non ne addestra
@@ -254,7 +254,7 @@ integrati.
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. Il tool `render_chart` — una specifica Vega-Lite sicura e dichiarativa.** Una spec
@@ -265,7 +265,7 @@ standard che Vega-Lite copre (barre/linea/dispersione/istogramma/mappa di calore
 l'extra opzionale `viz-vega` (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/ja/recipes.md
+++ b/docs/i18n/ja/recipes.md
@@ -13,7 +13,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 それだけです — `OPENROUTER_API_KEY` もクラウドも不要です。認証情報ゲートは `ollama/…`(および `ollama_chat/…`)をローカルランタイムとして認識し、通過させます。Ollamaを別の場所で実行している場合は、`CHIMERA_OLLAMA_BASE_URL=http://host:11434` を設定してください(デフォルトは `http://localhost:11434`)。
@@ -99,8 +99,8 @@ uv run chimera solve "Research 'on-device small language models 2026': web_searc
 - **`extract`** — 特定のフィールドを**検証済みJSON**として、安全に取り出します。`url`(または `content`)と `fields` のリスト(例: `["title", "price", "author"]`)を与えると、*それらのフィールドだけ*を返します。重要なのは、これがChimeraの**検疫リーダー**を通じてページを読むことです — 出力がスキーマ検証された、ツールを持たないモデルです — そのため、**ページに隠された指示がエージェントを乗っ取ることはできません**。これはFirecrawl/ScrapeGraphAIが与えてくれない安全保証です: 悪意のあるページが最悪でも返せるのは間違った値であり、新たな指示ではありません。大きなページはチャンク化されマージされ、すべてのフィールドが埋まった時点で早期に停止してコストを抑えます。**既知のページテンプレート**については、`selectors`(フィールド → CSS、例: `{"price": ".price", "link": "a.more::attr(href)"}`)を渡せば、それらのフィールドは**決定論的に抽出されます — 無料でLLM不要**。安全なLLMは、セレクターが埋めなかったフィールドにのみ使われます。
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 サイト全体については、さらに2つの動詞があります。
@@ -109,7 +109,7 @@ uv run chimera run "extract the fields title, price, availability from https://e
 - **`crawl`** — シードURLからリンクを辿り、各ページのクリーンなMarkdownを返します。`limit` と `max_depth` によって制限され、デフォルトでは同一ドメインのみで、**robots.txtに準拠**します(`Disallow` と `Crawl-delay` に従います)。`include`/`exclude` はURLのglobパターンです。長いクロールは**再開可能**です: フロンティアはページごとにディスクへチェックポイントされるため、ページNで中断されたクロールは次回の実行でN+1から続行されます(デフォルトで `resume=true`)。
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 すべてはデータフェンスされ、実行を汚染します(信頼できないウェブコンテンツのため)。そのため `solve --taint --guard` がそれに対して行動する安全な方法です。オプションのFirecrawlフォールバックは、組み込みエンジンがページを取得できず、かつキーが設定されている場合*のみ*使われます — Chimeraはウェブの大部分を、外部サービスなしに自力でスクレイピングします。
@@ -120,7 +120,7 @@ Chimeraは音声をテキストに変換できます — 画像生成やテキ�
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > このプロジェクトの正直な精神に則ったスコープについての注記: Chimeraは**エージェント**であり、モデルではありません。APIを呼ぶかコードサンドボックスでライブラリを実行することで、音声からテキストへの変換、画像生成、コンピュータビジョン、古典的なMLを*使う*ことはできますが、Whisper、Stable Diffusion、PyTorch、OpenCVを*再実装*することはしません(そして分別を持ってそうすることもできません)。データサイエンス/MLについては、`execute_code` サンドボックスがすでに、エージェントがscikit-learn、pandas、OpenCVなどに対してPythonを書いて実行することを可能にしています。オーケストレーションはエージェントを増強します。再実装は遅いコピーを生むだけです。
@@ -131,7 +131,7 @@ uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action ite
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 上記の `transcribe_audio` と自然に組み合わさります: ダウンロード → 文字起こし → 要約、すべて1回の実行で。
@@ -142,7 +142,7 @@ Chimeraはscikit-learnを再実装しません — `execute_code` サンドボ�
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## 画像生成(ホスト型または完全ローカル)
@@ -151,7 +151,7 @@ uv run chimera run "use the data_analysis skill: predict churn from customers.cs
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > 上記と同じ正直なスコープです: Chimeraはここで拡散モデルを*実行します*が、訓練はしません。動画生成(CogVideoなど)は意図的に組み込まれ**ていません** — それはヘビー級の訓練済みモデルであり、エージェントがベースに抱えるべきものではありません。必要な場合はホスト型APIを利用してください。コンピュータビジョン(OpenCV)は専用のツールを必要としません — エージェントはすでにコードサンドボックスで `import cv2` を行えます。
@@ -164,13 +164,13 @@ CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a 
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. `render_chart` ツール — 安全で宣言的なVega-Liteの仕様。** Vega-Liteの仕様は**コードではなく、不活性なJSONデータ**です: 検査可能で、スキーマ形状を持ち、再レンダリング可能です — Vega-Liteがカバーする標準的なチャート(棒/線/散布図/ヒストグラム/ヒートマップ/ファセット表示など)については、生成されたコードを実行するよりも強力なガバナンスの物語です。**HTML出力はエクストラ不要**です(仕様+Vega CDNを埋め込みます)。PNG/SVGはオプションの `viz-vega` エクストラ(`vl-convert-python`)を使います。
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/pl/recipes.md
+++ b/docs/i18n/pl/recipes.md
@@ -17,7 +17,7 @@ Zainstaluj [Ollama](https://ollama.com), pobierz model, potem skieruj na niego C
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 I to wszystko — bez `OPENROUTER_API_KEY`, bez chmury. Brama poświadczeń rozpoznaje `ollama/…`
@@ -146,8 +146,8 @@ instalacji:
   pól, których selektor nie wypełnił.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Dla całych stron są jeszcze dwa czasowniki:
@@ -163,7 +163,7 @@ Dla całych stron są jeszcze dwa czasowniki:
   (`resume=true` domyślnie).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Wszystko jest otoczone ogrodzeniem danych i skaża przebieg (to niezaufana treść webowa), więc
@@ -180,7 +180,7 @@ przeciwnym razie hostowanego API OpenAI Whisper (wymaga klucza OpenAI):
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Uwaga o zakresie, w uczciwym duchu tego projektu: Chimera jest **agentem**, nie modelem.
@@ -200,7 +200,7 @@ wymaga też `ffmpeg` w PATH:
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Naturalnie łączy się z `transcribe_audio` powyżej: pobierz → transkrybuj → podsumuj, wszystko w
@@ -215,7 +215,7 @@ następnie wykonuje.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Generowanie obrazów (hostowane lub w pełni lokalne)
@@ -227,7 +227,7 @@ lokalnie. `auto` (domyślne) używa lokalnego tylko wtedy, gdy nie ma klucza Ope
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Ten sam uczciwy zakres co powyżej: Chimera tutaj *uruchamia* model dyfuzyjny; nie trenuje go.
@@ -248,7 +248,7 @@ wbudowaną dyscypliną backendu headless (`matplotlib.use("Agg")`) i zapisu do w
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. Narzędzie `render_chart` — bezpieczna, deklaratywna specyfikacja Vega-Lite.**
@@ -260,7 +260,7 @@ specyfikację + CDN Vega); PNG/SVG używają opcjonalnego extra `viz-vega`
 (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/pt/recipes.md
+++ b/docs/i18n/pt/recipes.md
@@ -16,7 +16,7 @@ Rode o Chimera contra um modelo na sua própria máquina — sem chave, nada sai
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 Só isso — sem `OPENROUTER_API_KEY`, sem nuvem. O gate de credenciais reconhece `ollama/…` (e
@@ -146,8 +146,8 @@ para instalar:
   campos que um seletor não preencheu.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Para sites inteiros há mais dois verbos:
@@ -162,7 +162,7 @@ Para sites inteiros há mais dois verbos:
   interrompido na página N continua da N+1 na próxima execução (`resume=true` por padrão).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Tudo é cercado como dado e contamina a execução (é conteúdo web não confiável), então
@@ -179,7 +179,7 @@ imagem e texto-para-fala. Ele **orquestra um modelo Whisper** (não treina um): 
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Uma nota sobre escopo, no espírito honesto deste projeto: o Chimera é um **agente**, não um
@@ -199,7 +199,7 @@ cifra/formato/age-gate que afunda scrapers de site único como o pytube). Opt-in
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Combina naturalmente com o `transcribe_audio` acima: baixar → transcrever → resumir, tudo em uma
@@ -214,7 +214,7 @@ que o agente então executa.
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Geração de imagem (hospedada ou totalmente local)
@@ -226,7 +226,7 @@ localmente. `auto` (o padrão) usa local só quando nenhuma chave OpenAI está p
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Mesmo escopo honesto de antes: o Chimera *roda* um modelo de difusão aqui; ele não treina um. A
@@ -247,7 +247,7 @@ usando matplotlib/seaborn (PNG/SVG estático) ou plotly (HTML interativo), com o
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. A tool `render_chart` — uma especificação Vega-Lite segura e declarativa.** Uma spec
@@ -258,7 +258,7 @@ precisa de extra** (ela embute a spec + o CDN do Vega); PNG/SVG usam o extra opc
 (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/ru/recipes.md
+++ b/docs/i18n/ru/recipes.md
@@ -17,7 +17,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 Вот и всё — ни `OPENROUTER_API_KEY`, ни облака. Проверка учётных данных распознаёт `ollama/…` (и
@@ -147,8 +147,8 @@ uv run chimera solve "Research 'on-device small language models 2026': web_searc
   которые селектор не заполнил.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 Для целых сайтов есть ещё два действия:
@@ -163,7 +163,7 @@ uv run chimera run "extract the fields title, price, availability from https://e
   странице N, при следующем запуске продолжится с N+1 (`resume=true` по умолчанию).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Всё обособляется как данные и заражает запуск (это недоверенное содержимое из веба), поэтому
@@ -180,7 +180,7 @@ Chimera умеет превращать речь в текст — это сим
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > Замечание об охвате, в честном духе этого проекта: Chimera — **агент**, а не модель. Она может
@@ -200,7 +200,7 @@ pytube). Включается по желанию; для извлечения �
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Естественно сочетается с `transcribe_audio` выше: скачать → расшифровать → изложить, всё за один
@@ -215,7 +215,7 @@ Chimera не переписывает scikit-learn — она **пишет пр�
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Генерация изображений (в облаке или полностью локально)
@@ -228,7 +228,7 @@ OpenAI.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Тот же честный охват, что и выше: здесь Chimera *запускает* диффузионную модель, но не обучает её.
@@ -249,7 +249,7 @@ matplotlib и seaborn (статичный PNG или SVG) либо на plotly (
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. Инструмент `render_chart` — безопасная декларативная спецификация Vega-Lite.** Спецификация
@@ -260,7 +260,7 @@ Vega-Lite — это **инертные данные JSON, а не код**: и�
 Vega); PNG и SVG используют необязательное дополнение `viz-vega` (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/i18n/zh/recipes.md
+++ b/docs/i18n/zh/recipes.md
@@ -16,7 +16,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 就这么简单——不需要 `OPENROUTER_API_KEY`，也不涉及云端。凭据检查会把 `ollama/…`（以及
@@ -138,8 +138,8 @@ uv run chimera solve "Research 'on-device small language models 2026': web_searc
   不经过 LLM**——只有选择器没能填上的字段才会用到那个安全的 LLM。
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 针对整个站点，还有两个动词可用：
@@ -153,7 +153,7 @@ uv run chimera run "extract the fields title, price, availability from https://e
   会从第 N+1 页继续（默认 `resume=true`）。
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 所有内容都会被数据围栏并给这次运行打上污点（因为这些都是不可信的网页内容），因此
@@ -169,7 +169,7 @@ Chimera 能把语音转成文字——是它图像生成和文本转语音工具
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > 关于能力边界的说明，秉持本项目一贯的诚实态度：Chimera 是一个 **agent**，而不是一个模型。它
@@ -188,7 +188,7 @@ pytube 这类单站点抓取工具容易失效的地方）。这是可选安装�
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 和上面的 `transcribe_audio` 天然搭配：下载 → 转录 → 总结，一次运行全部完成。
@@ -201,7 +201,7 @@ Chimera 不会重新实现 scikit-learn——它会**编写正确的 pandas/skle
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## 图像生成（云端托管或完全本地）
@@ -213,7 +213,7 @@ uv run chimera run "use the data_analysis skill: predict churn from customers.cs
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > 和上文一样诚实地划定范围：Chimera 在这里*运行*一个扩散模型，而不是训练一个。视频生成
@@ -233,7 +233,7 @@ plotly（交互式 HTML）的脚本，并内置了无头后端设置（`matplotl
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. `render_chart` 工具——一份安全、声明式的 Vega-Lite 规范。** 一份 Vega-Lite 规范是**惰性
@@ -243,7 +243,7 @@ uv run chimera run "use data_visualization: line chart of revenue.csv over time,
 PNG/SVG 输出则需要可选的 `viz-vega` extra（`vl-convert-python`）。
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -12,7 +12,7 @@ Run Chimera against a model on your own machine — no key, nothing leaves the b
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
 export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
-chimera run "Summarise this file in 3 bullets" -w .
+chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
 That's it — no `OPENROUTER_API_KEY`, no cloud. The credential gate recognises `ollama/…` (and
@@ -135,8 +135,8 @@ Two built-in tools turn any page into clean, LLM-ready data — no extra to inst
   — free, no LLM** — with the safe LLM used only for fields a selector didn't fill.
 
 ```bash
-uv run chimera run "scrape https://news.ycombinator.com and summarize the top 5 stories"
-uv run chimera run "extract the fields title, price, availability from https://example.com/product --taint"
+uv run chimera agent "scrape https://news.ycombinator.com and summarize the top 5 stories"
+uv run chimera agent "extract the fields title, price, availability from https://example.com/product --taint"
 ```
 
 For whole sites there are two more verbs:
@@ -150,7 +150,7 @@ For whole sites there are two more verbs:
   next run (`resume=true` by default).
 
 ```bash
-uv run chimera run "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
+uv run chimera agent "map https://docs.example.com then crawl the /guide section (max 20 pages) and summarize it"
 ```
 
 Everything is data-fenced and taints the run (it's untrusted web content), so `solve --taint --guard`
@@ -167,7 +167,7 @@ Whisper API (needs an OpenAI key):
 
 ```bash
 uv sync --extra stt      # optional: local, offline transcription (heavier — downloads a model)
-uv run chimera run "transcribe meeting.m4a and give me 5 bullet-point action items"
+uv run chimera agent "transcribe meeting.m4a and give me 5 bullet-point action items"
 ```
 
 > A note on scope, in the honest spirit of this project: Chimera is an **agent**, not a model. It can
@@ -185,7 +185,7 @@ sinks single-site scrapers like pytube). Opt-in; audio extraction also needs `ff
 
 ```bash
 uv sync --extra media-dl
-uv run chimera run "download the audio of https://youtu.be/… then transcribe it and summarize"
+uv run chimera agent "download the audio of https://youtu.be/… then transcribe it and summarize"
 ```
 
 Pairs naturally with `transcribe_audio` above: download → transcribe → summarize, all in one run.
@@ -198,7 +198,7 @@ and it emits a self-contained script (load → explore → model → evaluate) t
 
 ```bash
 uv sync --extra data     # pandas + scikit-learn for the generated code
-uv run chimera run "use the data_analysis skill: predict churn from customers.csv and report accuracy"
+uv run chimera agent "use the data_analysis skill: predict churn from customers.csv and report accuracy"
 ```
 
 ## Image generation (hosted or fully local)
@@ -210,7 +210,7 @@ no OpenAI key is present.
 
 ```bash
 uv sync --extra imagegen-local     # pulls torch + diffusers; downloads multi-GB weights on first use
-CHIMERA_IMAGE_BACKEND=local uv run chimera run "generate an image of a fox in a snowy forest"
+CHIMERA_IMAGE_BACKEND=local uv run chimera agent "generate an image of a fox in a snowy forest"
 ```
 
 > Same honest scope as above: Chimera *runs* a diffusion model here; it does not train one. Video
@@ -230,7 +230,7 @@ matplotlib/seaborn (static PNG/SVG) or plotly (interactive HTML), with the headl
 
 ```bash
 uv sync --extra viz     # matplotlib + seaborn + plotly for the generated code
-uv run chimera run "use data_visualization: line chart of revenue.csv over time, save revenue.png"
+uv run chimera agent "use data_visualization: line chart of revenue.csv over time, save revenue.png"
 ```
 
 **2. The `render_chart` tool — a safe, declarative Vega-Lite spec.** A Vega-Lite spec is **inert JSON
@@ -240,7 +240,7 @@ heatmap/faceted…). **HTML output needs no extra** (it embeds the spec + the Ve
 optional `viz-vega` extra (`vl-convert-python`).
 
 ```bash
-uv run chimera run "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
+uv run chimera agent "build a Vega-Lite bar chart of {A:5,B:8,C:3} and render_chart it to chart.html"
 uv sync --extra viz-vega   # optional: static PNG/SVG rendering (heavy — Rust+V8 binary)
 ```
 

--- a/tests/test_documented_commands_exist.py
+++ b/tests/test_documented_commands_exist.py
@@ -1,0 +1,95 @@
+"""Every `chimera …` command in the docs and the UI has to be a command that exists.
+
+This is the guard for a whole class of defect that nothing was catching. The Governance screen told
+users to run `chimera run --guard` in ten languages; `run` is `gateway.quick(prompt)` — one
+completion, no tools, no such flag — so copying the command from the UI gives
+`No such option: --guard`. The capability table told them to transcribe a file, crawl a site and
+render a chart with the same `chimera run`, and the model politely explained it could not, which
+reads as the feature being broken rather than the instruction being wrong.
+
+None of it was a lie about the product. `--guard` is real and wired; the tools are real. The
+instructions named the wrong command, and a wrong instruction is indistinguishable from a missing
+feature to the person following it.
+
+Checked against `chimera/_cli_snapshot.json`, which CI already regenerates and diffs, so this can
+never drift from the real CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: `chimera <command>` optionally followed by flags, inside backticks or a shell line.
+_INVOCATION = re.compile(r"\bchimera\s+([a-z][a-z0-9-]*)((?:\s+--?[a-z][a-z0-9-]*)*)")
+
+#: Words that follow `chimera` in prose without being commands ("the chimera agent framework").
+_NOT_COMMANDS = frozenset({"agent-", "is", "in", "on", "as", "and", "to", "can", "will"})
+
+
+def _snapshot() -> dict[str, set[str]]:
+    """{command: {its flags}} from the snapshot CI keeps in step with the real CLI."""
+    data = json.loads((ROOT / "chimera" / "_cli_snapshot.json").read_text(encoding="utf-8"))
+    out: dict[str, set[str]] = {}
+    for command in data["commands"]:
+        out[command["name"]] = set(re.findall(r"--[a-z][a-z0-9-]*", json.dumps(command)))
+    return out
+
+
+def _sources() -> list[Path]:
+    files = [ROOT / "README.md", *sorted(ROOT.glob("README.*.md"))]
+    files += sorted((ROOT / "docs").rglob("*.md"))
+    files.append(ROOT / "apps" / "desktop" / "src" / "lib" / "i18n.tsx")
+    return [p for p in files if p.exists()]
+
+
+def _claims() -> list[tuple[Path, int, str, str]]:
+    found: list[tuple[Path, int, str, str]] = []
+    commands = _snapshot()
+    for path in _sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for name, flags in _INVOCATION.findall(line):
+                if name in _NOT_COMMANDS or name not in commands:
+                    # Unknown names are a separate assertion below; prose is full of "chimera is".
+                    continue
+                for flag in re.findall(r"--[a-z][a-z0-9-]*", flags):
+                    found.append((path, lineno, name, flag))
+    return found
+
+
+def test_every_flag_the_docs_name_exists_on_the_command_they_name_it_on() -> None:
+    commands = _snapshot()
+    wrong = [
+        f"{path.relative_to(ROOT)}:{lineno}: `chimera {name} {flag}` — {name} has no {flag}"
+        for path, lineno, name, flag in _claims()
+        if flag not in commands[name]
+    ]
+    assert not wrong, "\n".join(["commands the docs promise and the CLI does not have:", *wrong])
+
+
+def test_the_probe_finds_something_at_all() -> None:
+    """A regex that matched nothing would make the test above pass forever.
+
+    The failure this file exists to catch is a claim about a command; a probe that has stopped
+    seeing claims reports "no problems" for exactly the same reason it would report it on a fixed
+    codebase, and the two are indistinguishable from the outside.
+    """
+    claims = _claims()
+    assert len(claims) > 20, f"only {len(claims)} flagged invocations found — is the pattern stale?"
+
+
+@pytest.mark.parametrize("command", ["run", "agent", "solve"])
+def test_the_snapshot_is_the_shape_this_test_assumes(command: str) -> None:
+    """If the snapshot format changes, the guard above degrades to vacuous rather than failing."""
+    commands = _snapshot()
+    assert command in commands
+    assert commands["agent"], "a command with options must report some"
+    # The specific fact this whole file grew out of, pinned so it cannot quietly become true again
+    # in the wrong direction.
+    assert "--guard" in commands["agent"] and "--guard" in commands["solve"]
+    assert "--guard" not in commands["run"]


### PR DESCRIPTION
`chimera run` é `gateway.quick(prompt)`: uma completação, sem registry de ferramentas, sem loop, sem `--guard`.

Nos READMEs, nas receitas e no dicionário do próprio app, **174 invocações** mandavam o leitor transcrever um arquivo, rastejar um site, buscar na web, baixar áudio, analisar um CSV, renderizar um gráfico ou rodar o kernel de governança — tudo com `run`.

## Nada disso era mentira sobre o produto

`--guard` é real e está ligado; as ferramentas são reais. **As instruções nomeavam o comando errado** — e, para quem está seguindo uma, instrução errada é indistinguível de funcionalidade faltando: o modelo explica educadamente que não consegue transcrever seu arquivo, e o leitor conclui que o recurso está quebrado.

Uma receita era pior que resposta ruim: passa `-w .`, que o `run` **não aceita**, então sai com erro antes de chegar a um modelo. O `agent` aceita `-w` e tem as ferramentas.

## O que foi corrigido

- as **seis linhas** da tabela de capacidades nos dez READMEs, casadas pela **coluna de dependência** (`[stt]`, `[documents]`, `[media-dl]`, `[data,viz]`, `Tavily`) porque os prompts são traduzidos e esses marcadores não. A linha do navegador não tem marcador e é achada por posição — asserida por arquivo, não assumida.
- as **dez receitas**, nos dez idiomas.
- `chimera run --guard` em duas strings de Governança × dez idiomas.

## E o portão, que é o ponto

`tests/test_documented_commands_exist.py` lê todo `chimera <cmd> --flag` dos READMEs, dos docs e do `i18n.tsx` e confere contra `chimera/_cli_snapshot.json` — o arquivo que o CI já regenera e compara, então a checagem não tem como divergir da CLI real.

Foi rodado contra o texto pré-conserto e **nomeia o arquivo e a linha**. Um segundo teste garante que a sonda ainda casa alguma coisa: um regex que envelheceu reporta "nenhum problema" pelo mesmo motivo que um código consertado reporta, e os dois são indistinguíveis de fora.

## `chimera find`

`chimera/rag/` está na árvore desde a 0.44.0 — chunking em nível de símbolo sobre a AST do Python, um arquivo SQLite com índice FTS5, fusão RRF, 608 linhas, baseline pré-registrada em `bench/rag/` — e **alcançável a partir de nada**. Uma biblioteca sem entrada é uma biblioteca que ninguém tem.

Só recuperação por palavra-chave, e ela diz isso **toda vez**, com o número medido ao lado dos resultados: recall@10 de 0,4925 sobre 400 sondas — ou seja, cerca de metade do que você procura **não** está nos dez primeiros. Imprimir isso é a diferença entre uma ferramenta que dá para calibrar e uma que a pessoa aprende a não confiar.

## Verificação

Backend **3.684 passed** · frontend **674 passed** · mypy limpo · ruff limpo · typecheck limpo · snapshot da CLI regenerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
