### PR TITLE
fix(desktop): nine more labels, in the shape neither earlier rule could see

### DIFF
--- a/apps/desktop/src/components/Fusion.tsx
+++ b/apps/desktop/src/components/Fusion.tsx
@@ -154,7 +154,7 @@ function CascadeRoute({ meta, t }: { meta: CascadeMeta; t: TFunc }) {
               <span
                 className={cn(
                   "min-w-0 flex-1 truncate font-mono text-xs",
-                  accepted ? "text-accent" : "text-foreground",
+                  accepted ? "text-accent-ink" : "text-foreground",
                 )}
               >
                 {meta.models[tier] ?? "—"}

--- a/apps/desktop/src/components/code/Attachments.tsx
+++ b/apps/desktop/src/components/code/Attachments.tsx
@@ -66,7 +66,7 @@ export function AttachmentTray({
           key={a.id}
           className={cn(
             "flex items-center gap-1.5 rounded-chip border px-2 py-1 text-xs",
-            a.note ? "border-warn/40 text-warn" : "border-border text-muted-foreground",
+            a.note ? "border-warn/40 text-warn-foreground" : "border-border text-muted-foreground",
           )}
           title={a.note || undefined}
         >
@@ -99,7 +99,7 @@ export function AttachmentTray({
         <span
           className={cn(
             "flex items-center gap-1.5 text-xs",
-            vision.data.support === "no" ? "text-bad" : "text-warn",
+            vision.data.support === "no" ? "text-bad-foreground" : "text-warn-foreground",
           )}
         >
           <AlertTriangle className="h-3.5 w-3.5 shrink-0" />

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -139,7 +139,7 @@ function Verdict({
       <p
         className={cn(
           "text-xs",
-          undone === "ok" ? "text-ok" : undone === "partial" ? "text-warn" : "text-bad",
+          undone === "ok" ? "text-ok-foreground" : undone === "partial" ? "text-warn-foreground" : "text-bad-foreground",
         )}
       >
         {t(
@@ -162,7 +162,7 @@ function Verdict({
         <p
           className={cn(
             "text-xs",
-            v.state === "passed" ? "text-ok" : "text-warn",
+            v.state === "passed" ? "text-ok-foreground" : "text-warn-foreground",
           )}
         >
           {v.state === "none"
@@ -1224,7 +1224,7 @@ export function Conversation({
           <span
             className={cn(
               "ml-auto text-xs",
-              fuse ? "text-warn" : "text-muted-foreground",
+              fuse ? "text-warn-foreground" : "text-muted-foreground",
             )}
           >
             {fuse ? t("composer.fuseOn") : t("code.chat.hint")}

--- a/apps/desktop/src/components/code/SessionSidebar.tsx
+++ b/apps/desktop/src/components/code/SessionSidebar.tsx
@@ -207,7 +207,7 @@ export function SessionSidebar({
                     className={cn(
                       "flex min-w-0 flex-1 items-center gap-1.5 px-3 py-1 text-left text-xs font-semibold",
                       project === workspace
-                        ? "text-accent"
+                        ? "text-accent-ink"
                         : "text-foreground/70 hover:text-foreground",
                     )}
                   >

--- a/apps/desktop/src/components/editor/SearchPanel.tsx
+++ b/apps/desktop/src/components/editor/SearchPanel.tsx
@@ -44,7 +44,7 @@ function Hits({
           <p
             className={cn(
               "sticky top-0 truncate bg-card/80 px-2 py-1 text-xs backdrop-blur",
-              path === activePath ? "text-accent" : "text-muted-foreground",
+              path === activePath ? "text-accent-ink" : "text-muted-foreground",
             )}
             title={path}
           >

--- a/apps/desktop/src/components/run/RunLauncher.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.tsx
@@ -210,7 +210,7 @@ export function RunLauncher({
           is judging this, a model will read the answer" — reached the user only afterwards, in the
           receipt, when the run was already over. A warning that arrives after the fact is a report. */}
       {run.verify ? (
-        <p className={cn("text-xs", run.verify.command ? "text-muted-foreground" : "text-warn")}>
+        <p className={cn("text-xs", run.verify.command ? "text-muted-foreground" : "text-warn-foreground")}>
           {run.verify.command
             ? t("runs.judgedBy", { cmd: run.verify.command, src: run.verify.source })
             : t("runs.judgedByModel")}

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -159,14 +159,34 @@ describe("colour", () => {
     // variant map, so a className-only scan walks past them — which is the exact blind spot the
     // colour-literal test above documents having been written to avoid, and which this guard
     // inherited by reusing `classNameLiterals()`. Sabotage on two different tones proved it.
+    // Every quoted string, and every `cn(...)` call read as ONE class list.
+    //
+    // Three shapes had to be covered, each found only after the previous rule shipped:
+    //   1. size and colour in the same string   -> the original rule
+    //   2. a variant MAP, no size anywhere near -> caught by pairing `bg-x/NN` with `text-x`
+    //   3. size and colour in different ARMS of one `cn()` — `cn("... text-xs", on ? "text-accent"
+    //      : "...")`. Neither earlier rule sees it, and it is what left the project name in the
+    //      session sidebar at 4.29:1 after two rounds of sweeping.
     const strings: { file: string; value: string }[] = [];
+    const QUOTE = String.fromCharCode(34);
     for (const [file, text] of appSources()) {
-      // Split on the quote instead of matching. Written as a regex, the newline class became a
-      // real line break and the literal did not parse — the second time an escape has not
-      // survived being written into this file. Odd indices of a split on a quote ARE the quoted
-      // strings, exactly, with nothing to escape.
-      const chunks = text.split(String.fromCharCode(34));
+      const chunks = text.split(QUOTE);
       for (let i = 1; i < chunks.length; i += 2) strings.push({ file, value: chunks[i] });
+      // `cn(` spans, joined. Depth counting rather than a regex: a call can nest, and the arms
+      // are separated by commas that a flat match would not respect.
+      let at = text.indexOf("cn(");
+      while (at !== -1) {
+        let depth = 0;
+        let end = at + 2;
+        for (; end < text.length; end++) {
+          if (text[end] === "(") depth++;
+          else if (text[end] === ")") { depth--; if (depth === 0) break; }
+        }
+        const inner = text.slice(at, end).split(QUOTE);
+        const joined = inner.filter((_, i) => i % 2 === 1).join(" ");
+        if (joined) strings.push({ file, value: joined });
+        at = text.indexOf("cn(", end);
+      }
     }
     for (const { file, value } of strings) {
       const parts = value.split(" ").map((c) => c.trim()).filter(Boolean);


### PR DESCRIPTION
Testing rc21. The accent fix holds and the contrast sweep is clean on every screen in both themes — except one string.

## The third shape

The project name in the session sidebar was still at **4.29:1**. Its class list:

```tsx
cn("… text-xs font-semibold", project === workspace ? "text-accent" : "…")
```

The size is in one arm and the colour in another. The size rule saw a bare `"text-accent"` with nothing beside it; the fill rule saw no `bg-accent/` either. Two rounds of sweeping walked straight past it.

Each shape was found only after the previous rule shipped:

| | shape | caught by |
|---|---|---|
| 1 | size and colour in the same string | the original rule |
| 2 | a variant **map**, no size anywhere near | pairing `bg-x/NN` with `text-x` |
| 3 | size and colour in different **arms** | this one |

The guard now reads each `cn(...)` call as one class list, counting parentheses rather than matching — a call can nest, and the arms are separated by commas a flat match would not respect. It surfaced **nine** occurrences across seven files.

It also, correctly, did **not** flag `cn("shrink-0", ok ? "text-ok" : "text-bad")` — an icon, where the fill token is right and the bar is 3:1. A blanket conversion of every bare state colour would have changed it, which is why the conversion followed the guard's findings line by line rather than a grep.

## And one fix in the probe rather than the product

A `linear-gradient` reads as `transparent` through `backgroundColor`, so a white-on-gradient chip measured **1.00:1** against an ancestor it does not sit on. The probe now reports those separately as *not measurable this way* instead of inventing a number.

The gradient's real reading stands as the design question it was: **4.73** at the blue end, **2.62** at the cyan end.

## rc21 verified

Six screens, both themes, settled: **zero overlaps**, and zero contrast failures apart from the one above. 767 desktop tests, typecheck clean, `npm run build` clean. No token changed, so the site needs no sync this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)