### PR TITLE
fix(memory): merging and nudges spoke one language between them

### DIFF
--- a/chimera/memory/consolidate.py
+++ b/chimera/memory/consolidate.py
@@ -9,17 +9,29 @@ supplies the real, model-backed one. A merge is a write, so it's opt-in (``memor
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable
 
 from chimera.memory.models import MemoryItem
 
-_TOKEN = re.compile(r"[a-z0-9]+")
 Summarizer = Callable[[list[str]], str]
+
+#: Below this many characters a token is a fragment or a function word, and Jaccard overlap on
+#: those measures grammar rather than meaning. It does NOT apply to scripts where one character is
+#: a word: `tokens` splits Han per character, and a two-character rule would discard every one of
+#: them — which is how Chinese and Russian memories came to never cluster at all.
+_MIN_LENGTH = 3
 
 
 def _tokens(text: str) -> set[str]:
-    return {token for token in _TOKEN.findall(text.lower()) if len(token) >= 3}
+    """Significant tokens, through the shared tokenizer.
+
+    This module had its own ``[a-z0-9]+``, so two nearly identical Russian facts produced two empty
+    sets and `_similar` refused them both. Measured: Portuguese and English clustered, Russian and
+    Chinese never did — consolidation was inert in those languages rather than merely worse.
+    """
+    from chimera.memory.tokens import tokens as _shared
+
+    return {t for t in _shared(text) if len(t) >= _MIN_LENGTH or not t.isascii()}
 
 
 def _similar(a: str, b: str, threshold: float) -> bool:

--- a/chimera/memory/nudges.py
+++ b/chimera/memory/nudges.py
@@ -14,22 +14,73 @@ from __future__ import annotations
 
 import re
 
-# First-person preference verbs (optionally preceded by an adverb like "always"/"really").
+from chimera.memory.tokens import fold_for_match
+
+#: First-person preference statements, in the languages this app ships in.
+#:
+#: This was one English pattern — ``\bi (?:always )?(?:prefer|like|...)s?\b`` — and measured, that
+#: is exactly what it detected. "eu prefiro respostas curtas", "prefiero respuestas cortas",
+#: "je prefere des reponses courtes", "ich bevorzuge kurze antworten" and
+#: "я предпочитаю краткие ответы" all returned NOTHING. Not fewer suggestions: none, ever. The
+#: feature existed for one of ten audiences.
+#:
+#: Note what this fixed and what it did not. The tokenizer in this module was ASCII-only too, and
+#: repairing that alone would have changed nothing measurable — the pattern rejects a sentence
+#: before a token is ever taken. A fix that fixes nothing is worth naming rather than shipping.
+#:
+#: Romance and Germanic languages drop the pronoun freely ("prefiro", "prefiero"), so the pronoun is
+#: optional there; requiring it would miss the commonest phrasing. English keeps it required,
+#: because "like" without "I" is a simile far more often than a preference.
 _PREFERENCE = re.compile(
-    r"\bi (?:always |usually |generally |really |only |never )?"
-    r"(?:prefer|like|love|use|need|want|require|avoid|dislike|hate)s?\b",
-    re.IGNORECASE,
+    "|".join(
+        (
+            # English — pronoun required: bare "like" is usually a comparison, not a preference.
+            r"\bi (?:always |usually |generally |really |only |never )?"
+            r"(?:prefer|like|love|use|need|want|require|avoid|dislike|hate)s?\b",
+            # Portuguese
+            r"\b(?:eu )?(?:sempre |normalmente |realmente |so |nunca )?"
+            r"(?:prefiro|gosto de|adoro|uso|preciso de|quero|evito|detesto|odeio)\b",
+            # Spanish
+            r"\b(?:yo )?(?:siempre |normalmente |realmente |solo |nunca )?"
+            r"(?:prefiero|me gusta|me gustan|adoro|uso|necesito|quiero|evito|odio)\b",
+            # French — "je" REQUIRED. French does not drop the subject pronoun, and with it
+            # optional the folded "prefere" also matched Portuguese THIRD person ("o cliente
+            # prefere respostas curtas") and Portuguese questions ("voce prefere qual?").
+            # Both measured, both suggested saving somebody else's preference as the user's.
+            r"\bje (?:toujours |normalement |vraiment |seulement |jamais )?"
+            r"(?:prefere|aime|adore|utilise|ai besoin de|veux|evite|deteste)\b",
+            # Italian
+            r"\b(?:io )?(?:sempre |di solito |davvero |solo |mai )?"
+            r"(?:preferisco|mi piace|adoro|uso|ho bisogno di|voglio|evito|odio)\b",
+            # German — "ich" required: the verbs are common in other persons.
+            r"\bich (?:immer |normalerweise |wirklich |nur |nie )?"
+            r"(?:bevorzuge|mag|liebe|benutze|brauche|will|vermeide|hasse)\b",
+            # Polish
+            r"\b(?:ja )?(?:zawsze |zwykle |naprawde |tylko |nigdy )?"
+            r"(?:wole|lubie|uwielbiam|uzywam|potrzebuje|chce|unikam|nienawidze)\b",
+            # Russian — pronoun required, for the same reason as German.
+            r"\bя (?:всегда |обычно |действительно |только |никогда )?"
+            r"(?:предпочитаю|люблю|нравится|использую|нужно|хочу|избегаю|ненавижу)\b",
+        )
+    ),
+    re.IGNORECASE | re.UNICODE,
 )
