### PR TITLE
fix(desktop): code comments were below AA in both themes

### DIFF
--- a/apps/desktop/src/design/text-tokens-are-readable.test.ts
+++ b/apps/desktop/src/design/text-tokens-are-readable.test.ts
@@ -82,6 +82,22 @@ function contrastOn(ink: string, ground: [number, number, number]): number {
   return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
 }
 
+/** `H S% L% / A` composited over `base` — the editor's ground is the page plus its active-line wash.
+ *
+ *  Getting this wrong is what produced a wrong number the first time: `--code-active-line` reads
+ *  `222 40% 20% / 0.05` on the light theme, and 20% lightness LOOKS dark. At 5% over a near-white
+ *  page it composites to rgb(231,234,240) — a light surface. Measuring the comment against the
+ *  wash's base colour instead of the composite said 3.04:1 when the truth was 3.83:1, and pointed
+ *  the fix in the opposite direction.
+ */
+function over(washSpec: string, base: string): [number, number, number] {
+  const [colour, alphaPart] = washSpec.split("/");
+  const alpha = alphaPart ? parseFloat(alphaPart) : 1;
+  const w = hslToRgb(colour);
+  const b = hslToRgb(base);
+  return [0, 1, 2].map((i) => w[i] * alpha + b[i] * (1 - alpha)) as [number, number, number];
+}
+
 /** The two `:root` blocks, keyed by which theme they define. */
 function themes(): Record<"dark" | "light", Record<string, string>> {
   const blocks = [...CSS.matchAll(/:root[^{]*\{([\s\S]*?)\n\}/g)].map((m) => m[1]);
@@ -136,6 +152,24 @@ describe("text colours", () => {
       }
     },
   );
+
+  it.each([["light"], ["dark"]])("code comments are readable on the editor's ground (%s)", (which) => {
+    const theme = which === "light" ? light : dark;
+    const ground = over(theme["--code-active-line"], theme["--background"]);
+    const ratio = contrastOn(theme["--code-comment"], ground);
+    expect(ratio, `--code-comment is ${ratio.toFixed(2)}:1 on the editor ground`).toBeGreaterThanOrEqual(AA_SMALL);
+  });
+
+  it.each([["light"], ["dark"]])("a comment still reads as quieter than code (%s)", (which) => {
+    // The fix must not turn comments into ordinary text — the colour exists so the eye can skip
+    // them. Plain code sits near 14:1 on the same ground, so half of it is a generous ceiling and
+    // still leaves the two unmistakably different.
+    const theme = which === "light" ? light : dark;
+    const ground = over(theme["--code-active-line"], theme["--background"]);
+    expect(contrastOn(theme["--code-comment"], ground)).toBeLessThan(
+      contrastOn(theme["--code-plain"], ground) * 0.5,
+    );
+  });
 
   it("checks a ratio that a wrong value would actually fail", () => {
     // Guarding the guard. `hslToRgb` returning something constant, or `contrast` collapsing to 1,

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -64,7 +64,7 @@
      Hues are picked off the existing accents (blue keyword, cyan type) so a highlighted file looks
      like it belongs to this app rather than to whichever editor theme was copied in. */
   --code-plain: 210 22% 91%;
-  --code-comment: 214 14% 52%;
+  --code-comment: 214 15% 57%;
   --code-keyword: 217 91% 72%;
   --code-string: 152 48% 62%;
   --code-number: 28 90% 68%;
@@ -148,7 +148,13 @@
      would be invisible rather than merely wrong, because the dark value is chosen to sit on a dark
      page. Darkened and desaturated: the same hues at dark-theme lightness are unreadable on white. */
   --code-plain: 222 47% 14%;
-  --code-comment: 222 12% 48%;
+  /* Measured on the editor's own ground, which is the page plus the active-line wash — NOT the
+     page alone, and not the wash's base colour either. Reading that base as the background is
+     what first produced a wrong number here: `222 40% 20%` looks dark, but at 5% over a near
+     white page it composites to rgb(231,234,240).
+     Both themes were under the bar on their own ground: 3.83:1 light, 4.42:1 dark. Now 5.28 and
+     5.26, still an order of magnitude quieter than `--code-plain` at ~14. */
+  --code-comment: 222 16% 40%;
   --code-keyword: 217 82% 42%;
   --code-string: 152 52% 30%;
   --code-number: 24 78% 38%;


### PR DESCRIPTION
Measured on the editor's **own** ground, per theme:

| tema | token | ground | contrast |
|---|---|---|---|
| light | `222 12% 48%` | rgb(231,234,240) | **3.83:1** |
| dark | `214 14% 52%` | rgb(21,27,39) | **4.42:1** |

Both under the 4.5 small text needs. Now **5.28** and **5.26**, still an order of magnitude quieter than `--code-plain` at ~14:1 on the same ground — a comment should be skippable, not invisible.

## The ground is the page plus the active-line wash

Getting that wrong produced a wrong answer first. `--code-active-line` reads `222 40% 20% / 0.05` on the light theme, and 20% lightness *looks* dark — but at 5% over a near-white page it composites to rgb(231,234,240), a **light** surface. Reading the wash's base colour as the background said 3.04:1 and pointed the fix in the opposite direction. I changed both tokens the wrong way, caught it, and reverted before committing.

Two further readings were wrong before this one was right, and both were the apparatus rather than the product:

- the app had silently reverted to the **dark** theme, so a "light theme" number was the light token measured against the dark ground. The theme is now set through `localStorage` plus a reload instead of the toggle, which was not taking in a pane that does not composite;
- that same pane **freezes CSS transitions at their starting value** — separately why an earlier sweep read 35 contrast failures that settle to none. A reload sidesteps it: elements mount already final.

## The guard

It composites the wash itself, so it measures where the colour is actually used, and it checks the hierarchy as well as the ratio — a comment that passes contrast by becoming ordinary text fails it.

Sabotage confirms both directions: the old value fails at **3.85**, matching the browser's 3.83 to two decimals, and setting the comment to `--code-plain` passes contrast and fails the hierarchy.

Verified live in the running app, light theme, against the real composited ground: **3.83 → 5.28**.

771 desktop tests, typecheck clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)