### PR TITLE
fix(desktop): the accent had no ink, and the guard could not see a variant map

### DIFF
--- a/apps/desktop/src/components/IconRail.tsx
+++ b/apps/desktop/src/components/IconRail.tsx
@@ -95,7 +95,7 @@ function RailButton({
           // through fifteen destinations with nothing on screen telling them where they were.
           focusRing,
           active
-            ? "bg-accent/15 text-accent shadow-rail-active"
+            ? "bg-accent/15 text-accent-ink shadow-rail-active"
             : "text-muted-foreground hover:bg-surface-hover hover:text-foreground",
         )}
       >

--- a/apps/desktop/src/components/Onboarding.tsx
+++ b/apps/desktop/src/components/Onboarding.tsx
@@ -120,7 +120,7 @@ export function Onboarding({ onSkip }: { onSkip: () => void }) {
             href={pick.keys_url}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm text-accent hover:underline"
+            className="inline-flex items-center gap-1.5 text-sm text-accent-ink hover:underline"
           >
             {t("onboarding.getKeyLink", { provider: label })}
             <ExternalLink className="h-3.5 w-3.5" />

--- a/apps/desktop/src/components/Tasks.tsx
+++ b/apps/desktop/src/components/Tasks.tsx
@@ -52,7 +52,7 @@ function ProjectRow({
           type="button"
           onClick={onSelect}
           aria-pressed={selected}
-          className={cn("truncate font-mono text-sm hover:text-accent", focusRing)}
+          className={cn("truncate font-mono text-sm hover:text-accent-ink", focusRing)}
         >
           {p.id}
         </button>

--- a/apps/desktop/src/components/VersionBadge.tsx
+++ b/apps/desktop/src/components/VersionBadge.tsx
@@ -115,7 +115,7 @@ export function VersionBadge() {
         onClick={() => setOpen((o) => !o)}
         className={cn(
           "inline-flex items-center gap-1.5 rounded-chip px-2 py-1 text-xs font-medium",
-          "bg-accent/15 text-accent ring-1 ring-accent/25 transition-colors hover:bg-accent/25",
+          "bg-accent/15 text-accent-ink ring-1 ring-accent/25 transition-colors hover:bg-accent/25",
         )}
       >
         <ArrowUpCircle className="h-3.5 w-3.5" />

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -969,7 +969,7 @@ export function Conversation({
                   <button
                     type="button"
                     onClick={() => onOpenFile?.(edit.path)}
-                    className="font-mono text-xs text-accent underline decoration-dotted"
+                    className="font-mono text-xs text-accent-ink underline decoration-dotted"
                   >
                     {edit.path}
                   </button>

--- a/apps/desktop/src/components/code/ModelPicker.tsx
+++ b/apps/desktop/src/components/code/ModelPicker.tsx
@@ -111,7 +111,7 @@ export function ModelPicker({
             "transition-colors duration-1 ease-out disabled:opacity-50",
             focusRing,
             value
-              ? "bg-accent/20 text-accent"
+              ? "bg-accent/20 text-accent-ink"
               : "text-muted-foreground hover:text-foreground",
           )}
         >
@@ -387,7 +387,7 @@ function Row({
         <span className="flex flex-wrap items-center gap-1.5">
           <span className="truncate text-sm">{label}</span>
           {recommended ? (
-            <span className="rounded-chip bg-surface-2 px-1.5 text-xs text-accent">
+            <span className="rounded-chip bg-surface-2 px-1.5 text-xs text-accent-ink">
               ★
             </span>
           ) : null}

--- a/apps/desktop/src/components/code/ProviderPicker.tsx
+++ b/apps/desktop/src/components/code/ProviderPicker.tsx
@@ -70,7 +70,7 @@ export function ProviderPicker({
             "px-2.5 py-1 text-xs transition-colors duration-1 ease-out disabled:opacity-50",
             focusRing,
             value === ""
-              ? "bg-accent/20 text-accent"
+              ? "bg-accent/20 text-accent-ink"
               : "text-muted-foreground hover:text-foreground",
           )}
         >
@@ -116,7 +116,7 @@ export function ProviderPicker({
                 focusRing,
                 !agent.available && "cursor-not-allowed opacity-40",
                 value === agent.key
-                  ? "bg-accent/20 text-accent"
+                  ? "bg-accent/20 text-accent-ink"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >

--- a/apps/desktop/src/components/code/RolesBar.tsx
+++ b/apps/desktop/src/components/code/RolesBar.tsx
@@ -131,7 +131,7 @@ export function RolesBar({
           className={cn(
             "px-2.5 py-1 text-xs transition-colors disabled:opacity-50",
             profile === p
-              ? "bg-accent/20 text-accent"
+              ? "bg-accent/20 text-accent-ink"
               : "text-muted-foreground hover:text-foreground",
           )}
         >
@@ -163,7 +163,7 @@ export function RolesBar({
           {resolved[role] ?? t("code.roles.default")}
         </span>
       )}
-      {fused[role] ? <span className="shrink-0 text-accent">· {t("code.roles.panel")}</span> : null}
+      {fused[role] ? <span className="shrink-0 text-accent-ink">· {t("code.roles.panel")}</span> : null}
     </div>
   );
 

--- a/apps/desktop/src/components/code/SessionSidebar.tsx
+++ b/apps/desktop/src/components/code/SessionSidebar.tsx
@@ -248,7 +248,7 @@ export function SessionSidebar({
                     className={cn(
                       "min-w-0 flex-1 truncate px-3 py-1 pl-8 text-left text-xs transition-colors duration-1 ease-out",
                       session.id === activeSession
-                        ? "bg-accent/15 text-accent"
+                        ? "bg-accent/15 text-accent-ink"
                         : "text-muted-foreground hover:text-foreground",
                     )}
                   >

--- a/apps/desktop/src/components/editor/EditSidebar.tsx
+++ b/apps/desktop/src/components/editor/EditSidebar.tsx
@@ -61,7 +61,7 @@ export function EditSidebar({
                 "transition-colors duration-1 ease-out",
                 focusRing,
                 mode === key
-                  ? "bg-accent/20 text-accent"
+                  ? "bg-accent/20 text-accent-ink"
                   : "text-muted-foreground hover:text-foreground",
               )}
             >

--- a/apps/desktop/src/components/editor/FileTree.tsx
+++ b/apps/desktop/src/components/editor/FileTree.tsx
@@ -54,7 +54,7 @@ function Node({
           "transition-colors duration-1 ease-out",
           focusRing,
           active
-            ? "bg-accent/15 text-accent"
+            ? "bg-accent/15 text-accent-ink"
             : "text-muted-foreground hover:bg-surface-hover hover:text-foreground",
         )}
         // Indentation is data, not design: it comes from how deep the node is, so it cannot be a

--- a/apps/desktop/src/components/editor/SearchPanel.tsx
+++ b/apps/desktop/src/components/editor/SearchPanel.tsx
@@ -128,7 +128,7 @@ export function SearchPanel({
           className={cn(
             "rounded p-1 transition-colors duration-1 ease-out",
             focusRing,
-            caseSensitive ? "bg-accent/20 text-accent" : "text-muted-foreground",
+            caseSensitive ? "bg-accent/20 text-accent-ink" : "text-muted-foreground",
           )}
         >
           <CaseSensitive className="h-3.5 w-3.5" />
@@ -142,7 +142,7 @@ export function SearchPanel({
           className={cn(
             "rounded p-1 transition-colors duration-1 ease-out",
             focusRing,
-            regex ? "bg-accent/20 text-accent" : "text-muted-foreground",
+            regex ? "bg-accent/20 text-accent-ink" : "text-muted-foreground",
           )}
         >
           <Regex className="h-3.5 w-3.5" />

--- a/apps/desktop/src/components/orchestration/RunStepper.tsx
+++ b/apps/desktop/src/components/orchestration/RunStepper.tsx
@@ -33,7 +33,7 @@ export function RunStepper({ state }: { state: OrchestrationState }) {
             className={cn(
               "rounded-chip px-2 py-0.5 text-xs transition-colors duration-200 ease-out",
               current
-                ? "bg-accent/15 text-accent ring-1 ring-accent/25"
+                ? "bg-accent/15 text-accent-ink ring-1 ring-accent/25"
                 : done
                   ? "bg-surface-2 text-muted-foreground ring-1 ring-hairline"
                   : "text-muted-foreground/60",

--- a/apps/desktop/src/components/ui/panel.tsx
+++ b/apps/desktop/src/components/ui/panel.tsx
@@ -56,7 +56,7 @@ const tones: Record<Tone, string> = {
   ok: "bg-ok/15 text-ok-foreground ring-1 ring-ok/20",
   warn: "bg-warn/15 text-warn-foreground ring-1 ring-warn/25",
   bad: "bg-bad/15 text-bad-foreground ring-1 ring-bad/25",
-  accent: "bg-accent/15 text-accent ring-1 ring-accent/25",
+  accent: "bg-accent/15 text-accent-ink ring-1 ring-accent/25",
 };
 
 export function Badge({

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -140,13 +140,42 @@ describe("colour", () => {
     // passed while verifying nothing at all. Sabotage is the only reason that surfaced. Tailwind
     // class lists are space-separated, so exact membership says the same thing and cannot rot.
     const SIZES = new Set(["text-xs", "text-sm", "text-base", "text-lg", "text-xl"]);
-    const STATES = new Set(["text-ok", "text-bad", "text-warn"]);
+    // `text-accent` joined late, and the reason is worth keeping: `--accent-foreground` already
+    // existed, so it LOOKED like the accent had its ink pair. It is white — for text ON a solid
+    // accent fill, the opposite direction. Text IN the accent colour had no token at all and
+    // measured 4.29:1 on the page, 3.29:1 on the tint a selected toggle paints itself with.
+    const STATES = new Set(["text-ok", "text-bad", "text-warn", "text-accent"]);
     const offenders: string[] = [];
-    for (const { file, value } of classNameLiterals()) {
+    // Two ways to be sure a token is colouring TEXT, because the font size is not always in the
+    // same string. `panel.tsx` keeps its tones in a map — `bg-ok/15 text-ok ring-1 ring-ok/20` —
+    // while the `text-xs` that makes it text lives on the element. The size rule walked straight
+    // past it, which is how the badge tones were wrong to begin with, and sabotage proved the
+    // first version of THIS guard walked past it too.
+    //
+    // So: a size class in the same string, or a fill of the same colour in the same string. The
+    // second is the badge shape and means a label on its own wash by construction.
+    const ink = (c: string) => (c === "text-accent" ? "text-accent-ink" : `${c}-foreground`);
+    // EVERY quoted string, not just `className=` ones. `panel.tsx` keeps its badge tones in a
+    // variant map, so a className-only scan walks past them — which is the exact blind spot the
+    // colour-literal test above documents having been written to avoid, and which this guard
+    // inherited by reusing `classNameLiterals()`. Sabotage on two different tones proved it.
+    const strings: { file: string; value: string }[] = [];
+    for (const [file, text] of appSources()) {
+      // Split on the quote instead of matching. Written as a regex, the newline class became a
+      // real line break and the literal did not parse — the second time an escape has not
+      // survived being written into this file. Odd indices of a split on a quote ARE the quoted
+      // strings, exactly, with nothing to escape.
+      const chunks = text.split(String.fromCharCode(34));
+      for (let i = 1; i < chunks.length; i += 2) strings.push({ file, value: chunks[i] });
+    }
+    for (const { file, value } of strings) {
       const parts = value.split(" ").map((c) => c.trim()).filter(Boolean);
-      if (!parts.some((c) => SIZES.has(c))) continue;
       const hit = parts.find((c) => STATES.has(c));
-      if (hit) offenders.push(`${file}: ${hit} - use ${hit}-foreground`);
+      if (!hit) continue;
+      const fill = hit.replace("text-", "bg-");
+      const isText =
+        parts.some((c) => SIZES.has(c)) || parts.some((c) => c.startsWith(`${fill}/`));
+      if (isText) offenders.push(`${file}: ${hit} - use ${ink(hit)}`);
     }
     expect(offenders, "state colours used as text").toEqual([]);
   });

--- a/apps/desktop/src/design/text-tokens-are-readable.test.ts
+++ b/apps/desktop/src/design/text-tokens-are-readable.test.ts
@@ -102,7 +102,7 @@ function themes(): Record<"dark" | "light", Record<string, string>> {
 }
 
 const AA_SMALL = 4.5;
-const INK = ["--ok-foreground", "--bad-foreground", "--warn-foreground", "--muted-foreground", "--foreground"];
+const INK = ["--ok-foreground", "--bad-foreground", "--warn-foreground", "--accent-ink", "--muted-foreground", "--foreground"];
 
 describe("text colours", () => {
   const { dark, light } = themes();
@@ -127,7 +127,7 @@ describe("text colours", () => {
     }
   });
 
-  it.each([["--ok", "--ok-foreground"], ["--bad", "--bad-foreground"], ["--warn", "--warn-foreground"]])(
+  it.each([["--ok", "--ok-foreground"], ["--bad", "--bad-foreground"], ["--warn", "--warn-foreground"], ["--accent", "--accent-ink"]])(
     "%s reads on its own badge tint, in both themes",
     (fill, ink) => {
       for (const [name, theme] of [["light", light], ["dark", dark]] as const) {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -41,6 +41,7 @@
   --primary-foreground: 222 47% 11%;
   --accent: 217 91% 62%;
   --accent-foreground: 0 0% 100%;
+  --accent-ink: 217 91% 70%;
   --accent2: 189 94% 55%;
   --ring: 217 91% 62%;
   --ok: 152 58% 50%;
@@ -110,6 +111,12 @@
   --primary-foreground: 0 0% 100%;
   --accent: 217 91% 52%;
   --accent-foreground: 0 0% 100%;
+  /* The accent as INK, which `--accent-foreground` is not: that one is white, for text sitting
+     ON a solid accent fill. Text sitting IN the accent colour is the other direction, and it had
+     no token — measured 4.29:1 on the page and 3.29:1 on the `bg-accent/20` a selected toggle
+     paints itself with, both under the 4.5 small text needs. Same defect as `--ok` and `--bad`,
+     one token later, because the obvious name was taken and meant something else. */
+  --accent-ink: 217 91% 42%;
   --accent2: 189 90% 42%;
   --ring: 217 91% 52%;
   /* Fill and text are the same colour in the dark theme and cannot be here.

--- a/apps/desktop/tailwind.config.js
+++ b/apps/desktop/tailwind.config.js
@@ -12,7 +12,12 @@ export default {
         foreground: "hsl(var(--foreground))",
         muted: { DEFAULT: "hsl(var(--muted))", foreground: "hsl(var(--muted-foreground))" },
         card: { DEFAULT: "hsl(var(--card))", foreground: "hsl(var(--card-foreground))" },
-        accent: { DEFAULT: "hsl(var(--accent))", foreground: "hsl(var(--accent-foreground))" },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+          // Text IN the accent colour, as opposed to text ON it. See the note in index.css.
+          ink: "hsl(var(--accent-ink))",
+        },
         accent2: "hsl(var(--accent2))",
         primary: { DEFAULT: "hsl(var(--primary))", foreground: "hsl(var(--primary-foreground))" },
         ok: { DEFAULT: "hsl(var(--ok))", foreground: "hsl(var(--ok-foreground))" },


### PR DESCRIPTION
Testing rc20 on the light theme. The `text-ok` / `text-bad` / `text-warn` failures are **gone**. `text-accent` is still there, because it was the one state colour rc20 did not cover.

## It looked covered, and that is why it was missed

`--accent-foreground` already existed, so the accent appeared to have its ink pair. It is **white** — for text sitting *on* a solid accent fill. Text sitting *in* the accent colour is the other direction and had no token at all.

Measured in the running app:

| | contrast | needs |
|---|---|---|
| `--accent` as text on the page | **4.29:1** | 4.5 |
| `--accent` on its own `bg-accent/20` — a selected toggle | **3.29:1** | 4.5 |
| `--accent` on its tint, dark theme | **4.29:1** | 4.5 |

`--accent-ink`: **217 91% 42%** light (6.02 page / 4.62 tint), **217 91% 70%** dark (5.29 tint).

## The guard walked past the badge tones

Sabotaging `panel.tsx` changed nothing — twice. Its variant map holds `bg-ok/15 text-ok …` as a plain string, and the guard read only `className=` attributes. That is the exact blind spot the colour-literal test right above it documents having been written to avoid, and this one inherited it by reusing `classNameLiterals()`.

Scanning **every quoted string** instead surfaced seven more files whose selected state paints its own label on its own wash:

```
IconRail · VersionBadge · SessionSidebar · EditSidebar · FileTree · SearchPanel · RunStepper
```

Eight conversions, none visible to the previous rule. The guard also gained a second way to know a token is colouring text: a font size in the same string, **or** a fill of the same colour in the same string — the badge shape, which means a label on its own wash by construction.

> Two escapes did not survive being written into the guard, after the backspace in the last round: a newline class became a real line break and the file stopped parsing. It splits on the quote character now — odd indices of a split *are* the quoted strings, with nothing to escape.

## Verified live at 1280 with a viewer open

rc20's header fix holds: toolbar right edge **532** inside a column ending at 544, columns 240 + 248 + 448 = 936, header grown to 77px, **zero overlaps**. The contrast sweep goes to zero on Work and Editor.

767 desktop tests, typecheck clean, `npm run build` clean.

## Not fixed, and stated

White on the brand gradient reads **4.73** at the blue end and **2.62** at the cyan end. Making it pass needs the cyan darkened from `189 90% 42%` to roughly `189 92% 27%` — a visible change to the brand, and a decision for Bruno rather than a defect for me to fix quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)