### PR TITLE
fix: learned cards never reached the Code screen, and CHIMERA_MODEL is not a thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1606,7 +1606,7 @@ accept.
   price of the answer), and requests are **stateless**, each getting a fresh ephemeral session, so a
   benchmark's items stay independent instead of a shared transcript quietly making later items easier.
   Unsupported sampling knobs are accepted and ignored rather than faked.
-- **First-class local models (Ollama) — fully local, no API key.** `CHIMERA_MODEL=ollama/llama3` now
+- **First-class local models (Ollama) — fully local, no API key.** `CHIMERA_DEFAULT_MODEL=ollama/llama3` now
   runs out of the box: the credential gate recognises `ollama/…` / `ollama_chat/…` as a keyless local
   runtime and no longer demands a provider key, and the gateway points LiteLLM at your Ollama server
   (`CHIMERA_OLLAMA_BASE_URL`, default `http://localhost:11434`; a value you already set is respected).

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -660,6 +660,35 @@ def _remember_and_tidy(message: str, memory: Any, settings: Settings) -> tuple[s
     return fact, removed
 
 
+def _card_retriever(settings: Settings, gateway: Any) -> Any:
+    """The learned-skill retriever, or None when the owner has the feature off or it cannot build.
+
+    Best-effort: a coding turn must not fail because a card store is unreadable. The answer is the
+    product; the cards are advice about it.
+    """
+    if not getattr(settings, "skill_cards", False):
+        return None
+    try:
+        from chimera.evolution import build_evolution_context
+
+        return build_evolution_context(
+            settings,
+            # Required by the signature and unused on this path: `evolve_skills=False` means nothing
+            # here calls a model. Passing the turn's own gateway rather than a stub, so if that ever
+            # stops being true it is the right one.
+            gateway,
+            None,
+            home=settings.home,
+            evolve_skills=False,  # reading, never minting: no verify-or-revert signal on this path
+            skill_cards=True,
+            include_memory=False,
+            include_playbook=False,
+        ).cards
+    except Exception as exc:  # noqa: BLE001 -- see the docstring
+        _log.debug("skill-card retriever unavailable: %s", exc)
+        return None
+
+
 def register_code_api(
     app: FastAPI,
     guard: params.Depends,
@@ -762,6 +791,16 @@ def register_code_api(
                 instructions=render_identity(load_identity(settings.home)),
                 trace_path=settings.home / "traces.jsonl",
             ),
+            # What the agent LEARNED, read back when it matches this task. The Settings row that
+            # mints cards says "a learned skill is read back when it matches the task"; it was true
+            # on `/api/runs`, which builds an `AutonomousAgent`, and this endpoint builds a plain
+            # `Agent`. So on the Code screen — first in the navigation rail — nothing the agent had
+            # ever learned came back.
+            #
+            # Read-only: `build_evolution_context` is asked for the retriever alone, with skill
+            # evolution off, because minting a card needs a verify-or-revert signal this path does
+            # not have. Advisory either way — the card suggests, the verifier decides.
+            cards=_card_retriever(live(), gateway),
         )
         if req.open_file:
             # Path only, never content: what a compaction must restore is *which* file is being

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -510,7 +510,7 @@ class Settings(BaseSettings):
 
     # Base URL for a local Ollama server. A model like `ollama/llama3` runs on your machine with no
     # API key — set this only if Ollama listens somewhere other than the default. Reinforces the
-    # fully-local, self-hostable path: `CHIMERA_MODEL=ollama/llama3` and no key needed.
+    # fully-local, self-hostable path: `CHIMERA_DEFAULT_MODEL=ollama/llama3` and no key needed.
     ollama_base_url: str = Field(
         default="http://localhost:11434", validation_alias="CHIMERA_OLLAMA_BASE_URL"
     )

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -232,6 +232,7 @@ class Agent:
         tools: ToolRegistry,
         config: AgentConfig | None = None,
         skills: SkillRegistry | None = None,
+        cards: Any = None,
     ) -> None:
         self.backend = backend
         self.tools = tools
