### PR TITLE
fix(settings): three rows the screen confirmed and the next request ignored

### DIFF
--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -1250,13 +1250,18 @@ def build_api_app(
         from chimera.complete.inline import complete_inline
         from chimera.complete.outcomes import record_shown
 
+        # `live_settings()`, like the endpoint two hundred lines up that lists the models this one
+        # would run. Both rows are edited on the same Settings card, neither passes `applies`, and
+        # the tested contract is that silence means "next call" — so reading the mount-time closure
+        # here made the two rows disagree about their own scope while looking identical.
+        now = live_settings()
         found = await complete_inline(
             req.prefix,
             req.suffix,
-            base_url=settings.ollama_base_url,
-            model=settings.complete_model,
+            base_url=now.ollama_base_url,
+            model=now.complete_model,
             key=req.key,
-            budget_ms=settings.complete_budget_ms,
+            budget_ms=now.complete_budget_ms,
         )
         ident = ""
         if found.text:

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1741,7 +1741,17 @@ def desktop_app(
     static_dir = dist if (dist / "index.html").exists() else None
     api = build_api_app(
         factory,
-        settings=settings,
+        # NOT `settings=settings`. Passing one means "use THIS, frozen" — which is what a test or a
+        # bench comparing two configurations asks for, and the opposite of what the app needs. The
+        # object here IS `get_settings()`, so passing it changed nothing except to freeze
+        # `live_settings()` at launch: every row the Settings screen writes through
+        # `PATCH /api/config` — the reach floor, the deployment denylist, the vision model — kept
+        # returning the boot value while the screen said "saved". `live_settings()`'s own docstring
+        # states the rule this broke: "Saving a setting that silently does nothing is worse than not
+        # offering it, because the confirmation is what turns it into a lie."
+        #
+        # `home` stays fixed regardless: `build_api_app` binds it once from `get_settings()` and the
+        # data directory must not move under an open session.
         static_dir=static_dir,
         fuse_backend=fuse_backend,
         workspace=workspace_path,

--- a/chimera/fusion/engine.py
+++ b/chimera/fusion/engine.py
@@ -15,8 +15,10 @@ tool-calling — fusion is for hard reasoning/synthesis; tool turns stay single-
 from __future__ import annotations
 
 import difflib
-from collections.abc import Iterable
+import threading
+from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -257,12 +259,47 @@ class FusionEngine:
 
     def __init__(self, backend: SupportsComplete, config: FusionConfig | None = None) -> None:
         self.backend = backend
+        # Pinned when the caller supplied one, and that is load-bearing: `_cast_for_turn` overlays
+        # the request's own cast, `fusion_for_role` builds a role's panel, and a bench comparing two
+        # casts is asking for exactly this. Everything else re-reads at the start of a run.
+        self._pinned = config
         self.config = config or FusionConfig.from_settings()
+        # Guards the re-read below. The app hands ONE engine to every surface, so two fused turns
+        # can be inside `run` at once.
+        self._lock = threading.Lock()
+        self._in_flight = 0
+
+    @contextmanager
+    def _current_cast(self) -> Iterator[None]:
+        """Hold the cast steady for one run, and pick up an edited one between runs.
+
+        The app builds ONE engine at boot (`cli/main.py`) and keeps it for the life of the process,
+        and `FusionConfig` is a plain dataclass with no lazy re-read. So `CHIMERA_FUSION_PANEL`,
+        `_JUDGE` and `_SYNTHESIZER` landed in `.env`, the Fusion screen confirmed "New conversations
+        start with this cast", and every fused turn until the next relaunch still used the launch
+        cast. The confirmation is what turned it into a lie.
+
+        Re-read only when nothing else is running, because `self.config` is read fourteen times
+        across a run: a save landing mid-run would otherwise change the panel between the probe and
+        the rest of it, and a turn assembled from two different casts is a worse answer than one
+        assembled from a slightly stale one. A run that starts during another simply keeps the cast
+        already in force and picks up the new one next time.
+        """
+        with self._lock:
+            if self._pinned is None and self._in_flight == 0:
+                self.config = FusionConfig.from_settings()
+            self._in_flight += 1
+        try:
+            yield
+        finally:
+            with self._lock:
+                self._in_flight -= 1
 
     def run(self, messages: list[MessageLike]) -> FusionTrace:
-        if self.config.mode == "selective" and len(self.config.panel) >= 2:
-            return self._run_selective(messages)
-        return self._run_full(messages)
+        with self._current_cast():
+            if self.config.mode == "selective" and len(self.config.panel) >= 2:
+                return self._run_selective(messages)
+            return self._run_full(messages)
 
     def _run_full(self, messages: list[MessageLike]) -> FusionTrace:
         _log.debug("fusion engaged: %d-model panel -> judge -> synthesizer", len(self.config.panel))

--- a/tests/test_settings_that_take_effect.py
+++ b/tests/test_settings_that_take_effect.py
@@ -1,0 +1,163 @@
+"""A setting the screen says it saved has to be the one the next request reads.
+
+`live_settings()` exists for exactly this, and its own docstring states the rule: "Saving a setting
+that silently does nothing is worse than not offering it, because the confirmation is what turns it
+into a lie." It also carries a deliberate escape hatch — an explicitly injected `Settings` stays
+frozen, because that is what a test or a bench comparing two configurations is asking for.
+
+`chimera app` was passing one. The object it passed IS `get_settings()`, so the injection changed
+nothing except to take the escape hatch on every desktop launch: `live_settings()` returned the boot
+photograph for the life of the process, and the rows fed by it — the reach floor, the deployment
+denylist, `/api/vision`'s default model — kept answering with the launch value while the Settings
+screen said "saved".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from chimera.api import build_api_app
+from chimera.config import Settings, get_settings
+
+
+def _client(tmp_path: Path, **kwargs: object) -> TestClient:
+    """Built the way `chimera app` builds it — which is the configuration that shipped."""
+    return TestClient(build_api_app(lambda: None, workspace=tmp_path, **kwargs))  # type: ignore[arg-type]
+
+
+def _default_model(client: TestClient) -> str:
+    """Read through a real route, not through a private closure.
+
+    `GET /api/models` resolves its answer from `live_settings()`, so it reports what a request would
+    actually get — which is the only thing the user cares about and the thing that was wrong.
+    """
+    return str(client.get("/api/models").json()["default"])
+
+
+def test_the_desktop_app_reads_settings_as_they_are_now(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CHIMERA_DEFAULT_MODEL", "before/model")
+    get_settings.cache_clear()
+
+    client = _client(tmp_path)  # no `settings=`, exactly as `chimera app` now calls it
+    assert _default_model(client) == "before/model"
+
+    # What `PATCH /api/config` does: write the value, drop the cache, report success.
+    monkeypatch.setenv("CHIMERA_DEFAULT_MODEL", "after/model")
+    get_settings.cache_clear()
+
+    assert _default_model(client) == "after/model", (
+        "the screen said saved; the next request must read the saved value"
+    )
+
+
+def test_an_explicitly_injected_settings_still_stays_frozen(tmp_path: Path, monkeypatch) -> None:
+    """The escape hatch is load-bearing and stays.
+
+    A bench comparing two configurations hands the app one and means it. Thirty-two tests in this
+    suite pass `settings=` for the same reason.
+    """
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    get_settings.cache_clear()
+    pinned = Settings(  # type: ignore[call-arg]
+        CHIMERA_HOME=str(tmp_path / "home"), CHIMERA_DEFAULT_MODEL="pinned/model"
+    )
+
+    client = _client(tmp_path, settings=pinned)
+
+    monkeypatch.setenv("CHIMERA_DEFAULT_MODEL", "after/model")
+    get_settings.cache_clear()
+
+    assert _default_model(client) == "pinned/model", "passing one means USE THIS"
+
+
+def test_the_app_does_not_hand_the_api_a_frozen_settings(tmp_path: Path) -> None:
+    """The structural half, because the behavioural test above can only see the app it builds.
+
+    The defect was one keyword argument at one call site in `chimera app`, and nothing in the two
+    tests above would notice it coming back — they construct their own app. This reads the call
+    site itself. `chimera app` may pass anything to `build_api_app` except a `settings=`, because
+    that argument means "frozen" and the desktop is the one caller that must not be.
+    """
+    import re
+
+    source = (Path(__file__).resolve().parents[1] / "chimera" / "cli" / "main.py").read_text(
+        encoding="utf-8"
+    )
+    call = re.search(r"api = build_api_app\((.*?)\n    \)", source, re.S)
+    assert call is not None, "the app's build_api_app call moved — update this guard"
+    body = re.sub(r"#[^\n]*", "", call.group(1))  # the explanation names it; the code must not
+    assert "settings=" not in body, (
+        "chimera app is passing settings= again, which freezes live_settings() for the whole "
+        "process and makes every Settings row fed by it a confirmation that does nothing"
+    )
+
+
+# --- the fusion cast, which the app photographs at boot -------------------------------------------
+
+
+class _Echo:
+    """A backend that answers every stage, so a run completes without a provider."""
+
+    def __init__(self) -> None:
+        self.models: list[str] = []
+
+    def complete(self, messages, *, model=None, **kwargs):  # type: ignore[no-untyped-def]
+        from chimera.providers.gateway import CompletionResult
+
+        self.models.append(str(model))
+        return CompletionResult(content="ok", model=str(model), prompt_tokens=1, completion_tokens=1)
+
+
+def test_a_saved_fusion_cast_reaches_the_next_run(tmp_path: Path, monkeypatch) -> None:
+    """"Saved. New conversations start with this cast." — it did not.
+
+    The app builds ONE `FusionEngine` at boot and keeps it for the process, and `FusionConfig` is a
+    plain dataclass with no lazy re-read. So the panel landed in `.env`, the screen confirmed, and
+    every fused turn until the next relaunch still used the launch cast.
+    """
+    from chimera.fusion.engine import FusionEngine
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CHIMERA_FUSION_PANEL", "a/one,b/two")
+    get_settings.cache_clear()
+
+    backend = _Echo()
+    engine = FusionEngine(backend)  # built once, as the app builds it
+    engine.run([{"role": "user", "content": "hi"}])
+    assert "a/one" in backend.models and "b/two" in backend.models
+
+    monkeypatch.setenv("CHIMERA_FUSION_PANEL", "c/three,d/four")
+    get_settings.cache_clear()
+    backend.models.clear()
+
+    engine.run([{"role": "user", "content": "hi"}])
+
+    assert "c/three" in backend.models and "d/four" in backend.models
+    assert "a/one" not in backend.models, "the launch cast must not outlive the save"
+
+
+def test_a_pinned_cast_is_never_re_read(tmp_path: Path, monkeypatch) -> None:
+    """`_cast_for_turn` overlays a request's own cast, and `fusion_for_role` builds a role's panel.
+
+    Both hand the engine a config and mean it. A re-read would silently replace a caller's explicit
+    choice with the machine's default — which is the same class of bug in the other direction.
+    """
+    from chimera.fusion.engine import FusionConfig, FusionEngine
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("CHIMERA_FUSION_PANEL", "env/one,env/two")
+    get_settings.cache_clear()
+
+    backend = _Echo()
+    engine = FusionEngine(
+        backend,
+        FusionConfig(panel=["pinned/one", "pinned/two"], judge="j/model", synthesizer="s/model"),
+    )
+
+    engine.run([{"role": "user", "content": "hi"}])
+
+    assert "pinned/one" in backend.models
+    assert "env/one" not in backend.models


### PR DESCRIPTION
`live_settings()` existe exatamente para isso, e enuncia a regra na própria docstring:

> Salvar uma configuração que silenciosamente não faz nada é pior do que não oferecê-la, porque a confirmação é o que a transforma numa mentira.

Ela também carrega uma escotilha de fuga deliberada — um `Settings` injetado explicitamente fica congelado, porque é isso que um teste ou um bench comparando duas configurações está pedindo.

## 1 · O `chimera app` estava usando essa escotilha

Ele passava `settings=settings`. E o objeto que passava **é** o `get_settings()` — então a injeção não mudava nada **exceto** congelar o `live_settings()` pela vida inteira do processo.

Toda linha alimentada por ele — o piso de alcance, a denylist de implantação, o modelo padrão do `/api/vision` — continuava respondendo com o valor do lançamento enquanto a tela de Configurações dizia "salvo".

O `home` continua fixo de qualquer forma: o `build_api_app` o liga uma vez, e o diretório de dados não pode se mover embaixo de uma sessão aberta.

## 2 · A completação inline lia o closure do momento da montagem

O modelo e a URL do Ollama são editados **no mesmo cartão** de Configurações, nenhuma das duas linhas passa `applies`, e o contrato testado é que silêncio significa "na próxima chamada". Então este endpoint discordava do que fica duzentas linhas acima — o que lista os modelos que ele rodaria — parecendo idêntico na tela.

## 3 · O elenco de fusão era uma foto do boot

O app constrói **um** `FusionEngine` e o guarda pelo processo; `FusionConfig` é um dataclass simples sem releitura preguiçosa. O painel chegava no `.env`, a tela confirmava "Novas conversas começam com este elenco", e todo turno fundido até o próximo relançamento usava o elenco do lançamento.

**A releitura acontece entre runs, não dentro de um.** O `self.config` é lido quatorze vezes num run, e um save chegando no meio mudaria o painel entre a sonda e o resto — um turno montado com dois elencos é uma resposta pior que um montado com um elenco levemente velho. Um run que começa enquanto outro está em voo mantém o elenco em vigor e pega o novo na próxima.

Um config **pinado** nunca é relido: `_cast_for_turn` sobrepõe o elenco do próprio pedido e `fusion_for_role` monta o painel de um papel — substituir qualquer um pelo default da máquina seria o mesmo bug apontando para o outro lado.

## O portão

O guarda estrutural lê **o call site** do `build_api_app`, porque os testes comportamentais constroem o próprio app e nunca perceberiam o argumento voltando.

## Verificação

Backend **3.684 passed** · mypy limpo · ruff limpo. Os dois consertos foram sabotados de propósito e os testes ficam vermelhos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
