### PR TITLE
fix(desktop): two defects in the role picker, found by using it

### DIFF
--- a/apps/desktop/src/components/code/ModelPicker.tsx
+++ b/apps/desktop/src/components/code/ModelPicker.tsx
@@ -48,11 +48,21 @@ export function ModelPicker({
   value,
   onChange,
   disabled,
+  fallback: fallbackOverride,
+  label,
 }: {
   /** The chosen slug, or "" for whatever the install's default is. */
   value: string;
   onChange: (slug: string) => void;
   disabled?: boolean;
+  /** What "no choice" resolves to HERE, when that is not the install default.
+   *
+   *  Beside a role, it is not: `Explorar` with nothing picked runs on the profile's weak tier, not
+   *  on the install default. Without this the row printed both — the install default in the chip
+   *  and the role's real model beside it — and the wrong one was the prominent one. */
+  fallback?: string;
+  /** Replaces the "MODEL" caption. A row that already says `Explorar` does not need it. */
+  label?: string | null;
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
@@ -73,7 +83,7 @@ export function ModelPicker({
   // $0.25 rather than GPT-5.5 at $5. A control that hides what it is set to is a control you have to
   // click to read.
   const doctor = useQuery({ queryKey: ["doctor"], queryFn: getDoctor });
-  const fallback = doctor.data?.default_model ?? "";
+  const fallback = fallbackOverride ?? doctor.data?.default_model ?? "";
 
   // The chosen slug's own tail rather than its label, because the label is a sentence ("DeepSeek:
   // DeepSeek V3.1") and this is a chip in an already crowded row. Same for the default's name: the
@@ -87,9 +97,11 @@ export function ModelPicker({
   return (
     <>
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-xs uppercase tracking-wider text-muted-foreground">
-          {t("model.pick.label")}
-        </span>
+        {label === null ? null : (
+          <span className="text-xs uppercase tracking-wider text-muted-foreground">
+            {label ?? t("model.pick.label")}
+          </span>
+        )}
         <button
           type="button"
           disabled={disabled}

--- a/apps/desktop/src/components/code/RolesBar.tsx
+++ b/apps/desktop/src/components/code/RolesBar.tsx
@@ -70,6 +70,8 @@ export function RolesBar({
   compact,
   override,
   onOverride,
+  oneModel,
+  onOneModel,
 }: {
   profile: Profile;
   onProfile: (p: Profile) => void;
@@ -79,6 +81,9 @@ export function RolesBar({
   /** Per-role model choice. Omit both and the profile's tiers are shown read-only. */
   override?: RoleOverride;
   onOverride?: (o: RoleOverride) => void;
+  /** "One model does all four." Held by the caller, not derived — see the note by `single`. */
+  oneModel?: boolean;
+  onOneModel?: (v: boolean) => void;
 }) {
   const t = useT();
   const roles = useQuery({
@@ -89,11 +94,15 @@ export function RolesBar({
   // Narrowed once. Repeating `override && onOverride` at each use site made TS decide the second
   // half was always true and error on it — and read worse than the thing it was guarding.
   const pick = override && onOverride ? { value: override, set: onOverride } : null;
-  // "One model for everything" is a STATE, not a mode: it is true exactly when all four roles carry
-  // the same non-empty slug. A separate flag would let the checkbox and the rows disagree, and the
-  // disagreement would stay invisible until a run came back on a model nobody picked.
-  const single =
-    !!override && !!override.explore && ROLES.every((r) => override[r] === override.explore);
+  // A flag, and the first version's reasoning against one was wrong. Deriving "one model" from the
+  // four values cannot work, because THREE intents exist and two of them share the same values:
+  // "use the profile's tiers" and "one model, not chosen yet" are both four empty strings. Ticking
+  // the box before picking anything therefore did nothing at all — it wrote four blanks and the
+  // derivation read them back as "not single", so the box would not even stay ticked.
+  //
+  // What made a flag unsafe was drift between it and the rows. That is closed by construction here
+  // rather than by argument: while it is on, the only control rendered writes all four at once.
+  const single = !!oneModel;
 
   // Resolved server-side: the tiers honour the user's cost mode and per-tier settings, and a second
   // copy of that resolution here would display a model the run does not actually use.
@@ -136,22 +145,19 @@ export function RolesBar({
     <div key={role} className="flex items-baseline gap-2">
       <span className="w-20 shrink-0 text-muted-foreground">{t(ROLE_KEY[role])}</span>
       {pick ? (
-        <>
-          <ModelPicker
-            value={pick.value[role]}
-            onChange={(slug) => pick.set({ ...pick.value, [role]: slug })}
-            disabled={disabled}
-          />
-          {/* What the profile would give you, kept visible beside the picker rather than replaced by
-              it. The first version swapped one for the other, and the effect was that turning the
-              control ON hid the very information it exists to change: four empty fields where four
-              model names had been. A choice you cannot compare to the default is not a choice. */}
-          {pick.value[role] ? null : (
-            <span className="truncate font-mono text-foreground/60">
-              {resolved[role] ?? t("code.roles.default")}
-            </span>
-          )}
-        </>
+        // The role's OWN resolved model as the chip's "no choice" reading, and no caption — the row
+        // already says which role this is. Two earlier shapes were wrong in opposite directions: the
+        // first replaced the resolved slug with an empty field, hiding the information the control
+        // exists to change; the second showed both, and the chip's half was the INSTALL default, so
+        // `Explorar` read "padrão · deepseek-chat-v3.1" beside the mistral it actually runs on. Two
+        // model names on one row, and the prominent one wrong for that role.
+        <ModelPicker
+          value={pick.value[role]}
+          onChange={(slug) => pick.set({ ...pick.value, [role]: slug })}
+          fallback={resolved[role] ?? ""}
+          label={null}
+          disabled={disabled}
+        />
       ) : (
         <span className="truncate font-mono text-foreground/80">
           {resolved[role] ?? t("code.roles.default")}
@@ -175,6 +181,7 @@ export function RolesBar({
               onChange={(slug) =>
                 pick.set(Object.fromEntries(ROLES.map((r) => [r, slug])) as RoleOverride)
               }
+              label={null}
               disabled={disabled}
             />
           </div>
@@ -193,15 +200,19 @@ export function RolesBar({
               type="checkbox"
               checked={single}
               disabled={disabled}
-              onChange={(e) =>
+              onChange={(e) => {
+                onOneModel?.(e.target.checked);
+                // Collapse to whatever was already picked, so ticking the box never silently
+                // discards a choice — and untick clears, because four copies of one slug left
+                // behind would read as four deliberate per-role picks.
                 pick.set(
                   e.target.checked
                     ? (Object.fromEntries(
                         ROLES.map((r) => [r, pick.value.explore || pick.value.edit || ""]),
                       ) as RoleOverride)
                     : NO_OVERRIDE,
-                )
-              }
+                );
+              }}
             />
             {t("code.roles.oneModel")}
           </label>

--- a/apps/desktop/src/components/run/RunLauncher.roles.test.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.roles.test.tsx
@@ -85,15 +85,50 @@ describe("RunLauncher — the choice reaches the run", () => {
     expect(sent().roles).toBeNull();
   });
 
-  it("shows what the profile resolved to before anyone overrides it", async () => {
-    // The regression this exists for: the first version of the picker REPLACED the resolved slug
-    // instead of sitting beside it, so switching the control on emptied four fields that had been
-    // showing four model names. One per role, so a row wired to the wrong role fails here.
+  it("collapses to one picker when one model should do everything", async () => {
+    // The box did nothing at first, and the reason is worth keeping: "one model" was DERIVED from
+    // the four values being equal and non-empty, so ticking it before choosing anything wrote four
+    // blanks and read them straight back as "not one model" — the box would not even stay ticked.
+    // Three intents exist and two share the same four values, so it has to be held, not derived.
+    const user = await launch();
+    await user.click(screen.getByText(/which model does what|qual modelo faz o quê/i));
+
+    const box = screen.getByRole("checkbox", { name: /one model|um modelo/i });
+    await user.click(box);
+
+    expect((box as HTMLInputElement).checked).toBe(true);
+    expect(screen.getByText(/every step|todas as etapas/i)).toBeTruthy();
+    // And the per-role rows are gone: four pickers showing the same slug would invite editing one
+    // of them, which silently leaves the state the box still claims.
+    expect(screen.queryByText(/^Explore$|^Explorar$/)).toBeNull();
+  });
+
+  it("gives the roles back when it is unticked", async () => {
+    const user = await launch();
+    await user.click(screen.getByText(/which model does what|qual modelo faz o quê/i));
+    const box = screen.getByRole("checkbox", { name: /one model|um modelo/i });
+
+    await user.click(box);
+    await user.click(box);
+
+    expect((box as HTMLInputElement).checked).toBe(false);
+    expect(screen.getByText(/^Explore$|^Explorar$/)).toBeTruthy();
+  });
+
+  it("shows each role's own model as what 'no choice' means there", async () => {
+    // Two wrong shapes preceded this, in opposite directions. The first REPLACED the resolved slug
+    // with an empty picker, so switching the control on hid the four model names it exists to
+    // change. The second showed both — and the picker's own half was the INSTALL default, so
+    // `Explore` read "default · deepseek-chat-v3.1" beside the mistral it actually runs on: two
+    // model names on one row, the prominent one wrong for that role.
+    //
+    // One name per row now, inside the chip, and it is the role's. A row wired to the wrong role
+    // fails here, which is why all four are asserted rather than one.
     await launch();
     await userEvent.setup().click(screen.getByText(/which model does what|qual modelo faz o quê/i));
 
     for (const slug of ["scout-model", "planner-model", "writer-model", "critic-model"]) {
-      expect(await screen.findByText(slug), `${slug} is not shown`).toBeTruthy();
+      expect(await screen.findByText(new RegExp(slug)), `${slug} is not shown`).toBeTruthy();
     }
   });
 });

--- a/apps/desktop/src/components/run/RunLauncher.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.tsx
@@ -48,6 +48,7 @@ export function RunLauncher({
   // nobody touched would fabricate exactly that.
   const [profile, setProfile] = useState<Profile>("balanced");
   const [roles, setRoles] = useState<RoleOverride>(NO_OVERRIDE);
+  const [oneModel, setOneModel] = useState(false);
   const [touched, setTouched] = useState(false);
   // Runs parked before this window opened. A pause outlives the stream that reported it, so the
   // only way to see one you did not personally witness is to ask.
@@ -143,6 +144,8 @@ export function RunLauncher({
             setRoles(o);
             setTouched(true);
           }}
+          oneModel={oneModel}
+          onOneModel={setOneModel}
           disabled={running}
         />
       </div>


### PR DESCRIPTION
Two defects in the role picker that shipped in rc17, both found by driving the real screen rather than the tests — and the tests passed through both.

## Two model names on one row, the prominent one wrong

The row read:

```
Explorar   [Modelo: padrão · deepseek-chat-v3.1]   openrouter/mistralai/mistral-small-3.2-24b-instruct
```

The chip's "no choice" reading is the **install** default. The role actually runs on the profile's weak tier. So the row named two models and gave the larger, first-read position to the one that role does not use.

`ModelPicker` now takes what "no choice" resolves to *here*, and the caption goes — a row that already says `Explorar` does not need one. One name per row, and it is the role's:

```
Explorar    padrão · mistral-small-3.2-24b-instruct
Planejar    padrão · deepseek-r1 · painel
Editar      padrão · deepseek-chat-v3.1
Revisar     padrão · deepseek-r1
Verificar   roda o seu comando — sem modelo, nada a escolher
```

## "One model for everything" did nothing

It was **derived** from the four values being equal and non-empty, on the argument that a separate flag could drift out of sync with the rows.

The argument was wrong, because three intents exist and two of them share the same four values: *"use the profile's tiers"* and *"one model, not chosen yet"* are both four empty strings. So ticking the box before picking a model wrote four blanks, the derivation read them straight back as "not one model", and the box would not even stay ticked.

It is held now. What made a flag unsafe — drift between it and the rows — is closed **by construction** rather than by argument: while it is on, the only control rendered writes all four at once.

## Verified in the running app

The three profiles change the four models, and `máximo` adds the panel to review as well as plan. Ticking collapses five rows to "Todas as etapas" plus verify; unticking gives the roles back.

746 desktop tests, typecheck clean, sabotage on both fixes.

> One process note. The first sabotage of the fallback **silently did not apply** — a `str.replace` that matched nothing — and the result read exactly like a guard that fails to discriminate. It only surfaced because the second attempt asserted the target was present before replacing it. A sabotage that does not sabotage is indistinguishable from a test that does not catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
