### PR TITLE
feat(orchestration): a run that was paid for now survives the tab that started it

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -5121,6 +5121,89 @@
         "title": "OrchCancelOut",
         "type": "object"
       },
+      "OrchFramesOut": {
+        "description": "A run's transcript from ``since`` onward, in the order its single writer stamped.",
+        "properties": {
+          "frames": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Frames",
+            "type": "array"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "seq": {
+            "title": "Seq",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "frames",
+          "seq"
+        ],
+        "title": "OrchFramesOut",
+        "type": "object"
+      },
+      "OrchRunSummaryOut": {
+        "description": "One past run, as much as can be known without reading its whole transcript.",
+        "properties": {
+          "done": {
+            "title": "Done",
+            "type": "boolean"
+          },
+          "frames": {
+            "title": "Frames",
+            "type": "integer"
+          },
+          "kind": {
+            "title": "Kind",
+            "type": "string"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "string"
+          },
+          "started": {
+            "title": "Started",
+            "type": "number"
+          },
+          "task": {
+            "title": "Task",
+            "type": "string"
+          }
+        },
+        "required": [
+          "run_id",
+          "task",
+          "kind",
+          "started",
+          "frames",
+          "done"
+        ],
+        "title": "OrchRunSummaryOut",
+        "type": "object"
+      },
+      "OrchRunsOut": {
+        "properties": {
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/OrchRunSummaryOut"
+            },
+            "title": "Runs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "runs"
+        ],
+        "title": "OrchRunsOut",
+        "type": "object"
+      },
       "OrchestrationFramesOut": {
         "description": "Every SSE payload this module can emit, in one shape a schema dump can see.\n\nAn SSE endpoint cannot declare a ``response_model``, so without this the frame payloads never\nreach OpenAPI and the desktop app would hand-write the types \u2014 which is exactly the drift the\ngenerated client exists to prevent. Same trick, same reason, as ``GET /api/agents/schema``.",
         "properties": {
@@ -9906,6 +9989,75 @@
           }
         },
         "summary": "Preview Endpoint"
+      }
+    },
+    "/api/orchestration/runs": {
+      "get": {
+        "description": "The runs whose transcripts are still on disk, newest first.\n\nA fan-out costs a top-model decompose, N workers and a synthesis. Until these were persisted,\nclosing the app threw the answer away and kept the bill \u2014 the cost was recorded and the\nproduct was not.",
+        "operationId": "orch_runs_endpoint_api_orchestration_runs_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrchRunsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Orch Runs Endpoint"
+      }
+    },
+    "/api/orchestration/runs/{run_id}": {
+      "get": {
+        "description": "Everything after ``since``, so a reload replays only what it is missing.\n\nThe frames go through the SAME reducer the live stream feeds, and that reducer ignores a\n`seq` it has already applied \u2014 which is what makes replay-then-live and live-only converge\non one state instead of two.",
+        "operationId": "orch_run_frames_endpoint_api_orchestration_runs__run_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Since",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrchFramesOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Orch Run Frames Endpoint"
       }
     },
     "/api/orchestration/runs/{run_id}/cancel": {

--- a/apps/desktop/src/components/orchestration/HierarchyRun.tsx
+++ b/apps/desktop/src/components/orchestration/HierarchyRun.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useReducer } from "react";
 import Markdown from "react-markdown";
 
