### PR TITLE
fix(desktop): a toolbar that overflowed its column, and text nobody could read

### DIFF
--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -876,13 +876,18 @@ export function Conversation({
     // real overlap, with `elementFromPoint` returning `code.hljs` where the panel should be.
     // `min-h-0` was already here guarding the vertical axis; the horizontal one had nothing.
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
-      <div className="flex items-center gap-2 border-b border-hairline px-3 py-2 text-accent">
+      {/* `flex-wrap`, because this header is 261px of buttons and the column it lives in is 248px
+          once a file viewer opens at 1280. Its toolbar ran 95px PAST the column and painted "Limpar"
+          across the viewer's filename — the same defect the three top-level columns had, one level
+          down. Clipping instead would have hidden working controls; wrapping keeps all three
+          reachable and costs 28px of height only at the widths where they would not have fit. */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-hairline px-3 py-2 text-accent">
         <MessageSquare className="h-4 w-4" />
         <h2 className="text-sm font-semibold text-foreground">
           {t("code.chat.title")}
         </h2>
         {exchanges.length > 0 ? (
-          <div className="ml-auto flex items-center gap-1">
+          <div className="ml-auto flex min-w-0 items-center gap-1">
             {/* A record of what an agent did to a repository should be able to leave the window it
                 happened in. Until this, the only clipboard call in the whole app copied a `pip
                 install` line. */}

--- a/apps/desktop/src/components/code/columns-can-shrink.test.ts
+++ b/apps/desktop/src/components/code/columns-can-shrink.test.ts
@@ -44,6 +44,30 @@ function columnLine(file: string, marker: string): string {
   return line;
 }
 
+/** Rows INSIDE a column that hold controls, and must not push past it.
+ *
+ *  The columns guard below was written after two rounds of the row overflowing. It passed on rc18
+ *  while the conversation's own header ran 95px past its column and painted "Limpar" across the file
+ *  viewer's filename — 261px of buttons in a 248px column at 1280 with a viewer open.
+ *
+ *  A toolbar cannot both keep its buttons and fit, so the answer is `flex-wrap` rather than a clip:
+ *  hiding a working control to fix a layout is trading a visible bug for an invisible one.
+ */
+const TOOLBAR_ROWS = [
+  {
+    what: "the conversation header",
+    file: join("components", "code", "Conversation.tsx"),
+    marker: "border-b border-hairline px-3 py-2 text-accent",
+    must: ["flex-wrap"],
+  },
+  {
+    what: "the conversation header's button group",
+    file: join("components", "code", "Conversation.tsx"),
+    marker: "ml-auto flex min-w-0 items-center gap-1",
+    must: ["min-w-0"],
+  },
+];
+
 const COLUMNS = [
   {
     what: "the session sidebar",
@@ -88,6 +112,11 @@ describe("the Code screen's three columns", () => {
       for (const cls of mustNot) expect(line, `should not carry ${cls}`).not.toContain(cls);
     },
   );
+
+  it.each(TOOLBAR_ROWS)("$what can give ground rather than overflow", ({ file, marker, must }) => {
+    const line = columnLine(file, marker);
+    for (const cls of must) expect(line, `missing ${cls}`).toContain(cls);
+  });
 
   it("has exactly one column that grows", () => {
     // The property the whole layout rests on. Two growing columns is how the row stops having a

--- a/apps/desktop/src/components/orchestration/DelegationSavings.tsx
+++ b/apps/desktop/src/components/orchestration/DelegationSavings.tsx
@@ -47,7 +47,7 @@ export function DelegationSavings() {
         <h2 className="text-sm font-semibold text-foreground">{t("orch.saving.title")}</h2>
       </div>
 
-      <p className={tokens < 0 ? "text-xs text-warn" : "text-xs text-foreground"}>
+      <p className={tokens < 0 ? "text-xs text-warn-foreground" : "text-xs text-foreground"}>
         {t(tokens < 0 ? "orch.saving.tokensMore" : "orch.saving.tokens", {
           n: Math.abs(tokens).toLocaleString(),
           runs: summary.n,
@@ -55,7 +55,7 @@ export function DelegationSavings() {
       </p>
 
       {priced ? (
-        <p className={usd < 0 ? "text-xs tabular-nums text-warn" : "text-xs tabular-nums text-ok"}>
+        <p className={usd < 0 ? "text-xs tabular-nums text-warn-foreground" : "text-xs tabular-nums text-ok-foreground"}>
           {t(usd < 0 ? "orch.saving.usdMore" : "orch.saving.usd", { usd: Math.abs(usd).toFixed(4) })}
         </p>
       ) : (

--- a/apps/desktop/src/components/ui/panel.tsx
+++ b/apps/desktop/src/components/ui/panel.tsx
@@ -49,9 +49,13 @@ export function Panel({ title, action, children }: { title?: string; action?: Re
 type Tone = "muted" | "ok" | "warn" | "bad" | "accent";
 const tones: Record<Tone, string> = {
   muted: "bg-surface-2 text-muted-foreground ring-1 ring-hairline",
-  ok: "bg-ok/15 text-ok ring-1 ring-ok/20",
+  // Fill and ring take the plain token; the LABEL takes the -foreground pair. `warn` already did
+  // this and the other two did not, which is the whole defect: measured on the light theme, `text-ok`
+  // reads 3.06:1 as 11px text and `text-bad` 3.82:1, both under the 4.5 small text needs. The dark
+  // theme passes on either, so the split only shows up on light — and only when read with a ruler.
+  ok: "bg-ok/15 text-ok-foreground ring-1 ring-ok/20",
   warn: "bg-warn/15 text-warn-foreground ring-1 ring-warn/25",
-  bad: "bg-bad/15 text-bad ring-1 ring-bad/25",
+  bad: "bg-bad/15 text-bad-foreground ring-1 ring-bad/25",
   accent: "bg-accent/15 text-accent ring-1 ring-accent/25",
 };
 

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -54,7 +54,20 @@ const styles = readStyles(join(process.cwd(), "src"));
 
 /** Source files excluding this gate and its data, which necessarily contain the banned patterns. */
 function appSources(): [string, string][] {
-  return Object.entries(sources).filter(([path]) => !path.includes("/design/"));
+  // What SHIPS. Two exclusions, and the first one was silently doing nothing.
+  //
+  // The keys `import.meta.glob` hands back are relative to THIS file, so a sibling in `src/design/`
+  // arrives as `./thing.ts` and a component as `../components/Thing.tsx`. Neither contains
+  // "/design/", so the old filter matched no file at all — it read as an exclusion and was a no-op.
+  // A guard on this folder's own files is the one thing it was written to prevent, and it took a
+  // new sibling that talks ABOUT colour to notice.
+  //
+  // Test files go too, for the reason that surfaced it: a test that asserts a literal colour is
+  // wrong has to contain that literal, and flagging it is the same class of mistake as reading a
+  // comment about `hsl()` as a call to it.
+  return Object.entries(sources).filter(
+    ([path]) => !path.startsWith("./") && !/\.test\.tsx?$/.test(path),
+  );
 }
 
 /** Every `className="…"` / `className={"…"}` string literal in the app, with its file. */

--- a/apps/desktop/src/design/text-tokens-are-readable.test.ts
+++ b/apps/desktop/src/design/text-tokens-are-readable.test.ts
@@ -18,10 +18,19 @@ import { describe, expect, it } from "vitest";
  * and no layout, which is the point: the browser measurement that found this cannot run in CI, and
  * a defect nothing can re-check is a defect waiting to come back.
  *
+ * **It measures against the badge's tint, not the page.** That distinction is the whole calibration.
+ * A `Badge` paints its label on a 15% wash of its own colour (`bg-ok`, `bg-bad`, `bg-warn` at /15) — which pulls the ground toward
+ * the ink and costs most of a point of contrast. The first version of this file checked against
+ * `--background` and passed an `--ok-foreground` that scored 4.70 there and **4.04** on the tint:
+ * a guard that measured the fix in the easy place. `--warn-foreground` had been failing the same
+ * way since it was written, at 4.33, with nothing to say so.
+ *
  * **What it deliberately does not check.** Fills and icons take the plain token, where the bar is
  * 3:1, and this file has nothing to say about them. It also cannot see which class a component
  * actually reaches for — `panel.tsx`'s tone map is what routes labels to the -foreground pair, and
- * that is guarded by the app's own render tests.
+ * that is guarded by the app's own render tests. Nor does it model a badge sitting on a raised card
+ * rather than the page; measured in the running app that costs a further ~0.7, so treat these
+ * numbers as the ceiling and keep a margin.
  */
 
 const CSS = readFileSync(join(__dirname, "..", "index.css"), "utf8");
@@ -54,6 +63,22 @@ function luminance([r, g, b]: [number, number, number]): number {
 
 function contrast(a: string, b: string): number {
   const [x, y] = [luminance(hslToRgb(a)), luminance(hslToRgb(b))];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+/** `fill` at 15% over `base` — the ground a `Badge` actually paints its label on.
+ *
+ *  Writing the class as `bg-<state>` and the alpha in words, because spelling it with a star and a
+ *  slash closes the comment: this file failed to parse at all on the first attempt, and the error
+ *  pointed four lines past the cause. */
+function tinted(fill: string, base: string): [number, number, number] {
+  const f = hslToRgb(fill);
+  const b = hslToRgb(base);
+  return [0, 1, 2].map((i) => f[i] * 0.15 + b[i] * 0.85) as [number, number, number];
+}
+
+function contrastOn(ink: string, ground: [number, number, number]): number {
+  const [x, y] = [luminance(hslToRgb(ink)), luminance(ground)];
   return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
 }
 
@@ -102,10 +127,24 @@ describe("text colours", () => {
     }
   });
 
+  it.each([["--ok", "--ok-foreground"], ["--bad", "--bad-foreground"], ["--warn", "--warn-foreground"]])(
+    "%s reads on its own badge tint, in both themes",
+    (fill, ink) => {
+      for (const [name, theme] of [["light", light], ["dark", dark]] as const) {
+        const ratio = contrastOn(theme[ink], tinted(theme[fill], theme["--background"]));
+        expect(ratio, `${ink} on ${fill}/15 (${name}) is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(AA_SMALL);
+      }
+    },
+  );
+
   it("checks a ratio that a wrong value would actually fail", () => {
     // Guarding the guard. `hslToRgb` returning something constant, or `contrast` collapsing to 1,
     // would make every assertion above pass for the wrong reason — so pin one known-bad pairing.
     expect(contrast("152 55% 40%", light["--background"])).toBeLessThan(AA_SMALL);
     expect(contrast(light["--ok-foreground"], light["--background"])).toBeGreaterThanOrEqual(AA_SMALL);
+    // And that the tint is doing something: the value this file first shipped passed on the page
+    // and failed on the badge, so a `tinted()` that quietly returned the page would hide exactly
+    // the defect it was added for.
+    expect(contrastOn("152 62% 30%", tinted(light["--ok"], light["--background"]))).toBeLessThan(AA_SMALL);
   });
 });

--- a/apps/desktop/src/design/text-tokens-are-readable.test.ts
+++ b/apps/desktop/src/design/text-tokens-are-readable.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Every colour used for TEXT clears WCAG AA against the theme it belongs to.
+ *
+ * Found by measuring the running app rather than by reading the CSS: on the light theme, `text-ok`
+ * came out at 3.06:1 as 11px text and `text-bad` at 3.82:1, both under the 4.5 that small text
+ * needs. The dark theme passed on the same tokens, which is exactly why it survived — the palette
+ * is only wrong on one of the two, and only for text.
+ *
+ * `--warn` already carried the split (`--warn-foreground` is a darker ink for light, a lighter one
+ * for dark). `--ok` and `--bad` did not, so `Badge tone="ok"` and every small label reaching for
+ * them failed quietly while the badge beside them was correct.
+ *
+ * This computes the contrast from the token values themselves, in both themes. It needs no browser
+ * and no layout, which is the point: the browser measurement that found this cannot run in CI, and
+ * a defect nothing can re-check is a defect waiting to come back.
+ *
+ * **What it deliberately does not check.** Fills and icons take the plain token, where the bar is
+ * 3:1, and this file has nothing to say about them. It also cannot see which class a component
+ * actually reaches for — `panel.tsx`'s tone map is what routes labels to the -foreground pair, and
+ * that is guarded by the app's own render tests.
+ */
+
+const CSS = readFileSync(join(__dirname, "..", "index.css"), "utf8");
+
+/** `H S% L%` → sRGB, the same arithmetic the browser does for `hsl()`. */
+function hslToRgb(spec: string): [number, number, number] {
+  const [h, s, l] = spec.trim().split(/\s+/).map((p) => parseFloat(p));
+  const S = s / 100;
+  const L = l / 100;
+  const c = (1 - Math.abs(2 * L - 1)) * S;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = L - c / 2;
+  const [r, g, b] =
+    h < 60 ? [c, x, 0]
+    : h < 120 ? [x, c, 0]
+    : h < 180 ? [0, c, x]
+    : h < 240 ? [0, x, c]
+    : h < 300 ? [x, 0, c]
+    : [c, 0, x];
+  return [(r + m) * 255, (g + m) * 255, (b + m) * 255];
+}
+
+function luminance([r, g, b]: [number, number, number]): number {
+  const f = (v: number) => {
+    const n = v / 255;
+    return n <= 0.03928 ? n / 12.92 : Math.pow((n + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+function contrast(a: string, b: string): number {
+  const [x, y] = [luminance(hslToRgb(a)), luminance(hslToRgb(b))];
+  return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+}
+
+/** The two `:root` blocks, keyed by which theme they define. */
+function themes(): Record<"dark" | "light", Record<string, string>> {
+  const blocks = [...CSS.matchAll(/:root[^{]*\{([\s\S]*?)\n\}/g)].map((m) => m[1]);
+  expect(blocks.length, "expected two :root blocks — the theme structure changed").toBeGreaterThanOrEqual(2);
+
+  const read = (body: string) => {
+    const out: Record<string, string> = {};
+    for (const m of body.matchAll(/(--[\w-]+):\s*([^;]+);/g)) out[m[1]] = m[2].trim();
+    return out;
+  };
+  // The dark palette is written first in this file; the light one overrides it below.
+  const parsed = blocks.map(read);
+  const dark = parsed.find((p) => p["--ok"] && parseFloat(p["--background"]?.split(/\s+/)[2] ?? "50") < 50);
+  const light = parsed.find((p) => p["--ok"] && parseFloat(p["--background"]?.split(/\s+/)[2] ?? "50") >= 50);
+  expect(dark, "no dark :root block found").toBeTruthy();
+  expect(light, "no light :root block found").toBeTruthy();
+  return { dark: dark!, light: light! };
+}
+
+const AA_SMALL = 4.5;
+const INK = ["--ok-foreground", "--bad-foreground", "--warn-foreground", "--muted-foreground", "--foreground"];
+
+describe("text colours", () => {
+  const { dark, light } = themes();
+
+  it.each(INK)("%s is readable on the light theme", (token) => {
+    const ratio = contrast(light[token], light["--background"]);
+    expect(ratio, `${token} is ${ratio.toFixed(2)}:1, needs ${AA_SMALL}`).toBeGreaterThanOrEqual(AA_SMALL);
+  });
+
+  it.each(INK)("%s is readable on the dark theme", (token) => {
+    const ratio = contrast(dark[token], dark["--background"]);
+    expect(ratio, `${token} is ${ratio.toFixed(2)}:1, needs ${AA_SMALL}`).toBeGreaterThanOrEqual(AA_SMALL);
+  });
+
+  it("every state colour has an ink counterpart", () => {
+    // The shape of the original defect: `--warn` had one and the other two did not, so nothing said
+    // which class a label should use and half of them picked the fill.
+    for (const state of ["--ok", "--bad", "--warn"]) {
+      for (const [name, theme] of [["light", light], ["dark", dark]] as const) {
+        expect(theme[`${state}-foreground`], `${state}-foreground missing from the ${name} theme`).toBeTruthy();
+      }
+    }
+  });
+
+  it("checks a ratio that a wrong value would actually fail", () => {
+    // Guarding the guard. `hslToRgb` returning something constant, or `contrast` collapsing to 1,
+    // would make every assertion above pass for the wrong reason — so pin one known-bad pairing.
+    expect(contrast("152 55% 40%", light["--background"])).toBeLessThan(AA_SMALL);
+    expect(contrast(light["--ok-foreground"], light["--background"])).toBeGreaterThanOrEqual(AA_SMALL);
+  });
+});

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -44,9 +44,9 @@
   --accent2: 189 94% 55%;
   --ring: 217 91% 62%;
   --ok: 152 58% 50%;
-  --ok-foreground: 152 58% 50%;
+  --ok-foreground: 152 58% 58%;
   --bad: 0 72% 62%;
-  --bad-foreground: 0 72% 62%;
+  --bad-foreground: 0 78% 70%;
   --warn: 38 92% 50%;
   --warn-foreground: 38 92% 62%;
   /* The separator between surfaces, a panel raised inside a panel, and the fill a row takes on
@@ -116,13 +116,19 @@
      Measured against this theme's own card, `--ok` reads 3.06:1 as 11px text and `--bad` 3.82:1 —
      both under the 4.5 that small text needs, while both are fine as fills and as icons, where the
      bar is 3:1. `--warn` already had this split; `--ok` and `--bad` did not, so every small label
-     using them failed quietly. The values below are measured, not estimated: 4.70 and 5.87. */
+     using them failed quietly.
+
+     The values are measured against the BADGE's background, not the page's. That distinction is
+     the whole calibration: a `Badge` paints its label on `bg-*/15`, a tint of its own colour, which
+     moves the ground toward the ink and costs most of a point. The first pass here picked 4.70
+     against the page and scored 4.04 on the tint — a fix that measured itself in the easy place.
+     `--warn-foreground` had the same problem all along and read 4.33 there. */
   --ok: 152 55% 40%;
-  --ok-foreground: 152 62% 30%;
+  --ok-foreground: 152 65% 26%;
   --bad: 0 72% 50%;
-  --bad-foreground: 0 72% 42%;
+  --bad-foreground: 0 75% 38%;
   --warn: 32 95% 44%;
-  --warn-foreground: 28 90% 34%;
+  --warn-foreground: 28 92% 30%;
   /* Dark ink at low alpha — the mirror of the dark theme's low-alpha white. The literal this token
      replaced was a 5%-white border, i.e. white-on-white here: the light theme had NO visible
      panel edges at all. That is the bug this token exists to fix. */

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -119,7 +119,7 @@
      using them failed quietly.
 
      The values are measured against the BADGE's background, not the page's. That distinction is
-     the whole calibration: a `Badge` paints its label on `bg-*/15`, a tint of its own colour, which
+     the whole calibration: a `Badge` paints its label on a 15% wash of its own colour, which
      moves the ground toward the ink and costs most of a point. The first pass here picked 4.70
      against the page and scored 4.04 on the tint — a fix that measured itself in the easy place.
      `--warn-foreground` had the same problem all along and read 4.33 there. */

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -44,7 +44,9 @@
   --accent2: 189 94% 55%;
   --ring: 217 91% 62%;
   --ok: 152 58% 50%;
+  --ok-foreground: 152 58% 50%;
   --bad: 0 72% 62%;
+  --bad-foreground: 0 72% 62%;
   --warn: 38 92% 50%;
   --warn-foreground: 38 92% 62%;
   /* The separator between surfaces, a panel raised inside a panel, and the fill a row takes on
@@ -110,8 +112,15 @@
   --accent-foreground: 0 0% 100%;
   --accent2: 189 90% 42%;
   --ring: 217 91% 52%;
+  /* Fill and text are the same colour in the dark theme and cannot be here.
+     Measured against this theme's own card, `--ok` reads 3.06:1 as 11px text and `--bad` 3.82:1 —
+     both under the 4.5 that small text needs, while both are fine as fills and as icons, where the
+     bar is 3:1. `--warn` already had this split; `--ok` and `--bad` did not, so every small label
+     using them failed quietly. The values below are measured, not estimated: 4.70 and 5.87. */
   --ok: 152 55% 40%;
+  --ok-foreground: 152 62% 30%;
   --bad: 0 72% 50%;
+  --bad-foreground: 0 72% 42%;
   --warn: 32 95% 44%;
   --warn-foreground: 28 90% 34%;
   /* Dark ink at low alpha — the mirror of the dark theme's low-alpha white. The literal this token

--- a/apps/desktop/tailwind.config.js
+++ b/apps/desktop/tailwind.config.js
@@ -15,8 +15,8 @@ export default {
         accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
         accent2: "hsl(var(--accent2))",
         primary: { DEFAULT: "hsl(var(--primary))", foreground: "hsl(var(--primary-foreground))" },
-        ok: "hsl(var(--ok))",
-        bad: "hsl(var(--bad))",
+        ok: { DEFAULT: "hsl(var(--ok))", foreground: "hsl(var(--ok-foreground))" },
+        bad: { DEFAULT: "hsl(var(--bad))", foreground: "hsl(var(--bad-foreground))" },
         warn: { DEFAULT: "hsl(var(--warn))", foreground: "hsl(var(--warn-foreground))" },
         // The 1px separator between surfaces. Was written as `border-white/5` everywhere, which is
         // invisible on the light theme's white cards — this is a bug fix wearing a token's clothes.


### PR DESCRIPTION
Three findings from driving rc18, plus one caught in my own fix for the third.

## The conversation header ran 95px past its column

At 1280 with a file viewer open the Code row is 240 + 248 + 448. The conversation gets 248px; its header holds 261px of buttons. The toolbar pushed out and painted **"Limpar" across the file viewer's filename**.

Same defect as the three top-level columns, one level down — and `columns-can-shrink` passed the whole time, because it guards columns.

`flex-wrap` rather than a clip: hiding a working control to fix a layout trades a visible bug for an invisible one. Measured live — the toolbar's right edge goes 639 → 532 inside a column ending at 544, the header grows 49 → 77px, and the overlap probe goes to zero. The guard now covers rows inside a column.

## `text-ok` and `text-bad` were unreadable

Measured in the running app: **3.06:1** and **3.82:1** as 11px text, against the 4.5 small text needs. `--warn` already carried the split — a fill token and a darker `--warn-foreground` ink — and the other two did not, so `Badge tone="ok"` failed while the badge beside it was correct. One of the three bad sites was mine, from an hour earlier: I reached for `text-warn` where this codebase has `text-warn-foreground`.

### And the fix measured itself in the easy place

A badge paints its label on a 15% wash of its own colour, which pulls the ground toward the ink. My `--ok-foreground` read **4.70 against the page and 4.04 against the tint**. `--warn-foreground` had been failing the same way since it was written, at 4.33.

All three inks are recalibrated against the tint, in both themes:

| | light | dark |
|---|---|---|
| `--ok-foreground` | 152 65% 26% | 152 58% 58% |
| `--bad-foreground` | 0 75% 38% | 0 78% 70% |
| `--warn-foreground` | 28 92% 30% | 38 92% 62% |

`text-tokens-are-readable.test.ts` computes the ratios from the tokens, models the wash, and needs no browser — the measurement that found this cannot run in CI. Its sabotage is the 4.04 value itself, and it reproduces the browser's number exactly.

Two limits stated rather than hidden: a badge on a raised card loses a further ~0.7, so these are a ceiling; and nothing here sees which class a component reaches for.

## The design guard's own exclusion was a no-op

`appSources()` filtered on `path.includes("/design/")`, but `import.meta.glob` keys are relative to that file, so a sibling arrives as `./thing.ts` and never matches. It had been excluding nothing since it was written — a new sibling that talks *about* colour is what exposed it. Fixed to the real key shape, plus test files. Verified it still catches a real literal: an inline `#ff00aa` in `panel.tsx` fails it.

763 desktop tests, typecheck clean, sabotage on every new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)