### PR TITLE
fix: the four findings from the rc23 sweep

### DIFF
--- a/apps/desktop/src/components/Code.multiproject.test.tsx
+++ b/apps/desktop/src/components/Code.multiproject.test.tsx
@@ -55,6 +55,11 @@ async function withDraft(user: ReturnType<typeof userEvent.setup>) {
  * Two defects that are invisible with one project and routine with several — which is why neither
  * was found by a suite that only ever had one.
  */
+// `delay: null` on every `setup` here. This file types three sentences and a path through
+// `user.type`, which simulates a keystroke at a time with a delay between them; isolated that is
+// ~1.5s, and under a full parallel suite it crossed the 5s per-test budget and started failing
+// consistently. The delay models human typing speed, which none of these tests assert anything
+// about — what they assert is which `session_id` each turn carries.
 describe("Code — with more than one project", () => {
   beforeEach(() => {
     vi.mocked(getFsTree).mockResolvedValue(emptyTree());
@@ -75,7 +80,7 @@ describe("Code — with more than one project", () => {
     // keeping the id across a project change left the next turn writing into a conversation filed
     // under the OLD project: the screen said one thing, the disk said another, and the disk was
     // right.
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     renderWithProviders(<Code />);
 
     await send(user, "what is here?");
@@ -104,20 +109,20 @@ describe("Code — with more than one project", () => {
     // directory would race. That stops being true the moment the run is somewhere else, and
     // blocking anyway is a lie about why.
     runningIn("/some-other-project");
-    expect(await withDraft(userEvent.setup())).not.toBeDisabled();
+    expect(await withDraft(userEvent.setup({ delay: null }))).not.toBeDisabled();
   });
 
   it("a run in THIS project still does", async () => {
     // "" is the screen's project here: a fresh app has chosen none and the server falls back to its
     // own workspace. Same project, empty or not, is the case the block exists for.
     runningIn("");
-    expect(await withDraft(userEvent.setup())).toBeDisabled();
+    expect(await withDraft(userEvent.setup({ delay: null }))).toBeDisabled();
   });
 
   it("a run whose project is unknown still blocks", async () => {
     // "We cannot tell which directory it is editing" is a reason to be careful, not a reason to
     // allow — the unknown case has to fail towards the safe answer.
     runningIn(null);
-    expect(await withDraft(userEvent.setup())).toBeDisabled();
+    expect(await withDraft(userEvent.setup({ delay: null }))).toBeDisabled();
   });
 });

--- a/apps/desktop/src/components/Code.tsx
+++ b/apps/desktop/src/components/Code.tsx
@@ -33,6 +33,7 @@ import { SessionSidebar } from "@/components/code/SessionSidebar";
 import { ProjectPicker } from "@/components/code/ProjectPicker";
 import { useRunSession } from "@/lib/run-session";
 import { useT } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
 import { readWorkspace, writeWorkspace } from "@/lib/workspace";
 
 const fieldCls = "field w-full px-3 text-sm";
@@ -498,7 +499,13 @@ export function Code() {
             viewer was crushed to 0.67px, and the pair overflowed 82px into the activity panel.
             Measured by hit-testing a grid inside the panel: the composer strip and the transcript
             bubbles were painting there, not the code this time. */}
-        <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+        {/* Below `lg` the row is a column, and three stacked panes do not fit: the conversation
+            needs ~368px for its composer and header alone, and capping all three to make room
+            left it 161px and overflowing onto the viewer. So below `lg` the viewer REPLACES the
+            conversation rather than sharing the height with it — which is what the note over
+            the viewer already says it is: a consequence of opening a file, not a third of the
+            window. Close the file and the conversation is back. */}
+        <main className={cn("flex min-h-0 min-w-0 flex-1 flex-col", openFile && "max-lg:hidden")}>
           <Conversation
             key={conversationKey}
             resumeSession={sessionId}
@@ -594,7 +601,7 @@ export function Code() {
             `lg:w-[28rem]` is a BASIS, not a ceiling, and a flex child without it will not shrink —
             it overflowed the row instead and painted across the activity panel. */}
         {openFile ? (
-          <div className="flex min-h-0 min-w-0 shrink-0 flex-col border-hairline lg:w-[28rem] lg:border-l">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col border-hairline lg:w-[28rem] lg:flex-none lg:shrink-0 lg:border-l">
             <Viewer workspace={workspace} path={openFile} />
           </div>
         ) : null}

--- a/apps/desktop/src/components/Memory.tsx
+++ b/apps/desktop/src/components/Memory.tsx
@@ -5,11 +5,10 @@ import { addMemory, deleteMemory, getMemory, getMemoryLayers } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Badge, EmptyState, Panel, Screen, Spinner } from "@/components/ui/panel";
 import { ErrorState } from "@/components/ui/async";
-import { useT, type TFunc } from "@/lib/i18n";
+import { useNum, useT, type TFunc } from "@/lib/i18n";
 import type { MemoryLayers } from "@/lib/types";
 
 const inputCls = "field h-9 w-full px-3 text-sm";
-const num = (n: number): string => n.toLocaleString();
 
 type LayerRow = MemoryLayers["layers"][number];
 
@@ -28,6 +27,7 @@ function Tile({ label, value, tone }: { label: string; value: string; tone?: "ok
 
 /** One kind's row: name, count · clean N · unverified M, and a proportional bar (guard max ≥ 1). */
 function LayerBar({ row, max, t }: { row: LayerRow; max: number; t: TFunc }) {
+  const num = useNum();
   const pct = row.count > 0 ? Math.max((row.count / max) * 100, 3) : 0;
   return (
     <div className="px-4 py-3">
@@ -47,6 +47,7 @@ function LayerBar({ row, max, t }: { row: LayerRow; max: number; t: TFunc }) {
 
 /** The layers + provenance overview above the fact list, driven by /api/memory/layers. */
 function LayersPanel({ t }: { t: TFunc }) {
+  const num = useNum();
   const q = useQuery({ queryKey: ["memory-layers"], queryFn: getMemoryLayers });
   const data = q.data;
 

--- a/apps/desktop/src/components/Settings.names.test.tsx
+++ b/apps/desktop/src/components/Settings.names.test.tsx
@@ -1,0 +1,128 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Settings } from "@/components/Settings";
+import { getConfig, getDoctor, getInstructions, getMessaging } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", () => ({
+  getCompletionStats: vi.fn(async () => ({ accepted: 0, dismissed: 0, rate: null, mean_ms: null })),
+  getConfig: vi.fn(),
+  getDoctor: vi.fn(),
+  getInstructions: vi.fn(),
+  getMessaging: vi.fn(),
+  getOllamaModels: vi.fn(async () => ({ base_url: "", reachable: false, models: [], reason: "no_url" })),
+  patchConfig: vi.fn(async () => ({ updated: [] })),
+  putInstructions: vi.fn(),
+  startMessaging: vi.fn(),
+  stopMessaging: vi.fn(),
+}));
+
+/**
+ * Every control on this screen says what it is FOR, not just what is in it.
+ *
+ * Walking the running app turned up a dozen inputs with no accessible name. Buttons and tabs were
+ * all fine; form controls were not. They had placeholders, which is not the same thing — a
+ * placeholder disappears the moment the field has content, and screen readers differ on whether
+ * they announce one at all.
+ *
+ * The worst case was here: **five password fields rendering at once**, every one announcing "cole a
+ * chave…", with nothing saying which provider it belonged to. On the one screen where pasting the
+ * wrong secret into the wrong field is a real and silent error.
+ *
+ * Rendered rather than read from source, because the accessible name has several sources — an
+ * `aria-label`, a `<label for>`, a wrapping `<label>` — and a source scan that only looked for the
+ * first would have accused every checkbox on the screen of a defect it does not have. Testing
+ * Library computes the name the way a screen reader does, which is the only definition that counts.
+ */
+
+const PROVIDERS = [
+  { env: "OPENROUTER_API_KEY", label: "OpenRouter", hint: "sk-or-…", keys_url: "", llm: true, name: "openrouter", set: false, model: "" },
+  { env: "ANTHROPIC_API_KEY", label: "Anthropic", hint: "sk-ant-…", keys_url: "", llm: true, name: "anthropic", set: false, model: "" },
+  { env: "TAVILY_API_KEY", label: "Tavily", hint: "tvly-…", keys_url: "", llm: false, name: "tavily", set: false, model: "" },
+];
+
+function config() {
+  return {
+    models: { default: "openrouter/x", weak: "", mid: "", orchestrator: "", cost_mode: "auto", cascade: false, api_base: null, fallback_models: [], complete_model: "", ollama_base_url: "", tiers: { weak: "a", mid: "b", top: "c" } },
+    memory: { backend: "json", semantic: false, auto_consolidate: false, remember_from_chat: false, skill_cards: false, embed_model: "" },
+    cache: { completion: false, prompt: false },
+    autonomy: { reach: "", approval: "", host_exec: "ask", denied_tools: [] },
+    sandbox: { mode: "local", image: "python:3.12-slim" },
+    server: { token_set: false },
+    mcp: { autoload: false },
+    automation: { cron: true },
+    guard: { chat: false },
+    providers: PROVIDERS,
+    applies: {},
+  };
+}
+
+/** Controls the accessibility tree gives no name to. */
+function anonymous(): string[] {
+  const out: string[] = [];
+  for (const el of document.querySelectorAll("input, select, textarea")) {
+    const control = el as HTMLInputElement;
+    if (control.type === "hidden") continue;
+    const labelled =
+      control.getAttribute("aria-label")?.trim() ||
+      control.getAttribute("aria-labelledby") ||
+      (control.id && document.querySelector(`label[for="${control.id}"]`)) ||
+      control.closest("label");
+    if (!labelled) out.push(`<${control.tagName.toLowerCase()} placeholder="${control.placeholder ?? ""}">`);
+  }
+  return out;
+}
+
+describe("Settings — every control has a name", () => {
+  beforeEach(() => {
+    vi.mocked(getConfig).mockResolvedValue(config() as Awaited<ReturnType<typeof getConfig>>);
+    vi.mocked(getDoctor).mockResolvedValue({
+      has_any_key: true, configured_providers: ["openrouter"], default_model: "openrouter/x",
+      tiers: { weak: "a", mid: "b", top: "c" }, memory_backend: "json", cache: true,
+    } as Awaited<ReturnType<typeof getDoctor>>);
+    vi.mocked(getInstructions).mockResolvedValue({ instructions: "", language: "", name: "" });
+    vi.mocked(getMessaging).mockResolvedValue({} as Awaited<ReturnType<typeof getMessaging>>);
+  });
+
+  it("names the controls on the general tab", async () => {
+    renderWithProviders(<Settings />);
+    await screen.findByText(/Appearance|Aparência/i);
+
+    expect(anonymous(), "unnamed controls").toEqual([]);
+  });
+
+  it("names each API key field after its provider", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Settings />);
+
+    await screen.findByText(/Appearance|Aparência/i);
+    // The keys live on the GENERAL tab, and each renders a button until it is opened. Opening them
+    // all is what puts the identical password fields on screen at once — the state the defect lived
+    // in, and the reason "which one is this?" mattered.
+    for (const b of await screen.findAllByRole("button", { name: /^Set$|^Definir$/i })) await user.click(b);
+
+    expect(anonymous(), "unnamed controls").toEqual([]);
+    for (const p of PROVIDERS) {
+      expect(screen.getByLabelText(p.label), `no field named for ${p.label}`).toBeTruthy();
+    }
+  });
+
+  it("would notice if a name were removed", async () => {
+    // Guarding the guard. `anonymous()` returning [] for the wrong reason — a selector that matches
+    // nothing, a render that failed — is the failure mode that makes a green a11y test worthless.
+    renderWithProviders(<Settings />);
+    await screen.findByText(/Appearance|Aparência/i);
+
+    const first = document.querySelector("input, select, textarea") as HTMLElement;
+    expect(first, "found no controls at all").toBeTruthy();
+    const held = first.getAttribute("aria-label");
+    first.removeAttribute("aria-label");
+    first.removeAttribute("aria-labelledby");
+    first.removeAttribute("id");
+
+    expect(anonymous().length).toBeGreaterThan(0);
+    if (held) first.setAttribute("aria-label", held);
+  });
+});

--- a/apps/desktop/src/components/Settings.tsx
+++ b/apps/desktop/src/components/Settings.tsx
@@ -513,6 +513,9 @@ function LanguageSelect() {
   return (
     <select
       className={inputCls}
+      // A bare select announced as "combo box, Português" — the value, with no statement of what
+      // it selects. It sits in a Row like every other control here and simply never asked it.
+      aria-label={useContext(RowLabelContext)}
       value={lang}
       onChange={(e) =>
         setLang(e.target.value as (typeof LANGS)[number]["code"])
@@ -619,6 +622,12 @@ function SecretField({
         type="password"
         autoFocus
         placeholder={t("settings.pasteKey")}
+        // Named from its Row, like the model field above. Five of these render at once on the
+        // Conexões tab and every one announced the same thing — "cole a chave…", the placeholder,
+        // with nothing saying WHICH provider. A placeholder is not a label: it disappears the
+        // moment there is content, and on a password field where the wrong paste is a real error
+        // that is the point at which knowing matters most.
+        aria-label={useContext(RowLabelContext)}
         value={v}
         onChange={(e) => setV(e.target.value)}
       />
@@ -703,6 +712,10 @@ function PoolField({
           className={inputCls}
           type="password"
           placeholder={t("settings.pasteKey")}
+          // Third copy of this markup and the third to need naming. This one is not inside a Row,
+          // so it names itself from the pool's provider — which is the whole distinction between
+          // one pool's field and the next.
+          aria-label={`${t("settings.pasteKey")} — ${pool.provider}`}
           value={v}
           onChange={(e) => {
             setV(e.target.value);
@@ -770,6 +783,9 @@ export function MessagingCard({
               type="password"
               autoFocus
               placeholder={t("settings.pasteKey")}
+              // Named for its platform: Discord's token field and Telegram's are the same markup on
+              // the same screen, and the placeholder cannot tell them apart.
+              aria-label={t("settings.row.botToken", { platform: label })}
               value={token}
               onChange={(e) => setToken(e.target.value)}
             />

--- a/apps/desktop/src/components/Usage.tsx
+++ b/apps/desktop/src/components/Usage.tsx
@@ -3,7 +3,7 @@ import { BarChart3 } from "lucide-react";
 import { getUsage } from "@/lib/api";
 import { Badge, EmptyState, Panel, Screen, Spinner } from "@/components/ui/panel";
 import { ErrorState } from "@/components/ui/async";
-import { useT, type TFunc } from "@/lib/i18n";
+import { useNum, useT, type TFunc } from "@/lib/i18n";
 import type { UsageSummary } from "@/lib/types";
 
 /** Grouped rows carry a leading key field (day / model / session_id); type them structurally. */
@@ -11,7 +11,6 @@ type DayRow = UsageSummary["by_day"][number];
 type ModelRow = UsageSummary["by_model"][number];
 type SessionRow = UsageSummary["by_session"][number];
 
-const num = (n: number): string => n.toLocaleString();
 const usd = (n: number): string => `$${n.toFixed(4)}`;
 /** Honest per-group price: "—" when EVERY turn in the group is unpriced (unknown cost — never a fake
  *  $0.0000); otherwise the summed cost of the priced turns. */
@@ -42,6 +41,7 @@ function DayBars({
   chartUsd: boolean;
   t: TFunc;
 }) {
+  const num = useNum();
   const value = (d: DayRow): number => (chartUsd ? d.usd : d.prompt_tokens + d.completion_tokens);
   const label = (d: DayRow): string =>
     chartUsd ? groupUsd(d.usd, d.unpriced, d.turns) : num(d.prompt_tokens + d.completion_tokens);
@@ -109,6 +109,7 @@ function DayBars({
 
 /** A ranked horizontal bar (CSS width, accent gradient) with the model's turns/tokens/usd. */
 function ModelBar({ row, max }: { row: ModelRow; max: number }) {
+  const num = useNum();
   const tokens = row.prompt_tokens + row.completion_tokens;
   const pct = Math.max((row.turns / max) * 100, 3);
   return (
@@ -127,6 +128,7 @@ function ModelBar({ row, max }: { row: ModelRow; max: number }) {
 }
 
 export function Usage({ embedded = false }: { embedded?: boolean } = {}) {
+  const num = useNum();
   const t = useT();
   const q = useQuery({ queryKey: ["usage"], queryFn: getUsage });
 

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -60,7 +60,7 @@ import {
   transcriptFilename,
   type TranscriptExchange,
 } from "@/lib/transcript";
-import { useT, type TFunc } from "@/lib/i18n";
+import { useNum, useT, type TFunc } from "@/lib/i18n";
 import { useAgent } from "@/lib/agent-context";
 import { useStickToBottom } from "@/lib/useStickToBottom";
 import { cn } from "@/lib/utils";
@@ -295,6 +295,7 @@ const STOP_REASONS: Record<string, string> = {
  *  a saved memory against none, an unknown cost against a free one. Those are exactly the claims
  *  this file exists to keep honest, so they are worth asserting directly. */
 export function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
+  const num = useNum();
   // `stopped_reason` arrives on every `done` frame and, outside types and mocks, nothing read it.
   // So a turn that hit the step ceiling and stopped mid-task was pixel-for-pixel identical to one
   // that finished the work — the receipt drew nine badges and not the one that says whether to
@@ -319,7 +320,7 @@ export function TurnReceipt({ done, t }: { done: CodeTurnDone; t: TFunc }) {
       {done.context_peak_tokens !== null && done.context_peak_tokens > 0 ? (
         <Badge>
           {t("code.chat.peak", {
-            n: done.context_peak_tokens.toLocaleString(),
+            n: num(done.context_peak_tokens),
           })}
         </Badge>
       ) : null}

--- a/apps/desktop/src/components/code/SessionSidebar.tsx
+++ b/apps/desktop/src/components/code/SessionSidebar.tsx
@@ -124,7 +124,13 @@ export function SessionSidebar({
   return (
     // `shrink-0`: this is a fixed 240px rail, not a column that negotiates. Letting it shrink meant
     // three columns competing for the same pixels and none of them winning cleanly.
-    <aside className="flex min-h-0 w-60 shrink-0 flex-col border-r border-hairline">
+    //
+    // `max-h-40` only while STACKED. Below `lg` the row is a COLUMN, and `shrink-0` — right on the
+    // horizontal axis, where this is a fixed rail — then means "do not shrink my HEIGHT". Stacked,
+    // this and the file viewer ate the whole row and the conversation's `flex-1` resolved to zero:
+    // measured at 1000x900 it had height 0 at y=1068, off a 900px window, and the shell scrolled to
+    // 1424. The list scrolls inside itself already, so a cap costs only how many rows show at once.
+    <aside className="flex max-h-40 min-h-0 w-60 shrink-0 flex-col border-r border-hairline lg:max-h-none">
       <div className="flex items-center gap-1 p-2">
         <Button size="sm" variant="ghost" className="flex-1 justify-start" onClick={onNew}>
           <Plus className="h-4 w-4" /> {t("code.sessions.new")}

--- a/apps/desktop/src/components/code/columns-can-shrink.test.ts
+++ b/apps/desktop/src/components/code/columns-can-shrink.test.ts
@@ -87,8 +87,13 @@ const COLUMNS = [
     what: "the file viewer",
     file: join("components", "Code.tsx"),
     marker: "lg:w-[28rem]",
-    must: ["min-w-0", "shrink-0", "min-h-0"],
-    mustNot: ["flex-1"],
+    // `flex-1` WITHOUT a breakpoint would be wrong, and `flex-1` with `lg:flex-none` is the only
+    // way to be right on both axes: below `lg` the row is a column and the viewer must fill the
+    // height it is given and scroll inside; from `lg` up the row is a row and it must hold 28rem.
+    // Written as `shrink-0` alone it grew to its content height when stacked — 2273px in a 774px
+    // row — and the shell scrolled.
+    must: ["min-w-0", "min-h-0", "flex-1", "lg:flex-none", "lg:shrink-0"],
+    mustNot: [],
   },
   {
     what: "the conversation's inner column",
@@ -118,16 +123,40 @@ describe("the Code screen's three columns", () => {
     for (const cls of must) expect(line, `missing ${cls}`).toContain(cls);
   });
 
+  it("the stacked layout gives the conversation a real share", () => {
+    // Below `lg` the row is a COLUMN. Measured at 1000x900 before this rule, with a project and a
+    // file open: aside 968 tall, conversation height 0 at y=1068 — off a 900px window — viewer 2273,
+    // and the shell scrolled to 3341. Everything that is correct on the horizontal axis (`shrink-0`
+    // on a fixed rail and a fixed panel) is wrong on the vertical one, where it reads "do not shrink
+    // my height".
+    //
+    // Three panes do not fit: the conversation needs ~368px for its composer and header alone, and
+    // capping all three to make room left it 161 and overflowing. So below `lg` there are two: the
+    // capped rail, and EITHER the conversation OR the viewer.
+    const rail = columnLine(join("components", "code", "SessionSidebar.tsx"), "<aside className=");
+    expect(rail, "the rail must be capped while stacked").toContain("max-h-40");
+    expect(rail, "and uncapped once it is a column again").toContain("lg:max-h-none");
+
+    const source = readFileSync(join(SRC, "components", "Code.tsx"), "utf8");
+    expect(
+      /openFile && "max-lg:hidden"/.test(source),
+      "the conversation must yield to the viewer while stacked",
+    ).toBe(true);
+  });
+
   it("has exactly one column that grows", () => {
     // The property the whole layout rests on. Two growing columns is how the row stops having a
     // single answer to "who gives ground", and one is how the file viewer ended up at 0.67px.
     const growers = COLUMNS.filter((c) => {
       const line = columnLine(c.file, c.marker);
-      return /\bflex-1\b/.test(line) && !/\bshrink-0\b/.test(line);
+      // Growing on the HORIZONTAL axis, which is the row from `lg` up. A `flex-1` that is
+      // cancelled by `lg:flex-none` grows only while stacked, and that is a different question.
+      return /flex-1/.test(line) && !/shrink-0/.test(line) || /flex-1/.test(line) && /lg:flex-none/.test(line);
     });
 
     expect(growers.map((c) => c.what)).toEqual([
       "the conversation — the column that absorbs",
+      "the file viewer",
       "the conversation's inner column",
     ]);
   });

--- a/apps/desktop/src/components/orchestration/DelegationSavings.test.tsx
+++ b/apps/desktop/src/components/orchestration/DelegationSavings.test.tsx
@@ -20,15 +20,15 @@ vi.mock("@/lib/api", async () => (await import("@/test/code-api-mock")).makeCode
  * derived both lines from one verdict would have to call that either a win or a loss, and it is
  * both, so they are decided separately.
  */
-/** The digits, however the runtime's locale groups them.
+/** The digits as the APP's language groups them.
  *
- *  `toLocaleString()` takes no locale argument anywhere in this app, so it follows the OS rather
- *  than the language selector — 4200 renders "4,200" on an English machine and "4.200" on Bruno's.
- *  Hard-coding either separator would make this file pass or fail by whose laptop ran it, which is
- *  not what it is here to check. (The mismatch itself is real and filed separately: "4.200 tokens"
- *  inside an English sentence reads as four point two.)
+ *  This used to accept either separator, because `toLocaleString()` took no locale anywhere in the
+ *  app and so followed the machine — 4200 was "4,200" on one laptop and "4.200" on another, and
+ *  hard-coding either made the file pass or fail by whose laptop ran it. That is fixed: `useNum`
+ *  formats for the chosen language, the tests render in English, and the separator is now a fact
+ *  rather than a coin toss. `numbers-follow-the-language.test.tsx` is what keeps it one.
  */
-const grouped = (n: number) => new RegExp(n.toLocaleString().replace(/[.,]/g, "[.,]"));
+const grouped = (n: number) => new RegExp(new Intl.NumberFormat("en").format(n).replace(",", ","));
 
 function summary(token_saving: number, usd_saving: number | null) {
   vi.mocked(getDelegations).mockResolvedValue({
@@ -55,7 +55,7 @@ describe("DelegationSavings", () => {
     expect(line.textContent).toContain("MORE");
     expect(line.textContent).not.toContain("saved");
     // The minus belongs to the wording. "-12,961 tokens MORE" would be the same defect rephrased.
-    expect(line.textContent).not.toContain(`-${(12961).toLocaleString()}`);
+    expect(line.textContent).not.toContain(`-${new Intl.NumberFormat("en").format(12961)}`);
   });
 
   it("keeps the dollars honest on their own, not from the token verdict", async () => {

--- a/apps/desktop/src/components/orchestration/DelegationSavings.tsx
+++ b/apps/desktop/src/components/orchestration/DelegationSavings.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Split } from "lucide-react";
 
 import { getDelegations } from "@/lib/api";
-import { useT } from "@/lib/i18n";
+import { useNum, useT } from "@/lib/i18n";
 
 /**
  * What splitting the work actually saved, measured against what one agent would have cost.
@@ -28,6 +28,7 @@ import { useT } from "@/lib/i18n";
  */
 export function DelegationSavings() {
   const t = useT();
+  const num = useNum();
   const { data } = useQuery({ queryKey: ["delegations"], queryFn: getDelegations });
   const summary = data?.summary;
 
@@ -49,7 +50,7 @@ export function DelegationSavings() {
 
       <p className={tokens < 0 ? "text-xs text-warn-foreground" : "text-xs text-foreground"}>
         {t(tokens < 0 ? "orch.saving.tokensMore" : "orch.saving.tokens", {
-          n: Math.abs(tokens).toLocaleString(),
+          n: num(Math.abs(tokens)),
           runs: summary.n,
         })}
       </p>

--- a/apps/desktop/src/components/shell/AgentStatusBar.tsx
+++ b/apps/desktop/src/components/shell/AgentStatusBar.tsx
@@ -6,7 +6,7 @@ import { VersionBadge } from "@/components/VersionBadge";
 import { focusRing } from "@/components/ui/focus";
 import { useAgent } from "@/lib/agent-context";
 import { useRunSession } from "@/lib/run-session";
-import { useT } from "@/lib/i18n";
+import { useNum, useT } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 
 /**
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
  */
 export function AgentStatusBar({ onOpenUsage }: { onOpenUsage?: () => void }) {
   const t = useT();
+  const num = useNum();
   const { status, tools, report, busy, stop } = useAgent();
   const run = useRunSession();
   // A live run outranks the chat turn as the subject of this bar. Both can be going at once, but
@@ -74,7 +75,7 @@ export function AgentStatusBar({ onOpenUsage }: { onOpenUsage?: () => void }) {
         <>
           <Separator />
           {/* Prompt + completion, matching what the Activity panel shows for the same turn. */}
-          <span>{(report.prompt_tokens + report.completion_tokens).toLocaleString()} tok</span>
+          <span>{num(report.prompt_tokens + report.completion_tokens)} tok</span>
           <button
             type="button"
             onClick={onOpenUsage}

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -11351,3 +11351,21 @@ export function useI18n(): I18nValue {
 export function useT(): TFunc {
   return useI18n().t;
 }
+
+/** Group digits the way the CHOSEN language does, not the way the machine does.
+ *
+ *  `Number.toLocaleString()` with no argument follows the operating system. On a pt-BR machine with
+ *  the app set to English that renders 4200 as "4.200", and the English sentence around it —
+ *  "4.200 tokens saved across 3 delegated runs" — reads as four point two. A thousandfold misread,
+ *  in the one place a number is the whole content.
+ *
+ *  The formatter is memoised per language rather than built per call: these render inside lists that
+ *  can hold hundreds of rows, and `Intl.NumberFormat` construction is the expensive half.
+ */
+export function useNum(): (n: number) => string {
+  const { lang } = useI18n();
+  return useMemo(() => {
+    const fmt = new Intl.NumberFormat(lang);
+    return (n: number) => fmt.format(n);
+  }, [lang]);
+}

--- a/apps/desktop/src/lib/numbers-follow-the-language.test.tsx
+++ b/apps/desktop/src/lib/numbers-follow-the-language.test.tsx
@@ -1,0 +1,90 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { I18nProvider, useNum } from "@/lib/i18n";
+
+/**
+ * A number is grouped the way the CHOSEN language groups it, not the way the machine does.
+ *
+ * `Number.toLocaleString()` with no argument follows the operating system. On a pt-BR machine with
+ * the app set to English, 4200 renders "4.200" and the English sentence around it — "4.200 tokens
+ * saved across 3 delegated runs" — reads as four point two. A thousandfold misread, in the one
+ * place where the number IS the content.
+ *
+ * Found by a test failing for the right reason and the wrong cause: an assertion expecting "4,200"
+ * met "4.200" and the first instinct was to loosen the assertion. The separator was the defect.
+ *
+ * Two halves, because either alone would pass while the app stayed wrong: the behaviour has to
+ * change with the language, and no call site may go back to the locale-free form.
+ */
+
+function Amostra({ n }: { n: number }) {
+  const num = useNum();
+  return <span data-testid="n">{num(n)}</span>;
+}
+
+function renderIn(lang: string, n: number): string {
+  localStorage.setItem("chimera.lang", lang);
+  const { unmount } = render(
+    <I18nProvider>
+      <Amostra n={n} />
+    </I18nProvider>,
+  );
+  const out = screen.getByTestId("n").textContent ?? "";
+  unmount();
+  return out;
+}
+
+const SRC = join(__dirname, "..");
+
+function sources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) sources(full, out);
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("numbers", () => {
+  it("groups them differently in English and Portuguese", () => {
+    const en = renderIn("en", 1234567);
+    const pt = renderIn("pt", 1234567);
+
+    expect(en, "English should group with commas").toContain(",");
+    expect(pt, "Portuguese should group with dots").toContain(".");
+    expect(en).not.toBe(pt);
+  });
+
+  it("does not follow the machine", () => {
+    // The property that was broken. `toLocaleString()` with no argument gives ONE answer per
+    // machine; this must give a different one per language on the same machine, which the
+    // assertion above already proves — so this pins the direction rather than repeating it.
+    expect(renderIn("de", 1234567)).toBe("1.234.567");
+    expect(renderIn("en", 1234567)).toBe("1,234,567");
+  });
+
+  it("leaves no call site on the locale-free form", () => {
+    // `useNum` existing changes nothing if the five call sites still call the bare method. Scanned
+    // over production source only: a test may legitimately write `toLocaleString()` to describe
+    // what the runtime does, and `i18n.tsx` is where the one legitimate `Intl` construction lives.
+    const offenders: string[] = [];
+    for (const file of sources(SRC)) {
+      if (file.endsWith(join("lib", "i18n.tsx"))) continue;
+      const text = readFileSync(file, "utf8");
+      // The empty-argument form specifically. `toLocaleString("pt")` is a deliberate choice and
+      // this has nothing to say about it.
+      if (/toLocaleString\(\s*\)/.test(text)) offenders.push(file.slice(SRC.length + 1));
+    }
+    expect(offenders, "call sites that follow the OS instead of the app").toEqual([]);
+  });
+
+  it("would notice a call site coming back", () => {
+    // Guarding the guard: the regex above is the whole check, and a regex that matches nothing
+    // passes for the wrong reason.
+    expect(/toLocaleString\(\s*\)/.test("const x = n.toLocaleString();")).toBe(true);
+    expect(/toLocaleString\(\s*\)/.test('const x = n.toLocaleString("pt");')).toBe(false);
+  });
+});

--- a/chimera/governance/audit.py
+++ b/chimera/governance/audit.py
@@ -33,13 +33,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from chimera.core.filelock import locked
+
+_log = logging.getLogger(__name__)
 
 # Reserved on every entry; a payload may not override them, or the chain would be forgeable by the
 # caller that is supposed to be audited.
@@ -106,6 +110,22 @@ def _redacted(payload: dict[str, Any]) -> dict[str, Any]:
 #: larger than any entry written here — the kernel truncates ``action`` and ``reason`` to 200
 #: characters — so the loop below finds its newline on the first read in the ordinary case.
 _TAIL_CHUNK = 8192
+
+#: How many times `record` re-tries when the FILE lock could not be taken.
+#:
+#: `locked()` degrades rather than raising: on Windows `msvcrt.locking` retries for ~10s and then
+#: gives up, and the helper writes unlocked so a 24/7 process is never wedged. That is the right
+#: default for most callers and the wrong one here — two processes that both skip the lock read the
+#: same tail, claim the same `seq`, and chain onto the same `prev`. Caught as an intermittent CI
+#: failure: `seq duplicado: [0, 1, 2, 1, 2, 3, ...]`.
+#:
+#: Three attempts turn a ~10s window into ~30s of trying. It cannot close the hole — without a lock
+#: there is no way to make read-then-append atomic — but it makes losing the race require sustained
+#: contention rather than a moment of it.
+_LOCK_ATTEMPTS = 3
+
+#: Seconds between attempts, multiplied by the attempt number.
+_LOCK_BACKOFF_S = 0.25
 
 #: One lock per audit file per process, shared by every :class:`AuditLog` naming that file. Bounded
 #: by how many distinct audit files a process touches, never by how much it writes to them.
@@ -232,18 +252,42 @@ class AuditLog:
         # own thread. Holding the process lock first leaves the file lock arbitrating only BETWEEN
         # processes, which is the job it is good at and the one `chimera serve` needs: the cron
         # daemon and the HTTP gateway write this same file from different processes, all day.
-        with _process_lock(self.path), locked(self.path):
-            seq, prev = self._tail_state()
-            entry: dict[str, Any] = {"seq": seq, "type": event_type, **_redacted(payload)}
-            # Chain fields are written last on purpose: a payload cannot overwrite them.
-            entry["prev"] = prev
-            entry["hash"] = _digest(entry)
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            with self.path.open("a", encoding="utf-8") as handle:
-                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
-            self._count = seq + 1
-            self._head = entry["hash"]
-        return entry
+        # Retry rather than accept the degraded write. `locked()` yields whether a real lock was
+        # taken precisely so a caller can react, and this is the caller that must: an unlocked
+        # append duplicates `seq` and breaks the chain, which the Security screen then reports as
+        # tampering on a log nobody touched.
+        #
+        # The last attempt writes ANYWAY. An audit log that silently drops entries under contention
+        # is worse than one with a break somebody can see and explain — a missing entry is never
+        # honest about itself, and a break at least is.
+        #
+        # Marking the entry and letting `verify` treat it as unchained was the other candidate and
+        # is worse: `unlocked: true` would become a field anyone can forge to make the chain restart
+        # wherever they want it to, which widens the one hatch the legacy path already opens.
+        for attempt in range(_LOCK_ATTEMPTS):
+            with _process_lock(self.path), locked(self.path) as got_lock:
+                if not got_lock and attempt < _LOCK_ATTEMPTS - 1:
+                    continue
+                if not got_lock:
+                    _log.error(
+                        "appending to %s WITHOUT the file lock after %d attempts; a concurrent "
+                        "writer can duplicate seq and break the chain here",
+                        self.path.name,
+                        _LOCK_ATTEMPTS,
+                    )
+                seq, prev = self._tail_state()
+                entry: dict[str, Any] = {"seq": seq, "type": event_type, **_redacted(payload)}
+                # Chain fields are written last on purpose: a payload cannot overwrite them.
+                entry["prev"] = prev
+                entry["hash"] = _digest(entry)
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                with self.path.open("a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+                self._count = seq + 1
+                self._head = entry["hash"]
+                return entry
+            time.sleep(_LOCK_BACKOFF_S * (attempt + 1))
+        raise AssertionError("unreachable: the last attempt always writes")
 
     def entries(self) -> list[dict[str, Any]]:
         if not self.path.exists():

--- a/tests/test_audit_lock_degrades.py
+++ b/tests/test_audit_lock_degrades.py
@@ -1,0 +1,101 @@
+"""What `record` does when the file lock cannot be taken.
+
+`locked()` degrades rather than raising — on Windows `msvcrt.locking` retries for about ten seconds
+and then gives up, and the helper writes unlocked so a 24/7 process is never wedged. It yields
+whether a real lock was taken *"so a caller that wants to record degraded operation can"*, and the
+one caller that most needs that signal was discarding it.
+
+The consequence was measured, not theorised: an intermittent CI failure on Windows,
+``seq duplicado: [0, 1, 2, 1, 2, 3, ...]`` — two processes reading the same tail, claiming the same
+``seq`` and chaining onto the same ``prev``. It passed on a rerun of the identical commit, which is
+exactly what made it easy to wave away.
+
+**These tests drive that path deterministically**, by making the lock fail on demand. The Windows
+race is not reproducible on purpose and a guard that needs one is not a guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+import chimera.governance.audit as audit_mod
+from chimera.governance.audit import AuditLog
+
+
+@pytest.fixture
+def lock_falha(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Make the file lock unobtainable, and count how many times it was asked for."""
+    pedidos: list[int] = []
+
+    def _recusa(handle: object) -> None:
+        pedidos.append(1)
+        raise OSError("lock unavailable (test)")
+
+    # Patched where `locked()` reads it, so the degraded path inside the real helper runs — the
+    # point is to exercise `locked()`, not to replace it with a stand-in that only looks similar.
+    monkeypatch.setattr("chimera.core.filelock._acquire", _recusa)
+    monkeypatch.setattr(audit_mod, "_LOCK_BACKOFF_S", 0.0)  # the wait is not what is under test
+    return pedidos
+
+
+def test_it_tries_more_than_once(tmp_path: Path, lock_falha: list[int]) -> None:
+    """The whole point: one failure to lock is not a reason to write unlocked."""
+    AuditLog(tmp_path / "audit.jsonl").record("test", {})
+
+    assert len(lock_falha) == audit_mod._LOCK_ATTEMPTS, (
+        f"asked for the lock {len(lock_falha)} times, expected {audit_mod._LOCK_ATTEMPTS}"
+    )
+
+
+def test_the_entry_is_still_written(tmp_path: Path, lock_falha: list[int]) -> None:
+    """An audit log that drops entries under contention is worse than one with a visible break.
+
+    A missing entry is never honest about itself; a break at least is, and `verify` names it.
+    """
+    log = AuditLog(tmp_path / "audit.jsonl")
+    entry = log.record("test", {"a": 1})
+
+    assert entry["seq"] == 0
+    assert log.entries() == [entry]
+    assert log.verify().ok
+
+
+def test_it_says_so_at_error_level(tmp_path: Path, lock_falha: list[int], caplog: pytest.LogCaptureFixture) -> None:
+    """Loud, because the helper's own warning is one line in a log nobody reads during a run.
+
+    `locked()` logs at WARNING when it degrades, which is right for callers that can live with it.
+    This caller cannot: the next concurrent writer breaks the chain, and the Security screen reports
+    that break as tampering on a file nobody touched.
+    """
+    with caplog.at_level(logging.ERROR, logger="chimera.governance.audit"):
+        AuditLog(tmp_path / "audit.jsonl").record("test", {})
+
+    assert any("WITHOUT the file lock" in r.getMessage() for r in caplog.records), (
+        f"nothing said the write was unlocked; got {[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_a_lock_that_works_is_asked_for_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Guarding the guard: without this, a `record` that always retried would pass the tests above.
+
+    The retry must be a response to failure, not a fixed cost paid by every append — this file
+    writes one entry per governed action and the ordinary path has to stay one acquisition.
+    """
+    pedidos: list[int] = []
+    real = audit_mod.locked
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _contando(path: Path):  # type: ignore[no-untyped-def]
+        pedidos.append(1)
+        with real(path) as got:
+            yield got
+
+    monkeypatch.setattr(audit_mod, "locked", _contando)
+    AuditLog(tmp_path / "audit.jsonl").record("test", {})
+
+    assert len(pedidos) == 1, f"took the lock {len(pedidos)} times when it was available"


### PR DESCRIPTION
Four independent defects, one commit each, every one with a guard and sabotage.

## 1 · The Code screen was unusable below 1024px

At 1000x900 with a project and a file open:

```
ASIDE  240 wide,  968 tall
MAIN   646 wide,    0 tall,  top 1068   <- off a 900px window
DIV    646 wide, 2273 tall
document.scrollHeight 3341 vs 900       <- the shell scrolled
```

Below `lg` the row is a **column**, and everything right on the horizontal axis is wrong on the vertical one: `shrink-0` on a fixed rail and a fixed panel reads as *do not shrink my height*. Only this screen was affected.

Three panes do not fit — the conversation needs ~368px for its composer and header alone, and capping all three left it 161 and overflowing, 19 overlaps where there had been 1. Tuning the caps found a point that scores zero with **eight pixels of slack**, which is not a layout.

So below `lg` there are two panes: the capped rail, and *either* the conversation *or* the viewer — which is what the note over the viewer already claimed it was, "a consequence of opening a file, not a permanent third of the window". Verified by injecting exactly these properties into the running app: **aside 160 + viewer 614 = 774, no page scroll, zero overlaps.**

## 2 · The audit chain wrote without its lock and did not say so

`msvcrt.locking` retries ~10s then raises; `locked()` catches that and runs the body **unlocked** so a 24/7 process is never wedged; `AuditLog.record` discarded the flag saying so. Two processes then read the same tail and claim the same `seq` — caught as `seq duplicado: [0, 1, 2, 1, 2, 3, ...]`, which passed on a rerun and so was easy to wave away.

`record` retries three times and logs at ERROR when it still cannot lock. The last attempt writes anyway: an audit log that drops entries under contention is worse than one with a break somebody can see.

> **The other candidate was worse.** Marking the entry `unlocked: true` and letting `verify` treat it as unchained keeps the chain "ok" — and makes that a field anyone can forge to restart the chain wherever they like.

The new tests drive the degraded path by making `_acquire` raise, rather than depending on a Windows race — a guard that needs a race is not a guard. One of them checks the lock is taken exactly **once** when available, so a `record` that always retried would not pass.

## 3 · The API key fields did not say which key

Three copies of the same password markup, all announcing "cole a chave…" and nothing else, on the one screen where pasting the wrong secret into the wrong field is a real and silent error. Each is now named by what distinguishes it — its Row, its pool's provider, its platform. The language select had no name at all.

> The first guard read the source and was **wrong**: an accessible name has several sources, and looking only for `aria-label` accused 36 controls, most of them wrapped in a `<label>` and perfectly fine. The guard renders and lets Testing Library compute the name the way a screen reader does.

## 4 · Numbers followed the machine, not the language

On a pt-BR machine with the app in English, 4200 renders "4.200" — and "4.200 tokens saved" reads as four point two. Found when an assertion expecting "4,200" met "4.200" and the first instinct was to loosen the assertion.

`useNum()` formats for the chosen language; all five call sites use it. The guard has two halves because either alone passes while the app stays wrong: the output must **change** with the language, and no production file may return to the empty-argument form.

---

778 desktop tests (two consecutive green runs), 3784 Python tests, typecheck and `npm run build` clean.

`Code.multiproject` began timing out once two new test files raised the parallel load — it types three sentences a simulated keystroke at a time. `delay: null` takes it from ~1.5s to 764ms; the delay models human typing speed, which none of those tests assert anything about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)