### PR TITLE
fix(catalog): openai/gpt-oss-20b:free was withdrawn and we were still offering it

### DIFF
--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -83,9 +83,9 @@ CATALOG: tuple[CatalogEntry, ...] = (
         notes="the paid variant; the :free one was withdrawn on 2026-08-18",
     ),
     CatalogEntry(
-        "openrouter/openai/gpt-oss-20b:free", "weak", "OpenAI",
-        0.0, 0.0, tools=True, context_k=131,
-        notes="genuinely free and rate-limited; a free tier can be withdrawn without notice",
+        "openrouter/openai/gpt-oss-20b", "weak", "OpenAI",
+        0.03, 0.13, tools=True, context_k=131,
+        notes="the paid variant; the :free one was withdrawn on 2026-08-21",
     ),
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(


### PR DESCRIPTION
A checagem de provedor ao vivo pegou na `main`: `openrouter/openai/gpt-oss-20b:free` não está mais no índice da OpenRouter.

Confirmado **direto no índice**, não acreditando no teste — `openai/gpt-oss-20b:free` sumiu, `openai/gpt-oss-20b` está lá.

Trocado pela variante paga, o mesmo movimento que o `llama-3.3-70b-instruct` recebeu três dias atrás pela mesma razão. Os números reais, lidos do provedor: **US$ 0,03/M** entrada, **US$ 0,13/M** saída, contexto 131k, com ferramentas.

É sugestão de catálogo e **não** degrau de preset, então nada estava roteando para ele automaticamente — quem escolhesse recebia um 404 sem conseguir atribuir, que é a falha que essa checagem existe para achar antes do usuário.

## Verificação

`pytest -m integration tests/test_catalog_is_live.py` — **6 passed** (estava 1 failed). Suíte **3.728 passed** · mypy limpo · ruff limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
