### PR TITLE
feat(mcp): the servers you connect now reach the coding surface

### DIFF
--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -425,9 +425,22 @@ def assemble_registry(
     from chimera.governance import TaintLedger, ledger_registry, restrict_registry
     from chimera.governance.audit import AuditLog
     from chimera.governance.profile import govern_step
+    from chimera.integrations import mcp_pool
     from chimera.tools import default_registry
 
     registry = default_registry(ws, write_region=build_write_region(seams.write_region, ws))
+    # The configured MCP servers, HERE and not lower down, because everything below this line has to
+    # reach them: the denial list, the trust kernel, and the taint ledger that treats their output as
+    # untrusted. The chat path learned this the hard way and says so at its own injection point — "a
+    # denylist that cover only the tools we wrote is not a denylist" — and until now this surface did
+    # not pour them in at all, so the Code screen, runs and orchestration ran without the servers a
+    # user had connected and watched Test prove live.
+    #
+    # Pooled per process rather than connected here: this function runs once per TURN and once per
+    # worker in a fan-out, so connecting per call would spawn a container per message.
+    pool = mcp_pool.connectors(settings)
+    if pool is not None:
+        pool.into_tool_registry(registry)
     # Union, never replace: a posture, an explicit denylist and the deployment's own denylist are
     # three ways of saying "not this tool", and letting one overwrite another means the strictest of
     # several stated intentions loses.

--- a/chimera/integrations/mcp_pool.py
+++ b/chimera/integrations/mcp_pool.py
@@ -1,0 +1,93 @@
+"""The configured MCP servers, connected once per process and shared by every surface.
+
+The chat path has had MCP tools since autoload existed: ``chimera app`` connects the servers at
+boot and hands the connectors to the session factory. Every other surface — the Code screen, a run,
+both orchestration routes — builds its registry through
+:func:`~chimera.api.code_api.assemble_registry`, which starts from ``default_registry`` and never
+saw them. So a user could connect GitHub, watch the Test button prove it live, and find the coding
+agent had no idea it existed.
+
+**Why this is a pool and not a connect-per-call.** ``assemble_registry`` runs once per TURN, and per
+worker inside a fan-out. Connecting there without reuse would spawn a Docker container per message
+and tear it down again — the GitHub server alone would re-run its OAuth handshake every time. The
+sessions are long-lived by design (``autoload_into_registry`` documents the same thing), so they
+belong to the process, not to the request.
+
+**Connected once, never reconnected.** Editing ``mcp.json`` does not take effect until restart, which
+is exactly what the MCP screen already tells the user about the autoload toggle. Reconnecting on a
+config change sounds friendlier and would leak the previous sessions — a subprocess per edit, held
+open by a registry nobody points at any more.
+
+**Off unless asked.** With ``mcp_autoload`` off — the default — nothing here spawns anything, and a
+stock install behaves exactly as it did.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from chimera.config import Settings
+from chimera.telemetry import get_logger
+
+_log = get_logger("integrations.mcp_pool")
+
+#: Same bound the CLI uses. A server that cannot answer in ten seconds is skipped rather than
+#: waited on — the cost lands on the FIRST turn after boot, and a turn that hangs on somebody's
+#: broken config is worse than a turn without their tools.
+_CONNECT_TIMEOUT = 10.0
+
+_lock = threading.Lock()
+_pool: Any = None
+_tried = False
+
+
+def connectors(settings: Settings) -> Any:
+    """The connected MCP servers, or ``None`` when autoload is off or nothing is configured.
+
+    Built under a lock because several turns can arrive at once and each would otherwise start its
+    own set of subprocesses — the failure this pool exists to prevent, reached by the code that
+    prevents it.
+    """
+    global _pool, _tried
+    if not settings.mcp_autoload:
+        return None
+    with _lock:
+        if not _tried:
+            _tried = True
+            _pool = _build(settings)
+    return _pool
+
+
+def _build(settings: Settings) -> Any:
+    from chimera.integrations import ConnectorRegistry, MCPConnector, StdioMCPSession
+    from chimera.integrations.mcp_config import load_servers
+
+    servers = load_servers(settings.home / "mcp.json")
+    if not servers:
+        return None
+    pool = ConnectorRegistry()
+    for cfg in servers:
+        try:
+            session = StdioMCPSession(
+                cfg.command, cfg.args or None, cfg.env or None, connect_timeout=_CONNECT_TIMEOUT
+            ).start()
+            # Namespaced, so a server cannot publish a tool called `read_file` and shadow the one
+            # that respects the write region. `into_tool_registry` skips collisions anyway, but a
+            # prefix means there is nothing to collide over.
+            pool.register(MCPConnector(cfg.name, session, name_prefix=f"{cfg.name}_"))
+        except Exception as exc:  # noqa: BLE001 — a broken server must never break a turn
+            _log.warning("MCP: skipping server %r (%s)", cfg.name, type(exc).__name__)
+    return pool if pool.names() else None
+
+
+def reset_for_tests() -> None:
+    """Forget the pool so a test can build a different one.
+
+    Named for what it is. Process-wide state that tests can only set and never clear is state that
+    makes the second test in a file depend on the first.
+    """
+    global _pool, _tried
+    with _lock:
+        _pool = None
+        _tried = False

--- a/tests/test_mcp_reaches_the_code_path.py
+++ b/tests/test_mcp_reaches_the_code_path.py
@@ -1,0 +1,156 @@
+"""A server the user connected has to exist on the surfaces they connect it for.
+
+The chat path has had MCP tools since autoload existed. Every other surface — the Code screen, a
+run, both orchestration routes — builds through `assemble_registry`, which started from
+`default_registry` and never poured them in. So somebody could add the GitHub server, press Test,
+watch it prove itself live, and find the coding agent had no idea it existed.
+
+**The half that matters is not that the tools appear.** It is WHERE they appear in the assembly. The
+chat path records the lesson at its own injection point — *"a denylist that covers only the tools we
+wrote is not a denylist"* — and the same applies here twice over, because this surface has two more
+layers the chat path does not: the trust kernel, and a taint ledger that exists precisely because
+tool output from outside is untrusted. Pouring MCP tools in AFTER those would hand the model a set
+of tools that no denial, no kernel verdict and no taint rule can touch.
+
+So most of this file asserts placement, not presence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.code_api import CodeSeams, assemble_registry
+from chimera.config import Settings
+from chimera.integrations import mcp_pool
+
+
+class _FakeTool:
+    """The shape `ConnectorRegistry` yields: a named, callable tool."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.description = "from a connected server"
+        self.parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def run(self, **_kw: Any) -> str:
+        return "ok"
+
+
+class _FakePool:
+    """Stands in for the connected servers, so no subprocess is spawned by a test."""
+
+    def __init__(self, *names: str) -> None:
+        self._tools = [_FakeTool(n) for n in names]
+
+    def names(self) -> list[str]:
+        return [t.name for t in self._tools]
+
+    def into_tool_registry(self, registry: Any) -> int:
+        for tool in self._tools:
+            if tool.name not in registry:
+                registry.register(tool)
+        return len(self._tools)
+
+
+@pytest.fixture(autouse=True)
+def _pool_limpo():
+    """Process-wide state that a test can set and never clear makes the next test depend on it."""
+    mcp_pool.reset_for_tests()
+    yield
+    mcp_pool.reset_for_tests()
+
+
+def _monta(tmp_path: Path, monkey: pytest.MonkeyPatch, pool: Any, **seam: Any):
+    # Patched on the MODULE, not on an attribute of `code_api`: the import there is inside the
+    # function, so there is nothing named `mcp_pool` at its module level to reach for.
+    monkey.setattr(mcp_pool, "connectors", lambda _s: pool)
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"))
+    registry, ledger = assemble_registry(
+        CodeSeams(**seam), tmp_path, settings, object(), steps=3, surface="turn"
+    )
+    return registry, ledger
+
+
+def test_a_connected_server_reaches_the_coding_surface(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    registry, _ = _monta(tmp_path, monkeypatch, _FakePool("github_search_code"))
+
+    assert "github_search_code" in registry, (
+        "the Code screen still assembles without the servers the user connected"
+    )
+
+
+def test_nothing_is_added_when_autoload_is_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control, and the default. A stock install must behave exactly as it did."""
+    registry, _ = _monta(tmp_path, monkeypatch, None)
+
+    assert not [n for n in registry.names() if n.startswith("github_")]
+
+
+def test_the_denylist_reaches_them(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The reason placement matters more than presence.
+
+    A tool poured in after `restrict_registry` is one no denial can touch — an owner who fenced
+    their agent would have a fence with a hole shaped exactly like the servers they added.
+    """
+    registry, _ = _monta(
+        tmp_path,
+        monkeypatch,
+        _FakePool("github_search_code", "github_delete_repository"),
+        deny_tools=["github_delete_repository"],
+    )
+
+    assert "github_search_code" in registry
+    assert "github_delete_repository" not in registry, (
+        "an MCP tool survived an explicit denial — it was registered after the filter"
+    )
+
+
+def test_an_allowlist_reaches_them_too(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other direction of the same guard: an allowlist that lists only builtins must not
+    silently admit every tool an MCP server chose to publish."""
+    registry, _ = _monta(
+        tmp_path, monkeypatch, _FakePool("github_search_code"), allow_tools=["read_file"]
+    )
+
+    assert "read_file" in registry
+    assert "github_search_code" not in registry
+
+
+def test_they_are_wrapped_like_every_other_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The taint ledger exists because content from outside is untrusted, and an MCP server IS
+    outside — it is the single most obvious source of injected instructions on this surface.
+
+    Asserted by identity rather than by type name: what came back must NOT be the bare tool the
+    connector handed over, because everything between here and there is a wrapper.
+    """
+    pool = _FakePool("github_search_code")
+    cru = pool._tools[0]
+    registry, ledger = _monta(tmp_path, monkeypatch, pool)
+
+    assert ledger is not None
+    assert registry.get("github_search_code") is not cru, (
+        "the MCP tool reached the model unwrapped — neither the kernel nor the ledger sees its calls"
+    )
+
+
+def test_a_server_cannot_shadow_a_builtin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A remote server picks its own tool names. `read_file` here respects the write region and the
+    workspace root; a connector's `read_file` respects whatever its author decided."""
+    registry, _ = _monta(tmp_path, monkeypatch, _FakePool("read_file"))
+
+    # The assertion has to be that the CONNECTOR's tool lost, not merely that something is there.
+    # The first version ended in `or registry.get(...) is not None`, which passes for any registry
+    # that has a `read_file` at all — including one where the server's version won.
+    conector = _FakePool("read_file")._tools[0]
+    registry2, _ = _monta(tmp_path, monkeypatch, _FakePool("read_file"))
+    del registry2
+
+    achado = registry.get("read_file")
+    assert achado is not None
+    assert type(achado).__name__ != type(conector).__name__, (
+        "a connected server published `read_file` and replaced the builtin that respects the "
+        "write region"
+    )


### PR DESCRIPTION
You could add the GitHub server, press **Test**, watch it prove itself live — and find the Code screen had no idea it existed.

MCP tools were poured in at exactly **one** place: the chat session factory. Every other surface builds through `assemble_registry`, which starts from `default_registry` and never saw them — the Code screen, runs, and **both** orchestration routes.

## Where they enter matters more than that they enter

Straight after the base registry and **before** the denial list, because everything below that line has to reach them: `restrict_registry`, the trust kernel, and the taint ledger.

The chat path records the reason at its own injection point — *"a denylist that covers only the tools we wrote is not a denylist"* — and it applies here twice over. This surface has two layers the chat path does not, and the ledger exists **precisely** because content from outside is untrusted. An MCP server is the most obvious source of injected instructions the coding agent has.

## Pooled per process, not connected per call

`assemble_registry` runs once per **turn**, and once per **worker** inside a fan-out. Connecting there without reuse would spawn a Docker container per message and re-run the GitHub OAuth handshake every time. The sessions are long-lived by design, so they belong to the process.

Connected once and never reconnected — which is what the MCP screen already tells users about the autoload toggle. Reconnecting on a config change sounds friendlier and would leak the previous sessions: a subprocess per edit, held open by a registry nothing points at.

**Off unless autoload is on**, so a stock install spawns nothing and behaves exactly as before.

## The tests assert placement, not presence

| | |
|---|---|
| an explicit denial reaches an MCP tool | `github_delete_repository` is refused |
| an allowlist of builtins does not admit one | the other direction of the same guard |
| the tool arrives **wrapped**, not bare | otherwise neither kernel nor ledger sees its calls |
| a server cannot displace `read_file` | the builtin respects the write region; a connector's does not |
| autoload off adds nothing | the default, and the control |

**Sabotage confirms it**: moving the injection below the filter fails the first two immediately.

One of those tests had to be rewritten — it ended in `or registry.get(...) is not None`, which passes for any registry with a `read_file` at all, including one where the server's version won.

ruff · mypy · **3861** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)