### PR TITLE
fix(desktop): `embedded` reached one branch of three, and it was the error one

### DIFF
--- a/apps/desktop/src/components/Mcp.tsx
+++ b/apps/desktop/src/components/Mcp.tsx
@@ -234,7 +234,7 @@ export function Mcp({ embedded = false }: { embedded?: boolean } = {}) {
   }
   if (servers.isLoading || !servers.data) {
     return (
-      <Screen title={t("mcp.title")} icon={<Plug className="h-5 w-5" />}>
+      <Screen title={t("mcp.title")} icon={<Plug className="h-5 w-5" />} embedded={embedded}>
         <Panel>
           <Spinner />
         </Panel>
@@ -243,7 +243,7 @@ export function Mcp({ embedded = false }: { embedded?: boolean } = {}) {
   }
 
   return (
-    <Screen title={t("mcp.title")} icon={<Plug className="h-5 w-5" />}>
+    <Screen title={t("mcp.title")} icon={<Plug className="h-5 w-5" />} embedded={embedded}>
       {autoloadOff && (
         <div className="rounded-xl2 bg-surface-2 px-4 py-2.5 text-xs text-muted-foreground ring-1 ring-hairline">
           {t("mcp.autoloadOff")}

--- a/apps/desktop/src/components/Tools.tsx
+++ b/apps/desktop/src/components/Tools.tsx
@@ -168,7 +168,7 @@ export function Tools({ embedded = false }: { embedded?: boolean } = {}) {
   }
   if (q.isLoading || !q.data) {
     return (
-      <Screen title={t("tools.title")} icon={<Wrench className="h-5 w-5" />}>
+      <Screen title={t("tools.title")} icon={<Wrench className="h-5 w-5" />} embedded={embedded}>
         <Panel>
           <Spinner />
         </Panel>
@@ -177,7 +177,7 @@ export function Tools({ embedded = false }: { embedded?: boolean } = {}) {
   }
 
   return (
-    <Screen title={t("tools.title")} icon={<Wrench className="h-5 w-5" />}>
+    <Screen title={t("tools.title")} icon={<Wrench className="h-5 w-5" />} embedded={embedded}>
       <Panel
         title={t("tools.count", { n: q.data.count })}
         action={

--- a/apps/desktop/src/components/Usage.tsx
+++ b/apps/desktop/src/components/Usage.tsx
@@ -141,7 +141,7 @@ export function Usage({ embedded = false }: { embedded?: boolean } = {}) {
   }
   if (q.isLoading) {
     return (
-      <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />}>
+      <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />} embedded={embedded}>
         <Panel>
           <Spinner />
         </Panel>
@@ -154,7 +154,7 @@ export function Usage({ embedded = false }: { embedded?: boolean } = {}) {
 
   if (!data || !totals || totals.turns === 0) {
     return (
-      <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />}>
+      <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />} embedded={embedded}>
         <Panel>
           <EmptyState text={t("usage.empty")} />
         </Panel>
@@ -173,7 +173,7 @@ export function Usage({ embedded = false }: { embedded?: boolean } = {}) {
   const sessions: SessionRow[] = data.by_session;
 
   return (
-    <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />}>
+    <Screen title={t("usage.title")} icon={<BarChart3 className="h-5 w-5" />} embedded={embedded}>
       <Panel title={t("usage.totals")}>
         <div className="grid grid-cols-1 gap-3 p-4 sm:grid-cols-3">
           <Tile label={t("usage.turns")} value={num(totals.turns)} />

--- a/apps/desktop/src/components/embedded-screens.test.tsx
+++ b/apps/desktop/src/components/embedded-screens.test.tsx
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Screen } from "@/components/ui/panel";
+
+/**
+ * A screen rendered inside another screen's tab must not bring a second heading.
+ *
+ * `Screen` supplies an `<h1>`, a max-width column and its own scroll container unless told it is
+ * nested. Usage, Tools and Mcp all take an `embedded` prop — and passed it on exactly ONE of their
+ * branches, the error one. So the configuration people actually see, with the data loaded, rendered
+ * two headings and two scrollbars, and the branch that got it right was the one where the request
+ * had failed.
+ *
+ * Checked at the source, deliberately. A render test has to arrive at the loaded branch to see the
+ * bug, and the first version of this file asserted while the spinner was still up — it passed
+ * against a deliberately re-broken main path, which is a test that reports "fine" for the same
+ * reason a fixed file does.
+ */
+const SRC = join(__dirname);
+
+/** The attributes of an opening tag: everything up to the first `>` OUTSIDE a JSX expression.
+ *
+ *  Brace-aware because `icon={<BarChart3 className="h-5 w-5" />}` carries a `>` of its own, and
+ *  stopping at the first one cut every tag short — which made this guard fail on the fixed file. */
+function attributes(afterOpen: string): string {
+  let depth = 0;
+  for (let i = 0; i < afterOpen.length; i += 1) {
+    const ch = afterOpen[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    else if (ch === ">" && depth === 0) return afterOpen.slice(0, i);
+  }
+  return afterOpen;
+}
+
+describe("Screen", () => {
+  it("renders its own heading when it is the screen", () => {
+    render(
+      <Screen title="Usage" icon={null}>
+        <p>body</p>
+      </Screen>,
+    );
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Usage");
+  });
+
+  it("renders none when it is inside one", () => {
+    render(
+      <Screen title="Usage" icon={null} embedded>
+        <p>body</p>
+      </Screen>,
+    );
+
+    expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+    expect(screen.getByText("body")).toBeInTheDocument();
+  });
+});
+
+describe.each(["Usage", "Tools", "Mcp"])("%s", (name) => {
+  it("passes `embedded` to every Screen it renders, not just the error one", () => {
+    const source = readFileSync(join(SRC, `${name}.tsx`), "utf8");
+    const opens = source.split("<Screen").slice(1);
+
+    expect(opens.length).toBeGreaterThan(1);
+    for (const [index, tag] of opens.entries()) {
+      expect(attributes(tag), `${name}: <Screen> #${index + 1} drops embedded`).toContain(
+        "embedded=",
+      );
+    }
+  });
+});


### PR DESCRIPTION
O `Screen` fornece um `<h1>`, uma coluna de largura máxima e o próprio container de rolagem, a menos que seja avisado de que está aninhado.

Usage, Tools e Mcp **todos** recebem uma prop `embedded` — e a repassavam em exatamente **um** dos ramos: o de erro.

Então a configuração que as pessoas de fato veem, com os dados carregados, renderizava **dois títulos e duas barras de rolagem** dentro de Configurações e Conexões. E o ramo que acertava era aquele em que a requisição tinha falhado.

## O portão, e a segunda versão dele

Ele confere **no fonte**. A primeira versão renderizava o componente e afirmava — mas um teste de render precisa **chegar ao ramo carregado** para ver isso, e ele afirmava enquanto o spinner ainda estava na tela.

Passou contra um caminho principal deliberadamente re-quebrado — ou seja, um teste que reporta "tudo bem" pelo mesmo motivo que um arquivo consertado reporta.

A varredura de atributos é **ciente de chaves**, porque `icon={<BarChart3 className="h-5 w-5" />}` carrega um `>` próprio, e parar no primeiro cortava toda tag pela metade — o que fazia o portão falhar no arquivo já correto. Agora ele **nomeia qual `<Screen>`** larga a prop.

## Verificação

Frontend **683 passed** em 91 arquivos · typecheck limpo. Sabotado de propósito: o portão aponta `Usage: <Screen> #4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
