### PR TITLE
fix(mcp): the SDK never shipped, and the failure said the wrong thing

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -85,7 +85,13 @@ jobs:
           # complete ffmpeg — x264, x265, AV1 encoders — to decode microphone audio. A video codec
           # suite in every download so that dictation can avoid one API call is the wrong trade, and
           # on Linux the AppImage bundler then copies much of it a second time.
-          uv sync --extra desktop --extra documents --extra stt
+          # `mcp` ships too, and it is small (pure Python, no native code) — without it the MCP
+          # screen and its whole catalogue are decoration: every server fails to connect in the
+          # packaged app, and the failure reads as "did not become ready" rather than as a missing
+          # dependency. Verified by searching the frozen binary for the SDK's module names, with
+          # `chimera.integrations.mcp_client` and `litellm.utils` as controls to prove the search
+          # finds what IS there.
+          uv sync --extra desktop --extra documents --extra stt --extra mcp
           uv pip install pyinstaller
 
       - name: Freeze the backend sidecar

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.48.0-rc.29"
+version = "0.48.0-rc.30"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.48.0-rc.29",
+  "version": "0.48.0-rc.30",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.48.0rc29",
+  "generated_for": "0.48.0rc30",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5366,7 +5366,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.48.0rc29",
+  "generated_for": "0.48.0rc30",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.48.0rc29",
+  "generated_for": "0.48.0rc30",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/chimera/integrations/mcp_client.py
+++ b/chimera/integrations/mcp_client.py
@@ -146,6 +146,22 @@ class StdioMCPSession:
     def start(self) -> StdioMCPSession:
         import asyncio
 
+        # Checked HERE, before anything is spawned, and the reason is a message a user actually
+        # got. The SDK is imported inside `_serve`, which runs on the background loop — so with the
+        # package absent the ImportError was raised where nothing was listening, `_ready` never
+        # fired, and `start` reported "did not become ready". That is the SAME sentence a command
+        # which simply is not an MCP server produces, so somebody whose install lacked the optional
+        # dependency was told to go and check their configuration.
+        #
+        # Measured against the packaged desktop app, where the extra was not bundled at all: every
+        # server in the catalogue failed this way, and nothing on screen could say why.
+        try:
+            import mcp  # noqa: F401
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "the MCP SDK is not installed — install it with: pip install 'chimera-agent[mcp]'"
+            ) from exc
+
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.48.0rc29"
+version = "0.48.0rc30"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,16 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = [
-    "mcp>=1.0",
+    # Ceiling, not preference — the same shape as the litellm pin above, and measured the same way.
+    # `mcp>=1.0` resolves to 2.1.0 today, and 2.x removed the low-level decorator API that
+    # `ChimeraMCP.build` is written against: `@server.list_tools()` raises
+    # `AttributeError: 'Server' object has no attribute 'list_tools'`, so `chimera mcp-serve` dies
+    # on start for anyone who installed the extra this week. The CLIENT half is fine on both — the
+    # catalogue and the tool pool import `ClientSession` and `stdio_client`, which 2.x still has —
+    # so this ceiling costs the client nothing and is what keeps the server working.
+    #
+    # Lift it by porting `ChimeraMCP.build` to the 2.x handler API, not by widening the range.
+    "mcp>=1.0,<2",
 ]
 # Native messaging platform adapters. Install to run `chimera serve --discord/--slack`;
 # the core agent never requires it. (Telegram needs no extra — it is plain HTTP.)

