### PR TITLE
fix: três defeitos que o teste do rc14 encontrou

### DIFF
--- a/apps/desktop/src/lib/orchestration-replay.test.ts
+++ b/apps/desktop/src/lib/orchestration-replay.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import type { OrchFrame } from "@/lib/api";
+import { applyFrame, EMPTY_RUN, type OrchestrationState } from "@/lib/orchestration-run";
+
+/**
+ * A replayed run has to fold into the same state a live one does.
+ *
+ * The reducer was tested with live-shaped frames. The endpoint was tested for its `since` filter.
+ * Nobody tested the join, and the join was where the two disagreed: the transcript is written flat
+ * and keyed `event`, the stream delivers `{seq, kind, task_id, text, data}`, and the raw line went
+ * straight into a reducer that switches on `kind`.
+ *
+ * On screen that produced a run with a stepper — which draws its labels unconditionally, so it
+ * looked alive — and **no worker cards and no answer**. It had been that way since the transcripts
+ * started being written, invisible because until the run list was wired the only way to reach a
+ * replay was to reload the page mid-run.
+ *
+ * So this test starts from the RAW LINE as `runlog` writes it, applies the same normalisation the
+ * API now performs, and asserts the fold. Starting from an already-correct frame is what the
+ * existing suite did, and it is why nothing failed.
+ */
+
+/** One line of `frames.jsonl`, exactly as `runlog.append` writes it: flat, keyed `event`. */
+type PersistedLine = Record<string, unknown> & { event: string };
+
+/** The normalisation `GET /api/orchestration/runs/{id}` performs, mirrored here.
+ *
+ * Mirrored rather than imported because the two live on opposite sides of an HTTP boundary — the
+ * point of the test is that the shapes agree, and a shared helper would make them agree by
+ * construction while production still disagreed.
+ */
+function asStreamFrame(line: PersistedLine): OrchFrame {
+  const { event, seq, task_id: taskId, text, ...data } = line;
+  return {
+    seq: Number(seq ?? 0),
+    kind: String(event),
+    task_id: String(taskId ?? ""),
+    text: String(text ?? ""),
+    data,
+  };
+}
+
+/** What a real two-worker fan-out leaves on disk. Field for field from a live rc14 transcript. */
+const ON_DISK: PersistedLine[] = [
+  { event: "run", seq: 1, run_id: "779a0f", task: "compare the notes" },
+  { event: "classified", seq: 2, task_id: "", text: "parallel_read", shape: "parallel_read", sources: 2 },
+  {
+    event: "decomposed",
+    seq: 3,
+    task_id: "",
+    text: "2 subtasks",
+    specs: [
+      { task_id: "sub-1", objective: "read index.html" },
+      { task_id: "sub-2", objective: "read style.css" },
+    ],
+  },
+  { event: "worker_started", seq: 4, task_id: "sub-1", text: "read index.html", tier: "mid" },
+  { event: "worker_started", seq: 5, task_id: "sub-2", text: "read style.css", tier: "mid" },
+  { event: "worker_verified", seq: 6, task_id: "sub-1", text: "verified (accepted)", stage: "accepted", tokens: 11369 },
+  { event: "worker_verified", seq: 7, task_id: "sub-2", text: "verified (accepted)", stage: "accepted", tokens: 7384 },
+  { event: "synthesizing", seq: 8, task_id: "", text: "2 summaries", envelopes: 2 },
+  { event: "done", seq: 9, task_id: "", text: "synthesised", answer: "Both files agree.", shape: "parallel_read" },
+];
+
+function fold(frames: OrchFrame[]): OrchestrationState {
+  return frames.reduce(applyFrame, EMPTY_RUN);
+}
+
+describe("replaying a transcript", () => {
+  const state = fold(ON_DISK.map(asStreamFrame));
+
+  it("rebuilds the workers the run actually had", () => {
+    // The assertion that was false in production for three release candidates.
+    expect(state.workers.map((w) => w.taskId)).toEqual(["sub-1", "sub-2"]);
+  });
+
+  it("rebuilds the answer", () => {
+    expect(state.answer).toBe("Both files agree.");
+  });
+
+  it("knows the run is over", () => {
+    expect(state.stage).toBe("done");
+  });
+
+  it("would build nothing at all from the raw line", () => {
+    // The defect itself, pinned. Without this the test above passes for a reducer that quietly
+    // accepts either shape, and the normalisation could be deleted with nothing going red.
+    const raw = ON_DISK as unknown as OrchFrame[];
+    const wrong = fold(raw);
+
+    // Against the empty state rather than against literals: the claim is that nine frames changed
+    // NOTHING, which is stronger and does not go stale when a default does.
+    expect(wrong.workers).toEqual(EMPTY_RUN.workers);
+    expect(wrong.answer).toBe(EMPTY_RUN.answer);
+    expect(wrong.stage).toBe(EMPTY_RUN.stage);
+  });
+});

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -422,6 +422,47 @@ class OrchRunsOut(BaseModel):
     runs: list[OrchRunSummaryOut]  # newest first
 
 
