### PR TITLE
fix(release): advice that sent you to the wrong environment, and a race that dropped frames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,9 @@ apps/desktop/src-tauri/target/
 apps/desktop/src-tauri/gen/
 apps/desktop/src-tauri/sidecar-dist/
 apps/desktop/src-tauri/sidecar-build/
+
+# A personal WSL launcher: it hardcodes one machine's checkout path, so it is useful to exactly one
+# person and noise in everyone else's `git status`. What is NOT personal — that `gh` lives on the
+# Windows side and that `shutil.which` looks for `gh`, not `gh.exe` — is in `cut_release.py`'s
+# refusal message, which is where somebody actually hits it.
+_wsl.sh

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -702,16 +702,26 @@ def register_orchestration_api(
             # in parallel and has no order to offer; a consumer that needs one — to replay after a
             # reload without duplicating what it already has — gets it from the single writer.
             nonlocal seq
+            # Numbered, persisted AND enqueued under one lock. The number alone is not enough: the
+            # client's reducer drops a frame whose `seq` is not greater than the last it applied, so
+            # two workers that stamp 4 and 5 and then hand them over in the other order lose card 4
+            # entirely — silently, on the screen, with the run still reporting itself healthy.
+            #
+            # That window always existed and was one statement wide. Persisting the frame put a file
+            # append inside it and made it happen: CI went red on 3.12 with `[1, 2, 3, 5, 4, ...]`.
+            #
+            # The cost is that emits serialise around a buffered local append, which is microseconds
+            # and is already what the numbering does. `call_soon_threadsafe` appends to the loop's
+            # callback queue in call order and the loop runs it FIFO, so calling it here is what
+            # makes the stream's order the order the numbers claim.
             with seq_lock:
                 seq += 1
                 numbered = {**payload, "seq": seq}
-            # To disk BEFORE the queue. A fan-out costs a top-model decompose, N workers and a
-            # synthesis, and until this every frame of that existed only in an SSE stream: close the
-            # app, reload the page or lose the connection, and the answer was gone while the bill
-            # stayed. Written under the same lock that stamped `seq`, so the file is in the order
-            # the numbers claim.
-            runlog.append(read_settings().home, run_id, event, numbered)
-            loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
+                # A fan-out costs a top-model decompose, N workers and a synthesis, and until this
+                # every frame of it existed only in the stream: close the app and the answer was
+                # gone while the bill stayed.
+                runlog.append(read_settings().home, run_id, event, numbered)
+                loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
 
         # Sent before any work, so a Stop control can target this run from the first moment.
         emit("run", {"run_id": run_id, "task": req.task})
@@ -793,11 +803,13 @@ def register_orchestration_api(
 
         def emit(event: str, payload: dict[str, Any]) -> None:
             nonlocal seq
+            # One lock over all three, for the reason spelled out on the hierarchy's emit above: a
+            # frame that arrives out of order is not reordered by the client, it is DROPPED.
             with seq_lock:
                 seq += 1
                 numbered = {**payload, "seq": seq}
-            runlog.append(read_settings().home, run_id, event, numbered)
-            loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
+                runlog.append(read_settings().home, run_id, event, numbered)
+                loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
 
         emit("run", {"run_id": run_id, "task": req.task, "workspace": str(ws)})
 

--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -234,7 +234,14 @@ def preflight() -> None:
         raise Stop(
             "`gh` is not on PATH. This opens the pull request with it, and `main` is protected, "
             "so there is no way to finish without it.\n"
-            "  If you are in WSL and gh is installed on the Windows side, run this from there."
+            "  In WSL with gh installed on the Windows side, put a `gh` SHIM on PATH — this "
+            "looks for `gh`, not `gh.exe`, so inheriting the Windows PATH is not enough:\n"
+            "    mkdir -p /tmp/shims && ln -sfn '/mnt/c/Program Files/GitHub CLI/gh.exe' "
+            "/tmp/shims/gh && export PATH=/tmp/shims:$PATH\n"
+            "  Do NOT just run this from Windows instead. The snapshots stamp the version from "
+            "the INSTALLED package metadata, so they carry whatever THAT interpreter has — and "
+            "if it imports chimera from the source tree, cutting a release would install the "
+            "package there as a side effect of cutting it."
         )
     if subprocess.run(["gh", "auth", "status"], capture_output=True, check=False).returncode != 0:
         raise Stop("`gh` is installed but not logged in. Run `gh auth login` first.")

--- a/tests/test_orchestration_api.py
+++ b/tests/test_orchestration_api.py
@@ -501,3 +501,47 @@ def test_a_worker_says_what_it_wrote_even_when_it_was_thrown_away(
     assert all(p["landed"] is False for p in produced.values())
     # And the frame is published, so the generated client has the shape.
     assert "crew_worker_produced" in client.get("/api/orchestration/schema").json()
+
+
+def test_numbering_persisting_and_enqueuing_happen_under_one_lock() -> None:
+    """The ordering invariant, asserted where it cannot be flaky.
+
+    `test_every_frame_is_numbered_and_the_numbers_only_go_up` is the behavioural version, and it is
+    timing-dependent: the same commit passed on 3.11 and 3.13 and failed on 3.12 with
+    `[1, 2, 3, 5, 4, ...]`. A test that only sometimes sees the defect is a test the defect gets
+    past, so the shape is pinned here as well.
+
+    What went wrong is worth stating plainly, because "out of order" undersells it. The client's
+    reducer drops a frame whose `seq` is not greater than the last it applied — that is what makes
+    replay-after-reload idempotent — so a frame that arrives late is not reordered, it is GONE. Two
+    workers stamping 4 and 5 and handing them over the other way round lose card 4 from the screen,
+    with the run still reporting itself healthy.
+
+    The window always existed and was one statement wide. Persisting the transcript put a file
+    append inside it, which is what made it happen.
+    """
+    import ast
+    import inspect
+
+    from chimera.api import orchestration_api
+
+    source = inspect.getsource(orchestration_api)
+    emits = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.FunctionDef) and node.name == "emit"
+    ]
+    assert len(emits) == 2, f"expected the hierarchy's emit and the crew's, found {len(emits)}"
+
+    for emit in emits:
+        withs = [n for n in emit.body if isinstance(n, ast.With)]
+        assert len(withs) == 1, "the whole body's work belongs to one `with seq_lock:`"
+        inside = ast.dump(ast.Module(body=withs[0].body, type_ignores=[]))
+        assert "AugAssign" in inside and "numbered" in inside, (
+            "the number is stamped inside the lock"
+        )
+        assert "runlog" in inside, "the transcript is written inside the lock"
+        assert "call_soon_threadsafe" in inside, (
+            "the frame is handed to the stream inside the lock — outside it, two workers can stamp "
+            "4 and 5 and enqueue them the other way round, and the client DROPS 4"
+        )


### PR DESCRIPTION
## 1 · A recusa mandava para o ambiente errado

Cortar o rc11 do WSL bateu na checagem de `gh` do `preflight`, e o conselho dela era *"rode isto do Windows"*.

Essa é **exatamente** a coisa que não se pode fazer aqui: os três snapshots carimbam a versão vinda dos **metadados do pacote instalado**, e o interpretador do Windows importa o chimera direto da árvore de fontes como `0.0.0+source`.

Seguir o conselho daria uma de duas: recusa dois passos adiante, ou — porque o `regenerate_snapshots` chama `refresh_install()` justamente para consertar isso — **instalar o pacote num segundo ambiente como efeito colateral de cortar uma release**.

A recusa agora dá o comando que funciona: um **shim** de `gh`, porque o `shutil.which` procura `gh` e a instalação do Windows é `gh.exe`. Copiável, e verificado rodando o script com o `gh` fora do PATH.

`_wsl.sh` vai para o gitignore: é o lançador de uma máquina só — tem um caminho de checkout fixo — então serve a exatamente uma pessoa e era ruído no `git status` de todo mundo.

## 2 · E o CI achou uma corrida que eu tinha aberto

O 3.12 falhou enquanto o 3.11 e o 3.13 passaram o mesmo commit: `[1, 2, 3, 5, 4, ...]`.

**"Fora de ordem" subestima o problema.** O reducer do cliente **ignora** um frame cujo `seq` não é maior que o último aplicado — é justamente isso que torna o replay-após-reload idempotente. Então um frame que chega atrasado não é reordenado, ele **some**. Dois workers carimbando 4 e 5 e entregando na ordem trocada perdem um card da tela, com o run se reportando saudável.

A janela sempre existiu e tinha uma instrução de largura. Eu pus um append de arquivo dentro dela — e depois escrevi um comentário afirmando que o append estava sob o lock que carimbava o `seq`. **Não estava.**

Numerar, persistir e enfileirar agora acontecem sob **um** lock nos dois emissores.

### O teste que só às vezes via

O comportamental fica, e um estrutural entra junto: uma checagem que só às vezes enxerga o defeito é uma checagem por onde o defeito passa — e essa passou em dois de três interpretadores. Rodado contra o código re-quebrado, e ele **nomeia a consequência**, não a forma.

## Verificação

Backend **3.729 passed** · mypy limpo · ruff limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
