### PR TITLE
chore(release): 0.48.0rc22

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.48.0-rc.21"
+version = "0.48.0-rc.22"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.48.0-rc.21",
+  "version": "0.48.0-rc.22",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.48.0rc21",
+  "generated_for": "0.48.0rc22",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5366,7 +5366,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.48.0rc21",
+  "generated_for": "0.48.0rc22",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.48.0rc21",
+  "generated_for": "0.48.0rc22",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.48.0rc21"
+version = "0.48.0rc22"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a


### PR DESCRIPTION
Version bump to `0.48.0rc22` (`0.48.0-rc.22` for the desktop shell).

Cut by `scripts/cut_release.py`: the three snapshots are regenerated rather than string-replaced, and the script refuses to continue if they come out stamped for a different version than the one being cut.

Merging this changes numbers in the repository. Publishing is a separate act: create the GitHub Release afterwards, which is what triggers the wheel and the installers.
