### PR TITLE
fix(desktop): a default the app applied was recorded as a decision somebody made

### DIFF
--- a/apps/desktop/src/components/Code.model.test.tsx
+++ b/apps/desktop/src/components/Code.model.test.tsx
@@ -116,6 +116,26 @@ describe("Code — choosing the model", () => {
     });
   });
 
+  it("gives a new conversation the default back, as the chip promises", async () => {
+    // The chip says "Applies to this conversation" and the code calls it session-local, "because a
+    // model quietly carried over from a week ago is how a turn ends up costing thirty times what
+    // the person expected". It was screen state: it survived New conversation, Resume and a
+    // project switch. The fusion cast beside it was already remounted per conversation, which is
+    // what made the two disagree about the same word.
+    const user = userEvent.setup();
+    renderCode();
+
+    await user.click(await screen.findByRole("button", { name: /default/i }));
+    await user.click(await screen.findByText("DeepSeek: V3.1"));
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+
+    await user.type(screen.getByPlaceholderText(/Ask about this code/i), "oi");
+    await user.click(screen.getByRole("button", { name: /^Send$/i }));
+
+    await waitFor(() => expect(streamCodeTurn).toHaveBeenCalled());
+    expect(vi.mocked(streamCodeTurn).mock.calls[0][0]).not.toHaveProperty("model");
+  });
+
   it("asks the catalogue only once somebody opens the menu", async () => {
     // A composer nobody has touched must not reach a public catalogue on the network. This is the
     // whole reason the query is `enabled` rather than eager.

--- a/apps/desktop/src/components/Code.tsx
+++ b/apps/desktop/src/components/Code.tsx
@@ -335,8 +335,11 @@ export function Code() {
   // thirty times what the person expected. "" means the install's default, and the picker offers to
   // make a pick the standing default — which is the same intent, stated rather than accumulated.
   const [model, setModel] = useState("");
-  // Same: a default the system applies, and the receipt records `profile_source: "system"` so the
-  // cost panel never counts it beside a profile somebody deliberately picked.
+  // A default the system applies — there is no picker for it on any screen. A coding TURN files no
+  // delegation receipt, so nothing here reaches the cost panel; what does reach it is the run
+  // started below, and that one says `profile_source: "system"` so the panel never counts a default
+  // beside a profile somebody deliberately chose. This comment used to claim the turn recorded it,
+  // which was a claim about a receipt this screen does not write.
   const profile: Profile = "balanced";
 
   /** Change the project this screen is working in. One function, because it was three near-copies.
@@ -357,13 +360,29 @@ export function Code() {
       writeWorkspace(next);
       setProjectDraft(next);
       setSessionId(null);
-      setConversationKey((n) => n + 1);
-      setOpenFile(null);
+      startConversation();
       void qc.invalidateQueries({ queryKey: ["fs-file"] });
       void qc.invalidateQueries({ queryKey: ["git-status"] });
     },
     [qc, workspace],
   );
+
+  /** Everything that has to be true at the START of a conversation.
+   *
+   *  The model pick says "Applies to this conversation" and is described in code as session-local,
+   *  "because a model quietly carried over from a week ago is how a turn ends up costing thirty
+   *  times what the person expected". It was screen state: it survived New conversation, Resume and
+   *  a project switch, so the chip said one scope and the state had another. The fusion cast was
+   *  already correct — remounted by `key={conversationKey}` — which is what made the two disagree.
+   *
+   *  One function because it was three near-copies, and the copy that forgot a line is exactly how
+   *  this happened.
+   */
+  const startConversation = useCallback(() => {
+    setConversationKey((n) => n + 1);
+    setOpenFile(null);
+    setModel("");
+  }, []);
 
   const refreshOpenFile = useCallback(() => {
     if (openFile) void qc.invalidateQueries({ queryKey: ["fs-file", workspace, openFile] });
@@ -424,13 +443,11 @@ export function Code() {
             // A new conversation, not a cleared one: the old transcript stays on disk and stays in
             // the list. Clearing used to be the only way to start over, and it deleted the session.
             setSessionId(null);
-            setConversationKey((n) => n + 1);
-            setOpenFile(null);
+            startConversation();
           }}
           onResume={(session) => {
             setSessionId(session.id);
-            setConversationKey((n) => n + 1);
-            setOpenFile(null);
+            startConversation();
             if (session.workspace !== workspace) {
               setWorkspace(session.workspace);
               writeWorkspace(session.workspace);
@@ -457,7 +474,16 @@ export function Code() {
               // server infers the verify command from the project. Waiting for someone to press a
               // second button on a form with nothing left to fill in is not consent, it is friction.
               // The global status bar shows it and can stop it from any screen.
-              run.start({ task: text, verify: null, workspace: workspace || null, max_attempts: 3 })
+              run.start({
+                task: text,
+                verify: null,
+                workspace: workspace || null,
+                max_attempts: 3,
+                // Nobody picked a profile here either, and `worth.py` groups by
+                // (profile, profile_source) precisely so a run somebody chose "max" for and a run
+                // that got the default are not counted as the same evidence.
+                profile_source: "system",
+              })
             }
             onBatch={(tasks) => setBatch({ tasks, at: Date.now() })}
             onEdited={refreshOpenFile}

--- a/apps/desktop/src/components/RunLauncher.profile.test.tsx
+++ b/apps/desktop/src/components/RunLauncher.profile.test.tsx
@@ -1,0 +1,37 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Runs } from "@/components/Runs";
+import { getRuns, streamRun } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", async () => (await import("@/test/code-api-mock")).makeCodeApiMock());
+
+/**
+ * A default the app applied must not be recorded as a decision somebody made.
+ *
+ * `worth.py` groups delegation receipts by `(profile, profile_source)` precisely so a run somebody
+ * chose "max" for and a run that got the default because there is no picker are not counted as the
+ * same evidence. No screen in this app has a profile picker — and none of them sent
+ * `profile_source`, so the server's default, `"user"`, applied. Every app run entered the one view
+ * built to compare configurations labelled as a deliberate choice.
+ */
+describe("starting a run", () => {
+  beforeEach(() => {
+    vi.mocked(getRuns).mockResolvedValue([]);
+    vi.mocked(streamRun).mockImplementation(async () => {});
+  });
+
+  it("says the profile came from the system, because no screen asks", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Runs workspace="/repo" />);
+
+    await user.type(await screen.findByLabelText(/task/i), "fix the loader");
+    await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+    expect(vi.mocked(streamRun).mock.calls[0][0]).toMatchObject({
+      profile_source: "system",
+    });
+  });
+});

--- a/apps/desktop/src/components/run/RunLauncher.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.tsx
@@ -58,6 +58,8 @@ export function RunLauncher({
     max_attempts: maxAttempts,
     thread_id: threadId,
     pause_on_taint: pauseOnTaint,
+    // No profile picker on this screen either, so the receipt must not say a person picked one.
+    profile_source: "system",
   });
 
   function start() {


### PR DESCRIPTION
## 1 · `profile_source`

O `worth.py` agrupa recibos de delegação por `(profile, profile_source)` **precisamente** para que um run em que alguém escolheu "max" e um run que pegou o default porque não existe seletor **não sejam contados como a mesma evidência** — ele se recusa a retro-atribuir pela mesma razão.

Nenhuma tela deste app tem seletor de profile, e nenhuma tela mandava `profile_source`. Então o default do servidor valia: `"user"`.

**Todo run do app entrava na única visão construída para comparar configurações rotulado como escolha deliberada.**

Os dois caminhos que iniciam run agora dizem `"system"`. O comentário do profile fixo no `Code.tsx` afirmava que o turno já registrava isso — uma afirmação sobre um recibo de delegação que um **turno** de código não escreve. Agora ele diz qual chamada escreve.

## 2 · A escolha de modelo sobrevivia à conversa a que estava escopada

O chip diz *"Aplica-se a esta conversa"*, e o código a chama de session-local *"porque um modelo silenciosamente carregado de uma semana atrás é como um turno acaba custando trinta vezes o que a pessoa esperava"*.

Era estado de **tela**: sobrevivia a Nova conversa, a Retomar e à troca de projeto. O elenco de fusão ao lado **já era** remontado por conversa via `key={conversationKey}` — que é o que fazia dois controles na mesma linha discordarem sobre a mesma palavra.

Três quase-cópias de "começar uma conversa" viram uma função, porque **a cópia que esqueceu uma linha é exatamente como isso aconteceu**.

## Verificação

Frontend **680 passed** em 91 arquivos · typecheck limpo. Os dois consertos foram sabotados e os testes ficam vermelhos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
