### PR TITLE
fix(release): a command whose output is not ASCII took the cut down

### DIFF
--- a/scripts/cut_release.py
+++ b/scripts/cut_release.py
@@ -67,6 +67,11 @@ def run(*args: str, capture: bool = True, env: dict[str, str] | None = None) -> 
         text=True,
         check=False,
         encoding="utf-8",
+        # Not decoration. Every command here used to be git, whose output is ASCII; `uv lock` is the
+        # first that is not, and on a Windows console it emits cp1252 bytes. Without this the reader
+        # thread dies on a byte 0x97, prints a traceback nobody can act on, and — worse — leaves
+        # `stderr` empty, so a command that FAILED would be reported with no reason attached.
+        errors="replace",
         env={**os.environ, **env} if env else None,
     )
     if result.returncode != 0:

--- a/tests/test_cut_release.py
+++ b/tests/test_cut_release.py
@@ -213,3 +213,22 @@ def test_a_release_that_leaves_the_lock_behind_is_refused() -> None:
         "uv.lock is not in the expected-file set, so `refresh_lock` updating it would make the "
         "script refuse its own release"
     )
+
+
+def test_a_command_whose_output_is_not_utf8_does_not_take_the_release_down() -> None:
+    """Every command here used to be git, and git's output is ASCII.
+
+    `uv lock` — added to the release when the lock file joined the version files — is the first that
+    is not, and on a Windows console it emits cp1252 bytes. The first release cut after that change
+    printed a `UnicodeDecodeError` traceback from a reader thread: alarming, unactionable, and worse
+    than it looks, because a crashed reader leaves `stderr` EMPTY. A command that actually failed
+    would have been reported with no reason attached.
+
+    Written as a real subprocess rather than a source check: the assertion is about behaviour under
+    bytes that are not valid UTF-8, and `\x97` is exactly the byte that did it.
+    """
+    saida = cut_release.run(
+        sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'ok\\x97ok')"
+    )
+
+    assert "ok" in saida, f"the output was lost entirely: {saida!r}"


### PR DESCRIPTION
Every command the release script ran used to be git, and git's output is ASCII. `uv lock` — which joined the release when the lock file became one of the version files — is the first that is not, and on a Windows console it emits cp1252 bytes.

The first cut after that change printed a `UnicodeDecodeError` traceback from a subprocess reader thread.

Alarming and unactionable — and **worse than it looks**: a crashed reader leaves `stderr` empty, so a command that actually *failed* would be reported by `Stop` with no reason attached. The guard that exists to say what went wrong would have said nothing.

Found in a `--dry-run` before cutting rc31, which is what dry runs are for.

## On the test

It runs a real subprocess emitting `\x97` — the exact byte that did it — rather than checking that the keyword appears in the source. Removing `errors="replace"` fails it with the same `UnicodeDecodeError`, and fails nothing else.

ruff · mypy · **3872** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)