### PR TITLE
fix(desktop): a failed request rendered as a fact, and two controls only a mouse could find

### DIFF
--- a/apps/desktop/src/components/Cron.tsx
+++ b/apps/desktop/src/components/Cron.tsx
@@ -136,7 +136,7 @@ export function Cron({ embedded = false }: { embedded?: boolean } = {}) {
                 )}
               </div>
               <button
-                className="opacity-0 transition group-hover:opacity-100"
+                className="opacity-0 transition focus:opacity-100 group-hover:opacity-100"
                 title={t("common.delete")}
                 onClick={() => remove.mutate(j.id)}
               >

--- a/apps/desktop/src/components/Memory.tsx
+++ b/apps/desktop/src/components/Memory.tsx
@@ -175,7 +175,7 @@ export function Memory({ embedded = false }: { embedded?: boolean } = {}) {
                 </div>
               </div>
               <button
-                className="opacity-0 transition group-hover:opacity-100"
+                className="opacity-0 transition focus:opacity-100 group-hover:opacity-100"
                 title={t("common.delete")}
                 onClick={() => remove.mutate(f.id)}
               >

--- a/apps/desktop/src/components/Work.deeplink.test.tsx
+++ b/apps/desktop/src/components/Work.deeplink.test.tsx
@@ -1,0 +1,67 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Work } from "@/components/Work";
+import { getFsTree, getGitStatus, getRuns, streamRun } from "@/lib/api";
+import { emptyTree, gitStatus } from "@/test/code-api-mock";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", async () => (await import("@/test/code-api-mock")).makeCodeApiMock());
+
+/**
+ * A tab that writes itself into the URL has to be readable back out of it.
+ *
+ * `choose` already wrote `?tab=git`, and `readTab` recognised `orchestration` and nothing else. So
+ * switching to Git put a URL in the address bar that, reopened or reloaded, landed on Runs — the
+ * address said one thing and the screen showed another, which is worse than having no deep link.
+ */
+function at(tab: string) {
+  window.location.hash = tab ? `#/work?tab=${tab}` : "#/work";
+}
+
+describe("Work — the tab in the address", () => {
+  beforeEach(() => {
+    vi.mocked(getFsTree).mockResolvedValue(emptyTree());
+    vi.mocked(getRuns).mockResolvedValue([]);
+    vi.mocked(getGitStatus).mockResolvedValue(gitStatus());
+    vi.mocked(streamRun).mockImplementation(async () => {});
+  });
+
+  afterEach(() => {
+    window.location.hash = "";
+  });
+
+  it.each(["git", "worth", "orchestration"])("opens on ?tab=%s", async (tab) => {
+    at(tab);
+
+    renderWithProviders(<Work />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { selected: true })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      ),
+    );
+    const selected = screen.getByRole("tab", { selected: true });
+    expect(selected.textContent?.toLowerCase()).not.toBe("runs");
+  });
+
+  it("falls back to Runs for a tab name that is not one", async () => {
+    // A hand-edited or stale URL must not leave the screen blank.
+    at("nonsense");
+
+    renderWithProviders(<Work />);
+
+    expect(screen.getByRole("tab", { selected: true })).toHaveTextContent(/runs/i);
+  });
+
+  it("puts the tab it switched to into the address", async () => {
+    at("");
+    renderWithProviders(<Work />);
+
+    await userEvent.click(await screen.findByRole("tab", { name: /git/i }));
+
+    expect(window.location.hash).toContain("tab=git");
+  });
+});

--- a/apps/desktop/src/components/Work.tsx
+++ b/apps/desktop/src/components/Work.tsx
@@ -12,12 +12,21 @@ import { readWorkspace } from "@/lib/workspace";
 
 type Tab = "run" | "git" | "worth" | "orchestration";
 
