### PR TITLE
fix(memory): recall could not read three of the ten languages it ships in

### DIFF
--- a/chimera/memory/manager.py
+++ b/chimera/memory/manager.py
@@ -18,7 +18,6 @@ from chimera.memory.store import MemoryBackend
 from chimera.telemetry import get_logger
 
 _log = get_logger("memory.manager")
-_TOKEN = re.compile(r"[a-z0-9]+")
 
 
 def _normalize(text: str) -> str:
@@ -247,10 +246,14 @@ class MemoryManager:
         hits — ``"semantic"`` | ``"fts"`` | ``"keyword"`` — and never when a layer returns nothing,
         so a UI can honestly show which layer contributed rather than guessing.
         """
+        from chimera.memory.tokens import idf_weights, informative, tokens
+
         # A tokenless query (blank/whitespace/punctuation) has nothing to match — return [] up front
         # so every path agrees. Otherwise the semantic path would embed "" and return k arbitrary
-        # items while the keyword/FTS paths correctly return nothing.
-        if not _TOKEN.findall(query.lower()):
+        # items while the keyword/FTS paths correctly return nothing. Through the SAME tokenizer the
+        # keyword path uses: with two, a query written in Cyrillic was "tokenless" here and
+        # matchable there.
+        if not tokens(query):
             return []
         if self._semantic is not None:
             try:
@@ -267,15 +270,33 @@ class MemoryManager:
             if result and on_layer is not None:
                 on_layer("fts")
             return result
-        terms = set(_TOKEN.findall(query.lower()))
+        # Function words dropped BEFORE anything else. A real store of two facts recalled both of
+        # them for a sentence about compiling a kernel, on `o`, `com`, `a`, `e` — and inverse
+        # document frequency cannot catch that, because with two documents a word in one of them
+        # looks maximally rare. Measured, not assumed: the IDF-only version left every one of those
+        # false hits in place.
+        terms = informative(tokens(query))
         if not terms:
             return []
-        scored: list[tuple[int, str, MemoryItem]] = []
-        for item in self.store.all():
-            haystack = set(_TOKEN.findall(item.content.lower()))
-            score = len(terms & haystack)
-            if score:
-                scored.append((score, item.id, item))
+        # Read once: `store.all()` can be a file read, and this used to call it inside the loop's
+        # own iteration anyway.
+        corpus = [(item, set(tokens(item.content))) for item in self.store.all()]
+        weights = idf_weights(terms, [list(hay) for _, hay in corpus])
+        scored: list[tuple[float, str, MemoryItem]] = []
+        for item, haystack in corpus:
+            matched = terms & haystack
+            if not matched:
+                continue
+            # Ranked by how much each term distinguishes THIS fact from the others; a term
+            # common to every stored fact weighs nothing and simply does not lift a result up the
+            # list. NOT used to reject: a floor of `log(2)` was tried and dropped, because a query
+            # whose only real word appears in every fact ("how should answers be?" against two facts
+            # that both mention answers) scored exactly zero and recalled nothing. Rejecting the
+            # noise is the stopword list's job, and it does it without that side effect.
+            score = (
+                sum(weights.get(t, 0.0) for t in matched) if weights else 0.0
+            ) or float(len(matched))
+            scored.append((score, item.id, item))
         scored.sort(key=lambda entry: (-entry[0], entry[1]))
         top = [item for _, _, item in scored[:k]]
         if top and on_layer is not None:

--- a/chimera/memory/sqlite_store.py
+++ b/chimera/memory/sqlite_store.py
@@ -10,7 +10,6 @@ FTS5 ships with most Python builds; if it is missing, this degrades to a ``LIKE`
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
 from pathlib import Path
 
@@ -20,7 +19,6 @@ from chimera.memory.models import MemoryItem, MemoryKind
 # (a tainted memory must never launder itself to "clean"), and it must round-trip identically to the
 # JSON store or the guarantee breaks purely by backend choice.
 _COLUMNS = "id, kind, content, key, source, metadata, provenance"
-_TOKEN = re.compile(r"[a-z0-9]+")
 
 
 class SqliteMemoryStore:
@@ -118,8 +116,16 @@ class SqliteMemoryStore:
         return [self._to_item(row) for row in rows]
 
     def search(self, query: str, k: int = 5) -> list[MemoryItem]:
-        """Full-text recall (FTS5 MATCH; LIKE fallback), best matches first."""
-        terms = _TOKEN.findall(query.lower())
+        """Full-text recall (FTS5 MATCH; LIKE fallback), best matches first.
+
+        Through the same tokenizer and the same function-word list the keyword path uses. This
+        backend has its own search and so bypassed both: with the JSON store fixed, *"o que e isso?"*
+        recalled nothing, and against SQLite it still recalled every fact in the store. One rule
+        about what a query means, or the answer depends on which backend the owner picked.
+        """
+        from chimera.memory.tokens import informative, tokens
+
+        terms = sorted(informative(tokens(query)))
         if not terms:
             return []
         if self._fts:
@@ -129,7 +135,12 @@ class SqliteMemoryStore:
                     f"SELECT {_COLUMNS} FROM memories WHERE content MATCH ? ORDER BY rank LIMIT ?",
                     (match, k),
                 ).fetchall()
-                return [self._to_item(row) for row in rows]
+                if rows:
+                    return [self._to_item(row) for row in rows]
+                # Nothing, rather than an error — fall through to LIKE instead of returning empty.
+                # FTS5's tokenizer indexes a run of Han as ONE token, while `tokens` splits it per
+                # character so a query can reach inside a sentence; those two disagree, and LIKE
+                # (a substring match) is the one that can still find it.
             except sqlite3.OperationalError:
                 pass  # malformed FTS query — fall through to LIKE
         clause = " OR ".join("lower(content) LIKE ?" for _ in terms)

--- a/chimera/memory/tokens.py
+++ b/chimera/memory/tokens.py
@@ -1,0 +1,201 @@
+"""How a query and a stored fact are cut into comparable pieces, and which pieces mean anything.
+
+Every rule here replaced one that was measured wrong on a real install.
+
+**The alphabet.** The tokenizer was ``[a-z0-9]+`` over lowercased text, so it saw only ASCII::
+
+    "где находится проект"  -> []          (Russian)
+    "项目在哪里"              -> []          (Chinese)
+    "プロジェクトはどこ"        -> []          (Japanese)
+
+Three of the ten languages this app ships in. Keyword memory recall returned nothing for them, on
+every query, for ever — the feature was not degraded, it was absent, and silently.
+
+**The accents.** For the languages it did see, the same class did not merely drop accents, it
+*manufactured* tokens at them: ``"autenticação" -> ['autentica', 'o']``. Every ``-ção`` produced an
+``o``, which is exactly the token that matches everything. Writing correct Portuguese made recall
+worse; typing English never met the defect.
+
+**The meaning.** Scoring was ``len(query & fact)`` kept when non-zero — one shared token, any token.
+Against a real store of two facts, *"compile o kernel com suporte a NUMA e verifique o dmesg"*
+recalled BOTH, on ``o``, ``com``, ``a``, ``e``.
+
+Inverse document frequency was tried first and **measured inert**: with two stored facts, ``o``
+appears in one of them, so IDF rates it maximally informative. A corpus that small carries no
+evidence about which words are common — the statistic needs documents it does not have. It is kept
+below for RANKING, where it earns its place as the store grows, but it cannot be the filter.
+
+A rejection floor of ``log(2)`` was tried on top of it and dropped, measured: a query whose only
+real word appears in every stored fact (*"how should answers be?"* against two facts that both
+mention answers) scored exactly zero and recalled nothing at all.
+
+What can is a stopword list, and the honest version of one covers every language the app ships in
+rather than the one whose defect was noticed. That is the same rule this project wrote down for the
+website's alpha caveat: narrow the rule, never except the languages.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections.abc import Iterable, Sequence
+
+__all__ = ["idf_weights", "informative", "tokens"]
+
+#: Any letter or digit in any script, after folding. `[^\W_]` rather than a named list of ranges:
+#: a range list is a promise to remember every alphabet, and this file exists because one was
+#: forgotten. Underscore is excluded so `snake_case` splits into words.
+_WORD = re.compile(r"[^\W_]+", re.UNICODE)
+
+#: Function words for the languages this app ships in, written without diacritics because that is
+#: what `tokens` produces. Closed-class only — articles, prepositions, pronouns, conjunctions and
+#: the commonest auxiliaries. A content word must never be here: removing one makes a fact
+#: unfindable, which is a worse failure than admitting one noisy hit.
+#:
+#: Chinese and Japanese are absent on purpose. Chinese is split per character below, so a particle
+#: is indistinguishable from a character carrying meaning inside a compound; Japanese kana runs stay
+#: whole, so a particle is glued to the word beside it rather than standing alone to be removed.
+_BY_LANGUAGE: dict[str, str] = {
+    "en": (
+        "a an the and or but if of to in on at by for with from as is are was were be been being "
+        "this that these those it its he she they we you i my your his her their our me him them us "
+        "do does did done can could will would shall should may might must not no yes so than then "
+        "there here what which who whom whose when where why how all any both each few more most "
+        "other some such only own same too very just about into over under again further once"
+    ),
+    "pt": (
+        "o a os as um uma uns umas de do da dos das em no na nos nas por para com sem sob sobre e ou "
+        "mas se que ao aos as isso isto este esta esses essas aquele aquela meu minha seu sua nosso "
+        "nossa ser estar ter foi sao esta estao nao sim ja mais menos muito pouco todo toda todos "
+        "todas entao quando onde como qual quem porque eu tu ele ela nos eles elas voce voces me te "
+        "lhe lhes ha havia sera seria tambem ainda apos ate depois antes durante"
+    ),
+    "es": (
+        "el la los las un una unos unas de del al en por para con sin sobre y o pero si que se es "
+        "son era eran ser estar tener no si ya mas menos muy todo toda todos todas cuando donde como "
+        "cual quien porque yo tu el ella nosotros ellos ellas usted ustedes me te le les hay tambien "
+        "aun hasta despues antes durante entre"
+    ),
+    "fr": (
+        "le la les un une des du de au aux en dans sur sous pour par avec sans et ou mais si que qui "
+        "quoi dont ou est sont etait etaient etre avoir ne pas plus moins tres tout toute tous "
+        "toutes quand comment pourquoi je tu il elle nous vous ils elles me te se lui leur y il "
+        "aussi encore apres avant pendant entre"
+    ),
+    "de": (
+        "der die das den dem des ein eine einen einem eines und oder aber wenn dass zu in an auf aus "
+        "bei mit nach von vor uber unter fur ohne ist sind war waren sein haben hat hatte nicht kein "
+        "keine mehr weniger sehr alle alles wann wo wie warum ich du er sie es wir ihr mich dich "
+        "sich uns euch auch noch schon dann denn als"
+    ),
+    "it": (
+        "il lo la i gli le un uno una di del della dei delle da in su per con senza e o ma se che "
+        "chi cui e sono era erano essere avere non piu meno molto tutto tutta tutti tutte quando "
+        "dove come perche io tu lui lei noi voi loro mi ti si ci vi anche ancora dopo prima durante "
+        "tra fra"
+    ),
+    "pl": (
+        "i oraz albo lub ale jesli ze w we na do od za po pod nad przy bez dla o u z ze jest sa byl "
+        "byla bylo byc miec nie tak juz wiecej mniej bardzo wszystko wszyscy kiedy gdzie jak "
+        "dlaczego ja ty on ona ono my wy oni one mnie ciebie siebie nas was tez jeszcze"
+    ),
+    # Cyrillic, which the tokenizer could not even see before this file existed.
+    "ru": (
+        "и или но если что как когда где почему в во на к ко с со из от до по за под над при "
+        "без для о об у я ты он она оно мы вы они меня тебя себя нас вас их его ее это этот "
+        "эта эти тот та те не нет да уже еще очень все весь вся был была было быть есть также "
+        "тоже"
+    ),
+}
+
+#: One flat set. The split lives here, on a variable, rather than on each literal above.
+_STOPWORDS = frozenset(w for words in _BY_LANGUAGE.values() for w in words.split())
+
+
+def _fold(text: str) -> str:
+    """Lowercase, and drop diacritics from LATIN letters only.
+
+    The restriction is not caution, it is a measured correction. Folding the whole string turned
+    ``プロジェクト`` into ``フロシェクト``: the dakuten on ``プ`` and ``ジ`` decomposes like an accent
+    and is nothing of the sort — ``は`` / ``ば`` / ``ぱ`` are three different letters. The same
+    argument holds for Cyrillic ``й`` and Greek ``ά``.
+
+    So the fold applies where accent-insensitive matching is what people actually expect, and where
+    the defect that prompted this lived: ``ç`` and ``ã`` in Latin script.
+    """
+    out: list[str] = []
+    for ch in text.lower():
+        decomposed = unicodedata.normalize("NFKD", ch)
+        base = decomposed[0] if decomposed else ch
+        if "a" <= base <= "z" or "0" <= base <= "9":
+            out.append("".join(c for c in decomposed if not unicodedata.combining(c)))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def _han(ch: str) -> bool:
+    """A Han ideograph — the script where one character is roughly one unit of meaning."""
+    code = ord(ch)
+    return 0x3400 <= code <= 0x4DBF or 0x4E00 <= code <= 0x9FFF or 0xF900 <= code <= 0xFAFF
+
+
+def tokens(text: str) -> list[str]:
+    """Comparable pieces of ``text``: any script, Latin diacritics folded, Han split per character.
+
+    Folding rather than widening the character class does two jobs: it stops ``ç`` and ``ã`` from
+    splitting a word into fragments plus a stray vowel, and it makes ``voce`` match ``você`` —
+    which matters because people type both, and a store that distinguishes them remembers half of
+    what it was told.
+    """
+    out: list[str] = []
+    for match in _WORD.finditer(_fold(text)):
+        buffer = ""
+        for ch in match.group():
+            if _han(ch):
+                # One character, one token. Chinese puts no spaces between words, so a whole
+                # sentence arrives as a single run; per-character is the cheap segmentation that
+                # lets a query for 项目 reach a fact containing 项目在哪里.
+                if buffer:
+                    out.append(buffer)
+                    buffer = ""
+                out.append(ch)
+            else:
+                buffer += ch
+        if buffer:
+            out.append(buffer)
+    return out
+
+
+def informative(terms: Iterable[str]) -> set[str]:
+    """``terms`` with function words removed. Empty when every one of them was a function word.
+
+    The first version fell back to the words themselves when stripping left nothing, on the
+    reasoning that an empty set must not silently mean "no filter". Measured, that fallback
+    reproduced the defect it was meant to guard: *"o que e isso?"* recalled both stored facts.
+
+    Empty is the honest answer. A question built only of function words asks for nothing in
+    particular, and the caller reads an empty set as "nothing to search for" rather than as
+    "everything matches".
+    """
+    return {t for t in terms if t not in _STOPWORDS}
+
+
+def idf_weights(terms: Iterable[str], documents: Sequence[Sequence[str]]) -> dict[str, float]:
+    """How much each of ``terms`` distinguishes one of ``documents`` from the others.
+
+    ``log(n / df)``: zero for a term in every document, largest for one in a single document.
+    Returns weights only for terms that appear somewhere — an unseen term cannot inform.
+
+    Empty below two documents, and the caller falls back to plain overlap: one fact cannot make
+    another common, and zeros there would mean a store holding a single memory recalls nothing.
+    """
+    n = len(documents)
+    if n < 2:
+        return {}
+    df: dict[str, int] = {}
+    for doc in documents:
+        for token in set(doc):
+            df[token] = df.get(token, 0) + 1
+    return {t: math.log(n / df[t]) for t in set(terms) if df.get(t)}