@@ -247,6 +248,15 @@ class Agent:
         # The skill library surfaced as context. Defaults to the built-in registry (lazy, shared),
         # so every construction site picks up skills without changes; pass an explicit one to override.
         self.skills = skills
+        # What this agent LEARNED, as opposed to what it shipped with — a `CardRetriever`, or None.
+        # Keyword-only in practice and duck-typed on `card_context`, so a caller with a search-only
+        # retriever, or none at all, gets nothing rather than an error.
+        #
+        # It exists here because `AutonomousAgent` had this seam and a plain `Agent` did not, and
+        # the Code screen — first in the navigation rail — builds a plain one. So the Settings row
+        # that mints cards promised "a learned skill is read back when it matches the task", and on
+        # the surface most people use, nothing learned ever came back.
+        self.cards = cards
 
     def _skill_context(self, task: str) -> str:
         """Task-relevant built-in skills as a prompt block ("" when none match or on any error)."""
@@ -261,6 +271,16 @@ class Agent:
             _log.debug("skill-context retrieval skipped: %s", exc)
             block = ""
         return block + self._bundle_context()
+
+    def _card_context(self, task: str) -> str:
+        """Learned skill cards relevant to this task ("" when there are none or on any error)."""
+        if self.cards is None:
+            return ""
+        try:
+            return str(self.cards.card_context(task) or "")
+        except Exception as exc:  # noqa: BLE001 -- retrieval must never break the loop
+            _log.debug("skill-card retrieval skipped: %s", exc)
+            return ""
 
     def _bundle_context(self) -> str:
         """The installed skill bundles the owner has switched ON, as one line each.
@@ -343,6 +363,12 @@ class Agent:
         skill_block = self._skill_context(task)
         if skill_block:
             system_prompt = f"{system_prompt}\n\n{skill_block}"
+        # What it LEARNED, after what it shipped with: a card comes from a run that
+        # actually worked here, so it is the more specific advice of the two. Advisory
+        # either way — the cards suggest, the verifier decides.
+        card_block = self._card_context(task)
+        if card_block:
+            system_prompt = f"{system_prompt}\n\n{card_block}"
         # After the skills, so the project's own conventions outrank a generic skill card that
         # happens to have been retrieved — a repository that says "never use bare except" should
         # win over one. Not last any more: see the owner's instructions below.

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -240,7 +240,7 @@ def _credential_error(exc: BaseException) -> CredentialRejectedError | None:
         return None
     return CredentialRejectedError(
         f"{what} {fix} — the relevant variables are {list(_KEY_ENV_VARS.values())} "
-        "(or use a local model, e.g. CHIMERA_MODEL=ollama/llama3, which needs no key). "
+        "(or use a local model, e.g. CHIMERA_DEFAULT_MODEL=ollama/llama3, which needs no key). "
         f"Provider said: {exc}"
     )
 
@@ -329,7 +329,7 @@ class LLMGateway:
             if value and not os.environ.get(env_var):
                 os.environ[env_var] = value
         # Point LiteLLM's Ollama provider at the configured local server (default localhost:11434), so
-        # `CHIMERA_MODEL=ollama/llama3` works out of the box — and a remote Ollama is one env var away.
+        # `CHIMERA_DEFAULT_MODEL=ollama/llama3` works out of the box — and a remote Ollama is one env var away.
         ollama_base = getattr(self.settings, "ollama_base_url", "") or ""
         if ollama_base and not os.environ.get("OLLAMA_API_BASE"):
             os.environ["OLLAMA_API_BASE"] = ollama_base
@@ -360,7 +360,7 @@ class LLMGateway:
             + (f" for '{head}'. Set {wanted}" if wanted else ". Set a provider key")
             + " in your environment or .env — any provider LiteLLM supports works, "
             f"not only {list(_KEY_ENV_VARS.values())} "
-            "(or use a local model, e.g. CHIMERA_MODEL=ollama/llama3, which needs no key)."
+            "(or use a local model, e.g. CHIMERA_DEFAULT_MODEL=ollama/llama3, which needs no key)."
         )
 
     def _provider_kwargs(self) -> dict[str, Any]:

--- a/docs/i18n/de/recipes.md
+++ b/docs/i18n/de/recipes.md
@@ -17,7 +17,7 @@ verweisen:
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/es/recipes.md
+++ b/docs/i18n/es/recipes.md
@@ -16,7 +16,7 @@ Instala [Ollama](https://ollama.com), descarga un modelo, y luego apunta Chimera
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/fr/recipes.md
+++ b/docs/i18n/fr/recipes.md
@@ -17,7 +17,7 @@ dessus :
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/it/recipes.md
+++ b/docs/i18n/it/recipes.md
@@ -16,7 +16,7 @@ esso:
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/ja/recipes.md
+++ b/docs/i18n/ja/recipes.md
@@ -12,7 +12,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/pl/recipes.md
+++ b/docs/i18n/pl/recipes.md
@@ -16,7 +16,7 @@ Zainstaluj [Ollama](https://ollama.com), pobierz model, potem skieruj na niego C
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/pt/recipes.md
+++ b/docs/i18n/pt/recipes.md
@@ -15,7 +15,7 @@ Rode o Chimera contra um modelo na sua própria máquina — sem chave, nada sai
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/ru/recipes.md
+++ b/docs/i18n/ru/recipes.md
@@ -16,7 +16,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/i18n/zh/recipes.md
+++ b/docs/i18n/zh/recipes.md
@@ -15,7 +15,7 @@ source_sha256: f08c31cf980c0d86795fe456d5f9ed6871b58325c9e429e93f48c71b6e998356
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -11,7 +11,7 @@ Run Chimera against a model on your own machine — no key, nothing leaves the b
 
 ```bash
 ollama pull llama3.1                     # or qwen2.5, mistral, phi3, …
-export CHIMERA_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
+export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local, keyless
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 

--- a/tests/test_documented_commands_exist.py
+++ b/tests/test_documented_commands_exist.py
@@ -93,3 +93,71 @@ def test_the_snapshot_is_the_shape_this_test_assumes(command: str) -> None:
     # in the wrong direction.
     assert "--guard" in commands["agent"] and "--guard" in commands["solve"]
     assert "--guard" not in commands["run"]
+
+
+# --- environment variables ------------------------------------------------------------------------
+
+def _settings_aliases() -> set[str]:
+    """Every `CHIMERA_*` name `Settings` actually reads, from the model itself."""
+    from chimera.config import Settings
+
+    names: set[str] = set()
+    for name, field in Settings.model_fields.items():
+        alias = field.validation_alias
+        names.add(str(alias) if isinstance(alias, str) else name.upper())
+    return {n for n in names if n.startswith("CHIMERA_")}
+
+
+def _direct_env_reads() -> set[str]:
+    """`CHIMERA_*` names read straight from the environment, bypassing `Settings`.
+
+    A few genuinely belong outside the settings model — `CHIMERA_BROWSER_AUTO_INSTALL` gates a
+    one-off install inside the browser tool, far from anything a `Settings` field would describe.
+    Discovered by scanning rather than listed by hand, so adding one does not silently need this
+    file edited, and deleting one does not leave a permanent exemption behind.
+    """
+    reader = re.compile(r"(?:os\.environ(?:\.get)?|os\.getenv)\(\s*[\"'](CHIMERA_[A-Z0-9_]+)")
+    names: set[str] = set()
+    for path in (ROOT / "chimera").rglob("*.py"):
+        names.update(reader.findall(path.read_text(encoding="utf-8")))
+    return names
+
+
+def _env_claims() -> list[tuple[Path, int, str]]:
+    """`CHIMERA_X=...` in the docs, the error messages and the app's own strings."""
+    assignment = re.compile(r"\b(CHIMERA_[A-Z0-9_]+)\s*=")
+    found: list[tuple[Path, int, str]] = []
+    for path in _sources():
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for name in assignment.findall(line):
+                found.append((path, lineno, name))
+    for module in ("providers/gateway.py", "config.py", "cli/main.py"):
+        path = ROOT / "chimera" / module
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            # Only inside a string: `CHIMERA_X = ...` as CODE is a different thing entirely.
+            if '"' not in line and "'" not in line:
+                continue
+            for name in assignment.findall(line):
+                found.append((path, lineno, name))
+    return found
+
+
+def test_every_env_var_the_docs_tell_you_to_set_is_one_settings_reads() -> None:
+    """`CHIMERA_MODEL` was in eighteen places, including the keyless error, and read by nothing.
+
+    `Settings` sets `extra="ignore"`, so the variable is accepted, ignored, and never complained
+    about. A user following the first error message they ever see sets it, runs the command again,
+    and gets the same error — with no way to tell that the instruction was the problem.
+    """
+    real = _settings_aliases() | _direct_env_reads()
+    wrong = sorted({
+        f"{path.relative_to(ROOT)}:{lineno}: {name} — Settings does not read it"
+        for path, lineno, name in _env_claims()
+        if name not in real
+    })
+    assert not wrong, "\n".join(["variables the docs tell you to set and nothing reads:", *wrong])
+
+
+def test_the_env_probe_finds_something_at_all() -> None:
+    claims = _env_claims()
+    assert len(claims) > 10, f"only {len(claims)} env assignments found — is the pattern stale?"