-/** The tab named in the URL, if any. Read straight from the hash rather than through `useRoute`
- *  so the FIRST render already has it: a deep link that resolved one render late would show the
- *  Runs tab and then jump, which reads as a bug even though it settles correctly. */
-function readTab(): string {
+const TABS = ["run", "git", "worth", "orchestration"] as const;
+
+/** The tab named in the URL, or "run".
+ *
+ *  Read straight from the hash rather than through `useRoute` so the FIRST render already has it: a
+ *  deep link that resolved one render late would show the Runs tab and then jump, which reads as a
+ *  bug even though it settles correctly.
+ *
+ *  Checked against the whole list. It used to recognise `orchestration` and nothing else, so
+ *  `choose` wrote `?tab=git` into the URL and reopening that URL landed on Runs — the address bar
+ *  said one thing and the screen showed another, which is worse than having no deep link at all. */
+function readTab(): Tab {
   const query = window.location.hash.split("?")[1] ?? "";
-  return new URLSearchParams(query).get("tab") ?? "";
+  const named = new URLSearchParams(query).get("tab") ?? "";
+  return (TABS as readonly string[]).includes(named) ? (named as Tab) : "run";
 }
 
 /**
@@ -41,7 +50,7 @@ function readTab(): string {
 export function Work() {
   const t = useT();
   const id = useId();
-  const [tab, setTab] = useState<Tab>(() => (readTab() === "orchestration" ? "orchestration" : "run"));
+  const [tab, setTab] = useState<Tab>(readTab);
   // Only to leave: the fallback note on a write-shaped task offers the screen that IS for writing
   // work, and a suggestion you have to act on yourself is a suggestion with a step missing.
   const { navigate, setParams } = useRoute();

--- a/apps/desktop/src/components/code/GitPanel.tsx
+++ b/apps/desktop/src/components/code/GitPanel.tsx
@@ -5,6 +5,7 @@ import { Check, GitBranch, Loader2 } from "lucide-react";
 import { getGitDiff, getGitStatus, gitCommit } from "@/lib/api";
 import type { GitFile } from "@/lib/types";
 import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/async";
 import { DiffView } from "@/components/code/DiffView";
 import { GitInitButton } from "@/components/code/GitInitButton";
 import { useT } from "@/lib/i18n";
@@ -173,6 +174,14 @@ export function GitPanel({ workspace }: { workspace: string }) {
         <div className="flex justify-center py-4 text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
         </div>
+      ) : statusQ.isError ? (
+        // A failed request used to fall through to the branch below, because `status` is undefined
+        // on error and `!status?.is_repo` is then true. So "we could not ask" rendered as "this is
+        // not a git repository", under a button offering to `git init` a folder that may well
+        // already be one. Two different problems, one screen, and the wrong fix on offer.
+        <div className="px-4 py-3">
+          <ErrorState error={statusQ.error} onRetry={() => void statusQ.refetch()} />
+        </div>
       ) : !status?.is_repo ? (
         <div className="flex flex-col items-start gap-2 px-4 py-3">
           <p className="text-xs text-muted-foreground">{t("code.git.notRepo")}</p>
@@ -219,6 +228,10 @@ export function GitPanel({ workspace }: { workspace: string }) {
         <div className="px-4 pb-3">
           {diffQ.isLoading ? (
             <div className="py-2 text-xs text-muted-foreground">…</div>
+          ) : diffQ.isError ? (
+            // "No diff" and "we could not fetch the diff" are different sentences. The first sends
+            // you looking for why your edit did not register.
+            <ErrorState error={diffQ.error} onRetry={() => void diffQ.refetch()} />
           ) : diffQ.data?.patch ? (
             <DiffView patch={diffQ.data.patch} />
           ) : (


### PR DESCRIPTION
## 1 · Status de git que falhou dizia que a pasta não era um repositório

`status` é `undefined` no erro, então `!status?.is_repo` era verdadeiro e o erro caía no ramo de "não é repositório" — **debaixo de um botão oferecendo `git init` numa pasta que pode muito bem já ser um.**

"Não conseguimos perguntar" e "isto não é um repositório" são dois problemas diferentes, e só um deles tem essa solução.

O painel de diff tinha a mesma forma: um fetch que falhava renderizava *"sem diff"*, o que manda você procurar por que sua edição não registrou.

## 2 · Dois botões de excluir que um teclado alcançava e nunca via

`opacity-0 … group-hover:opacity-100` e mais nada, no Cron e na Memória.

Um elemento com `opacity: 0` **continua focável** — diferente de `display:none` — então o Tab pousa nele, a linha parece inalterada, e não há como saber qual controle está prestes a disparar. Todo outro controle revelado por hover neste app já carrega `focus:opacity-100`; esses dois eram as exceções.

## 3 · Três das quatro abas de Trabalho não podiam ser linkadas

O `choose` **já escrevia** `?tab=git` na URL, e o `readTab` reconhecia `orchestration` e mais nada. Então trocar para Git produzia um endereço que, reaberto ou recarregado, caía em Runs.

**A barra de endereços dizia uma coisa e a tela mostrava outra** — o que é pior do que não ter deep link nenhum.

Um nome que não é aba continua caindo em Runs, para que uma URL editada à mão não deixe a tela em branco.

## Verificação

Frontend **683 passed** em 91 arquivos · typecheck limpo. Sabotado de propósito: dois testes do deep-link ficam vermelhos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