--- a/tests/test_mcp_dependency_is_real.py
+++ b/tests/test_mcp_dependency_is_real.py
@@ -1,0 +1,107 @@
+"""The MCP screen is decoration unless the SDK actually ships, and unless it says so when it does not.
+
+Three things went wrong together, and each hid the next:
+
+1. The desktop installer built the backend with ``--extra desktop --extra documents --extra stt``
+   and **not** ``--extra mcp``, so the packaged app could not speak MCP at all. Verified by
+   searching the frozen binary for the SDK's module names, with ``chimera.integrations.mcp_client``
+   and ``litellm.utils`` as controls to prove the search finds what IS present.
+2. The SDK is imported inside ``_serve``, which runs on a background loop. With the package absent
+   the ImportError was raised where nothing was listening, ``_ready`` never fired, and ``start``
+   reported *"did not become ready"* — the SAME sentence a command that simply is not an MCP server
+   produces. So the one user who could have diagnosed this was told to check their config.
+3. ``mcp>=1.0`` had no ceiling and resolves to 2.x, which removed the low-level decorator API
+   ``ChimeraMCP.build`` is written against. The CLIENT half is fine on both; the SERVER half dies
+   with ``AttributeError: 'Server' object has no attribute 'list_tools'``.
+
+These are cheap to assert and were expensive to find, which is exactly the trade a test is for.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parent.parent
+
+
+def test_the_installer_bundles_the_sdk() -> None:
+    """Without this the catalogue offers servers the shipped app can never connect to.
+
+    Asserted against the workflow rather than a built binary, because a test cannot freeze one —
+    but the line it checks is the line that was missing, and it is one word.
+    """
+    fluxo = (RAIZ / ".github" / "workflows" / "desktop-release.yml").read_text(encoding="utf-8")
+    sync = [linha for linha in fluxo.splitlines() if "uv sync --extra" in linha]
+
+    assert sync, "the sidecar build no longer syncs extras — this guard is now looking at nothing"
+    assert any("--extra mcp" in linha for linha in sync), (
+        "the desktop sidecar is built without the MCP SDK, so every catalogue entry fails to "
+        f"connect in the packaged app. Extras line: {sync}"
+    )
+
+
+def test_the_sdk_pin_has_a_ceiling() -> None:
+    """2.x removed the API `ChimeraMCP.build` uses, and `>=1.0` resolves straight into it."""
+    dados = tomllib.loads((RAIZ / "pyproject.toml").read_text(encoding="utf-8"))
+    extras = dados["project"]["optional-dependencies"]["mcp"]
+    mcp = [d for d in extras if d.startswith("mcp")]
+
+    assert mcp, "the mcp extra no longer pins the SDK"
+    assert re.search(r"<\s*2", mcp[0]), (
+        f"{mcp[0]!r} admits mcp 2.x, where `@server.list_tools()` raises AttributeError and "
+        "`chimera mcp-serve` dies on start"
+    )
+
+
+def test_a_missing_sdk_says_so_rather_than_timing_out() -> None:
+    """The message is the fix.
+
+    A user whose install lacks the optional dependency has to be told THAT, not handed the same
+    sentence a wrong command produces — the two have opposite remedies and only one of them is
+    about their configuration.
+    """
+    import chimera.integrations.mcp_client as mod
+
+    real = __import__
+
+    def sem_mcp(nome: str, *args: object, **kw: object):
+        if nome == "mcp" or nome.startswith("mcp."):
+            raise ModuleNotFoundError("No module named 'mcp'")
+        return real(nome, *args, **kw)  # type: ignore[arg-type]
+
+    sessao = mod.StdioMCPSession("python", ["-c", "pass"], None, connect_timeout=1.0)
+    import builtins
+
+    original = builtins.__import__
+    builtins.__import__ = sem_mcp  # type: ignore[assignment]
+    try:
+        with pytest.raises(ModuleNotFoundError) as erro:
+            sessao.start()
+    finally:
+        builtins.__import__ = original
+
+    texto = str(erro.value)
+    assert "chimera-agent[mcp]" in texto, f"the message does not say how to fix it: {texto!r}"
+    assert "did not become ready" not in texto, (
+        "a missing dependency is still reported as a server that failed to start"
+    )
+
+
+def test_it_still_fails_normally_when_the_sdk_is_there() -> None:
+    """Guarding the guard: raising ModuleNotFoundError unconditionally would satisfy the test above
+    and break every working install. With the SDK present, a command that is not a server must
+    still reach the ordinary timeout."""
+    pytest.importorskip("mcp")
+    import chimera.integrations.mcp_client as mod
+
+    sessao = mod.StdioMCPSession("python", ["-c", "pass"], None, connect_timeout=2.0)
+    with pytest.raises((TimeoutError, Exception)) as erro:
+        sessao.start()
+
+    assert not isinstance(erro.value, ModuleNotFoundError), (
+        "a working install is being told the SDK is missing"
+    )


### PR DESCRIPTION
Three faults, and each hid the next. Found while preparing a release whose headline was *"the servers you connect now reach the coding surface"* — on a packaged app that could not connect to **any** server at all.

## 1. The desktop installer never bundled the SDK

The sidecar is built with `--extra desktop --extra documents --extra stt`. `mcp` is an optional extra and was not among them.

So the catalogue shipped in rc28 offered **nine servers the packaged app could never reach**, and the MCP screen's Test button could never succeed.

### Verified rather than inferred, and it took four attempts

| probe | result | why it was wrong |
|---|---|---|
| look for a `mcp/` directory in `_internal` | absent | so are `pydantic` and `httpx`, which are certainly there |
| look for `mcp-*.dist-info` | absent | so are `httpx`, `anyio`, `fastapi` — metadata is copied selectively |
| look in `base_library.zip` | absent | that archive holds stdlib, not site-packages |
| **search the 43MB binary for module names** | **absent** | **controls: `chimera.integrations.mcp_client` and `litellm.utils` are found** |

Only the last has a control proving the instrument finds what *is* present.

## 2. The failure blamed the user's configuration

The SDK is imported inside `_serve`, which runs on a background loop — so with the package absent, the `ImportError` was raised where nothing was listening, `_ready` never fired, and `start` reported:

```
MCP server 'X' did not become ready
```

Which is the **same sentence** produced by pointing at a command that simply is not an MCP server. Two causes with opposite remedies, one message — and the message named the wrong remedy. It is checked now before anything is spawned, and it says which one it is.

## 3. `mcp>=1.0` has no ceiling and resolves to 2.x

2.1.0 removed the low-level decorator API `ChimeraMCP.build` is written against:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

So `chimera mcp-serve` dies on start for anyone who installed the extra this week. Confirmed by running it on Windows **and** Linux. The **client** half is fine on both — which is why this went unnoticed — so the ceiling costs it nothing. Lift it by porting `build` to the 2.x handler API, not by widening the range.

## The proof the client was never the problem

With the ceiling in place, the Chimera MCP client connects to the Chimera MCP server over stdio, lists `chimera_solve` / `chimera_fuse` / `chimera_memory_search`, and calls one. No network, no Docker.

## One note on method

The first sabotage removed the import guard *and broke the file*, so all four tests failed — which proves nothing about any of them. Redone surgically: the module still imports, **exactly one** test fails, and the control saying a working install must not be told the SDK is missing still passes.

ruff · mypy · **3864** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)