### PR TITLE
fix(desktop): the shell cache grew by a release, every release

### DIFF
--- a/apps/desktop/public/sw.js
+++ b/apps/desktop/public/sw.js
@@ -15,6 +15,40 @@
 // for them and there is nothing to revalidate.
 const CACHE = "chimera-shell-v2";
 
+// How many hashed assets to keep. Cache-first is CORRECT for them — the name changes when the
+// content does — but nothing ever removed the old ones, so the cache grew by a release every
+// release and never shrank. Measured on a machine that had followed the rc series: 61 entries,
+// 49.3 MB, holding twenty generations of index-*.js nothing would ever ask for again.
+//
+// Twelve, because one release ships FOUR files under /assets (the bundle, the stylesheet and two
+// lazy chunks) totalling 3.1 MB. So this keeps three releases: the running one can never be the
+// victim, and the ceiling is ~10 MB instead of none.
+const MAX_ASSETS = 12;
+
+// One trim at a time. A page load puts several assets within milliseconds, and N trims each
+// computing a victim list from the same snapshot would each delete the same overshoot — N times.
+let trimming = null;
+
+function trimAssets(cache) {
+  if (trimming) return trimming;
+  trimming = (async () => {
+    // `keys()` is insertion-ordered, so the front of this list is the oldest — the previous
+    // releases. The document and the icon are deliberately not candidates: `/` is the offline
+    // fallback, and trading an unbounded cache for a blank window with no network is not a fix.
+    const assets = (await cache.keys()).filter((request) =>
+      new URL(request.url).pathname.startsWith("/assets/"),
+    );
+    for (const stale of assets.slice(0, Math.max(0, assets.length - MAX_ASSETS))) {
+      await cache.delete(stale);
+    }
+  })()
+    .catch(() => {})
+    .finally(() => {
+      trimming = null;
+    });
+  return trimming;
+}
+
 self.addEventListener("install", () => self.skipWaiting());
 
 self.addEventListener("activate", (event) =>
@@ -73,7 +107,14 @@ self.addEventListener("fetch", (event) => {
       const cached = await cache.match(event.request);
       const network = fetch(event.request)
         .then((resp) => {
-          if (resp && resp.ok) cache.put(event.request, resp.clone());
+          // Trimmed after the put, never before the response: this is housekeeping, and a user
+          // waiting on it would be paying for a problem that is not theirs. Detached on purpose —
+          // if the worker is killed mid-trim, the next asset put picks it up.
+          if (resp && resp.ok)
+            cache
+              .put(event.request, resp.clone())
+              .then(() => trimAssets(cache))
+              .catch(() => {});
           return resp;
         })
         .catch(() => cached);

--- a/apps/desktop/src/sw.test.ts
+++ b/apps/desktop/src/sw.test.ts
@@ -51,7 +51,24 @@ class FakeCache {
   ) {
     const key =
       typeof request === "string" ? request : new URL(request.url).pathname;
+    // Delete first, so a re-put moves the entry to the BACK. That is what the spec says a Cache
+    // does, and the trim reads insertion order to decide who is oldest — a Map that kept the
+    // original position would make this fake disagree with the browser about the one thing the
+    // eviction depends on.
+    this.entries.delete(key);
     this.entries.set(key, response);
+  }
+  /** Insertion-ordered, as the spec requires — the property the eviction reads. */
+  async keys() {
+    return [...this.entries.keys()].map((path) => ({
+      url: `http://127.0.0.1:59592${path}`,
+      method: "GET",
+    }));
+  }
+  async delete(request: FakeRequest | string) {
+    const key =
+      typeof request === "string" ? request : new URL(request.url).pathname;
+    return this.entries.delete(key);
   }
 }
 
@@ -283,5 +300,87 @@ describe("the service worker", () => {
     await waited;
 
     expect(clients[0].navigated).toBe(0);
+  });
+});
+
+/**
+ * The shell cache stopped growing.
+ *
+ * Cache-first is correct for hashed assets — the name changes when the content does — but nothing
+ * ever removed the old ones, so every release added a generation and none left. Measured on a real
+ * install that had followed the rc series: **61 entries, 49.3 MB**, holding twenty generations of
+ * `index-*.js` that nothing would ever request again.
+ *
+ * The eviction had to go where entries are ADDED, not in `activate`: `sw.js` changes about once a
+ * quarter, so `activate` almost never fires, and a prune there would have been a fix that ran
+ * roughly never while reading as if it worked.
+ */
+describe("the shell cache has a ceiling", () => {
+  /** Fill the cache as N releases would: four assets each, the way a real build ships. */
+  async function releases(n: number) {
+    const cache = new FakeCache();
+    const { listeners, stores } = loadWorker({ caches: { "chimera-shell-v2": cache } });
+    for (let r = 0; r < n; r += 1) {
+      for (const nome of [`index-r${r}.js`, `index-r${r}.css`, `Edit-r${r}.js`, `EditSidebar-r${r}.js`]) {
+        await respond(listeners, request(`/assets/${nome}`));
+        // The trim is detached from the response on purpose, so let its microtasks run.
+        await new Promise((done) => setTimeout(done, 0));
+      }
+    }
+    return { cache, stores, listeners };
+  }
+
+  it("keeps the newest assets and drops the oldest", async () => {
+    const { cache } = await releases(5);
+    const guardados = [...cache.entries.keys()];
+
+    expect(guardados.length).toBeLessThanOrEqual(12);
+    // The release that just loaded is intact — evicting the running one would be a worse bug than
+    // the growth, because offline it would leave the app without its own bundle.
+    for (const nome of ["index-r4.js", "index-r4.css", "Edit-r4.js", "EditSidebar-r4.js"]) {
+      expect(guardados, `${nome} was evicted while it was the current release`).toContain(
+        `/assets/${nome}`,
+      );
+    }
+    // And the first release is gone, which is the point.
+    expect(guardados).not.toContain("/assets/index-r0.js");
+  });
+
+  it("grows without a ceiling when nothing evicts", async () => {
+    // Guarding the guard: the assertion above passes trivially if the fake never stores anything.
+    // Twenty releases of four files each is eighty entries, and the cap must be what stops it.
+    const { cache } = await releases(20);
+
+    expect(cache.entries.size).toBeGreaterThan(0);
+    expect(cache.entries.size).toBeLessThanOrEqual(12);
+  });
+
+  it("never evicts the document", async () => {
+    // `/` is the offline fallback. Trading an unbounded cache for a blank window with no network
+    // is not a fix, so the document is not a candidate however full the cache gets.
+    const { cache, listeners } = await releases(1);
+    await respond(listeners, request("/", { mode: "navigate" }));
+    await new Promise((done) => setTimeout(done, 0));
+
+    const { cache: cheia } = await releases(0);
+    void cheia;
+    for (let r = 1; r < 6; r += 1) {
+      await respond(listeners, request(`/assets/index-x${r}.js`));
+      await new Promise((done) => setTimeout(done, 0));
+    }
+
+    expect([...cache.entries.keys()]).toContain("/");
+  });
+
+  it("still serves an asset from cache without going to the network", async () => {
+    // The behaviour the cache exists for, asserted after the eviction was added — a trim that
+    // emptied the cache on every put would pass every test above.
+    const rede = vi.fn(async () => ({ body: "from network", ok: true, clone: () => ({ body: "from network", ok: true }) }));
+    const cache = new FakeCache(new Map([["/assets/index-abc.js", { body: "from cache", ok: true }]]));
+    const { listeners } = loadWorker({ caches: { "chimera-shell-v2": cache }, network: rede as never });
+
+    const resposta = (await respond(listeners, request("/assets/index-abc.js"))) as { body: string };
+
+    expect(resposta.body).toBe("from cache");
   });
 });