--- a/tests/test_memory_recall_speaks_every_language.py
+++ b/tests/test_memory_recall_speaks_every_language.py
@@ -1,0 +1,173 @@
+"""Keyword recall, measured on a real install and found wrong three ways.
+
+The store under test is the one a person actually had in the desktop app: two facts, one about a
+project and one about how they like to be answered. Every case below was run against it before any
+code changed, and the numbers in the comments are what came back.
+
+The three defects were independent:
+
+1. ``[a-z0-9]+`` saw only ASCII, so recall returned NOTHING for Russian, Chinese and Japanese — three
+   of the ten languages the app ships in. Not degraded: absent, silently, always.
+2. The same class manufactured tokens at accents (``"autenticação" -> ['autentica', 'o']``), so
+   writing correct Portuguese produced the very token that matches everything.
+3. One shared token, any token, was a hit — so a sentence about compiling a kernel recalled both
+   stored facts on ``o``, ``com``, ``a``, ``e``.
+
+Inverse document frequency was implemented first for (3) and **measured inert**: with two documents,
+``o`` appears in one of them and so scores as maximally rare. That negative is worth a test of its
+own, below, so nobody removes the stopword list believing IDF covers it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.memory.manager import MemoryManager
+from chimera.memory.store import MemoryStore
+from chimera.memory.tokens import informative, tokens
+
+#: The two facts that were really in the app, verbatim.
+PROJETO = "O projeto de teste do Cafe Aurora fica em Desktop/teste-chimera/site-institucional"
+ESTILO = "Prefiro respostas curtas e diretas, sem rodeios"
+
+
+def _real_store(tmp_path: Path) -> MemoryManager:
+    mgr = MemoryManager(MemoryStore(tmp_path / "mem.json"))
+    mgr.remember(PROJETO)
+    mgr.remember(ESTILO, "persona")
+    return mgr
+
+
+# --- the alphabet -------------------------------------------------------------------------------
+
+
+def test_recall_sees_scripts_that_are_not_ascii() -> None:
+    """Russian, Chinese and Japanese all came back as zero tokens, which is zero recall for ever."""
+    assert tokens("где находится проект"), "Russian tokenizes to nothing"
+    assert tokens("项目在哪里"), "Chinese tokenizes to nothing"
+    assert tokens("プロジェクトはどこ"), "Japanese tokenizes to nothing"
+    assert tokens("που ειναι το εργο"), "Greek tokenizes to nothing"
+
+
+def test_han_is_split_per_character_so_a_query_can_reach_a_sentence() -> None:
+    """Chinese writes no spaces, so a whole clause arrives as one run and would match only itself."""
+    fato = set(tokens("项目在哪里"))
+    assert set(tokens("项目")) <= fato, "a query for 项目 cannot reach a fact containing it"
+
+
+def test_kana_keeps_its_dakuten() -> None:
+    """A fix for one script must not damage another.
+
+    Folding diacritics across the whole string turned ``プロジェクト`` into ``フロシェクト``: the
+    dakuten decomposes like an accent and is nothing of the sort. This is the guard for that
+    regression, which was introduced and caught in the same sitting.
+    """
+    assert tokens("プロジェクト") == ["プロジェクト"]
+    assert tokens("ば") != tokens("は"), "ば and は collapsed into the same token"
+
+
+# --- the accents --------------------------------------------------------------------------------
+
+
+def test_accents_do_not_manufacture_tokens() -> None:
+    """`autenticação` produced an `o` that nobody wrote, and an `o` matches everything."""
+    assert tokens("autenticação") == ["autenticacao"]
+    assert tokens("coordenação") == ["coordenacao"]
+    assert tokens("você") == ["voce"]
+
+
+def test_the_same_word_typed_with_and_without_accents_is_the_same_word() -> None:
+    """People type both, and a store that distinguishes them remembers half of what it was told."""
+    assert tokens("a autenticação do usuário") == tokens("a autenticacao do usuario")
+
+
+# --- the meaning --------------------------------------------------------------------------------
+
+
+def test_a_sentence_sharing_only_function_words_recalls_nothing(tmp_path: Path) -> None:
+    """Measured before: recalled the project fact. On `o` and `de`."""
+    mgr = _real_store(tmp_path)
+    assert mgr.search("corrija o erro de tipo neste arquivo", k=3) == []
+    assert mgr.search("explique o que este codigo faz", k=3) == []
+
+
+def test_a_sentence_that_shares_real_words_still_recalls(tmp_path: Path) -> None:
+    """The other half of the trade. Removing noise must not remove the signal."""
+    mgr = _real_store(tmp_path)
+
+    projeto = mgr.search("onde fica o projeto do Cafe Aurora?", k=3)
+    assert projeto and PROJETO in projeto[0].content
+
+    estilo = mgr.search("prefiro respostas curtas?", k=3)
+    assert estilo and ESTILO in estilo[0].content
+
+
+def test_idf_alone_does_not_catch_this_which_is_why_the_word_list_exists() -> None:
+    """The negative result, kept so the list is not removed as redundant later.
+
+    With two documents, ``o`` appears in one of them — so ``log(n/df)`` rates it exactly as
+    informative as ``aurora``, a word that appears in one fact and nowhere else. A statistic about
+    how common a word is needs documents it does not have here.
+    """
+    from chimera.memory.tokens import idf_weights
+
+    docs = [tokens(PROJETO), tokens(ESTILO)]
+    pesos = idf_weights({"o", "aurora"}, docs)
+
+    assert pesos["o"] == pesos["aurora"], (
+        "IDF now separates `o` from `aurora` on a two-document store; if that is really true the "
+        "stopword list may be reconsidered — it was not true when this was written"
+    )
+
+
+def test_a_word_common_to_every_fact_still_recalls_them(tmp_path: Path) -> None:
+    """Why there is no rejection floor, and the case that removed the one there was.
+
+    A floor of ``log(2)`` was added first: it read as "the match must carry at least as much
+    information as a term appearing in at most half the store". It also rejected this, where the
+    query's only real word is in every fact — score exactly zero, recall nothing. Both facts are
+    about answers and the person asked about answers; returning them is the useful answer.
+    """
+    mgr = MemoryManager(MemoryStore(tmp_path / "m.json"))
+    mgr.remember("answers should be short")
+    mgr.remember("the user prefers concise answers")
+
+    assert mgr.search("how should answers be?", k=3), (
+        "a word shared by every stored fact now recalls nothing — the rejection floor is back"
+    )
+
+
+def test_a_query_of_only_function_words_recalls_nothing(tmp_path: Path) -> None:
+    """The first fix fell back to the stripped words here, and that reproduced the whole defect.
+
+    "o que e isso?" recalled both stored facts, which is exactly what removing function words was
+    for. A question built only of function words asks for nothing in particular, and empty is the
+    honest answer.
+    """
+    mgr = _real_store(tmp_path)
+    assert mgr.search("o que e isso?", k=3) == []
+    assert informative(["o", "que", "e"]) == set()
+
+
+# --- the other backend ---------------------------------------------------------------------------
+
+
+def test_the_sqlite_backend_answers_the_same_way(tmp_path: Path) -> None:
+    """It has its own `search`, so it bypassed all three fixes.
+
+    Measured with the JSON store already fixed: "o que e isso?" recalled nothing there and every
+    fact in the store here. Which backend the owner picked is not supposed to change what a query
+    means.
+    """
+    from chimera.memory.sqlite_store import SqliteMemoryStore
+
+    mgr = MemoryManager(SqliteMemoryStore(tmp_path / "mem.db"))
+    mgr.remember(PROJETO)
+    mgr.remember(ESTILO, "persona")
+    mgr.remember("проект находится в папке документы")
+    mgr.remember("项目在文档文件夹中")
+
+    assert mgr.search("o que e isso?", k=5) == [], "function words still recall everything"
+    assert mgr.search("onde fica o projeto do Café Aurora?", k=5), "accented query finds nothing"
+    assert mgr.search("где проект", k=5), "Russian finds nothing"
+    assert mgr.search("项目", k=5), "Chinese finds nothing"


### PR DESCRIPTION
Measured on a real install — the desktop app's own memory, two facts in it — and found wrong three ways at once. The brief was "stopwords, a floor, and accents". Two of those turned out to be the same defect, one of them was a mistake, and a third defect nobody had asked about was the worst of them.

## 1. It could not read three of the ten languages this app ships in

`[a-z0-9]+` over lowercased text sees only ASCII:

| query | tokens |
|---|---|
| `где находится проект` | `[]` |
| `项目在哪里` | `[]` |
| `プロジェクトはどこ` | `[]` |

Russian, Chinese and Japanese. Keyword memory recall returned **nothing for them, on every query, always** — not degraded, absent, and silently. Greek and Korean too, which are not shipped yet.

Now: any script. Han is split per character, because Chinese writes no spaces and a whole clause would otherwise arrive as one token that matches only itself.

## 2. Accents did not lose information, they invented it

```
"autenticação" -> ['autentica', 'o']      <- an 'o' nobody wrote
"coordenação"  -> ['coordena', 'o']
"você"         -> ['voc']
```

Every `-ção` produced an `o` — precisely the token that matches everything. **Writing correct Portuguese made recall worse**, and a user typing English never met the defect.

Folded now, and only for Latin script. Folding everything turned `プロジェクト` into `フロシェクト`: the dakuten decomposes like an accent and is nothing of the sort — `は`/`ば`/`ぱ` are three different letters. That regression was introduced and caught in the same sitting; there is a test for it.

## 3. One shared token, any token, was a hit

Against the real store of two facts:

| query | recalled, before |
|---|---|
| "corrija o erro de tipo neste arquivo" | the unrelated project fact |
| "explique o que este codigo faz" | the unrelated project fact |
| "compile o kernel com suporte a NUMA e verifique o dmesg" | **both facts** |
| "o que e isso?" | **both facts** |

On `o`, `de`, `com`, `a`, `e`.

### What did not work, kept as a test

**Inverse document frequency was implemented first and measured inert.** With two documents, `o` appears in one of them, so `log(n/df)` rates it *exactly as informative as* `aurora`. A statistic about which words are common needs documents it does not have. There is a test asserting that equality, so nobody removes the word list later believing IDF covers it.

**A rejection floor of `log(2)` was added and removed.** It read well — "the match must carry at least as much information as a term appearing in at most half the store" — and it broke a legitimate case that an existing test already covered: *"how should answers be?"* against two facts that both mention answers scores exactly zero, so recall returned nothing. Rejecting noise is the word list's job and it does it without that side effect. IDF stays, for ranking only.

**The word list this project already had is English** — `{i, you, the, a, an, for, and, to, of, my, is, are, it}`, in `nudges.py`. Using it here would have fixed English recall and left Portuguese exactly as broken: the same defect one layer up, and the one this project has already written the rule for. The list here covers all eight alphabetic languages the app ships in.

## After

| query | before | after |
|---|---|---|
| "corrija o erro de tipo neste arquivo" | project fact | **nothing** |
| "explique o que este codigo faz" | project fact | **nothing** |
| "o que e isso?" | both facts | **nothing** |
| "onde fica o projeto do Café Aurora?" | found | **found** |
| "prefiro respostas curtas?" | found | **found** |
| Russian / Chinese / Japanese | **nothing, ever** | **found** |

Two cases are unchanged and not papered over: *"adicione um teste para a função de login"* still recalls the project fact, because `teste` is a real shared content word; and *"como você deve escrever para mim?"* still misses the persona fact about answer style, which only the semantic layer can bridge.

## The other backend

SQLite has its own `search` and bypassed all three fixes — with the JSON store already fixed, *"o que e isso?"* recalled nothing there and **every fact in the store** here. Same tokenizer and same list now, plus a fall-through from FTS to LIKE when FTS finds nothing: FTS5 indexes a run of Han as one token while `tokens` splits it per character, and LIKE is the one that can still find it. Which backend the owner picked is not supposed to change what a query means.

## Sabotage

Each fix reverted on its own, and each takes down only the tests about its own concern:

| reverted | fails |
|---|---|
| ASCII-only character class | the script tests |
| no accent folding | the accent tests |
| no word list | the function-word tests |
| no per-character Han | the Han test |

ruff · mypy · full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
