### PR TITLE
fix(mcp): one configured server was becoming two connections

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1767,21 +1767,18 @@ def desktop_app(
     # across sessions. Off by default (fast, no subprocess). A broken server is skipped gracefully so
     # it can never break boot; toggling this needs a restart to take effect. Connect eagerly here (not
     # per-session) so the subprocesses aren't respawned for every new chat.
+    # Through the shared pool rather than a second set of connections. This block used to build its
+    # own, and when the coding surfaces gained MCP they built THEIR own too — so with autoload on,
+    # one configured server became two subprocesses, two Docker containers, and for GitHub two
+    # sign-ins. Measured on a running app: one connection at boot with no turn run, two after a
+    # single turn on the Code screen. `connectors` is idempotent per process, so whichever surface
+    # asks first pays for the connect and the other reuses it.
     mcp_connectors = None
     if settings.mcp_autoload:
-        from chimera.integrations import ConnectorRegistry, MCPConnector, StdioMCPSession
-        from chimera.integrations.mcp_config import load_servers
+        from chimera.integrations import mcp_pool
 
-        mcp_connectors = ConnectorRegistry()
-        for cfg in load_servers(settings.home / "mcp.json"):
-            try:
-                sess = StdioMCPSession(
-                    cfg.command, cfg.args or None, cfg.env or None, connect_timeout=10.0
-                ).start()
-                mcp_connectors.register(MCPConnector(cfg.name, sess, name_prefix=f"{cfg.name}_"))
-            except Exception as exc:  # noqa: BLE001 — a broken server must never break app boot
-                console.print(f"[yellow]MCP: skipping '{cfg.name}' ({type(exc).__name__})[/yellow]")
-        loaded = len(mcp_connectors.names())
+        mcp_connectors = mcp_pool.connectors(settings)
+        loaded = len(mcp_connectors.names()) if mcp_connectors is not None else 0
         console.print(f"[dim]MCP autoload: {loaded} server(s) connected[/dim]")
 
     def factory() -> ChatSession:

--- a/tests/test_mcp_connects_once_per_process.py
+++ b/tests/test_mcp_connects_once_per_process.py
@@ -1,0 +1,136 @@
+"""One configured server, one connection — however many surfaces ask for it.
+
+Found by watching processes on a running app rather than by reading code. With autoload on and a
+single server in `mcp.json`:
+
+    API up, no turn run ........ 1 connection   (the chat path, at boot)
+    after one turn on Code ..... 2 connections  (the coding path, its own)
+
+Both paths were correct in isolation and the pair was not: two subprocesses per configured server,
+two Docker containers for the GitHub entry, and its sign-in run twice. The chat path built its
+connectors as a local inside the `app` command, closed over by the session factory and reachable
+from nowhere else — so when the coding surfaces needed MCP tools, a second set was the only thing
+available to build.
+
+The tests assert the COUNT OF CONNECTS, not the count of tools. A test that only checked the tools
+arrive passes just as happily with two connections as with one, which is how this shipped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chimera.config import Settings
+from chimera.integrations import mcp_pool
+
+
+@pytest.fixture(autouse=True)
+def _fresh_pool():
+    mcp_pool.reset_for_tests()
+    yield
+    mcp_pool.reset_for_tests()
+
+
+def _settings(tmp_path, monkeypatch) -> Settings:
+    home = tmp_path / ".chimera"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "mcp.json").write_text(
+        '[{"name": "srv", "command": "x", "args": [], "env": {}}]', encoding="utf-8"
+    )
+    monkeypatch.setenv("CHIMERA_HOME", str(home))
+    monkeypatch.setenv("CHIMERA_MCP_AUTOLOAD", "1")
+    settings = Settings()
+    assert settings.mcp_autoload and settings.home == home, (
+        "the fixture did not produce the settings it claims to — nothing below measures anything"
+    )
+    return settings
+
+
+class _Sessao:
+    """A session that records that it was started, and lists one tool."""
+
+    def __init__(self, *a: Any, **k: Any) -> None:
+        pass
+
+    def start(self) -> _Sessao:
+        _conexoes.append(1)
+        return self
+
+    def list_tools(self) -> list[dict[str, str]]:
+        return [{"name": "t", "description": "d"}]
+
+    def call_tool(self, name: str, args: dict[str, Any]) -> str:  # pragma: no cover - unused here
+        return ""
+
+
+_conexoes: list[int] = []
+
+
+@pytest.fixture(autouse=True)
+def _zera_contagem(monkeypatch):
+    _conexoes.clear()
+    monkeypatch.setattr("chimera.integrations.StdioMCPSession", _Sessao)
+    yield
+
+
+def test_asking_twice_connects_once(tmp_path, monkeypatch) -> None:
+    """The pool's whole reason to exist, asserted on the number that shows it."""
+    settings = _settings(tmp_path, monkeypatch)
+
+    primeiro = mcp_pool.connectors(settings)
+    segundo = mcp_pool.connectors(settings)
+
+    assert primeiro is segundo, "two callers got two different pools"
+    assert len(_conexoes) == 1, (
+        f"one configured server produced {len(_conexoes)} connections — each is a subprocess, and "
+        "for the GitHub entry each is a container and a sign-in"
+    )
+
+
+def test_many_callers_at_once_still_connect_once(tmp_path, monkeypatch) -> None:
+    """Turns arrive concurrently, and a fan-out builds a registry per worker.
+
+    Without the lock each of them starts its own set of subprocesses — the failure the pool exists
+    to prevent, reached by the code that prevents it.
+    """
+    import threading
+
+    settings = _settings(tmp_path, monkeypatch)
+    resultados: list[Any] = []
+
+    fios = [
+        threading.Thread(target=lambda: resultados.append(mcp_pool.connectors(settings)))
+        for _ in range(8)
+    ]
+    for f in fios:
+        f.start()
+    for f in fios:
+        f.join()
+
+    assert len(_conexoes) == 1, f"8 concurrent callers made {len(_conexoes)} connections"
+    assert all(r is resultados[0] for r in resultados), "concurrent callers got different pools"
+
+
+def test_the_chat_path_goes_through_the_pool_rather_than_building_its_own() -> None:
+    """Asserted on the source, because the alternative is booting a real app in a unit test.
+
+    The line it checks is the line that was wrong: `chimera app` used to construct
+    `StdioMCPSession` itself, which is what made the second connection.
+    """
+    from pathlib import Path
+
+    fonte = (Path(__file__).resolve().parent.parent / "chimera" / "cli" / "main.py").read_text(
+        encoding="utf-8"
+    )
+    inicio = fonte.index("mcp_connectors = None")
+    trecho = fonte[inicio : inicio + 900]
+
+    assert "mcp_pool.connectors(" in trecho, (
+        "the app command no longer gets its MCP connections from the shared pool"
+    )
+    assert "StdioMCPSession(" not in trecho, (
+        "the app command is opening its own MCP sessions again — one configured server becomes two "
+        "subprocesses, and for GitHub two sign-ins"
+    )


### PR DESCRIPTION
Found by watching processes on the running app, not by reading code.

With autoload on and a **single** server in `mcp.json`:

| state | direct connections from the API |
|---|---:|
| API up, no turn run | **1** — the chat path, at boot |
| after one turn on the Code screen | **2** |

Two subprocesses per configured server. For the GitHub entry that is two Docker containers and its sign-in run **twice**; for a database entry, two sessions against someone's database.

## Both halves were correct, and the pair was not

`chimera app` built its connectors as a local variable inside the command, closed over by the session factory and reachable from nowhere else. So when the coding surfaces gained MCP last release, building a **second** set was the only thing available to do.

The pool's docstring says *"connected once per process"*. That was true of the pool while being false of the app.

`chimera app` now asks the same pool. `connectors` is idempotent per process, so whichever surface asks first pays for the connect and the other reuses it.

## Measured again after the change

On the running app: **1** direct connection where there were 2 — and a coding turn still works (`list_dir`, correct answer, $0.0037). Reducing the connection count must not cost the tools, and it did not.

## Why these tests and not the obvious ones

They assert the **count of connects**, not the count of tools. A test that only checks the tools arrive passes just as happily with two connections as with one — which is how this shipped.

| sabotage | what fails |
|---|---|
| `app` opens its own session again | the source assertion, alone |
| the pool forgets between calls | both counting tests, alone |

ruff · mypy · **3871** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)