### PR DESCRIPTION
Measured on a real install that had followed the rc series: **61 entries, 49.3 MB**, holding twenty generations of `index-*.js` that nothing would ever request again.

Cache-first is *correct* for hashed assets — the name changes when the content does — but nothing ever removed the old ones, and none of it is visible from inside the app.

## How it surfaced

Checking whether the service worker was registered at all. The console in my test pane reported registration failures, which turned out to be that pane's sandbox rather than the app. Proving the worker WAS alive meant reading the app's own WebView2 profile — and the cache directory there is what showed the size.

## The decision that shaped the fix

The eviction had to go **where entries are added**, not in `activate`. `activate` is the obvious place and the wrong one: `sw.js` changes about once a quarter, so it almost never fires — a prune there would have been a fix that runs roughly never while reading as though it works.

## The number is measured, not picked

One release ships **four** files under `/assets` — bundle, stylesheet, two lazy chunks — totalling **3.1 MB**. A cap of 12 keeps three releases: the running one can never be the victim, and the ceiling is ~10 MB instead of none.

## Three things it is careful about, each with a test

- **Insertion order is the whole mechanism.** `keys()` is ordered, so the front is the oldest. The fake cache now deletes before re-putting, because that is what a real Cache does — a fake that kept the original position would agree with itself and disagree with the browser about the one property this depends on.
- **The document is never a candidate.** `/` is the offline fallback; trading an unbounded cache for a blank window with no network is not a fix.
- **One trim at a time, after the response.** A page load puts several assets within milliseconds, and N concurrent trims computing victims from one snapshot would each delete the same overshoot. Detached from the response — housekeeping is not something a user should wait on.

The cache **name is deliberately unchanged**. Bumping it to `v3` would empty the cache and re-download everything, when the trim already brings an existing install down to the cap on its next asset load.

Both sabotage directions fail: removing the trim call, and a cap of zero. 826 desktop tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)