### PR TITLE
fix: a lock five releases stale, and a message its only reader threw away

### DIFF
--- a/chimera/integrations/mcp_pool.py
+++ b/chimera/integrations/mcp_pool.py
@@ -77,7 +77,16 @@ def _build(settings: Settings) -> Any:
             # prefix means there is nothing to collide over.
             pool.register(MCPConnector(cfg.name, session, name_prefix=f"{cfg.name}_"))
         except Exception as exc:  # noqa: BLE001 — a broken server must never break a turn
-            _log.warning("MCP: skipping server %r (%s)", cfg.name, type(exc).__name__)
+            # The MESSAGE, not just the class. `ModuleNotFoundError` on its own is the least useful
+            # half of "the MCP SDK is not installed — install it with: pip install
+            # 'chimera-agent[mcp]'": the sentence was written precisely so this case would stop
+            # looking like a broken config, and logging only the type threw it away again.
+            #
+            # Bounded, and the bound is not decoration: a connect failure carries the command and
+            # its arguments, and `mcp.json` is also where a user's tokens live. `env` is never in
+            # an exception message today, and a log line is the wrong place to bet on that staying
+            # true forever.
+            _log.warning("MCP: skipping server %r — %s", cfg.name, str(exc)[:300])
     return pool if pool.names() else None
 
 

--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -33,6 +33,9 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 CARGO = ROOT / "apps" / "desktop" / "src-tauri" / "Cargo.toml"
 TAURI = ROOT / "apps" / "desktop" / "src-tauri" / "tauri.conf.json"
+#: Not a version file by appearance, and one by behaviour: it records this package's own
+#: version, so a release that skips it leaves the repository contradicting itself.
+LOCK = ROOT / "uv.lock"
 
 #: Generated, not edited. Each embeds the version it was produced for, so a release regenerates
 #: them rather than substituting a string — a hand-edited "generated" file is correct exactly once.
@@ -206,15 +209,38 @@ def regenerate_snapshots(version: str) -> None:
         raise Stop(f"these snapshots came out stamped for another version: {wrong}")
 
 
