### PR TITLE
fix(desktop): 58 labels painted in a fill colour, and the guard that could not see them

### DIFF
--- a/apps/desktop/src/components/AgentRegistry.tsx
+++ b/apps/desktop/src/components/AgentRegistry.tsx
@@ -80,7 +80,7 @@ export function AgentRegistry({ embedded = false }: { embedded?: boolean }) {
       </div>
 
       {error && (
-        <p role="alert" className="px-3 py-2 text-xs text-bad">
+        <p role="alert" className="px-3 py-2 text-xs text-bad-foreground">
           {error}
         </p>
       )}

--- a/apps/desktop/src/components/Agents.tsx
+++ b/apps/desktop/src/components/Agents.tsx
@@ -119,7 +119,7 @@ function AgentCard({
                 being wrong. Printed verbatim from the server (`timed out after Ns`, or the
                 exception that killed the unit); this component never invents the reason. */}
             {result.error ? (
-              <p className="break-words font-mono text-xs text-bad">{result.error}</p>
+              <p className="break-words font-mono text-xs text-bad-foreground">{result.error}</p>
             ) : null}
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
               <span>
@@ -336,7 +336,7 @@ export function Agents({
                 <Square className="h-4 w-4" /> {t("agents.stopAll")}
               </Button>
             ) : null}
-            {error ? <span className="text-xs text-bad">{error}</span> : null}
+            {error ? <span className="text-xs text-bad-foreground">{error}</span> : null}
           </div>
         </div>
 
@@ -360,7 +360,7 @@ export function Agents({
             </div>
             {batch.conflicts.length > 0 ? (
               <div className="rounded-chip border border-bad/30 bg-bad/10 px-3 py-2">
-                <div className="flex items-center gap-1.5 text-xs font-semibold text-bad">
+                <div className="flex items-center gap-1.5 text-xs font-semibold text-bad-foreground">
                   <AlertTriangle className="h-3.5 w-3.5" />
                   {t("agents.conflictsTitle")} ({batch.conflicts.length})
                 </div>

--- a/apps/desktop/src/components/Code.tsx
+++ b/apps/desktop/src/components/Code.tsx
@@ -127,7 +127,7 @@ function ImagePreview({ workspace, path }: { workspace: string; path: string }) 
     // Named separately from the generic binary note: "we could not load this image" is a different
     // fact from "this is not an image", and answering the second when the first happened would send
     // someone looking for a bug in a file that is fine.
-    return <div className="px-4 py-6 text-sm text-bad">{t("code.imageError")}</div>;
+    return <div className="px-4 py-6 text-sm text-bad-foreground">{t("code.imageError")}</div>;
   }
   if (!url) {
     return (
@@ -222,7 +222,7 @@ function Viewer({ workspace, path }: { workspace: string; path: string | null })
         {dirty ? <Badge tone="warn">{t("code.dirty")}</Badge> : null}
         {q.data?.truncated ? <Badge tone="warn">{t("code.truncated")}</Badge> : null}
         {savedFlash && !editing ? (
-          <span className="text-xs text-ok">{t("code.saved")}</span>
+          <span className="text-xs text-ok-foreground">{t("code.saved")}</span>
         ) : null}
         {editing ? (
           <>
@@ -269,7 +269,7 @@ function Viewer({ workspace, path }: { workspace: string; path: string | null })
               <Loader2 className="h-5 w-5 animate-spin" />
             </div>
           ) : q.isError ? (
-            <div className="px-4 py-6 text-sm text-bad">{t("code.fileError")}</div>
+            <div className="px-4 py-6 text-sm text-bad-foreground">{t("code.fileError")}</div>
           ) : q.data?.note && path !== null && isImagePath(path) ? (
             <ImagePreview workspace={workspace} path={path} />
           ) : q.data?.note ? (

--- a/apps/desktop/src/components/Cron.tsx
+++ b/apps/desktop/src/components/Cron.tsx
@@ -76,7 +76,7 @@ function AddSchedule() {
             <Plus className="h-3.5 w-3.5" /> {t("cron.add.submit")}
           </Button>
         </div>
-        {create.isError && <div className="text-xs text-bad">{t("cron.add.error")}</div>}
+        {create.isError && <div className="text-xs text-bad-foreground">{t("cron.add.error")}</div>}
       </div>
     </Panel>
   );
@@ -130,7 +130,7 @@ export function Cron({ embedded = false }: { embedded?: boolean } = {}) {
                     a tooltip is found by accident. Truncated to one line: the full text is in the
                     title, and a stack trace must not push every other job off the screen. */}
                 {j.consecutive_failures > 0 && j.last_error && (
-                  <div className="mt-0.5 truncate font-mono text-xs text-bad" title={j.last_error}>
+                  <div className="mt-0.5 truncate font-mono text-xs text-bad-foreground" title={j.last_error}>
                     {j.last_error}
                   </div>
                 )}

--- a/apps/desktop/src/components/Fusion.tsx
+++ b/apps/desktop/src/components/Fusion.tsx
@@ -50,7 +50,7 @@ function PanelRow({ entry }: { entry: FusionPanelEntry }) {
         {tok ? <span className="shrink-0 text-xs text-muted-foreground">{tok}</span> : null}
       </div>
       {entry.error ? (
-        <div className="mt-1 whitespace-pre-wrap text-xs text-bad">{entry.error}</div>
+        <div className="mt-1 whitespace-pre-wrap text-xs text-bad-foreground">{entry.error}</div>
       ) : (
         <div className="mt-1 whitespace-pre-wrap text-sm text-muted-foreground">
           {truncate(entry.content)}

--- a/apps/desktop/src/components/Governance.tsx
+++ b/apps/desktop/src/components/Governance.tsx
@@ -103,7 +103,7 @@ function InjectionPanel({ data, t }: { data: InjectionReport; t: TFunc }) {
           and with it off the defended column describes a configuration nobody on this machine is
           running. */}
       {!data.armed ? (
-        <p className="border-b border-hairline px-4 py-3 text-xs text-bad">
+        <p className="border-b border-hairline px-4 py-3 text-xs text-bad-foreground">
           {t("governance.injection.disarmed")}
         </p>
       ) : null}

--- a/apps/desktop/src/components/Mcp.tsx
+++ b/apps/desktop/src/components/Mcp.tsx
@@ -76,7 +76,7 @@ function ServerRow({
 
       {result && result.ok && (
         <div className="rounded-xl2 bg-ok/[0.06] px-3 py-2 ring-1 ring-ok/15">
-          <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-ok">
+          <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-ok-foreground">
             <Check className="h-3.5 w-3.5" /> {t("mcp.toolsExposed", { n: result.tools.length })}
           </div>
           <div className="flex flex-col gap-1">
@@ -94,7 +94,7 @@ function ServerRow({
         </div>
       )}
       {result && !result.ok && (
-        <div className="flex items-center gap-1.5 rounded-xl2 bg-bad/[0.08] px-3 py-2 text-xs text-bad ring-1 ring-bad/20">
+        <div className="flex items-center gap-1.5 rounded-xl2 bg-bad/[0.08] px-3 py-2 text-xs text-bad-foreground ring-1 ring-bad/20">
           <X className="h-3.5 w-3.5 shrink-0" /> {result.error ?? t("mcp.testFailed")}
         </div>
       )}
@@ -193,7 +193,7 @@ function AddForm({ onAdded }: { onAdded: () => void }) {
           {add.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t("mcp.add")}
         </Button>
       </div>
-      {add.isError && <p className="text-xs text-bad">{t("mcp.addError")}</p>}
+      {add.isError && <p className="text-xs text-bad-foreground">{t("mcp.addError")}</p>}
     </div>
   );
 }

--- a/apps/desktop/src/components/Onboarding.tsx
+++ b/apps/desktop/src/components/Onboarding.tsx
@@ -232,11 +232,11 @@ export function Onboarding({ onSkip }: { onSkip: () => void }) {
         {/* Honest status: "saved (present)" after Save; only "verified — it works" after a passed test. */}
         {result ? (
           result.ok ? (
-            <p className="flex items-center gap-1.5 text-sm text-ok">
+            <p className="flex items-center gap-1.5 text-sm text-ok-foreground">
               <Check className="h-4 w-4" /> {t("onboarding.verified")}
             </p>
           ) : (
-            <p className="flex items-start gap-1.5 text-sm text-bad">
+            <p className="flex items-start gap-1.5 text-sm text-bad-foreground">
               <X className="mt-0.5 h-4 w-4 shrink-0" />
               <span>
                 {t("onboarding.testFailed")}

--- a/apps/desktop/src/components/Servers.tsx
+++ b/apps/desktop/src/components/Servers.tsx
@@ -121,7 +121,7 @@ export function Servers() {
               </p>
             </div>
             {s.id === current ? (
-              <span className="flex items-center gap-1 text-xs text-ok">
+              <span className="flex items-center gap-1 text-xs text-ok-foreground">
                 <Check className="h-3 w-3" aria-hidden />
                 {t("server.inUse")}
               </span>
@@ -155,10 +155,10 @@ export function Servers() {
           role="status"
           className={
             note.kind === "ok"
-              ? "text-xs text-ok"
+              ? "text-xs text-ok-foreground"
               : note.kind === "warn"
                 ? "text-xs text-warn-foreground"
-                : "text-xs text-bad"
+                : "text-xs text-bad-foreground"
           }
         >
           {note.text}

--- a/apps/desktop/src/components/Settings.tsx
+++ b/apps/desktop/src/components/Settings.tsx
@@ -68,7 +68,7 @@ function AppliesNote({ when }: { when?: string }) {
   const t = useT();
   if (when !== "next_conversation" && when !== "next_launch") return null;
   return (
-    <div className="text-xs text-warn">
+    <div className="text-xs text-warn-foreground">
       {t(
         when === "next_launch"
           ? "settings.applies.nextLaunch"
@@ -99,7 +99,7 @@ function PinnedNote({ env }: { env?: string }) {
   const t = useT();
   const pinned = useContext(PinnedContext);
   if (!env || !pinned.has(env)) return null;
-  return <div className="text-xs text-warn">{t("settings.pinned")}</div>;
+  return <div className="text-xs text-warn-foreground">{t("settings.pinned")}</div>;
 }
 
 /**
@@ -210,7 +210,7 @@ function IdentityCard() {
             {t("common.save")}
           </Button>
           {dirty && (
-            <span className="text-xs text-warn">{t("settings.unsaved")}</span>
+            <span className="text-xs text-warn-foreground">{t("settings.unsaved")}</span>
           )}
         </div>
       </div>
@@ -296,7 +296,7 @@ function AutonomyCard({
       </Row>
       {confirmingHostExec && (
         <div className="flex flex-col gap-2 px-4 py-3">
-          <p className="text-xs text-bad">{t("settings.hostExec.warning")}</p>
+          <p className="text-xs text-bad-foreground">{t("settings.hostExec.warning")}</p>
           <div className="flex items-center gap-2">
             <Button
               size="sm"
@@ -717,7 +717,7 @@ function PoolField({
           {t("settings.pool.add")}
         </Button>
       </div>
-      {error ? <p className="text-xs text-bad">{error}</p> : null}
+      {error ? <p className="text-xs text-bad-foreground">{error}</p> : null}
     </div>
   );
 }
@@ -815,7 +815,7 @@ export function MessagingCard({
         <div className="flex items-center gap-2">
           {d?.error && !running && (
             <span
-              className="max-w-[16rem] truncate text-xs text-bad"
+              className="max-w-[16rem] truncate text-xs text-bad-foreground"
               title={d.error}
             >
               {d.error}
@@ -1342,7 +1342,7 @@ export function Settings() {
                 </Card>
 
                 {mutation.isError && (
-                  <p className="text-sm text-bad">{t("settings.saveError")}</p>
+                  <p className="text-sm text-bad-foreground">{t("settings.saveError")}</p>
                 )}
               </div>
             )}

--- a/apps/desktop/src/components/SkillCatalog.tsx
+++ b/apps/desktop/src/components/SkillCatalog.tsx
@@ -119,7 +119,7 @@ function Row({ entry }: { entry: CatalogEntry }) {
           <p className="text-xs text-muted-foreground">{t("catalog.by", { author: entry.author })}</p>
         ) : null}
         {failed ? (
-          <p className="text-xs text-bad">{failed instanceof Error ? failed.message : String(failed)}</p>
+          <p className="text-xs text-bad-foreground">{failed instanceof Error ? failed.message : String(failed)}</p>
         ) : null}
       </div>
 

--- a/apps/desktop/src/components/code/Attachments.tsx
+++ b/apps/desktop/src/components/code/Attachments.tsx
@@ -173,7 +173,7 @@ export function AttachButton({ onAdded }: { onAdded: (a: Attachment) => void }) 
         {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
         {t("code.attach.label")}
       </Button>
-      {failed ? <span className="text-xs text-bad">{t("code.attach.failed", { name: failed })}</span> : null}
+      {failed ? <span className="text-xs text-bad-foreground">{t("code.attach.failed", { name: failed })}</span> : null}
     </>
   );
 }
@@ -263,7 +263,7 @@ export function DictateButton({ onText }: { onText: (text: string) => void }) {
       {unavailable ? (
         <span className="text-xs text-muted-foreground">{t("code.dictate.unavailable")}</span>
       ) : note ? (
-        <span className="text-xs text-warn">{note}</span>
+        <span className="text-xs text-warn-foreground">{note}</span>
       ) : null}
     </>
   );

--- a/apps/desktop/src/components/code/BatchProposal.tsx
+++ b/apps/desktop/src/components/code/BatchProposal.tsx
@@ -57,7 +57,7 @@ export function BatchProposal({
       </ol>
       {noIsolation ? (
         <div className="space-y-2">
-          <p className="flex items-start gap-1.5 text-xs text-bad">
+          <p className="flex items-start gap-1.5 text-xs text-bad-foreground">
             <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             {t("code.batch.noIsolation")}
           </p>

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -177,7 +177,7 @@ function Verdict({
 
   return (
     <div className="space-y-1.5 rounded-chip border border-bad/40 p-2">
-      <p className="text-xs text-bad">{t("code.chat.verdict.failed", args)}</p>
+      <p className="text-xs text-bad-foreground">{t("code.chat.verdict.failed", args)}</p>
       {v.output ? (
         <pre className="max-h-40 overflow-auto whitespace-pre-wrap font-mono text-xs text-muted-foreground">
           {v.output}
@@ -926,7 +926,7 @@ export function Conversation({
       {/* Said out loud rather than logged. "Your export is missing four turns" is exactly the kind
           of thing that must not be discovered later, by someone reading the file. */}
       {exportNote ? (
-        <p className="border-b border-hairline px-3 py-1 text-xs text-warn">
+        <p className="border-b border-hairline px-3 py-1 text-xs text-warn-foreground">
           {exportNote}
         </p>
       ) : null}
@@ -1023,7 +1023,7 @@ export function Conversation({
               ) : null}
               {e.failed ? (
                 <div className="space-y-1">
-                  <p className="text-xs text-bad">{t("code.chat.error")}</p>
+                  <p className="text-xs text-bad-foreground">{t("code.chat.error")}</p>
                   {/* Folded, not hidden: the headline stays one line for the common case where the
                     user only wants to retry, and the raw provider message is one click away for
                     the case where it says `invalid_api_key` and settles the whole question. */}
@@ -1043,7 +1043,7 @@ export function Conversation({
                 // At the answer, which is the only place it lands in time. The composer warns before
                 // the click; neither warning is visible at the moment someone reads a confident
                 // description of a file that was never opened.
-                <p className="flex items-start gap-1.5 text-xs text-warn">
+                <p className="flex items-start gap-1.5 text-xs text-warn-foreground">
                   <Network className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                   {t("composer.fusedAnswer")}
                 </p>
@@ -1107,7 +1107,7 @@ export function Conversation({
             <span className="min-w-0 flex-1 truncate text-xs">{queued}</span>
             <button
               type="button"
-              className="shrink-0 text-xs text-muted-foreground hover:text-bad"
+              className="shrink-0 text-xs text-muted-foreground hover:text-bad-foreground"
               // Back into the box rather than deleted: the user wrote it, and a cancel that destroys
               // text is a worse trade than one that hands it back.
               onClick={() => {
@@ -1173,7 +1173,7 @@ export function Conversation({
             itself; a file that arrived by clipboard has no button to stand beside, and silence
             would leave someone waiting for a screenshot that was never uploaded. */}
         {uploadFailed ? (
-          <p className="text-xs text-bad">
+          <p className="text-xs text-bad-foreground">
             {t("code.attach.failed", { name: uploadFailed })}
           </p>
         ) : null}

--- a/apps/desktop/src/components/code/GitInitButton.tsx
+++ b/apps/desktop/src/components/code/GitInitButton.tsx
@@ -63,7 +63,7 @@ export function GitInitButton({ workspace }: { workspace: string }) {
         )}
         {t("code.git.init")}
       </Button>
-      {failed ? <span className="text-xs text-bad">{t("code.git.initError")}</span> : null}
+      {failed ? <span className="text-xs text-bad-foreground">{t("code.git.initError")}</span> : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/code/GitPanel.tsx
+++ b/apps/desktop/src/components/code/GitPanel.tsx
@@ -256,11 +256,11 @@ export function GitPanel({ workspace }: { workspace: string }) {
                 {t("code.git.revert")} ({selectedPaths.length})
               </Button>
               {commitHash ? (
-                <span className="font-mono text-xs text-ok">
+                <span className="font-mono text-xs text-ok-foreground">
                   {t("code.git.committed")} {commitHash}
                 </span>
               ) : null}
-              {commitErr ? <span className="text-xs text-bad">{t("code.git.commitError")}</span> : null}
+              {commitErr ? <span className="text-xs text-bad-foreground">{t("code.git.commitError")}</span> : null}
             </div>
           </div>
         </div>

--- a/apps/desktop/src/components/code/ModelPicker.tsx
+++ b/apps/desktop/src/components/code/ModelPicker.tsx
@@ -291,7 +291,7 @@ export function ModelDialog({
             </p>
           ) : null}
           {listing.isError ? (
-            <p className="px-2 py-3 text-xs text-bad">
+            <p className="px-2 py-3 text-xs text-bad-foreground">
               {t("model.pick.failed")}
             </p>
           ) : null}

--- a/apps/desktop/src/components/code/PostureNote.tsx
+++ b/apps/desktop/src/components/code/PostureNote.tsx
@@ -95,13 +95,13 @@ export function PostureNote({
       ) : facts.isError ? (
         // Silence here would read as "nothing to worry about", which is the opposite of what an
         // unknown posture means.
-        <p className="text-xs text-bad">{t("code.posture.unknown")}</p>
+        <p className="text-xs text-bad-foreground">{t("code.posture.unknown")}</p>
       ) : null}
       {facts.data?.unguarded ? (
         // The condition that makes a permissive default defensible. Nothing marks this conversation
         // after it reads untrusted content, so a page carrying a planted instruction can still get
         // a file written. Saying it is the whole difference between a trade-off and a trap.
-        <p className="flex items-start gap-1.5 text-xs text-warn">
+        <p className="flex items-start gap-1.5 text-xs text-warn-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           {t("code.posture.unguarded")}
         </p>
@@ -111,7 +111,7 @@ export function PostureNote({
         // shell tools of their own, so the write region governs only the calls they route through
         // us. Claiming prevention here would be the one lie the product cannot afford; what is real
         // is the snapshot taken before the turn and the revert offered after it.
-        <p className="flex items-start gap-1.5 text-xs text-warn">
+        <p className="flex items-start gap-1.5 text-xs text-warn-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           {t("code.posture.externalNote")}
         </p>
@@ -120,7 +120,7 @@ export function PostureNote({
         // The one case where the honest answer contradicts what the user set up. Pre-emptive on
         // purpose: telling someone their sandbox was not running AFTER a shell command already ran
         // on their machine is a report, not a warning.
-        <p className="flex items-start gap-1.5 text-xs text-bad">
+        <p className="flex items-start gap-1.5 text-xs text-bad-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           {t("code.posture.fellBack")}
         </p>

--- a/apps/desktop/src/components/code/WorthPanel.tsx
+++ b/apps/desktop/src/components/code/WorthPanel.tsx
@@ -113,7 +113,7 @@ export function WorthPanel({ workspace }: { workspace?: string } = {}) {
       {/* Shown when the data is thin, and NOT hidden once it is thick: these groups stay
           observational no matter how many rows accumulate. */}
       {!any_readable ? (
-        <p className="text-xs text-warn">{t("code.worth.tooFew", { n: readable_n })}</p>
+        <p className="text-xs text-warn-foreground">{t("code.worth.tooFew", { n: readable_n })}</p>
       ) : null}
       <p className="text-xs text-muted-foreground">{t("code.worth.notAnExperiment")}</p>
       <DelegationSavings />

--- a/apps/desktop/src/components/editor/FileTree.tsx
+++ b/apps/desktop/src/components/editor/FileTree.tsx
@@ -115,7 +115,7 @@ function Level({
     // A directory that cannot be read is a fact about that directory, not a reason to blank the
     // tree. The rest of the workspace stays usable.
     return (
-      <div className="py-1 text-xs text-bad" style={{ paddingLeft: `${depth * 12 + 6}px` }}>
+      <div className="py-1 text-xs text-bad-foreground" style={{ paddingLeft: `${depth * 12 + 6}px` }}>
         {t("edit.tree.unreadable")}
       </div>
     );

--- a/apps/desktop/src/components/editor/Runner.tsx
+++ b/apps/desktop/src/components/editor/Runner.tsx
@@ -160,7 +160,7 @@ export function Runner({ workspace }: { workspace: string | null }) {
               type="button"
               onClick={() => void stop()}
               className={cn(
-                "flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-bad hover:bg-surface-hover",
+                "flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-bad-foreground hover:bg-surface-hover",
                 focusRing,
               )}
             >

--- a/apps/desktop/src/components/editor/SearchPanel.tsx
+++ b/apps/desktop/src/components/editor/SearchPanel.tsx
@@ -157,7 +157,7 @@ export function SearchPanel({
         ) : result.data ? (
           <>
             {result.data.error ? (
-              <p className="p-2 text-xs text-bad">{result.data.error}</p>
+              <p className="p-2 text-xs text-bad-foreground">{result.data.error}</p>
             ) : result.data.hits.length === 0 ? (
               <p className="p-2 text-xs text-muted-foreground">{t("edit.search.none")}</p>
             ) : (

--- a/apps/desktop/src/components/orchestration/CrewForm.tsx
+++ b/apps/desktop/src/components/orchestration/CrewForm.tsx
@@ -191,9 +191,9 @@ export function CrewForm({
           the mechanism and hide the mistake, which is that two identical roles write the same
           diff, both pass, and the conflict rule then discards both. */}
       {sameApproach ? (
-        <p className="text-xs text-bad">{t("crew.workers.sameApproach")}</p>
+        <p className="text-xs text-bad-foreground">{t("crew.workers.sameApproach")}</p>
       ) : duplicated ? (
-        <p className="text-xs text-bad">{t("crew.workers.duplicate")}</p>
+        <p className="text-xs text-bad-foreground">{t("crew.workers.duplicate")}</p>
       ) : null}
 
       <Button

--- a/apps/desktop/src/components/orchestration/CrewRun.tsx
+++ b/apps/desktop/src/components/orchestration/CrewRun.tsx
@@ -97,7 +97,7 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
 
         {worker.status === "rejected" ? (
           <div className="space-y-1">
-            <p className="text-xs text-bad">
+            <p className="text-xs text-bad-foreground">
               {worker.reason === "cancelled"
                 ? t("crew.rejected.cancelled")
                 : /could not run|not found|no such file/i.test(worker.detail)
@@ -124,7 +124,7 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
         ) : null}
 
         {worker.status === "failed" && worker.detail ? (
-          <p className="text-xs text-bad">{worker.detail}</p>
+          <p className="text-xs text-bad-foreground">{worker.detail}</p>
         ) : null}
 
         {/* Two lists, not one with a heading that swings. A worker can pass the check and still
@@ -135,7 +135,7 @@ function CrewWorkerCard({ worker }: { worker: CrewWorkerState }) {
             nothing landed. */}
         {worker.files.length > 0 ? (
           <div className="space-y-1">
-            <p className="text-xs text-ok">{t("crew.produced.landed")}</p>
+            <p className="text-xs text-ok-foreground">{t("crew.produced.landed")}</p>
             <ul className="space-y-0.5">
               {worker.files.map((file) => (
                 <li key={file} className="font-mono text-xs text-muted-foreground">
@@ -276,7 +276,7 @@ export function CrewRun({
       ) : null}
 
       {state.error ? (
-        <p className="rounded-card border border-bad/25 bg-bad/5 p-3 text-sm text-bad">
+        <p className="rounded-card border border-bad/25 bg-bad/5 p-3 text-sm text-bad-foreground">
           {state.error}
         </p>
       ) : null}

--- a/apps/desktop/src/components/orchestration/DelegationSavings.tsx
+++ b/apps/desktop/src/components/orchestration/DelegationSavings.tsx
@@ -59,7 +59,7 @@ export function DelegationSavings() {
           {t(usd < 0 ? "orch.saving.usdMore" : "orch.saving.usd", { usd: Math.abs(usd).toFixed(4) })}
         </p>
       ) : (
-        <p className="text-xs text-warn">
+        <p className="text-xs text-warn-foreground">
           {t("orch.saving.unpriced", { priced: summary.priced_n ?? 0, n: summary.n })}
         </p>
       )}

--- a/apps/desktop/src/components/orchestration/HierarchyRun.tsx
+++ b/apps/desktop/src/components/orchestration/HierarchyRun.tsx
@@ -128,7 +128,7 @@ export function HierarchyRun({
       ) : null}
 
       {state.error ? (
-        <p className="rounded-card border border-bad/25 bg-bad/5 p-3 text-sm text-bad">
+        <p className="rounded-card border border-bad/25 bg-bad/5 p-3 text-sm text-bad-foreground">
           {state.error}
         </p>
       ) : null}

--- a/apps/desktop/src/components/orchestration/Orchestration.tsx
+++ b/apps/desktop/src/components/orchestration/Orchestration.tsx
@@ -129,7 +129,7 @@ export function Orchestration({
           <span className="text-xs text-muted-foreground">{t("orch.previewCost")}</span>
         </div>
 
-        {error ? <p className="text-xs text-bad">{error}</p> : null}
+        {error ? <p className="text-xs text-bad-foreground">{error}</p> : null}
       </div>
 
       {plan && !run && !crew ? (

--- a/apps/desktop/src/components/orchestration/WorkerCard.tsx
+++ b/apps/desktop/src/components/orchestration/WorkerCard.tsx
@@ -84,7 +84,7 @@ export function WorkerCard({ worker }: { worker: WorkerState }) {
 
         {worker.status === "rejected" ? (
           <div className="space-y-1">
-            <p className="text-xs text-bad">
+            <p className="text-xs text-bad-foreground">
               {worker.reason === "no_output"
                 ? t("orch.worker.noOutput")
                 : worker.reason === "deadline"

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -126,6 +126,31 @@ describe("colour", () => {
     expect(offenders, "colour literals").toEqual([]);
   });
 
+  it("uses the ink pair whenever a state colour is a TEXT colour", () => {
+    // `--ok` and `--bad` are fills. Read as 11px text on the light theme they measure 3.06:1 and
+    // 3.82:1, under the 4.5 small text needs — which is why each has a darker `-foreground` pair.
+    //
+    // The rule is mechanical because the distinction is: a className carrying a font size is
+    // styling TEXT, and one that only carries `h-4 w-4` is styling an icon, where the bar is 3:1
+    // and the plain token is right. 58 sites were on the wrong side of that line, spread over 28
+    // files, and every one of them looked correct beside a badge that had already been fixed.
+    // Split on spaces instead of matching with word boundaries. The first version used regexes
+    // and the escape did not survive being written to disk: `size` ended up as a BACKSPACE
+    // character followed by `text-`, which matches nothing, so the check skipped every value and
+    // passed while verifying nothing at all. Sabotage is the only reason that surfaced. Tailwind
+    // class lists are space-separated, so exact membership says the same thing and cannot rot.
+    const SIZES = new Set(["text-xs", "text-sm", "text-base", "text-lg", "text-xl"]);
+    const STATES = new Set(["text-ok", "text-bad", "text-warn"]);
+    const offenders: string[] = [];
+    for (const { file, value } of classNameLiterals()) {
+      const parts = value.split(" ").map((c) => c.trim()).filter(Boolean);
+      if (!parts.some((c) => SIZES.has(c))) continue;
+      const hit = parts.find((c) => STATES.has(c));
+      if (hit) offenders.push(`${file}: ${hit} - use ${hit}-foreground`);
+    }
+    expect(offenders, "state colours used as text").toEqual([]);
+  });
+
   it("never separates surfaces with raw white or black alpha", () => {
     // `border-white/5` is invisible on a white card. Every one of these became `--hairline`,
     // `--surface-2` or `--surface-hover`, each of which has a real light-theme value.


### PR DESCRIPTION
Sweeping the screens with a contrast probe turned up one badge. Sweeping the **source** turned up 58 more, across 28 files.

## The defect

On the light theme `--ok` reads **3.06:1** as 11px text and `--bad` **3.82:1**, under the 4.5 that small text needs. rc19 gave each a darker `-foreground` pair; this applies it everywhere the token is a text colour.

The rule is mechanical because the distinction is: a class list carrying a font size is styling **text** and takes the ink; one carrying only `h-4 w-4` is styling an **icon**, where the bar is 3:1 and the fill is correct.

## The guard for it passed while checking nothing

This is the part worth recording. Written with regexes, the escape did not survive being written to disk: `size` became a literal **BACKSPACE character** followed by `text-`, which matches no class list at all. Every value was skipped, `offenders` was always empty, and eleven green tests included one that was inert.

Four things hid it:

- a terminal renders a backspace by **erasing**, so every `grep` and `sed` readback showed a clean-looking regex;
- `console.log` of an array is multi-line, so a grepped debug line looked like an empty result when it was a truncated one;
- a first debug read `Cron.test.tsx` where it meant `Cron.tsx`;
- and an earlier sabotage attempt had **silently failed to apply**, which reads exactly like a guard that does not discriminate.

It surfaced only because sabotage is a step rather than a formality — and it took dumping `String(regex)` from inside the test to a file, then reading that file with a tool that escapes control characters, to see the byte.

Rewritten without a single backslash: Tailwind class lists are space-separated, so exact set membership says the same thing and cannot rot this way. Sabotage now names the file and the fix:

```
+ "../components/Cron.tsx: text-bad - use text-bad-foreground"
```

764 desktop tests, typecheck clean, and `npm run build` — which is what caught the last round's CSS comment and what tests and types alone do not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)