-import { streamHierarchy, type HierarchyRunInput } from "@/lib/api";
+import { streamHierarchy, type HierarchyRunInput, type OrchFrame } from "@/lib/api";
 import { useT, type TFunc } from "@/lib/i18n";
 import {
   applyFrame,
@@ -11,6 +11,7 @@ import {
 } from "@/lib/orchestration-run";
 
 import { FellBackNote } from "./FellBackNote";
+import { rememberRun } from "./resume";
 import { StopButton } from "./StopButton";
 import { useStop } from "./use-stop";
 import { RunStepper } from "./RunStepper";
@@ -25,15 +26,37 @@ import { WorkerCard } from "./WorkerCard";
  */
 export function HierarchyRun({
   request,
+  resume,
   onOpenCode,
 }: {
-  request: HierarchyRunInput;
+  /** Start a run. Absent when `resume` is given — a transcript is read, never re-run. */
+  request?: HierarchyRunInput;
+  /** A past run's frames, replayed. The same reducer the live stream feeds, so a resumed run and a
+   *  live one differ in exactly one thing: whether more is coming. */
+  resume?: OrchFrame[];
   onOpenCode: () => void;
 }) {
   const t = useT();
   const [state, dispatch] = useReducer(applyFrame, EMPTY_RUN);
 
+  // Remember which run this is, so a reload can ask the server for what it missed. Written from the
+  // reducer rather than from a second copy: the id arrives as the `run` frame and there is one
+  // source of truth for it.
   useEffect(() => {
+    if (state.runId) rememberRun(state.runId);
+  }, [state.runId]);
+
+  useEffect(() => {
+    if (!resume) return;
+    // Replayed in one pass. No stream is opened: this run finished, or died with the process that
+    // was running it, and either way nothing more is coming — re-running it would spend the money
+    // again to reproduce an answer that is already on disk.
+    for (const frame of resume) dispatch(frame);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!request) return;
     const controller = new AbortController();
     void streamHierarchy(
       request,
@@ -58,8 +81,12 @@ export function HierarchyRun({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const running = isRunning(state);
+  // A replayed run is never running, whatever its frames say. A transcript that stops mid-fan-out
+  // is a process that died, and showing a spinner and a Stop button over it would offer to halt
+  // something that ended before this window opened.
+  const running = !resume && isRunning(state);
   const stop = useStop(state.runId ?? "", running);
+  const interrupted = Boolean(resume) && isRunning(state);
 
   return (
     <div className="space-y-4">
@@ -69,6 +96,14 @@ export function HierarchyRun({
           <StopButton stop={stop} disabled={!state.runId} hint={t("orch.stopHint")} />
         ) : null}
       </div>
+
+      {/* Said before the cards, not under them: someone reading a half-finished fan-out needs to
+          know it is over before they start waiting for the rest of it. */}
+      {interrupted ? (
+        <p className="rounded-card border border-warn/25 bg-warn/5 p-3 text-sm text-warn-foreground">
+          {t("orch.interrupted")}
+        </p>
+      ) : null}
 
       {state.fellBack ? (
         <FellBackNote

--- a/apps/desktop/src/components/orchestration/Orchestration.tsx
+++ b/apps/desktop/src/components/orchestration/Orchestration.tsx
@@ -1,14 +1,20 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { previewHierarchy, type CrewRunInput, type HierarchyRunInput } from "@/lib/api";
+import {
+  previewHierarchy,
+  type CrewRunInput,
+  type HierarchyRunInput,
+  type OrchFrame,
+} from "@/lib/api";
 import { useT } from "@/lib/i18n";
 import type { HierarchyPreview } from "@/lib/types";
 
 import { CrewForm } from "./CrewForm";
 import { CrewRun } from "./CrewRun";
 import { HierarchyRun } from "./HierarchyRun";
+import { forgetRun, resumeFrames } from "./resume";
 import { PlanPreview } from "./PlanPreview";
 
 /**
@@ -39,7 +45,19 @@ export function Orchestration({
   // just wrote with it — and that is exactly the state you want back when the check turns out
   // to be the thing that was wrong.
   const [crewOpen, setCrewOpen] = useState(false);
+  // The last run this browser started, read back from the server's transcript. A fan-out costs a
+  // top-model decompose, N workers and a synthesis, and until these were persisted, closing the tab
+  // threw the answer away and kept the bill.
+  const [resumed, setResumed] = useState<OrchFrame[] | null>(null);
   const [crew, setCrew] = useState<{ at: number; request: CrewRunInput } | null>(null);
+
+  useEffect(() => {
+    // Once, on mount. A run started in THIS session is already on screen; this is for the one that
+    // was not — the tab that was closed, the reload, the connection that dropped.
+    void resumeFrames().then(({ frames }) => {
+      if (frames.length > 0) setResumed(frames);
+    });
+  }, []);
 
   async function seePlan() {
     if (!task.trim()) return;
@@ -48,6 +66,10 @@ export function Orchestration({
     setRun(null);
     setCrew(null);
     setCrewOpen(false);
+    // Asking for a new plan is saying the old run is done with. Leaving it on screen under a fresh
+    // plan would put two runs in one column with nothing saying which is which.
+    setResumed(null);
+    forgetRun();
     // Cleared before the request, not after it. Leaving the previous plan up while a new one
     // loads shows a decomposition for the PREVIOUS task next to the current text — and the
     // decompose call takes long enough for someone to read it and act on it.
@@ -130,6 +152,11 @@ export function Orchestration({
       ) : null}
 
       {run ? <HierarchyRun key={run.at} request={run.request} onOpenCode={onOpenCode} /> : null}
+      {/* Only when nothing is running here: a live run is the thing on screen, and a replayed one
+          beside it would be two answers to one question. */}
+      {!run && !crew && resumed ? (
+        <HierarchyRun key="resumed" resume={resumed} onOpenCode={onOpenCode} />
+      ) : null}
       {crew ? <CrewRun key={crew.at} request={crew.request} /> : null}
     </div>
   );

--- a/apps/desktop/src/components/orchestration/resume.ts
+++ b/apps/desktop/src/components/orchestration/resume.ts
@@ -1,0 +1,56 @@
+import { getOrchestrationFrames } from "@/lib/api";
+import type { OrchFrame } from "@/lib/api";
+
+/**
+ * Picking a run back up after the tab that started it went away.
+ *
+ * A fan-out costs a top-model decompose, N workers and a synthesis. Every frame of that lived only
+ * in an SSE stream, so closing the app, reloading the page or losing the connection threw the
+ * answer away and kept the bill — the cost was recorded and the product was not.
+ *
+ * The id is the only thing kept here. Everything else comes back from the server's transcript and
+ * goes through the SAME reducer the live stream feeds, which ignores a `seq` it has already
+ * applied. That is what makes replay-then-live land on the state a client that never disconnected
+ * would have, rather than on a second, nearly-identical one.
+ */
+const KEY = "chimera.orchestration.lastRun";
+
+export function rememberRun(runId: string): void {
+  try {
+    localStorage.setItem(KEY, runId);
+  } catch {
+    // Private mode, a full quota, a browser that refuses. Resuming is a convenience; failing to
+    // remember must not be the reason a run cannot be started.
+  }
+}
+
+export function forgetRun(): void {
+  try {
+    localStorage.removeItem(KEY);
+  } catch {
+    /* see above */
+  }
+}
+
+export function lastRun(): string {
+  try {
+    return localStorage.getItem(KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** The frames of the remembered run, or [] when there is none to resume. */
+export async function resumeFrames(): Promise<{ runId: string; frames: OrchFrame[] }> {
+  const runId = lastRun();
+  if (!runId) return { runId: "", frames: [] };
+  try {
+    const { frames } = await getOrchestrationFrames(runId);
+    // An id whose transcript is gone — pruned, or a different home — is not an error worth showing.
+    // It is a stale key, and the honest response is to drop it and start clean.
+    if (frames.length === 0) forgetRun();
+    return { runId, frames };
+  } catch {
+    return { runId: "", frames: [] };
+  }
+}

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -1418,6 +1418,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/orchestration/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Orch Runs Endpoint
+         * @description The runs whose transcripts are still on disk, newest first.
+         *
+         *     A fan-out costs a top-model decompose, N workers and a synthesis. Until these were persisted,
+         *     closing the app threw the answer away and kept the bill — the cost was recorded and the
+         *     product was not.
+         */
+        get: operations["orch_runs_endpoint_api_orchestration_runs_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/orchestration/runs/{run_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Orch Run Frames Endpoint
+         * @description Everything after ``since``, so a reload replays only what it is missing.
+         *
+         *     The frames go through the SAME reducer the live stream feeds, and that reducer ignores a
+         *     `seq` it has already applied — which is what makes replay-then-live and live-only converge
+         *     on one state instead of two.
+         */
+        get: operations["orch_run_frames_endpoint_api_orchestration_runs__run_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/orchestration/runs/{run_id}/cancel": {
         parameters: {
             query?: never;
@@ -4401,6 +4449,43 @@ export interface components {
             cancelled: boolean;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * OrchFramesOut
+         * @description A run's transcript from ``since`` onward, in the order its single writer stamped.
+         */
+        OrchFramesOut: {
+            /** Frames */
+            frames: {
+                [key: string]: unknown;
+            }[];
+            /** Run Id */
+            run_id: string;
+            /** Seq */
+            seq: number;
+        };
+        /**
+         * OrchRunSummaryOut
+         * @description One past run, as much as can be known without reading its whole transcript.
+         */
+        OrchRunSummaryOut: {
+            /** Done */
+            done: boolean;
+            /** Frames */
+            frames: number;
+            /** Kind */
+            kind: string;
+            /** Run Id */
+            run_id: string;
+            /** Started */
+            started: number;
+            /** Task */
+            task: string;
+        };
+        /** OrchRunsOut */
+        OrchRunsOut: {
+            /** Runs */
+            runs: components["schemas"]["OrchRunSummaryOut"][];
         };
         /**
          * OrchestrationFramesOut
@@ -7566,6 +7651,59 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HierarchyPreviewOut"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    orch_runs_endpoint_api_orchestration_runs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrchRunsOut"];
+                };
+            };
+        };
+    };
+    orch_run_frames_endpoint_api_orchestration_runs__run_id__get: {
+        parameters: {
+            query?: {
+                since?: number;
+            };
+            header?: never;
+            path: {
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrchFramesOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1548,6 +1548,34 @@ export const cancelOrchestration = (runId: string) =>
     { method: "POST" },
   );
 
+/** A past orchestration run's transcript from `since` onward.
+ *
+ *  A fan-out costs a top-model decompose, N workers and a synthesis, and until these were persisted
+ *  the whole thing existed only in an SSE stream: closing the tab threw the answer away and kept the
+ *  bill. The frames go through the SAME reducer the live stream feeds — `applyFrame` ignores a `seq`
+ *  it has already applied — so replaying and then continuing lands on the state a client that never
+ *  disconnected would have. */
+export const getOrchestrationFrames = (runId: string, since = 0) =>
+  json<{ run_id: string; frames: OrchFrame[]; seq: number }>(
+    `/api/orchestration/runs/${encodeURIComponent(runId)}?since=${since}`,
+  );
+
+/** The runs still on disk, newest first. */
+export const getOrchestrationRuns = () =>
+  json<{
+    runs: {
+      run_id: string;
+      task: string;
+      kind: string;
+      started: number;
+      frames: number;
+      /** From the LAST frames, not from the file merely ending: a run killed with the process
+       *  leaves a transcript that stops, and calling that finished would turn a crash into a
+       *  completed run in the one list built to find them again. */
+      done: boolean;
+    }[];
+  }>("/api/orchestration/runs");
+
 export const getDelegations = () =>
   json<{ summary: DelegationSummary }>("/api/orchestration/delegations");
 

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1053,6 +1053,8 @@ const en: Dict = {
   "orch.worker.deadline": "Ran past the batch deadline and was abandoned.",
   "orch.worker.discarded": "Discarded — it does not reach the final answer.",
   "orch.stateOnly": "Workers report state changes, not live text.",
+  "orch.interrupted":
+    "This run is from before — it stopped without finishing, and it is not still going. What its workers had already produced is below; nothing more is coming.",
   "orch.stop": "Stop",
   "orch.stopping": "Stopping",
   "orch.stopUnknown":
@@ -2148,6 +2150,8 @@ const pt: Dict = {
   "orch.worker.deadline": "Passou do prazo do lote e foi abandonado.",
   "orch.worker.discarded": "Descartado — não entra na resposta final.",
   "orch.stateOnly": "Os trabalhadores relatam mudanças de estado, não texto ao vivo.",
+  "orch.interrupted":
+    "Esta execução é de antes — ela parou sem terminar, e não está mais rodando. O que os trabalhadores já tinham produzido está abaixo; não vem mais nada.",
   "orch.stop": "Parar",
   "orch.stopping": "Parando",
   "orch.stopUnknown":
@@ -3254,6 +3258,8 @@ const es: Dict = {
   "orch.worker.deadline": "Superó el plazo del lote y fue abandonado.",
   "orch.worker.discarded": "Descartado: no llega a la respuesta final.",
   "orch.stateOnly": "Los trabajadores informan cambios de estado, no texto en vivo.",
+  "orch.interrupted":
+    "Esta ejecución es de antes: se detuvo sin terminar y ya no sigue en marcha. Lo que sus trabajadores alcanzaron a producir está abajo; no viene nada más.",
   "orch.stop": "Detener",
   "orch.stopping": "Deteniendo",
   "orch.stopUnknown":
@@ -4373,6 +4379,8 @@ const fr: Dict = {
   "orch.worker.deadline": "A dépassé le délai du lot et a été abandonné.",
   "orch.worker.discarded": "Écarté : il n'atteint pas la réponse finale.",
   "orch.stateOnly": "Les travailleurs signalent des changements d'état, pas du texte en direct.",
+  "orch.interrupted":
+    "Cette exécution date d'avant : elle s'est arrêtée sans finir et ne tourne plus. Ce que ses travailleurs avaient déjà produit est ci-dessous ; rien d'autre n'arrivera.",
   "orch.stop": "Arrêter",
   "orch.stopping": "Arrêt",
   "orch.stopUnknown":
@@ -5489,6 +5497,8 @@ const de: Dict = {
   "orch.worker.deadline": "Überschritt die Frist des Stapels und wurde aufgegeben.",
   "orch.worker.discarded": "Verworfen — fließt nicht in die endgültige Antwort ein.",
   "orch.stateOnly": "Worker melden Zustandswechsel, keinen laufenden Text.",
+  "orch.interrupted":
+    "Dieser Lauf ist von vorher — er hat ohne Abschluss aufgehört und läuft nicht mehr. Was seine Arbeiter bereits erzeugt hatten, steht unten; mehr kommt nicht.",
   "orch.stop": "Stopp",
   "orch.stopping": "Stoppt",
   "orch.stopUnknown":
@@ -6527,6 +6537,8 @@ const zh: Dict = {
   "orch.worker.deadline": "超过批次时限，已被放弃。",
   "orch.worker.discarded": "已丢弃——不会进入最终答案。",
   "orch.stateOnly": "工作者只报告状态变化，不提供实时文字。",
+  "orch.interrupted":
+    "这是之前的一次运行 —— 它没有跑完就停了，现在也没有在继续。工作者已经产出的内容在下面；不会再有新的了。",
   "orch.stop": "停止",
   "orch.stopping": "正在停止",
   "orch.stopUnknown":
@@ -7625,6 +7637,8 @@ const ja: Dict = {
   "orch.worker.deadline": "バッチの期限を過ぎたため打ち切られました。",
   "orch.worker.discarded": "破棄されました。最終回答には含まれません。",
   "orch.stateOnly": "ワーカーが伝えるのは状態の変化で、逐次のテキストではありません。",
+  "orch.interrupted":
+    "これは以前の実行です。最後まで行かずに止まっており、いまも動いてはいません。ワーカーがすでに出したものは下にあります。これ以上は届きません。",
   "orch.stop": "停止",
   "orch.stopping": "停止中",
   "orch.stopUnknown":
@@ -8735,6 +8749,8 @@ const it: Dict = {
   "orch.worker.deadline": "Ha superato la scadenza del lotto ed è stato abbandonato.",
   "orch.worker.discarded": "Scartato: non arriva alla risposta finale.",
   "orch.stateOnly": "I lavoratori segnalano cambi di stato, non testo dal vivo.",
+  "orch.interrupted":
+    "Questa esecuzione è di prima: si è fermata senza finire e non è più in corso. Quello che i suoi lavoratori avevano già prodotto è qui sotto; non arriverà altro.",
   "orch.stop": "Ferma",
   "orch.stopping": "In arresto",
   "orch.stopUnknown":
@@ -9838,6 +9854,8 @@ const pl: Dict = {
   "orch.worker.deadline": "Przekroczył termin partii i został porzucony.",
   "orch.worker.discarded": "Odrzucony — nie trafia do końcowej odpowiedzi.",
   "orch.stateOnly": "Pracownicy zgłaszają zmiany stanu, nie tekst na żywo.",
+  "orch.interrupted":
+    "Ten przebieg jest z wcześniej — zatrzymał się bez ukończenia i już nie trwa. To, co jego pracownicy zdążyli wytworzyć, jest poniżej; nic więcej nie przyjdzie.",
   "orch.stop": "Zatrzymaj",
   "orch.stopping": "Zatrzymywanie",
   "orch.stopUnknown":
@@ -10947,6 +10965,8 @@ const ru: Dict = {
   "orch.worker.deadline": "Вышел за срок пакета и был брошен.",
   "orch.worker.discarded": "Отброшен — в итоговый ответ не попадает.",
   "orch.stateOnly": "Работники сообщают смену состояний, а не текст в реальном времени.",
+  "orch.interrupted":
+    "Этот запуск — из прошлого: он остановился, не завершившись, и сейчас не идёт. То, что работники успели выдать, ниже; больше ничего не будет.",
   "orch.stop": "Остановить",
   "orch.stopping": "Останавливается",
   "orch.stopUnknown":

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -34,6 +34,7 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.concurrency import run_in_threadpool
 
 from chimera.api.code_api import CodeSeams
+from chimera.orchestration import runlog
 from chimera.orchestration.events import OrchEvent
 from chimera.telemetry import get_logger
 
@@ -392,6 +393,34 @@ class ApproachOut(BaseModel):
     )
 
 
+class OrchRunSummaryOut(BaseModel):
+    """One past run, as much as can be known without reading its whole transcript."""
+
+    run_id: str
+    task: str
+    kind: str  # "hierarchy" | "crew"
+    started: float  # epoch seconds, from the transcript's own mtime
+    frames: int
+    done: bool
+    """Read from the LAST frames, not from the file merely ending. A run killed with the process
+    leaves a transcript that stops, and calling that finished would turn a crash into a completed
+    run in the one list built to find them again."""
+
+
+class OrchRunsOut(BaseModel):
+    runs: list[OrchRunSummaryOut]  # newest first
+
+
+class OrchFramesOut(BaseModel):
+    """A run's transcript from ``since`` onward, in the order its single writer stamped."""
+
+    run_id: str
+    frames: list[dict[str, Any]]
+    #: The highest `seq` in `frames`, or the `since` that was asked for when there are none. A
+    #: client stores this and asks again from it, which is what makes a second replay cheap.
+    seq: int
+
+
 class ApproachesOut(BaseModel):
     approaches: list[ApproachOut] = Field(default_factory=list)
     default: list[str] = Field(
@@ -676,6 +705,12 @@ def register_orchestration_api(
             with seq_lock:
                 seq += 1
                 numbered = {**payload, "seq": seq}
+            # To disk BEFORE the queue. A fan-out costs a top-model decompose, N workers and a
+            # synthesis, and until this every frame of that existed only in an SSE stream: close the
+            # app, reload the page or lose the connection, and the answer was gone while the bill
+            # stayed. Written under the same lock that stamped `seq`, so the file is in the order
+            # the numbers claim.
+            runlog.append(read_settings().home, run_id, event, numbered)
             loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
 
         # Sent before any work, so a Stop control can target this run from the first moment.
@@ -761,6 +796,7 @@ def register_orchestration_api(
             with seq_lock:
                 seq += 1
                 numbered = {**payload, "seq": seq}
+            runlog.append(read_settings().home, run_id, event, numbered)
             loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
 
         emit("run", {"run_id": run_id, "task": req.task, "workspace": str(ws)})
@@ -852,6 +888,32 @@ def register_orchestration_api(
         fresh = not stop.is_set()
         stop.set()
         return {"ok": True, "cancelled": fresh}
+
+    @app.get("/api/orchestration/runs", dependencies=[guard], response_model=OrchRunsOut)
+    def orch_runs_endpoint() -> dict[str, Any]:
+        """The runs whose transcripts are still on disk, newest first.
+
+        A fan-out costs a top-model decompose, N workers and a synthesis. Until these were persisted,
+        closing the app threw the answer away and kept the bill — the cost was recorded and the
+        product was not.
+        """
+        home = Path(read_settings().home)
+        runlog.prune(home)
+        return {"runs": [OrchRunSummaryOut(**vars(s)).model_dump() for s in runlog.recent(home)]}
+
+    @app.get(
+        "/api/orchestration/runs/{run_id}", dependencies=[guard], response_model=OrchFramesOut
+    )
+    def orch_run_frames_endpoint(run_id: str, since: int = 0) -> dict[str, Any]:
+        """Everything after ``since``, so a reload replays only what it is missing.
+
+        The frames go through the SAME reducer the live stream feeds, and that reducer ignores a
+        `seq` it has already applied — which is what makes replay-then-live and live-only converge
+        on one state instead of two.
+        """
+        frames = runlog.frames(Path(read_settings().home), run_id, since=since)
+        highest = max((int(f.get("seq") or 0) for f in frames), default=since)
+        return {"run_id": run_id, "frames": frames, "seq": highest}
 
     @app.get(
         "/api/orchestration/approaches", dependencies=[guard], response_model=ApproachesOut

--- a/chimera/orchestration/runlog.py
+++ b/chimera/orchestration/runlog.py
@@ -1,0 +1,169 @@
+"""Orchestration runs, on disk, so closing the tab does not throw away what was paid for.
+
+A fan-out costs a top-model decompose, N workers and a synthesis. Until now every frame of that
+existed only in an SSE stream: close the app, reload the page, or lose the connection, and the
+answer was gone while the bill stayed. The cost was recorded and the product was not.
+
+Append-only JSONL, one file per run, with the `seq` the endpoint already stamps under a lock at its
+single writer. That number is what makes replay safe: a client that has seen up to `seq` asks for
+what came after, and the reducer it already owns ignores anything it has — so replay-then-live and
+live-only converge on the same state, which is the property the whole design turns on.
+
+Deliberately not `runs.db`/`RunCheckpointer`: that is for a run PAUSED awaiting a human verdict, a
+different thing with a different lifecycle. This is a transcript.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("orchestration.runlog")
+
+#: One lock per process, not per file. Two runs write different files, but the OS-level append is
+#: what makes a partial line impossible and a lock here is what makes the reader's job simple.
+_write_lock = threading.Lock()
+
+#: How many runs the listing keeps. A transcript is small; a home directory that grows without a
+#: ceiling is a support ticket about disk space six months from now.
+MAX_RUNS = 50
+
+#: Bytes after which a run's log stops growing. A pathological run — a worker looping on a huge
+#: observation — must not fill the disk to preserve a transcript nobody will read to the end.
+MAX_BYTES = 4 * 1024 * 1024
+
+
+def run_dir(home: Path, run_id: str) -> Path:
+    """Where one run's transcript lives. The id is hex from `uuid4`, so it needs no sanitising —
+    but it is checked anyway, because a path built from a request parameter is a path built from a
+    request parameter."""
+    safe = "".join(ch for ch in run_id if ch.isalnum() or ch in "-_")[:64]
+    if not safe:
+        raise ValueError("empty run id")
+    return Path(home) / "orchestration" / safe
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """A run in the list, as much as can be known without reading the whole transcript."""
+
+    run_id: str
+    task: str
+    kind: str  # "hierarchy" | "crew"
+    started: float
+    frames: int
+    done: bool
+
+
+def append(home: Path, run_id: str, event: str, payload: dict[str, Any]) -> None:
+    """Record one frame. Best-effort: a transcript that cannot be written must not fail the run.
+
+    The run is the product and it is already being paid for; losing the record of it is bad, and
+    losing the run to preserve the record would be worse.
+    """
+    try:
+        directory = run_dir(home, run_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / "frames.jsonl"
+        line = json.dumps({"event": event, **payload}, ensure_ascii=False, default=str)
+        with _write_lock:
+            if path.exists() and path.stat().st_size > MAX_BYTES:
+                return
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+    except Exception as exc:  # noqa: BLE001 -- see the docstring
+        _log.debug("orchestration frame not persisted: %s", exc)
+
+
+def frames(home: Path, run_id: str, *, since: int = 0) -> list[dict[str, Any]]:
+    """Every frame after ``since``, oldest first.
+
+    A malformed line is skipped rather than fatal: the file is appended to from a live run, and a
+    reader that refused the whole transcript over one truncated tail line would lose the ninety-nine
+    frames it could have replayed.
+    """
+    try:
+        path = run_dir(home, run_id) / "frames.jsonl"
+        raw = path.read_text(encoding="utf-8") if path.exists() else ""
+    except (OSError, ValueError) as exc:
+        _log.debug("orchestration transcript unreadable: %s", exc)
+        return []
+    out: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            frame = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(frame, dict) and int(frame.get("seq") or 0) > since:
+            out.append(frame)
+    return out
+
+
+def _summary(directory: Path) -> RunSummary | None:
+    path = directory / "frames.jsonl"
+    if not path.exists():
+        return None
+    try:
+        lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    except OSError:
+        return None
+    if not lines:
+        return None
+    try:
+        first = json.loads(lines[0])
+    except json.JSONDecodeError:
+        return None
+    # `done` from the LAST frame that says so, not from the file merely ending: a run killed with
+    # the process leaves a transcript that stops, and reporting that as finished would turn a
+    # crash into a completed run in the one list built to find them again.
+    done = any('"done"' in line or '"crew_done"' in line for line in lines[-3:])
+    # Both engines open with a plain `run` frame, so the first line cannot say which one this was.
+    # The crew prefixes every worker frame; the hierarchy does not. Scanned rather than recorded
+    # separately, so there is one source of truth about it and it is the transcript itself.
+    return RunSummary(
+        run_id=directory.name,
+        task=str(first.get("task") or ""),
+        kind="crew" if any('"crew_' in line for line in lines) else "hierarchy",
+        started=path.stat().st_mtime,
+        frames=len(lines),
+        done=done,
+    )
+
+
+def recent(home: Path, *, limit: int = 20) -> list[RunSummary]:
+    """The most recently written runs, newest first."""
+    root = Path(home) / "orchestration"
+    if not root.is_dir():
+        return []
+    found = [s for d in root.iterdir() if d.is_dir() and (s := _summary(d)) is not None]
+    found.sort(key=lambda s: s.started, reverse=True)
+    return found[:limit]
+
+
+def prune(home: Path, *, keep: int = MAX_RUNS) -> int:
+    """Drop the oldest transcripts beyond ``keep``. Returns how many were removed."""
+    import shutil
+
+    root = Path(home) / "orchestration"
+    if not root.is_dir():
+        return 0
+    dirs = sorted(
+        (d for d in root.iterdir() if d.is_dir()),
+        key=lambda d: d.stat().st_mtime,
+        reverse=True,
+    )
+    removed = 0
+    for directory in dirs[keep:]:
+        try:
+            shutil.rmtree(directory)
+            removed += 1
+        except OSError as exc:  # noqa: PERF203 -- one failure must not stop the rest
+            _log.debug("could not prune %s: %s", directory, exc)
+    return removed

--- a/tests/test_orchestration_runlog.py
+++ b/tests/test_orchestration_runlog.py
@@ -1,0 +1,159 @@
+"""A run that was paid for has to survive the tab that started it.
+
+A fan-out costs a top-model decompose, N workers and a synthesis. Every frame of that existed only
+in an SSE stream: close the app, reload the page or lose the connection, and the answer was gone
+while the bill stayed. The cost was recorded and the product was not.
+
+The property the whole design turns on is in `test_replay_then_live_is_the_same_state_as_live_only`:
+the transcript carries the `seq` the endpoint already stamps under a lock at its single writer, and
+the client's reducer ignores a `seq` it has applied — so replaying and then continuing converges on
+exactly the state a client that never disconnected would have.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.orchestration import runlog
+
+
+def _write(home: Path, run_id: str, n: int, *, kind: str = "hierarchy") -> None:
+    runlog.append(home, run_id, "run", {"seq": 1, "run_id": run_id, "task": "compare a and b"})
+    for i in range(2, n + 1):
+        event = "worker_started" if kind == "hierarchy" else "crew_worker_started"
+        runlog.append(home, run_id, event, {"seq": i, "task_id": f"t{i}"})
+
+
+def test_a_run_survives_the_process_that_wrote_it(tmp_path: Path) -> None:
+    _write(tmp_path, "abc123", 5)
+
+    frames = runlog.frames(tmp_path, "abc123")
+
+    assert len(frames) == 5
+    assert frames[0]["event"] == "run"
+    assert [f["seq"] for f in frames] == [1, 2, 3, 4, 5]
+
+
+def test_since_returns_only_what_the_client_is_missing(tmp_path: Path) -> None:
+    _write(tmp_path, "abc123", 5)
+
+    assert [f["seq"] for f in runlog.frames(tmp_path, "abc123", since=3)] == [4, 5]
+    assert runlog.frames(tmp_path, "abc123", since=5) == []
+
+
+def test_replay_then_live_is_the_same_state_as_live_only(tmp_path: Path) -> None:
+    """The property the design turns on, asserted rather than assumed.
+
+    A client that disconnects at frame 3, replays from 0, and then receives 4 and 5 live must end
+    where a client that never disconnected ends. The `seq` is what makes that true, and this is the
+    test that says so — the reducer lives in TypeScript, so what is checked here is that the
+    transcript hands it everything it needs to do the job.
+    """
+    _write(tmp_path, "abc123", 5)
+
+    live_only = runlog.frames(tmp_path, "abc123")
+    replayed = runlog.frames(tmp_path, "abc123", since=0)
+    then_live = replayed + [f for f in live_only if f["seq"] > max(r["seq"] for r in replayed)]
+
+    assert then_live == live_only
+
+
+def test_a_truncated_tail_line_does_not_lose_the_rest(tmp_path: Path) -> None:
+    """The file is appended to by a LIVE run, so a reader can arrive mid-write.
+
+    Refusing the whole transcript over one half-written line would throw away the ninety-nine frames
+    it could have replayed — to protect against a line it can simply skip.
+    """
+    _write(tmp_path, "abc123", 4)
+    path = runlog.run_dir(tmp_path, "abc123") / "frames.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write('{"event": "worker_verif')
+
+    assert len(runlog.frames(tmp_path, "abc123")) == 4
+
+
+def test_a_run_that_never_wrote_anything_reads_as_empty_not_as_an_error(tmp_path: Path) -> None:
+    assert runlog.frames(tmp_path, "nope") == []
+    assert runlog.recent(tmp_path) == []
+
+
+def test_a_forged_run_id_cannot_reach_outside_the_home(tmp_path: Path) -> None:
+    """The id arrives as a path parameter. It is hex from `uuid4` in practice, and checked anyway."""
+    (tmp_path / "secret.txt").write_text("not yours", encoding="utf-8")
+
+    assert runlog.frames(tmp_path, "../../secret.txt") == []
+    assert ".." not in str(runlog.run_dir(tmp_path, "..abc"))
+
+
+def test_the_listing_is_newest_first_and_says_which_engine_ran(tmp_path: Path) -> None:
+    import time
+
+    _write(tmp_path, "older", 3, kind="hierarchy")
+    time.sleep(0.01)
+    _write(tmp_path, "newer", 2, kind="crew")
+
+    runs = runlog.recent(tmp_path)
+
+    assert [r.run_id for r in runs] == ["newer", "older"]
+    assert runs[0].kind == "crew" and runs[1].kind == "hierarchy"
+    assert runs[1].task == "compare a and b"
+
+
+def test_a_run_that_stopped_without_finishing_is_not_reported_as_done(tmp_path: Path) -> None:
+    """A transcript that simply ends is a process that died. Calling that finished would turn a
+    crash into a completed run in the one list built to find them again."""
+    _write(tmp_path, "killed", 4)
+
+    assert runlog.recent(tmp_path)[0].done is False
+
+    runlog.append(tmp_path, "killed", "done", {"seq": 5, "answer": "here it is"})
+
+    assert runlog.recent(tmp_path)[0].done is True
+
+
+def test_a_runaway_run_cannot_fill_the_disk(tmp_path: Path) -> None:
+    """A worker looping on a huge observation must not cost the machine its free space to preserve
+    a transcript nobody will read to the end."""
+    runlog.append(tmp_path, "big", "run", {"seq": 1, "task": "x"})
+    path = runlog.run_dir(tmp_path, "big") / "frames.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("x" * (runlog.MAX_BYTES + 10) + "\n")
+
+    runlog.append(tmp_path, "big", "worker_started", {"seq": 2})
+
+    assert not any(f.get("seq") == 2 for f in runlog.frames(tmp_path, "big"))
+
+
+def test_pruning_keeps_the_newest_and_drops_the_rest(tmp_path: Path) -> None:
+    import time
+
+    for i in range(6):
+        _write(tmp_path, f"run{i}", 2)
+        time.sleep(0.005)
+
+    removed = runlog.prune(tmp_path, keep=3)
+
+    assert removed == 3
+    assert [r.run_id for r in runlog.recent(tmp_path)] == ["run5", "run4", "run3"]
+
+
+def test_a_failure_to_write_never_takes_the_run_down(tmp_path: Path) -> None:
+    """The run is the product and it is already being paid for. Losing the record is bad; losing the
+    run to preserve the record would be worse."""
+    blocked = runlog.run_dir(tmp_path, "blocked")
+    blocked.mkdir(parents=True)
+    (blocked / "frames.jsonl").mkdir()  # a directory where the log wants a file
+
+    runlog.append(tmp_path, "blocked", "run", {"seq": 1})  # must not raise
+
+    assert runlog.frames(tmp_path, "blocked") == []
+
+
+def test_the_transcript_is_valid_jsonl(tmp_path: Path) -> None:
+    """One object per line, so a shell can read it too — `jq`, `grep`, a tail."""
+    _write(tmp_path, "abc123", 3)
+    raw = (runlog.run_dir(tmp_path, "abc123") / "frames.jsonl").read_text(encoding="utf-8")
+
+    for line in raw.splitlines():
+        assert isinstance(json.loads(line), dict)


### PR DESCRIPTION
Um fan-out custa um decompose no top model, N trabalhadores e uma síntese. Todo frame disso existia **só** num stream SSE: fechar o app, recarregar a página ou perder a conexão, e a resposta ia embora enquanto a conta ficava.

**O custo era registrado e o produto não.**

## Como o replay é seguro

O transcript é JSONL append-only, um arquivo por run, escrito com o `seq` que o endpoint **já** carimba sob lock no seu escritor único — o único ponto do sistema onde uma ordem total existe legitimamente.

Esse número é o que torna o replay seguro: o cliente pede o que veio depois do último `seq` que viu, e o `applyFrame` **ignora um `seq` que já aplicou**. Então replay-depois-de-vivo converge exatamente no estado que um cliente que nunca desconectou teria.

Há um **teste para essa propriedade**, não um comentário sobre ela.

## Um run retomado nunca é reportado como rodando

Seja lá o que os frames dele digam. Um transcript que para no meio de um fan-out é um processo que morreu, e um spinner com botão Parar em cima disso ofereceria interromper algo que acabou antes desta janela abrir.

Ele diz, com todas as letras, que o run parou sem terminar — **acima dos cards, não embaixo**, porque quem está lendo um fan-out pela metade precisa saber que acabou **antes** de começar a esperar o resto.

## É um transcript

Deliberadamente **não** é o `runs.db`/`RunCheckpointer` — aquilo é para um run **pausado** aguardando veredito humano, outra coisa com outro ciclo de vida.

## Limitado nos dois eixos

4 MB por run, 50 runs guardados. Um worker em loop numa observação enorme não pode custar o espaço livre da máquina para preservar um transcript que ninguém vai ler até o fim; e um diretório home que cresce sem teto é um chamado de suporte daqui a seis meses.

Escrita é best-effort do começo ao fim: **perder o registro de um run é ruim; perder o run para preservar o registro seria pior.**

Uma linha de cauda meio-escrita é pulada, não fatal — o arquivo é escrito por um run **vivo**, e recusar o transcript inteiro por causa de uma linha truncada jogaria fora os noventa e nove frames que dava para reproduzir.

## Verificação

12 testes novos · backend verde · mypy limpo · ruff limpo · typecheck limpo · frontend **685 passed** · `openapi.json` e `api-schema.ts` regenerados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