+def refresh_lock(version: str) -> None:
+    """Re-resolve ``uv.lock`` so it names the version just written.
+
+    Left out of the original six, and it drifted five releases before anyone looked: the lock said
+    0.43.0 while ``pyproject.toml`` said 0.48.0rc30. Nothing broke, which is exactly why nobody
+    looked — the release workflow runs a bare ``uv sync``, which re-locks silently. But "re-locks
+    silently" is a property of today's workflow rather than a guarantee, and a repository whose
+    lock disagrees with its own manifest fails ``uv sync --locked`` for everyone who uses it.
+
+    Conservative by construction: ``uv lock`` keeps every pin that still satisfies its constraint,
+    so this rewrites the two lines describing THIS package and nothing else. It is not a dependency
+    upgrade wearing a release's clothes — which is the reason it can be part of a release at all.
+    """
+    print("  re-resolving uv.lock so it names the new version...", file=sys.stderr)
+    run("uv", "lock")
+    if 'version = "' + version + '"' not in LOCK.read_text(encoding="utf-8"):
+        raise Stop(
+            "`uv lock` ran but " + LOCK.name + " still does not name " + version + ". Cutting the "
+            "release would leave the lock disagreeing with pyproject.toml, which is the drift this "
+            "exists to end."
+        )
+
+
 def check_only_expected_files_changed(version: str) -> list[str]:
     changed = sorted(run("git", "diff", "--name-only").splitlines())
     expected = sorted(
         str(path.relative_to(ROOT)).replace("\\", "/")
-        for path in [PYPROJECT, CARGO, TAURI, *SNAPSHOTS]
+        for path in [PYPROJECT, CARGO, TAURI, LOCK, *SNAPSHOTS]
     )
     if changed != expected:
         raise Stop(
-            "a release should touch exactly the six version files. This run changed:\n    "
+            "a release should touch exactly the seven version files. This run changed:\n    "
             + "\n    ".join(changed or ["(nothing — is that already the version?)"])
             + "\n  expected:\n    "
             + "\n    ".join(expected)
@@ -329,6 +355,7 @@ def main() -> None:
     write_versions(version)
     try:
         regenerate_snapshots(version)
+        refresh_lock(version)
         changed = check_only_expected_files_changed(version)
     except SystemExit:
         # Leave the tree as it was: a half-applied bump is a trap for whoever runs `git status`

--- a/tests/test_cut_release.py
+++ b/tests/test_cut_release.py
@@ -1,6 +1,6 @@
 """Cutting a release — the two spellings, and the files it must not touch.
 
-The script exists because a release is six files and two version formats, and both are the kind of
+The script exists because a release is seven files and two version formats, and both are the kind of
 thing that is right until one day it is not. So the tests are about the parts that would be wrong
 quietly: a version converted into the wrong SemVer, and a substitution that hits more than the
 line it was aimed at.
@@ -173,3 +173,43 @@ def test_it_checks_for_gh_before_writing_anything(monkeypatch) -> None:
     # Checking late means bumping six files and regenerating three snapshots before finding out
     # the release cannot be opened at all — which is what the first WSL run did.
     assert "gh" in str(refused.value)
+
+
+def test_the_lock_is_one_of_the_files_a_release_updates(monkeypatch, tmp_path: Path) -> None:
+    """It was not, and it drifted five releases: the lock said 0.43.0, pyproject said 0.48.0rc30.
+
+    Nothing broke, which is the whole reason it went unnoticed — the release workflow runs a bare
+    `uv sync`, and that re-locks silently. So the defect had no symptom until somebody ran
+    `uv sync --locked`, and the guard has to be about the file rather than about a failure.
+    """
+    lock = tmp_path / "uv.lock"
+    lock.write_text('version = "0.48.0rc31"\n', encoding="utf-8")
+    monkeypatch.setattr(cut_release, "LOCK", lock)
+    monkeypatch.setattr(cut_release, "run", lambda *a, **k: "")
+
+    cut_release.refresh_lock("0.48.0rc31")  # names the new version: accepted
+
+    lock.write_text('version = "0.43.0"\n', encoding="utf-8")
+    with pytest.raises(SystemExit) as refused:
+        cut_release.refresh_lock("0.48.0rc31")
+
+    assert "0.48.0rc31" in str(refused.value)
+    assert "pyproject" in str(refused.value), "the message must say what disagrees with what"
+
+
+def test_a_release_that_leaves_the_lock_behind_is_refused() -> None:
+    """The check that says "exactly these files" is what kept the lock OUT for five releases.
+
+    Adding `refresh_lock` without adding the lock here would produce the opposite failure — the
+    script would update it and then refuse its own change as unexpected. So the two belong in one
+    commit, and this asserts the pair rather than either half.
+    """
+    fonte = (
+        Path(cut_release.__file__).parent / "cut_release.py"
+    ).read_text(encoding="utf-8")
+
+    esperados = fonte.split("for path in [")[1].split("]")[0]
+    assert "LOCK" in esperados, (
+        "uv.lock is not in the expected-file set, so `refresh_lock` updating it would make the "
+        "script refuse its own release"
+    )

--- a/tests/test_mcp_pool_says_why.py
+++ b/tests/test_mcp_pool_says_why.py
@@ -1,0 +1,119 @@
+"""A server that fails to connect has to say WHY, and the pool is where that sentence was lost.
+
+:mod:`chimera.integrations.mcp_client` was given a message for the one failure a user can actually
+act on — *the MCP SDK is not installed — install it with: pip install 'chimera-agent[mcp]'*. The
+pool then caught the exception and logged ``ModuleNotFoundError``, which is the half that does not
+say what to do. Found by running the real path rather than by reading it: a probe against a venv
+without the SDK produced exactly that log line and nothing else.
+
+The bound on the message is deliberate. A connect failure carries the command and its arguments,
+and ``mcp.json`` is also where a user's tokens live; ``env`` never appears in an exception message
+today, and a log line is the wrong place to bet on that staying true.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from chimera.config import Settings
+from chimera.integrations import mcp_pool
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pool():
+    mcp_pool.reset_for_tests()
+    yield
+    mcp_pool.reset_for_tests()
+
+
+def _settings(tmp_path, monkeypatch, servers: str) -> Settings:
+    """Built through the ENVIRONMENT, because that is the only way these fields are populated.
+
+    Both carry a ``validation_alias``, so ``Settings(mcp_autoload=True)`` is accepted and silently
+    ignored — it returns a Settings with autoload OFF. Which produced a first version of this test
+    that passed for the wrong reason on the way to failing for another one.
+    """
+    home = tmp_path / ".chimera"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "mcp.json").write_text(servers, encoding="utf-8")
+    monkeypatch.setenv("CHIMERA_HOME", str(home))
+    monkeypatch.setenv("CHIMERA_MCP_AUTOLOAD", "1")
+    settings = Settings()
+    assert settings.mcp_autoload and settings.home == home, (
+        "the fixture did not produce the settings it claims to — nothing below would be measuring "
+        f"anything (home={settings.home}, autoload={settings.mcp_autoload})"
+    )
+    return settings
+
+
+def test_a_server_that_cannot_start_says_what_went_wrong(tmp_path, monkeypatch, caplog) -> None:
+    """`command-that-does-not-exist` is the cheapest real failure, and it needs no SDK."""
+    settings = _settings(
+        tmp_path, monkeypatch, '[{"name": "quebrado", "command": "comando-que-nao-existe-mesmo", "args": []}]'
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert mcp_pool.connectors(settings) is None
+
+    linhas = [r.getMessage() for r in caplog.records if "quebrado" in r.getMessage()]
+    assert linhas, "a server that failed to connect was skipped silently"
+    (linha,) = linhas
+    # No disjunction here, deliberately. The first draft read `... in linha or len(linha) > N`,
+    # and the fallback clause is true of the OLD line too — sabotaging the fix back to
+    # `type(exc).__name__` left this test passing. A guard that survives its own defect is not one.
+    assert "comando-que-nao-existe-mesmo" in linha, (
+        f"the line names the server and not the reason: {linha!r}"
+    )
+
+
+def test_the_sentence_about_the_missing_sdk_survives_the_pool(tmp_path, monkeypatch, caplog) -> None:
+    """The failure this whole message exists for, and the one the pool used to swallow.
+
+    `mcp_client.start` raises this exact ModuleNotFoundError so a user without the optional
+    dependency is told what to install instead of being handed a timeout that reads as a broken
+    config. Through the pool, all that reached the log was the words `ModuleNotFoundError`.
+    """
+    frase = "the MCP SDK is not installed — install it with: pip install 'chimera-agent[mcp]'"
+
+    class SemSDK:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        def start(self):
+            raise ModuleNotFoundError(frase)
+
+    monkeypatch.setattr("chimera.integrations.StdioMCPSession", SemSDK)
+    settings = _settings(tmp_path, monkeypatch, '[{"name": "srv", "command": "x", "args": []}]')
+
+    with caplog.at_level(logging.WARNING):
+        assert mcp_pool.connectors(settings) is None
+
+    (linha,) = [r.getMessage() for r in caplog.records if "srv" in r.getMessage()]
+    assert "chimera-agent[mcp]" in linha, (
+        f"the one actionable failure still reaches the user as a bare exception class: {linha!r}"
+    )
+
+
+def test_the_reason_is_bounded_so_a_long_failure_cannot_paste_a_config_into_the_log(
+    tmp_path, caplog, monkeypatch
+) -> None:
+    """Guarding the guard: "log the message" must not become "log whatever the message contains"."""
+    segredo = "ghp_" + "s" * 4000
+
+    class Explode:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        def start(self):
+            raise RuntimeError(segredo)
+
+    monkeypatch.setattr("chimera.integrations.StdioMCPSession", Explode)
+    settings = _settings(tmp_path, monkeypatch, '[{"name": "longo", "command": "x", "args": []}]')
+
+    with caplog.at_level(logging.WARNING):
+        mcp_pool.connectors(settings)
+
+    (linha,) = [r.getMessage() for r in caplog.records if "longo" in r.getMessage()]
+    assert len(linha) < 400, f"the reason is unbounded ({len(linha)} chars) — a log is not a dump"

--- a/tests/test_mcp_pool_says_why.py
+++ b/tests/test_mcp_pool_says_why.py
@@ -49,10 +49,30 @@ def _settings(tmp_path, monkeypatch, servers: str) -> Settings:
 
 
 def test_a_server_that_cannot_start_says_what_went_wrong(tmp_path, monkeypatch, caplog) -> None:
-    """`command-that-does-not-exist` is the cheapest real failure, and it needs no SDK."""
-    settings = _settings(
-        tmp_path, monkeypatch, '[{"name": "quebrado", "command": "comando-que-nao-existe-mesmo", "args": []}]'
-    )
+    """End to end, through the real session — and the reason is ASKED FOR, not assumed.
+
+    A command that does not exist fails for one of two reasons depending on the machine: with the
+    SDK installed it is a `FileNotFoundError` naming the command; without it, the import guard fires
+    first and it is the sentence about the missing SDK. Both lines are correct.
+
+    The first draft asserted the command's name, which passed on a laptop where the optional
+    dependency happened to be installed and went red on all three CI Pythons where it is not — a
+    test about a log line that was quietly a test about the environment. So it triggers the failure
+    itself, reads whatever message came out, and requires THAT to survive into the log.
+    """
+    from chimera.integrations import StdioMCPSession
+
+    comando = "comando-que-nao-existe-mesmo"
+    try:
+        StdioMCPSession(comando, [], None, connect_timeout=5.0).start()
+    except Exception as exc:
+        motivo = str(exc)
+    else:  # pragma: no cover - would mean that name really is an MCP server
+        pytest.fail(f"{comando!r} started successfully, so there is no failure to report")
+
+    assert motivo.strip(), "the failure carries no message at all, so nothing could be logged"
+
+    settings = _settings(tmp_path, monkeypatch, f'[{{"name": "quebrado", "command": "{comando}", "args": []}}]')
 
     with caplog.at_level(logging.WARNING):
         assert mcp_pool.connectors(settings) is None
@@ -63,8 +83,8 @@ def test_a_server_that_cannot_start_says_what_went_wrong(tmp_path, monkeypatch, 
     # No disjunction here, deliberately. The first draft read `... in linha or len(linha) > N`,
     # and the fallback clause is true of the OLD line too — sabotaging the fix back to
     # `type(exc).__name__` left this test passing. A guard that survives its own defect is not one.
-    assert "comando-que-nao-existe-mesmo" in linha, (
-        f"the line names the server and not the reason: {linha!r}"
+    assert motivo[:60] in linha, (
+        f"the line names the server and not the reason.\n  logged:   {linha!r}\n  reason:   {motivo!r}"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -487,7 +487,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.43.0"
+version = "0.48.0rc30"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },
@@ -604,7 +604,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.40,<1.92" },
     { name = "markitdown", extras = ["docx", "pptx", "xlsx", "pdf"], marker = "extra == 'documents'", specifier = ">=0.1" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.7" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.3" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "numpy", marker = "extra == 'data'", specifier = ">=1.24" },


### PR DESCRIPTION
Two things that were already true and were not being said: a lock file five releases out of date, and a failure message that existed and never reached anybody.

## 1. `uv.lock` drifted five releases

It said `0.43.0` while `pyproject.toml` said `0.48.0rc30`.

Nothing broke, which is exactly why nobody looked. The release workflow runs a bare `uv sync`, which re-locks silently — verified rather than assumed: no workflow in this repository passes `--locked` or `--frozen`. But "re-locks silently" is a property of today's workflow, not a guarantee, and anyone running `uv sync --locked` on a fresh clone gets a refusal.

**The cause is the release script, not the file.** `cut_release.py` bumps six files and stops — and its own `check_only_expected_files_changed` is what kept the lock out: adding a seventh file to what a release touches would have been refused by the guard that says a release touches exactly six.

So the two halves cannot land separately, and the test asserts the pair rather than either side:

- `refresh_lock` runs `uv lock` and refuses if the result still does not name the new version;
- `LOCK` joins the expected-file set, without which the script would update the lock and then reject its own release.

`uv lock` is conservative — it keeps every pin that still satisfies its constraint. The regenerated lock in this PR is **two lines**: this package's version and the `mcp` specifier that gained its ceiling yesterday. It is not a dependency upgrade wearing a release's clothes, which is the only reason it can be part of a release at all.

## 2. The pool swallowed the one message a user can act on

`mcp_client.start` was given a specific sentence for the failure that has a remedy:

> the MCP SDK is not installed — install it with: `pip install 'chimera-agent[mcp]'`

`mcp_pool._build` caught it and logged `MCP: skipping server 'github' (ModuleNotFoundError)`. The half with the instruction was discarded at the only place a user would ever see it.

**Found by running the path, not by reading it.** A live probe connecting a real MCP server to the Code registry hit a venv without the SDK, and that log line was the entire output. The message worked; its only consumer threw it away.

The reason is bounded to 300 characters, and the bound is not decoration: a connect failure carries the command and its arguments, and `mcp.json` is also where a user's tokens live. `env` never appears in an exception message today, and a log line is the wrong place to bet on that staying true.

## On the tests

Each fix was sabotaged back to its broken state, and the sabotage checked for having applied — a `replace` that matches nothing reads exactly like a guard that does not discriminate.

Worth recording that **the first version of the log test survived its own defect.** It read `assert "…" in linha or len(linha) > N`, and the fallback clause is true of the old line too, so reverting the fix left it green. It now asserts the content, with no disjunction, and the sabotage takes down two of the three tests while the third — the bound — still passes.

ruff · mypy · 3869 Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