+#: What the SSE client lifts out of a frame's payload and onto the frame itself. Everything else
+#: rides under ``data``. Kept as one constant because the split has to match ``api.ts`` exactly.
+_FRAME_TOP_LEVEL = ("seq", "task_id", "text")
+
+
+def _as_stream_frame(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """One persisted line in the shape the live stream delivers, or None if it is not a frame.
+
+    The transcript is written as ``{"event": event, **payload}`` — flat, and keyed ``event``. The
+    stream delivers ``{seq, kind, task_id, text, data}``, because the client lifts three fields out
+    and nests the rest. The desktop's reducer switches on ``kind``, so handing back the raw line
+    gave it ``kind is undefined`` and it matched nothing: a replayed run drew its stepper, which
+    renders unconditionally, and **no worker cards and no answer**.
+
+    That made the whole persistence feature a shell. Transcripts were written from rc11 onward, and
+    reading one back produced an empty run — which nobody saw, because until the run list was wired
+    the only way to reach a replay was to reload the page mid-run.
+
+    Normalised here rather than on disk. The file is also a debugging artefact and every transcript
+    already written would be stranded by a format change; converting on the way out costs nothing
+    and makes the contract the one the client was always promised — *this endpoint returns what the
+    stream returns*.
+
+    A line with no ``event`` is dropped rather than given an empty ``kind``. The reducer would
+    accept such a frame and ignore it, which turns a damaged transcript into a silently short one.
+    """
+    event = raw.get("event")
+    if not event:
+        return None
+    data = {k: v for k, v in raw.items() if k != "event" and k not in _FRAME_TOP_LEVEL}
+    return {
+        "seq": int(raw.get("seq") or 0),
+        "kind": str(event),
+        # Coerced rather than passed through: an older transcript may not carry these at all, and a
+        # replay that raised on one frame would lose the run it was meant to preserve.
+        "task_id": str(raw.get("task_id") or ""),
+        "text": str(raw.get("text") or ""),
+        "data": data,
+    }
+
+
 class OrchFramesOut(BaseModel):
     """A run's transcript from ``since`` onward, in the order its single writer stamped."""
 
@@ -953,8 +994,9 @@ def register_orchestration_api(
         `seq` it has already applied — which is what makes replay-then-live and live-only converge
         on one state instead of two.
         """
-        frames = runlog.frames(Path(read_settings().home), run_id, since=since)
-        highest = max((int(f.get("seq") or 0) for f in frames), default=since)
+        raw = runlog.frames(Path(read_settings().home), run_id, since=since)
+        frames = [f for f in (_as_stream_frame(line) for line in raw) if f is not None]
+        highest = max((int(f["seq"]) for f in frames), default=since)
         return {"run_id": run_id, "frames": frames, "seq": highest}
 
     @app.get(

--- a/chimera/core/worktree.py
+++ b/chimera/core/worktree.py
@@ -29,8 +29,33 @@ T = TypeVar("T")
 
 
 def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run one git command and read its output as UTF-8.
+
+    The encoding is named, and that is the whole point of this function existing. ``text=True``
+    alone decodes with the machine's locale — cp1252 on a default Windows install, where the bytes
+    ``0x81 0x8D 0x8F 0x90 0x9D`` are undefined. Those bytes are ordinary inside UTF-8: they appear
+    in emoji, in most CJK, and in plenty of prose.
+
+    The failure was worse than an error. ``UnicodeDecodeError`` is raised on the reader thread, so
+    the call returns a *successful* process whose ``stdout`` is ``None`` — and ``GET /api/git/diff``
+    fed that ``None`` into a response field typed ``str`` and answered **500, in plain text**, so a
+    client calling ``.json()`` on the body broke a second time. Reproducible against Chimera's own
+    installation directory, whose JavaScript bundles contain those bytes; ``git/status`` survived
+    the same repository only because status prints file names and diff prints content.
+
+    ``errors="replace"`` rather than strict: a diff viewer that refuses to show a file because one
+    byte in it is not valid UTF-8 helps nobody. Git writes UTF-8 on every platform, so this is the
+    right codec rather than a guess — and every git call in the app goes through here, so naming it
+    once is also the only way to be sure it is named at all.
+    """
     return subprocess.run(
-        ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=60
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
     )
 
 

--- a/chimera/features.py
+++ b/chimera/features.py
@@ -128,13 +128,41 @@ def _bin_present(binary: str | None) -> bool:
     return binary is None or shutil.which(binary) is not None
 
 
+def _is_configured(settings: Settings, var: str) -> bool:
+    """Whether the variable a feature names is actually set, by the name a user would type.
+
+    Two namespaces answer to that question and this used to consult only one. ``credentials()``
+    holds thirteen unprefixed provider slots — ``OPENAI_API_KEY`` and friends — while four features
+    declare ``CHIMERA_*`` names: IMAP host, SMTP host, the calendar URL, the OpenAI key pool. A
+    ``dict.get`` for a key that cannot be in that dict returns ``None`` every single time, so those
+    four reported ``has_key=False`` no matter what was configured.
+
+    What that produced is worse than a missing feature. With ``CHIMERA_IMAP_HOST`` exported and
+    ``Settings`` reading it correctly, ``chimera features`` printed *"set CHIMERA_IMAP_HOST"* in
+    yellow while ``default_registry()`` in the same process registered ``read_email``. **The tool
+    worked and the report said it could not**, which sends someone to debug configuration that was
+    already right.
+
+    The second namespace is read from the model's own field aliases rather than from another
+    hand-written table. A second hand-written table is what drifted here; a third would drift too,
+    and this way a field added tomorrow answers without anyone remembering to add it.
+    """
+    creds = settings.credentials()
+    if var in creds:
+        return bool(creds[var])
+    for name, field in type(settings).model_fields.items():
+        if field.validation_alias == var:
+            return bool(getattr(settings, name, None))
+    return False
+
+
 def feature_status(settings: Settings | None = None) -> list[FeatureStatus]:
     """Resolve each catalog feature against the current credentials, deps, and system binaries."""
-    creds = (settings or get_settings()).credentials()
+    resolved = settings or get_settings()
     return [
         FeatureStatus(
             feature=feature,
-            has_key=any(creds.get(var) for var in feature.env_any),
+            has_key=any(_is_configured(resolved, var) for var in feature.env_any),
             has_dep=_dep_present(feature.dep),
             has_bin=_bin_present(feature.bin),
         )

--- a/tests/test_feature_report_sees_chimera_vars.py
+++ b/tests/test_feature_report_sees_chimera_vars.py
@@ -1,0 +1,91 @@
+"""`chimera features` told people to set variables they had already set.
+
+`feature_status` asked `settings.credentials()` whether a variable was configured. That dict holds
+thirteen slots, every one of them an unprefixed provider key — `OPENAI_API_KEY`, `TAVILY_API_KEY`,
+and so on. Four features declare `CHIMERA_*` names instead: `CHIMERA_IMAP_HOST`,
+`CHIMERA_SMTP_HOST`, `CHIMERA_CALENDAR_ICS_URL`, `CHIMERA_OPENAI_KEYS`. A `dict.get` for a key that
+cannot be in the dict is `None` every time.
+
+Measured: with `CHIMERA_IMAP_HOST` exported and `Settings` reading it correctly, the report says
+`has_key=False` and prints *"set CHIMERA_IMAP_HOST"* in yellow — while `default_registry()` in the
+same process registers `read_email`. **The tool works and the report says it cannot.** That is worse
+than a missing feature: it sends someone to debug configuration that was already right.
+
+The fix resolves a variable name against the model's own field aliases rather than against a second
+hand-written table, because a second hand-written table is exactly what drifted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.config import Settings
+from chimera.features import CATALOG, feature_status
+
+
+def _status(settings: Settings, name: str):
+    return next(s for s in feature_status(settings) if s.feature.name == name)
+
+
+@pytest.mark.parametrize(
+    ("feature", "env", "value"),
+    [
+        ("read_email", "CHIMERA_IMAP_HOST", "imap.example.com"),
+        ("email", "CHIMERA_SMTP_HOST", "smtp.example.com"),
+        ("calendar", "CHIMERA_CALENDAR_ICS_URL", "https://example.com/cal.ics"),
+    ],
+)
+def test_a_chimera_variable_that_is_set_is_reported_as_set(
+    monkeypatch: pytest.MonkeyPatch, feature: str, env: str, value: str
+) -> None:
+    monkeypatch.setenv(env, value)
+    settings = Settings()
+
+    assert _status(settings, feature).has_key is True
+
+
+def test_it_is_still_false_when_nothing_is_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The other direction, and the one that keeps the fix from being "always true": a report that
+    # said yes to everything would pass every assertion above and be useless.
+    for var in ("CHIMERA_IMAP_HOST", "CHIMERA_SMTP_HOST", "CHIMERA_CALENDAR_ICS_URL"):
+        monkeypatch.delenv(var, raising=False)
+    settings = Settings()
+
+    assert _status(settings, "read_email").has_key is False
+    assert _status(settings, "email").has_key is False
+    assert _status(settings, "calendar").has_key is False
+
+
+def test_the_unprefixed_provider_keys_still_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The path that was never broken. Without this, a fix that only looked at model fields would
+    # break the twelve features that read a plain provider key.
+    monkeypatch.setenv("TAVILY_API_KEY", "sk-whatever")
+    settings = Settings()
+
+    assert _status(settings, "web_search").has_key is True
+
+
+def test_every_name_a_feature_asks_for_is_a_name_something_can_answer() -> None:
+    """The class, not the four instances.
+
+    A feature naming a variable that no lookup can resolve is silently always-false, which is the
+    defect and not a spelling mistake. Checked against both sources at once so a fifth feature
+    added with a `CHIMERA_*` name — or with a typo in a provider key — fails here rather than in a
+    user's terminal.
+    """
+    settings = Settings()
+    known = set(settings.credentials())
+    aliases = {
+        field.validation_alias
+        for field in type(settings).model_fields.values()
+        if isinstance(field.validation_alias, str)
+    }
+
+    unanswerable = [
+        (feature.name, var)
+        for feature in CATALOG
+        for var in feature.env_any
+        if var not in known and var not in aliases
+    ]
+
+    assert unanswerable == []

--- a/tests/test_git_reads_utf8.py
+++ b/tests/test_git_reads_utf8.py
@@ -1,0 +1,95 @@
+"""Git output is UTF-8. Decoding it with the machine's locale loses whole repositories.
+
+`_git` ran `subprocess.run(..., text=True)` with no `encoding=`, so Python decoded git's stdout
+with the locale codec. On Windows that is cp1252, where the bytes `0x81 0x8D 0x8F 0x90 0x9D` are
+undefined — and those bytes appear in the UTF-8 encoding of an emoji, of most CJK, and of a great
+deal of ordinary content.
+
+What happens then is worse than an error. The `UnicodeDecodeError` is raised on the reader thread,
+`CompletedProcess.stdout` comes back as `None`, and the caller sees a successful process with no
+output. `GET /api/git/diff` then fed `None` into a response model whose field is `str` and returned
+**500 with a plain-text body**, so a client calling `.json()` on it broke a second time.
+
+Measured on rc14: reproducible 7/7 against the app's own installation directory, whose JavaScript
+bundles contain those bytes. A two-line repository whose only change is adding an emoji reproduces
+it, while `git/status` on that same repository answers 200 — because status prints file names and
+diff prints content.
+
+`errors="replace"` rather than strict: a diff viewer that refuses to show a file because one byte
+in it is not valid UTF-8 is less useful than one that shows the byte as a replacement character.
+Git's own output is UTF-8 on every platform, so this is the correct codec, not a guess.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from chimera.core.worktree import _git, is_git_repo
+
+
+def _repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    (root / "a.txt").write_text("linha um\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=root, check=True)
+    return root
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [
+        ("emoji", "linha um\numa cobra: \U0001F40D\n"),
+        ("cjk", "linha um\n你好世界\n"),
+        # Inside cp1252, so this one passed even before the fix. Kept so a regression that
+        # narrowed the codec instead of widening it would still be caught.
+        ("acentos", "linha um\ncoração, maçã, único\n"),
+    ],
+)
+def test_a_diff_survives_content_the_locale_cannot_decode(
+    tmp_path: Path, label: str, content: str
+) -> None:
+    root = _repo(tmp_path)
+    (root / "a.txt").write_text(content, encoding="utf-8")
+
+    result = _git(["diff"], root)
+
+    assert result.returncode == 0
+    assert result.stdout is not None, f"{label}: stdout came back None — the decode threw"
+    assert "a.txt" in result.stdout
+
+
+def test_the_text_itself_arrives_not_just_a_non_empty_string(tmp_path: Path) -> None:
+    # `errors="replace"` must not be reached for content that IS valid UTF-8. Without this, a fix
+    # that decoded as latin-1 would pass every assertion above while mangling every accent.
+    root = _repo(tmp_path)
+    (root / "a.txt").write_text("linha um\numa cobra: \U0001F40D\n", encoding="utf-8")
+
+    out = _git(["diff"], root).stdout
+
+    assert "\U0001F40D" in out
+
+
+def test_file_names_survive_too(tmp_path: Path) -> None:
+    # `git status --porcelain` prints paths, and a path is as free to hold an emoji as a line is.
+    root = _repo(tmp_path)
+    (root / "relatório \U0001F40D.txt").write_text("x\n", encoding="utf-8")
+
+    out = _git(["status", "--porcelain"], root).stdout
+
+    assert out is not None
+    assert "relat" in out
+
+
+def test_a_repo_check_still_works(tmp_path: Path) -> None:
+    # The cheapest caller of `_git`, and the one everything else is gated on. Named separately
+    # because a change to the wrapper that broke this would look like "not a git repository"
+    # everywhere rather than like an error.
+    assert is_git_repo(_repo(tmp_path)) is True
+    assert is_git_repo(tmp_path / "nowhere") is False

--- a/tests/test_replay_matches_the_stream.py
+++ b/tests/test_replay_matches_the_stream.py
@@ -1,0 +1,168 @@
+"""A replayed frame has to be the same shape as a streamed one, or replay renders nothing.
+
+The design was written down in the desktop's own `resume.ts`: *the frames go through the SAME
+reducer the live stream feeds*. They did not.
+
+The SSE client builds each frame as `{seq, kind, task_id, text, data}` — `kind` is the event name,
+`data` is everything else. The transcript on disk is written as `{"event": event, **payload}`:
+`event` instead of `kind`, and the payload flattened rather than nested. `GET /runs/{id}` handed
+those raw dicts straight back, so every replayed frame reached a reducer that switches on
+`frame.kind` with `frame.kind === undefined`.
+
+What that looked like on screen: a run replayed nine frames and drew a stepper — which renders its
+labels unconditionally — and **zero worker cards, and no answer**. Measured on rc14 against a real
+transcript from the day before.
+
+So the whole persistence feature has been a shell since rc11: the transcripts were written, the
+list was there once it was wired, and reading one back produced an empty run.
+
+Normalised at the API boundary rather than on disk. Transcripts already written keep working — they
+are also a debugging artefact and rewriting the format would strand every one of them — and the
+contract becomes the one the client was promised: this endpoint returns what the stream returns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sse_starlette")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from chimera.config import Settings  # noqa: E402
+from chimera.core.agent import Agent, AgentConfig  # noqa: E402
+from chimera.interface import ChatSession  # noqa: E402
+from chimera.orchestration import runlog  # noqa: E402
+from chimera.tools.registry import ToolRegistry  # noqa: E402
+
+#: The fields the SSE client lifts OUT of the payload and onto the frame itself. Everything else
+#: belongs under `data` — the same split `api.ts` performs, kept in one place so the two cannot
+#: drift again without a test noticing.
+TOP_LEVEL = {"seq", "kind", "task_id", "text"}
+
+
+def _client(tmp_path: Path) -> tuple[TestClient, Path]:
+    from chimera.api import build_api_app
+
+    ws = tmp_path / "ws"
+    ws.mkdir(exist_ok=True)
+    home = tmp_path / "home"
+    settings = Settings(CHIMERA_HOME=str(home))
+    agent = Agent(None, ToolRegistry(), AgentConfig())
+    app = build_api_app(lambda: ChatSession(agent), workspace=ws, settings=settings)
+    return TestClient(app), home
+
+
+def _a_real_run(home: Path) -> str:
+    """The exact frames a two-worker fan-out writes, with the fields it really carries."""
+    run_id = "abc123"
+    runlog.append(home, run_id, "run", {"seq": 1, "run_id": run_id, "task": "compare A and B"})
+    runlog.append(home, run_id, "classified", {"seq": 2, "task_id": "", "text": "parallel_read",
+                                               "shape": "parallel_read", "sources": 2})
+    runlog.append(home, run_id, "worker_started", {"seq": 3, "task_id": "sub-1", "text": "read A",
+                                                  "tier": "mid"})
+    runlog.append(home, run_id, "worker_verified", {"seq": 4, "task_id": "sub-1",
+                                                   "text": "verified", "tokens": 11369})
+    runlog.append(home, run_id, "done", {"seq": 5, "task_id": "", "text": "synthesised",
+                                        "answer": "A and B differ in one place."})
+    return run_id
+
+
+def test_every_replayed_frame_carries_kind(tmp_path: Path) -> None:
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+
+    assert len(frames) == 5
+    assert [f["kind"] for f in frames] == [
+        "run", "classified", "worker_started", "worker_verified", "done"
+    ]
+
+
+def test_the_routing_key_survives_the_round_trip(tmp_path: Path) -> None:
+    # `task_id` is what puts a frame on a worker card. Losing it is losing the cards.
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+    started = next(f for f in frames if f["kind"] == "worker_started")
+
+    assert started["task_id"] == "sub-1"
+    assert started["text"] == "read A"
+
+
+def test_the_rest_of_the_payload_arrives_under_data(tmp_path: Path) -> None:
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+    done = next(f for f in frames if f["kind"] == "done")
+
+    assert done["data"]["answer"] == "A and B differ in one place."
+    # And NOT left at the top level, where the reducer does not look for it.
+    assert "answer" not in done
+
+
+def test_a_replayed_frame_has_exactly_the_streamed_shape(tmp_path: Path) -> None:
+    # The strongest form of the claim, and the one that keeps the two from drifting apart again:
+    # a frame off this endpoint has the same keys as a frame off the stream, no more and no fewer.
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+
+    for frame in frames:
+        assert set(frame) == TOP_LEVEL | {"data"}, f"{frame['kind']} has the wrong keys"
+        assert isinstance(frame["data"], dict)
+        assert isinstance(frame["seq"], int)
+
+
+def test_since_still_skips_what_the_client_already_has(tmp_path: Path) -> None:
+    # Normalising must not disturb the property that makes a second replay cheap.
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    body = client.get(f"/api/orchestration/runs/{run_id}?since=3").json()
+
+    assert [f["seq"] for f in body["frames"]] == [4, 5]
+    assert body["seq"] == 5
+
+
+def test_a_frame_that_never_had_a_task_id_gets_an_empty_one(tmp_path: Path) -> None:
+    # Real, not hypothetical: the `run` frame carries `run_id` and `task` and no `task_id` at all,
+    # and so do `classified`, `synthesizing` and `done` in some paths. Handing the reducer a frame
+    # missing the key it routes on would be a different way of losing the same cards.
+    #
+    # A missing `seq` is NOT tested, because no path can produce one: both callers of
+    # `runlog.append` stamp it before writing. A test for a state the code cannot reach describes
+    # nothing and would have to be maintained anyway.
+    client, home = _client(tmp_path)
+    run_id = _a_real_run(home)
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+    first = frames[0]
+
+    assert first["kind"] == "run"
+    assert first["task_id"] == ""
+    assert first["data"]["task"] == "compare A and B"
+
+
+def test_a_line_with_no_event_at_all_is_dropped_rather_than_renamed(tmp_path: Path) -> None:
+    # Garbage in the file should not become a frame with an empty `kind`, which the reducer would
+    # accept and silently ignore. Dropping it is the honest reading of "this is not a frame".
+    run_id = "damaged"
+    client, home = _client(tmp_path)
+    _a_real_run(home)  # a healthy run, so the assertion is not about an empty file
+    directory = runlog.run_dir(home, run_id)
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "frames.jsonl").write_text(
+        '{"seq": 1, "note": "not a frame"}\n{"event": "done", "seq": 2}\n', encoding="utf-8"
+    )
+
+    frames = client.get(f"/api/orchestration/runs/{run_id}?since=0").json()["frames"]
+
+    assert [f["kind"] for f in frames] == ["done"]


### PR DESCRIPTION
Encontrados usando o rc14 — a UI dirigida no navegador, a API direto, e duas varreduras mecânicas em paralelo. Cada achado foi **reproduzido à mão** antes de ser aceito.

## 1 · Reexibir uma corrida desenhava um stepper e mais nada
`chimera/api/orchestration_api.py`

O desenho está escrito no próprio `resume.ts`: *"os quadros passam pelo MESMO redutor que o stream vivo alimenta"*. Não passavam.

O cliente SSE monta `{seq, kind, task_id, text, data}`. O disco guarda `{"event": event, **payload}` — chaveado `event`, e achatado. A rota devolvia a linha crua, então todo quadro reexibido chegava num redutor que decide por `frame.kind` com `frame.kind === undefined`.

**Medido no rc14 contra um transcript real da véspera:** nove quadros reexibidos, um stepper desenhado — ele renderiza os rótulos incondicionalmente, então parecia vivo — e **zero cartões de trabalhador, nenhuma resposta**.

Ou seja: a persistência é uma casca desde que os transcripts começaram a ser gravados. Ninguém viu porque, até a lista de corridas ser ligada na release passada, o único jeito de chegar num replay era recarregar a página no meio de uma corrida. **Ligar a lista foi o que revelou** — a primeira coisa que fiz com o histórico novo foi abrir uma corrida, e ela abriu vazia.

Normalizado na fronteira da API, não em disco: todo transcript já escrito continua funcionando.

**Por que nada pegou.** O redutor era testado com a forma viva. A rota era testada pelo filtro `since`. Ninguém testava a **junção**, que é onde as duas discordavam.

## 2 · `GET /api/git/diff` respondia 500, de forma reprodutível
`chimera/core/worktree.py`

`subprocess.run(text=True)` sem `encoding=` decodifica com a locale da máquina — **cp1252** num Windows padrão, onde `0x81 0x8D 0x8F 0x90 0x9D` são indefinidos. Esses bytes são banais dentro de UTF-8: aparecem em emoji, em quase todo CJK, em prosa comum.

O modo de falha é pior que um erro: o `UnicodeDecodeError` sobe na thread leitora, o processo volta **com sucesso** e `stdout = None`, e a rota enfia isso num campo tipado `str` → **500 em texto puro**, então um cliente que faça `.json()` quebra uma segunda vez.

Reproduzido contra o diretório de instalação do próprio Chimera, cujos bundles JS contêm esses bytes, e com um repo de duas linhas cuja única mudança é um emoji. O `git/status` sobrevive ao mesmo repo porque status imprime **nomes** e diff imprime **conteúdo** — que é exatamente por que isso se escondeu.

O teste discrimina **no Windows**, onde a locale é cp1252, e o CI roda a suíte lá. Sob a locale UTF-8 do WSL ele passa dos dois jeitos — e dizer isso é o ponto: um teste que não pode falhar na máquina em que você o lê não é evidência ali.

## 3 · `chimera features` mandava setar variáveis já setadas
`chimera/features.py`

`feature_status` perguntava ao `credentials()` se uma variável estava configurada. Esse dicionário tem treze chaves, **todas sem prefixo**. Quatro funcionalidades declaram nomes `CHIMERA_*` — IMAP, SMTP, calendário, pool da OpenAI — e `dict.get` de uma chave que não pode estar no dicionário é `None` sempre.

**Medido:** com `CHIMERA_IMAP_HOST` exportado e o `Settings` lendo como `'imap.exemplo.com'`, o relatório diz `has_key=False` e imprime *"set CHIMERA_IMAP_HOST"*. A ferramenta funciona. O relatório diz que não — e manda a pessoa depurar uma configuração que já estava certa.

Resolvido contra os aliases do próprio modelo, não contra uma segunda tabela escrita à mão — porque foi uma segunda tabela que divergiu.

## Verificação
**3761** testes de backend · **714** do desktop · mypy limpo em 317 arquivos · ruff limpo · sem drift de schema.

Cada conserto foi quebrado de propósito antes de aceito. Um teste meu foi **substituído** por postular um estado impossível (quadro sem `seq`: os dois chamadores carimbam antes de escrever).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
