### PR TITLE
fix: a failed stream reported success, and Profile rendered a prompt at the user

### DIFF
--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -256,7 +256,11 @@ def register_features(
     def memory_profile() -> dict[str, Any]:
         mgr = _memory_manager()
         return {
-            "profile": mgr.profile(),
+            # The FACTS, not the prompt block. `profile()` opens with "What you know about the
+            # user:" — an instruction addressed to a model — and the screen was rendering that
+            # verbatim under an already-translated panel heading, in an app translated into ten
+            # languages. The screen supplies its own heading; this supplies what goes under it.
+            "profile": '\n'.join(mgr.profile_facts()),
             "persona": [_item_dict(it) for it in mgr.store.by_kind("persona")],
         }
 

--- a/chimera/api/openai_compat.py
+++ b/chimera/api/openai_compat.py
@@ -190,6 +190,16 @@ def build_completion(report: TurnReport, *, model: str, completion_id: str, crea
     }
 
 
+def _error_event(message: str) -> str:
+    """A mid-stream failure, in the shape OpenAI's own streams use and the SDKs raise on.
+
+    No internals: the same discipline as the non-streaming path, which returns a 500 with a fixed
+    sentence. A caller learns that the turn failed, not how our loop is built.
+    """
+    payload = {"error": {"message": message, "type": "server_error", "code": None}}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
 def _chunk(completion_id: str, created: int, model: str, delta: dict[str, Any], finish: str | None) -> str:
     payload = {
         "id": completion_id,
@@ -260,7 +270,16 @@ def register_openai_compat(
                 report = turn_fn(session, message)
             except Exception as exc:  # noqa: BLE001
                 _log.warning("openai-compat stream turn failed: %s", exc)
-                yield _chunk(completion_id, created, req.model, {}, "stop")
+                # NOT `finish_reason: "stop"` with an empty delta. That is a successful turn that
+                # produced nothing, and no client can tell it from a model that legitimately
+                # answered with an empty string — so a failed turn was billed, logged and retried
+                # as if it had worked. OpenAI's own streams signal a mid-flight failure with an
+                # `error` object, which is what the SDKs raise on, so that is what this emits.
+                #
+                # No terminal chunk after it: a `finish_reason` here would have to be one of
+                # stop / length / tool_calls / content_filter, and none of them means "the
+                # server failed". Picking any would be the same lie in a different word.
+                yield _error_event("the agent turn failed")
                 yield "data: [DONE]\n\n"
                 return
             model = report.model or req.model

--- a/chimera/memory/manager.py
+++ b/chimera/memory/manager.py
@@ -206,20 +206,32 @@ class MemoryManager:
         gives cross-session personalization without the user re-stating preferences. Empty
         string when no persona facts are stored.
         """
+        facts = self.profile_facts(max_items=max_items)
+        if not facts:
+            return ""
+        listed = '\n'.join(f"- {fact}" for fact in facts)
+        return f"What you know about the user:\n{listed}"
+
+    def profile_facts(self, *, max_items: int = 12) -> list[str]:
+        """The persona facts themselves, highest-value first — no preamble.
+
+        Split out from :meth:`profile` because the two have different readers. `profile` is a
+        system-prompt block whose first line is an instruction TO A MODEL, and the Profile screen
+        rendered that whole block verbatim — so an English sentence addressed to the agent showed
+        up under an already-translated panel heading, in an app translated into ten languages.
+        """
         from chimera.memory.value import rank
 
         personas = self.store.by_kind("persona")
         if not personas:
-            return ""
-        top = [item for _, item in rank(personas)][:max_items]
+            return []
         # Surface trust provenance on recall: a fact learned from untrusted content must
         # not read as verified — the model is told, in-line, which facts to weigh less.
-        facts = "\n".join(
-            f"- {item.content}"
+        return [
+            item.content
             + (" [unverified: learned from untrusted content]" if item.provenance == "tainted" else "")
-            for item in top
-        )
-        return f"What you know about the user:\n{facts}"
+            for _, item in rank(personas)[:max_items]
+        ]
 
     def search(
         self, query: str, *, k: int = 5, on_layer: Callable[[str], None] | None = None

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -275,3 +275,57 @@ def test_models_endpoint_lists_the_catalog() -> None:
     ids = [m["id"] for m in body["data"]]
     assert ids[0] == "chimera"
     assert any(i.startswith("chimera/openrouter/") for i in ids)
+
+
+def _events(body: str) -> list[dict[str, Any]]:
+    return [
+        json.loads(line[len("data: ") :])
+        for line in body.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+
+
+def _stream(run_turn: Any) -> str:
+    client, _ = _client(run_turn)
+    return client.post(
+        "/v1/chat/completions",
+        json={"model": "m", "stream": True, "messages": [{"role": "user", "content": "hi"}]},
+    ).text
+
+
+def test_a_failed_streamed_turn_is_not_reported_as_a_finished_one() -> None:
+    """`finish_reason: "stop"` with an empty delta is a SUCCESSFUL turn that produced nothing.
+
+    No client can tell that from a model that legitimately answered with an empty string, so a
+    failed turn was billed, logged and retried as if it had worked.
+    """
+
+    def boom(_session: Any, _message: str) -> Any:
+        raise RuntimeError("the loop died")
+
+    events = _events(_stream(boom))
+
+    assert events, "the stream must say something"
+    # OpenAI's own shape for a mid-flight failure, which is what the SDKs raise on.
+    assert "error" in events[-1], events
+    # And no finish_reason at all: stop / length / tool_calls / content_filter are the only ones,
+    # and none of them means "the server failed".
+    assert not any("choices" in e for e in events)
+
+
+def test_the_stream_error_says_nothing_about_our_internals() -> None:
+    def boom(_session: Any, _message: str) -> Any:
+        raise RuntimeError("TraceStore at /home/secret/path exploded")
+
+    body = _stream(boom)
+
+    assert "/home/secret/path" not in body and "TraceStore" not in body
+    assert body.rstrip().endswith("[DONE]")
+
+
+def test_a_successful_stream_still_finishes_with_stop() -> None:
+    """Or the tests above would pass against a version that had stopped reporting completion."""
+    events = _events(_stream(lambda _s, msg: _report(answer=f"echo:{msg}")))
+
+    assert any(e.get("choices", [{}])[0].get("finish_reason") == "stop" for e in events)
+    assert not any("error" in e for e in events)

--- a/tests/test_profile_facts.py
+++ b/tests/test_profile_facts.py
@@ -1,0 +1,49 @@
+"""The Profile screen was rendering a sentence addressed to the agent.
+
+`MemoryManager.profile()` is a system-prompt block and its first line — "What you know about
+the user:" — is an instruction TO A MODEL. The screen rendered the whole block verbatim, under
+an already-translated panel heading, in an app translated into ten languages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_the_profile_screen_gets_facts_not_a_sentence_addressed_to_the_model(
+    tmp_path: Path,
+) -> None:
+    from chimera.memory import MemoryManager, MemoryStore
+
+    mgr = MemoryManager(MemoryStore(tmp_path / "memory.json"))
+    mgr.remember("prefers Portuguese", "persona")
+    mgr.remember("works on three SaaS products", "persona")
+
+    facts = mgr.profile_facts()
+
+    assert "prefers Portuguese" in facts
+    assert not any("What you know about the user" in f for f in facts)
+
+
+def test_the_prompt_block_keeps_its_preamble() -> None:
+    """It is an instruction to a model and the model needs it. Only the SCREEN did not."""
+    import tempfile
+
+    from chimera.memory import MemoryManager, MemoryStore
+
+    with tempfile.TemporaryDirectory() as tmp:
+        mgr = MemoryManager(MemoryStore(Path(tmp) / "memory.json"))
+        mgr.remember("prefers Portuguese", "persona")
+
+        block = mgr.profile()
+
+    assert block.startswith("What you know about the user:")
+    assert "- prefers Portuguese" in block
+
+
+def test_no_persona_facts_is_empty_on_both(tmp_path: Path) -> None:
+    from chimera.memory import MemoryManager, MemoryStore
+
+    mgr = MemoryManager(MemoryStore(tmp_path / "memory.json"))
+
+    assert mgr.profile() == "" and mgr.profile_facts() == []


### PR DESCRIPTION
## 1 · O stream

Um turno que estourava no meio em `/v1/chat/completions` emitia `finish_reason: "stop"` com delta vazio.

Isso é um turno **bem-sucedido que não produziu nada** — e nenhum cliente consegue distinguir isso de um modelo que legitimamente respondeu com string vazia. Então um turno que falhou era cobrado, logado e reprocessado como se tivesse funcionado.

Agora emite o objeto `error` que os próprios streams da OpenAI usam e que os SDKs levantam — e **nenhum chunk terminal**: `finish_reason` tem quatro valores (stop, length, tool_calls, content_filter) e nenhum deles significa "o servidor falhou". Escolher qualquer um seria a mesma mentira em outra palavra.

A mensagem continua genérica, como o 500 do caminho não-streaming: quem chama fica sabendo que o turno falhou, não como o nosso loop é construído. Há teste de que uma exceção carregando um caminho de sistema de arquivos **não chega ao fio**.

## 2 · O perfil

`MemoryManager.profile()` é um bloco de system prompt cuja primeira linha — *"What you know about the user:"* — é uma instrução endereçada a um **modelo**. A tela Perfil renderizava o bloco inteiro, literalmente, **debaixo de um título de painel já traduzido**, num app traduzido em dez idiomas.

`profile_facts()` devolve os fatos; `profile()` mantém o preâmbulo, porque o modelo precisa dele e só a tela não precisava.

O sufixo de procedência num fato não confiável fica **nos dois** — um fato aprendido de conteúdo não confiável não pode ler como verificado numa tela também.

## Verificação

Backend **3.699 passed** · mypy limpo · ruff limpo. Sabotado de propósito: o teste do stream fica vermelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