-_TOKEN = re.compile(r"[a-z0-9]+")
-_STOPWORDS = frozenset(
-    {"i", "you", "the", "a", "an", "for", "and", "to", "of", "my", "is", "are", "it"}
-)
-# A suggestion whose significant tokens are mostly present in a stored fact is "known".
-_KNOWN_OVERLAP = 0.6
+
+#: Function words, shared with recall so one list serves both. This module had its own English
+#: thirteen; the shared one covers the eight alphabetic languages the app ships in.
+_KNOWN_OVERLAP = 0.6  # a suggestion this much inside a stored fact is already known
 
 
 def _significant(text: str) -> set[str]:
-    return {t for t in _TOKEN.findall(text.lower()) if len(t) >= 3 and t not in _STOPWORDS}
+    """Meaningful tokens of ``text``, through the shared tokenizer and word list.
+
+    The length rule keeps its exception for scripts where one character is a word — Han is split per
+    character, and a three-character floor would discard all of them.
+    """
+    from chimera.memory.tokens import informative
+    from chimera.memory.tokens import tokens as _shared
+
+    return {t for t in informative(_shared(text)) if len(t) >= 3 or not t.isascii()}
 
 
 def _normalize(text: str) -> str:
@@ -56,7 +107,12 @@ def detect_nudges(
     suggestions: list[str] = []
     for text in user_texts:
         for sentence in re.split(r"[.\n;!?]+", text):
-            match = _PREFERENCE.search(sentence)
+            # Matched against the FOLDED sentence and sliced out of the original one. The
+            # patterns are written without diacritics, and run against raw text they silently
+            # excluded every correctly written French and Polish sentence: `je prefere` matched,
+            # `je préfère` did not. `fold_for_match` preserves length, so the offsets still cut
+            # the original sentence in the right place.
+            match = _PREFERENCE.search(fold_for_match(sentence))
             if match is None:
                 continue
             phrase = sentence[match.start() :].strip().strip(",")

--- a/chimera/memory/tokens.py
+++ b/chimera/memory/tokens.py
@@ -41,7 +41,7 @@ import re
 import unicodedata
 from collections.abc import Iterable, Sequence
 
-__all__ = ["idf_weights", "informative", "tokens"]
+__all__ = ["fold_for_match", "idf_weights", "informative", "tokens"]
 
 #: Any letter or digit in any script, after folding. `[^\W_]` rather than a named list of ranges:
 #: a range list is a promise to remember every alphabet, and this file exists because one was
@@ -130,6 +130,26 @@ def _fold(text: str) -> str:
         base = decomposed[0] if decomposed else ch
         if "a" <= base <= "z" or "0" <= base <= "9":
             out.append("".join(c for c in decomposed if not unicodedata.combining(c)))
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def fold_for_match(text: str) -> str:
+    """``text`` with Latin diacritics folded, and EXACTLY the same length.
+
+    For matching a pattern against prose and then slicing the ORIGINAL string by the match's
+    offsets. `_fold` is free to change length (a ligature decomposes into two characters); here a
+    character whose fold is not exactly one character is left alone, because a shifted offset would
+    cut a sentence in the wrong place — and the sentence is what gets shown to the user and saved.
+    """
+    out: list[str] = []
+    for ch in text:
+        decomposed = unicodedata.normalize("NFKD", ch.lower())
+        base = decomposed[0] if decomposed else ch
+        if "a" <= base <= "z":
+            folded = "".join(c for c in decomposed if not unicodedata.combining(c))
+            out.append(folded if len(folded) == 1 else ch)
         else:
             out.append(ch)
     return "".join(out)

--- a/tests/test_memory_helpers_speak_every_language.py
+++ b/tests/test_memory_helpers_speak_every_language.py
@@ -1,0 +1,117 @@
+"""Consolidation and nudges, measured in the languages this app ships in.
+
+Both modules carried their own ``[a-z0-9]+``, the same one recall had. The damage was not the same
+in each, and the difference is the point:
+
+* **Consolidation** was really blocked by the tokenizer. Two nearly identical Russian facts produced
+  two empty token sets, so Jaccard overlap refused them. Measured before: English and Portuguese
+  clustered, Russian and Chinese never did.
+
+* **Nudges** was not. Repairing its tokenizer alone would have changed nothing measurable, because
+  the pattern that decides whether a sentence is a preference rejects it before a token is taken —
+  and that pattern was English. "eu prefiro respostas curtas", "prefiero respuestas cortas",
+  "je préfère des réponses courtes", "ich bevorzuge kurze Antworten" and "я предпочитаю краткие
+  ответы" all returned NOTHING. A fix that fixes nothing is worth naming rather than shipping.
+
+The false-positive half is the one that matters most here: nudges suggests text to SAVE as a fact
+about the person, so admitting somebody else's preference is worse than missing their own.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.memory.consolidate import group_similar
+from chimera.memory.nudges import detect_nudges
+
+
+def _grouped(textos: list[str]) -> bool:
+    return any(len(g) > 1 for g in group_similar(textos, threshold=0.5))
+
+
+# --- consolidation ------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("lingua", "textos"),
+    [
+        ("en", ["the user prefers concise answers in chat",
+                "the user prefers concise answers when chatting"]),
+        ("pt", ["o usuario prefere respostas concisas no chat",
+                "o usuario prefere respostas concisas quando conversa"]),
+        ("pt-acentos", ["a autenticação do usuário usa OAuth no projeto",
+                        "a autenticação do usuário é por OAuth neste projeto"]),
+        ("ru", ["пользователь предпочитает краткие ответы в чате",
+                "пользователь предпочитает краткие ответы при общении"]),
+        ("zh", ["用户喜欢在聊天中得到简洁的回答", "用户喜欢聊天时得到简洁回答"]),
+    ],
+)
+def test_near_identical_facts_cluster_in_every_script(lingua: str, textos: list[str]) -> None:
+    """Russian and Chinese produced empty token sets, so nothing ever merged for those users."""
+    assert _grouped(textos), f"{lingua}: two nearly identical facts did not cluster"
+
+
+@pytest.mark.parametrize(
+    ("lingua", "textos"),
+    [
+        ("en", ["the user prefers concise answers", "the project lives in the documents folder"]),
+        ("pt", ["o usuario prefere respostas curtas", "o projeto fica na pasta documentos"]),
+        ("ru", ["пользователь предпочитает краткие ответы", "проект находится в папке документы"]),
+        ("zh", ["用户喜欢简洁的回答", "项目在文档文件夹中"]),
+    ],
+)
+def test_unrelated_facts_still_do_not_cluster(lingua: str, textos: list[str]) -> None:
+    """The other half of the trade. Making everything tokenize must not make everything merge.
+
+    Non-Latin tokens are kept regardless of length, because Han is split per character — so the
+    control matters more here than usual, since short function words survive the length rule.
+    """
+    assert not _grouped(textos), f"{lingua}: unrelated facts were merged into one"
+
+
+# --- nudges -------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("lingua", "frase"),
+    [
+        ("en", "i prefer short answers"),
+        ("pt", "eu prefiro respostas curtas"),
+        ("es", "prefiero respuestas cortas"),
+        ("fr", "je préfère des réponses courtes"),
+        ("it", "preferisco risposte brevi"),
+        ("de", "ich bevorzuge kurze Antworten"),
+        ("pl", "wolę krótkie odpowiedzi"),
+        ("ru", "я предпочитаю краткие ответы"),
+    ],
+)
+def test_a_stated_preference_is_offered_in_every_shipped_language(lingua: str, frase: str) -> None:
+    """Only English produced a suggestion before. The rest produced none, ever.
+
+    The accented spellings are the real ones on purpose: the patterns are written without
+    diacritics, and matched against raw text they excluded correctly written French and Polish —
+    `je prefere` matched and `je préfère` did not.
+    """
+    assert detect_nudges([frase], [], max_suggestions=2), f"{lingua}: no suggestion offered"
+
+
+@pytest.mark.parametrize(
+    ("porque", "frase"),
+    [
+        ("pt third person", "o cliente prefere respostas curtas"),
+        ("pt question", "voce prefere qual abordagem?"),
+        ("en third person", "the team prefers tabs"),
+        ("en simile", "this works like a charm"),
+        ("de third person", "er bevorzugt kurze antworten"),
+        ("ru third person", "он предпочитает краткие ответы"),
+        ("pt instruction to the agent", "use o modo escuro neste projeto"),
+    ],
+)
+def test_what_is_not_the_persons_own_preference_is_not_offered(porque: str, frase: str) -> None:
+    """This is the half that matters: a suggestion here becomes a stored fact ABOUT THE PERSON.
+
+    Two of these were real regressions while the patterns were being written. French drops no
+    subject pronoun, so an optional `je` let the folded `prefere` match Portuguese third person and
+    Portuguese questions — offering to save somebody else's preference as the user's own.
+    """
+    assert detect_nudges([frase], [], max_suggestions=2) == [], f"{porque}: offered {frase!r}"


### PR DESCRIPTION
The recall fix left the same `[a-z0-9]+` in two more modules. Measuring what it cost there changed what the fix had to be — the damage was not the same in each, and in one of them the tokenizer was not the binding constraint at all.

## Consolidation: the tokenizer really was the problem

| language | two nearly identical facts | |
|---|---|---|
| English | clustered | |
| Portuguese, accents included | clustered | |
| Russian | **never** | two empty token sets, so Jaccard refused them |
| Chinese | **never** | same |

Merging similar memories was inert in those languages. Through the shared tokenizer now, with the length rule keeping an exception for scripts where one character is a word — Han is split per character, and a three-character floor would discard every one of them.

**The control matters more than usual here**, precisely because that exception lets short tokens through: unrelated facts must still refuse to merge, and there is a test per language saying so.

## Nudges: it was not the tokenizer, and saying so is the point

Repairing the alphabet here would have changed **nothing measurable**. The pattern that decides whether a sentence expresses a preference rejects it long before a token is taken, and that pattern was English:

```
\bi (?:always |usually |...)?(?:prefer|like|love|use|need|want|...)s?\b
```

Measured: *"eu prefiro respostas curtas"*, *"prefiero respuestas cortas"*, *"je préfère des réponses courtes"*, *"ich bevorzuge kurze Antworten"*, *"я предпочитаю краткие ответы"* — **zero suggestions, every one**. The feature existed for one of ten audiences. A fix that fixes nothing is worth naming rather than shipping quietly.

Patterns for all eight alphabetic languages now, and the tokenizer shared too, so "already known" is judged the same way recall judges relevance.

### Two regressions I introduced writing them, both caught by measurement

**French with an optional pronoun matched Portuguese third person.** French does not drop the subject, unlike Portuguese, Spanish and Italian — and with `(?:je )?` optional, the folded `prefere` matched *"o cliente prefere respostas curtas"* and *"voce prefere qual abordagem?"*. Both would have offered to save **somebody else's preference as the user's own**, which is the worst thing this function can do, since a suggestion here becomes a stored fact *about the person*. `je` is required now, which is also what the language actually does.

**The pattern ran against raw text.** Written without diacritics and matched against prose, it silently excluded every correctly written French and Polish sentence: `je prefere` matched and `je préfère` did not; `wole` matched and `wolę` did not. It now matches against a length-preserving fold and slices the original sentence by those offsets — length-preserving because a shifted offset would cut the sentence in the wrong place, and that sentence is what gets shown and saved.

## After

| | before | after |
|---|---|---|
| consolidation, ru/zh/ja | never merged | merges |
| consolidation, unrelated facts | refused | **still refused** |
| nudges, 7 non-English languages | 0 suggestions | offered |
| nudges, third person / questions / similes / instructions | *(2 became false positives mid-work)* | **all declined** |

Seven false-positive controls across four languages, because a wrong suggestion here is a wrong fact about you.

## Sabotage

| reverted | fails |
|---|---|
| ASCII tokenizer in consolidation | the Russian and Chinese clustering tests, alone |
| the Portuguese pattern | the Portuguese suggestion test, alone |
| matching raw text instead of folded | the French and Polish tests, alone |
| French pronoun made optional again | the two Portuguese false-positive tests, alone |

ruff · mypy · **3906** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