--- a/tests/test_learned_cards_reach_the_code_screen.py
+++ b/tests/test_learned_cards_reach_the_code_screen.py
@@ -1,0 +1,132 @@
+"""What the agent learned has to come back on the screen people actually use.
+
+Settings mints skill cards and says of them: "a learned skill is read back when it matches the
+task." That was true on `/api/runs`, which builds an `AutonomousAgent` — the one class with a
+`cards` seam. The Code screen builds a plain `Agent`, and the Code screen is FIRST in the
+navigation rail. So on the surface most people use, nothing the agent had ever learned came back,
+while the toggle that mints them said otherwise.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.core.agent import Agent, AgentConfig
+from chimera.providers.gateway import CompletionResult
+from chimera.tools.registry import ToolRegistry
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.systems: list[str] = []
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> CompletionResult:
+        first = messages[0]
+        data = first.as_dict() if hasattr(first, "as_dict") else first
+        self.systems.append(str(data.get("content", "")))
+        return CompletionResult(content="done", model="m", prompt_tokens=1, completion_tokens=1)
+
+
+class _Cards:
+    """Duck-typed like `CardRetriever` for the one method this seam touches."""
+
+    def __init__(self, block: str = "") -> None:
+        self.block = block
+        self.asked: list[str] = []
+        self.last_retrieved: list[str] = []
+
+    def card_context(self, task: str) -> str:
+        self.asked.append(task)
+        return self.block
+
+
+def _run(cards: Any, task: str = "rename the loader") -> _Backend:
+    backend = _Backend()
+    Agent(backend, ToolRegistry(), AgentConfig(inject_skill_context=False), cards=cards).run(task)
+    return backend
+
+
+def test_a_matching_card_reaches_the_prompt() -> None:
+    cards = _Cards("Learned: the loader is generated; edit the template instead.")
+
+    backend = _run(cards)
+
+    assert cards.asked == ["rename the loader"], "the retriever is asked about THIS task"
+    assert "edit the template instead" in backend.systems[0]
+
+
+def test_the_card_comes_after_the_built_in_skills_and_before_the_project() -> None:
+    """Order is the argument.
+
+    A learned card came from a run that actually worked HERE, so it is more specific than a built-in
+    skill. The project's own conventions are more specific still — `agents_md` already makes that
+    case for itself — and the owner's instructions are last because a repository is a convention and
+    this is the owner.
+    """
+    cards = _Cards("CARD-MARKER")
+    backend = _Backend()
+
+    Agent(
+        backend,
+        ToolRegistry(),
+        AgentConfig(system_prompt="BASE", inject_skill_context=False, instructions="OWNER-MARKER"),
+        cards=cards,
+    ).run("go")
+
+    system = backend.systems[0]
+    assert system.index("BASE") < system.index("CARD-MARKER") < system.index("OWNER-MARKER")
+
+
+def test_no_retriever_changes_nothing() -> None:
+    """The default, and every caller that predates this seam."""
+    backend = _Backend()
+
+    Agent(backend, ToolRegistry(), AgentConfig(system_prompt="BASE", inject_skill_context=False)).run("go")
+
+    assert backend.systems[0] == "BASE"
+
+
+def test_an_empty_result_adds_no_empty_section() -> None:
+    """A heading with nothing under it costs tokens on every turn to convey nothing."""
+    with_cards = _run(_Cards(""))
+    without = _run(None)
+
+    assert with_cards.systems[0] == without.systems[0]
+
+
+def test_a_retriever_that_raises_does_not_take_the_turn_down() -> None:
+    """The answer is the product; the cards are advice about it."""
+
+    class _Broken:
+        last_retrieved: list[str] = []
+
+        def card_context(self, task: str) -> str:
+            raise RuntimeError("card store unreadable")
+
+    backend = _run(_Broken())
+
+    assert backend.systems, "the turn must still have happened"
+
+
+def test_the_code_turn_asks_for_a_retriever_only_when_the_owner_wants_one() -> None:
+    """Off is off. Building one anyway would read cards the owner switched off minting."""
+    from chimera.api.code_api import _card_retriever
+    from chimera.config import Settings
+
+    off = Settings(CHIMERA_SKILL_CARDS=False)  # type: ignore[call-arg]
+    assert _card_retriever(off, None) is None
+
+
+def test_the_code_turn_never_mints_from_this_path() -> None:
+    """Reading, never writing.
+
+    Minting a card credits a skill for an outcome, and this path has no verify-or-revert signal to
+    credit it with. `build_evolution_context` is asked for the retriever with `evolve_skills=False`
+    for exactly that reason.
+    """
+    import inspect
+
+    from chimera.api import code_api
+
+    source = inspect.getsource(code_api._card_retriever)
+    assert "evolve_skills=False" in source


### PR DESCRIPTION
## 1 · Os cards aprendidos

Configurações cunha skill cards e diz sobre eles: *"uma skill aprendida é lida de volta quando combina com a tarefa."*

Verdade no `/api/runs`, que monta um `AutonomousAgent` — a única classe com um seam de `cards`. **A tela Código monta um `Agent` simples, e a tela Código é a primeira do rail de navegação.** Então, na superfície que a maioria usa, nada do que o agente aprendeu voltava — enquanto o interruptor que os cunha dizia o contrário.

O `Agent` simples ganha o seam. **Só leitura**: o recuperador é montado com `evolve_skills=False`, porque cunhar um card credita uma skill por um desfecho e este caminho não tem sinal de verify-or-revert para creditar.

Ele fica **depois** das skills embutidas (um card veio de um run que funcionou **aqui**, então é o conselho mais específico dos dois) e **antes** das convenções do projeto e das instruções do dono. Há teste sobre essa ordem, porque **a ordem é o argumento**.

## 2 · `CHIMERA_MODEL`

Citada em **quinze lugares** e lida por nada.

Provado, não suposto: com `CHIMERA_MODEL=ollama/llama3`, o `get_settings().default_model` continua imprimindo o default embutido — porque `Settings` usa `extra="ignore"`, então a variável é aceita, ignorada e nunca reclamada. O alias é `CHIMERA_DEFAULT_MODEL`.

**Duas dessas quinze são a mensagem de erro sem chave**, que é a primeira frase que um usuário novo lê. Ela manda configurar uma variável que não faz nada — então a pessoa configura, roda o comando de novo, recebe o erro idêntico, e não tem como saber que o problema era a instrução. É o pior lugar do produto para isso estar errado.

## O portão

Junta-se ao que foi feito para as flags de CLI: todo `CHIMERA_X=` nos READMEs, nos docs, no dicionário do app e nas mensagens de erro é conferido contra os aliases que o `Settings` de fato declara — mais os lidos direto de `os.environ`, **descobertos por varredura e não listados à mão**, para que adicionar um não exija editar este arquivo em silêncio, nem remover um deixe uma isenção permanente para trás.

## Verificação

Backend **3.697 passed** · mypy limpo · ruff limpo. Os dois consertos foram sabotados e os testes ficam vermelhos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
