### PR TITLE
fix(stores): a lost update was being written, confirmed, then silently overwritten

### DIFF
--- a/chimera/core/filelock.py
+++ b/chimera/core/filelock.py
@@ -160,3 +160,54 @@ def locked(path: Path) -> Iterator[bool]:
             _release(handle)
     finally:
         handle.close()
+
+
+class LockUnavailable(OSError):
+    """The exclusive lock could not be taken within the retry budget.
+
+    An ``OSError`` so that a caller already handling I/O failures around a store catches it without
+    knowing this type exists; a distinct class so that one which wants to tell "the disk is full"
+    from "somebody else is writing" can.
+    """
+
+
+#: How many times :func:`exclusively` re-enters the lock before giving up, and the pause between
+#: attempts (multiplied by the attempt number).
+#:
+#: Three turns Windows' own ~10s wait into roughly thirty seconds of trying. The numbers match the
+#: audit log's, which arrived at them first and for the same reason — losing the race should require
+#: sustained contention rather than a moment of it.
+LOCK_ATTEMPTS = 3
+LOCK_BACKOFF_S = 0.25
+
+
+@contextmanager
+def exclusively(path: Path, *, attempts: int = LOCK_ATTEMPTS) -> Iterator[None]:
+    """Hold a REAL lock for ``path`` while the body runs, or raise :class:`LockUnavailable`.
+
+    :func:`locked` degrades: when the OS refuses the lock it runs the body unlocked and says so by
+    yielding ``False``. That is deliberate and right for a caller that would rather write than stop
+    — the audit log takes it, loudly, because a broken hash chain it can complain about beats a
+    wedged 24/7 process.
+
+    It is the wrong answer for a whole-file store, and that was measured rather than argued. Twelve
+    processes each adding twenty-five learned skills: ``locked`` yielded ``False`` two or three
+    times per run, every caller discarded that boolean, and two to five skills vanished — no error,
+    no warning the operator would see, and a rerun of the same commit passing cleanly. The CI
+    failure this chased read ``assert 49 == 50``.
+
+    So this retries, and then refuses. A caller that cannot get the lock has two honest options and
+    "write anyway" is not one of them: what it is about to lose is another process's record.
+    """
+    for attempt in range(attempts):
+        with locked(path) as got_lock:
+            if got_lock:
+                yield
+                return
+        # Outside the `with`, so the failed handle is closed before the next try.
+        if attempt < attempts - 1:
+            time.sleep(LOCK_BACKOFF_S * (attempt + 1))
+    raise LockUnavailable(
+        f"could not take the exclusive lock for {path.name} after {attempts} attempts; "
+        "another process is holding it. Nothing was written."
+    )

--- a/chimera/evolution/experience.py
+++ b/chimera/evolution/experience.py
@@ -28,7 +28,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ValidationError
 
-from chimera.core.filelock import atomic_write_text, locked, read_text
+from chimera.core.filelock import atomic_write_text, exclusively, read_text
 from chimera.telemetry import get_logger
 
 _log = get_logger("evolution.experience")
@@ -125,7 +125,7 @@ class ExperienceBuffer:
         The blunt form, kept for callers holding the whole picture: it does **not** merge concurrent
         writes. :meth:`record` does.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self._write()
 
     def record(self, task: str, outcome: Outcome, detail: str = "") -> Experience:
@@ -135,7 +135,7 @@ class ExperienceBuffer:
         runs the autonomous work in one process and an operator can run ``chimera`` in another, and
         without it whichever writes second republishes a snapshot from before the other started.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self.load()
             exp = Experience(seq=self._next_seq, task=task, outcome=outcome, detail=detail)
             self._next_seq += 1

--- a/chimera/evolution/skill_store.py
+++ b/chimera/evolution/skill_store.py
@@ -28,7 +28,7 @@ import threading
 from collections.abc import Callable
 from pathlib import Path
 
-from chimera.core.filelock import atomic_write_text, locked, read_text
+from chimera.core.filelock import atomic_write_text, exclusively, read_text
 from chimera.evolution.learned_skill import LearnedSkill
 from chimera.providers.gateway import SupportsComplete
 
@@ -81,7 +81,7 @@ class SkillStore:
         The blunt form, kept for callers that hold the whole picture. It does **not** merge a
         concurrent writer — use the mutating methods, which do.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self._write()
 
     def _mutate(self, apply: Callable[[dict[str, dict[str, object]]], None]) -> None:
@@ -90,7 +90,7 @@ class SkillStore:
         The re-read is the part that was missing. Without it every write publishes the dict this
         object loaded at construction, so the sibling instance's just-added skill disappears.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self.load()
             apply(self._dicts)
             self._write()
@@ -105,7 +105,7 @@ class SkillStore:
         a second ago.
         """
         found = False
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self.load()
             if name in self._dicts:
                 found = True

--- a/chimera/memory/store.py
+++ b/chimera/memory/store.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Protocol
 
-from chimera.core.filelock import atomic_write_text, locked, read_text
+from chimera.core.filelock import atomic_write_text, exclusively, read_text
 from chimera.memory.models import MemoryItem, MemoryKind
 from chimera.telemetry import get_logger
 
@@ -92,7 +92,7 @@ class MemoryStore:
         This is the blunt form and it is kept for callers that hold the whole picture. It does
         **not** merge concurrent writes — use :meth:`add` / :meth:`remove`, which do.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self._write()
 
     def _mutate(self, apply: Callable[[dict[str, MemoryItem]], None]) -> None:
@@ -102,7 +102,7 @@ class MemoryStore:
         whatever the file held when this object was constructed, so a second writer's records
         vanish on the next save with nothing to show it happened.
         """
-        with self._lock, locked(self.path):
+        with self._lock, exclusively(self.path):
             self.load()
             apply(self._items)
             self._write()

--- a/tests/test_stores_refuse_to_write_unlocked.py
+++ b/tests/test_stores_refuse_to_write_unlocked.py
@@ -1,0 +1,134 @@
+"""What a whole-file store does when the file lock cannot be taken.
+
+``locked()`` degrades: when the OS refuses the lock it runs the body **unlocked** and says so by
+yielding ``False``. That is deliberate, and right for the audit log, which takes it loudly because a
+broken hash chain it can complain about beats a wedged 24/7 process.
+
+It is the wrong answer for a store, and this was measured rather than argued. Twelve processes each
+adding twenty-five learned skills, on Windows:
+
+    entered without the lock ... 2–3 per run
+    skills lost ................ 2–5 per run
+    warnings the operator sees . none
+
+Every caller discarded the boolean, so the read-modify-write ran with no exclusion at all and
+another process's record went away. The CI failure that started this read ``assert 49 == 50``, and
+it passed on a rerun of the identical commit — which is exactly what makes this kind of thing easy
+to wave away.
+
+After the change, the same twenty-process probe lands 500 of 500, three runs running.
+
+**These tests drive the failure deterministically**, by making the lock fail on demand — the same
+approach ``test_audit_lock_degrades`` takes, and for the same reason: the Windows race is not
+reproducible on purpose, and a guard that needs one is not a guard.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+import chimera.core.filelock as filelock_mod
+from chimera.core.filelock import LOCK_ATTEMPTS, LockUnavailable, exclusively
+from chimera.evolution.learned_skill import LearnedSkill
+from chimera.evolution.skill_store import SkillStore
+from chimera.memory.manager import MemoryManager
+from chimera.memory.store import MemoryStore
+
+
+@pytest.fixture
+def lock_sempre_falha(monkeypatch):
+    """`locked` yielding False every time — the degraded path, on demand.
+
+    Patched where `exclusively` reads it, so the real helper runs rather than a stand-in that only
+    looks similar.
+    """
+    tentativas: list[Path] = []
+
+    @contextmanager
+    def falso(path: Path):
+        tentativas.append(path)
+        yield False
+
+    monkeypatch.setattr(filelock_mod, "locked", falso)
+    monkeypatch.setattr("chimera.evolution.skill_store.exclusively", exclusively)
+    monkeypatch.setattr("chimera.memory.store.exclusively", exclusively)
+    monkeypatch.setattr(filelock_mod, "LOCK_BACKOFF_S", 0.0)  # no waiting in a unit test
+    return tentativas
+
+
+def test_it_retries_before_giving_up(tmp_path: Path, lock_sempre_falha) -> None:
+    """One refusal is a moment of contention; the budget is what tells that from a stuck lock."""
+    with pytest.raises(LockUnavailable), exclusively(tmp_path / "x.json"):
+        pytest.fail("the body must not run without the lock")
+
+    assert len(lock_sempre_falha) == LOCK_ATTEMPTS, (
+        f"tried {len(lock_sempre_falha)} times, expected {LOCK_ATTEMPTS}"
+    )
+
+
+def test_the_body_never_runs_unlocked(tmp_path: Path, lock_sempre_falha) -> None:
+    """The whole point. Running the body is what loses the other process's record."""
+    rodou = False
+
+    with pytest.raises(LockUnavailable), exclusively(tmp_path / "x.json"):
+        rodou = True
+
+    assert not rodou
+
+
+def test_the_message_says_nothing_was_written(tmp_path: Path, lock_sempre_falha) -> None:
+    """An operator reading this needs to know whether to retry the operation or not."""
+    with pytest.raises(LockUnavailable) as erro, exclusively(tmp_path / "skills.json"):
+        pass
+
+    texto = str(erro.value)
+    assert "skills.json" in texto
+    assert "Nothing was written" in texto
+
+
+def test_a_skill_store_refuses_rather_than_losing_somebody_elses_skill(
+    tmp_path: Path, lock_sempre_falha
+) -> None:
+    """The measured failure, at the level a user meets it.
+
+    Before: `add` wrote unlocked and a concurrent writer's skill disappeared, silently. Now the
+    write refuses — and an error the operator can read is a better outcome than a skill that was
+    learned and is not there.
+    """
+    caminho = tmp_path / "skills.json"
+    caminho.write_text('[{"name": "ja-existia", "description": "x"}]', encoding="utf-8")
+    store = SkillStore(caminho)
+
+    with pytest.raises(LockUnavailable):
+        store.add(LearnedSkill(name="nova", description="x"))
+
+    # And the file it could not lock is untouched: refusing must not be a half-write.
+    assert "ja-existia" in caminho.read_text(encoding="utf-8")
+    assert "nova" not in caminho.read_text(encoding="utf-8")
+
+
+def test_a_memory_store_refuses_too(tmp_path: Path, lock_sempre_falha) -> None:
+    """Same helper, same failure, same silence — memory was losing facts the same way."""
+    mgr = MemoryManager(MemoryStore(tmp_path / "m.json"))
+
+    with pytest.raises(LockUnavailable):
+        mgr.remember("um fato que nao pode sumir")
+
+
+def test_locked_itself_still_degrades(tmp_path: Path, monkeypatch) -> None:
+    """The contract that was NOT changed, asserted so nobody widens the fix into the audit log.
+
+    `locked` degrading is a deliberate choice with its own tests: the audit log would rather write a
+    chain it can complain about than wedge a process that runs all day. This adds a stricter helper
+    beside it; it does not replace it.
+    """
+    def recusa(handle):
+        raise OSError("no lock for you")
+
+    monkeypatch.setattr(filelock_mod, "_acquire", recusa)
+
+    with filelock_mod.locked(tmp_path / "y.json") as got_lock:
+        assert got_lock is False, "locked() started raising — the audit log depends on it not doing that"


### PR DESCRIPTION
A learned skill was being written, confirmed on disk, and then quietly overwritten by another process. Same for memory facts and experience records — they share one helper.

The CI failure that started this read `assert 49 == 50`, on a pull request that touched none of it, and it passed on a rerun of the identical commit.

## The mechanism, measured

Twelve processes each adding twenty-five learned skills, on Windows. Capturing the value `locked()` actually yields:

| run | entered **without** the lock | exclusion violations | skills lost |
|---:|---:|---:|---:|
| 1 | 3 | 6 | 3 |
| 2 | 2 | 3 | 2 |
| 3 | 3 | 6 | 5 |
| 4 | 2 | 4 | 2 |

`locked()` **degrades by design**: when the OS refuses the lock it runs the body unlocked and reports that by yielding `False`. Under contention on Windows, `msvcrt.locking` gives up after its own retry window, and that path fires two or three times per run.

**Every store discarded the boolean.** So the read-modify-write ran with no exclusion at all: two processes read the same snapshot, each added its own record, and the second publish erased the first. No error, no warning an operator would ever see.

This is not a new discovery so much as a missed one — `test_audit_lock_degrades.py` documents the identical defect found in the audit log, in its own words: *"the one caller that most needs that signal was discarding it."* It was fixed there and nowhere else.

## The fix

`exclusively()` beside `locked()`: retries the lock three times with growing pauses, and **raises `LockUnavailable` rather than running the body**. Used by `SkillStore`, `MemoryStore` and `ExperienceStore`.

`locked()` itself is unchanged, and there is a test asserting that. Its degrading is a deliberate choice with its own tests — the audit log would rather write a chain it can complain about than wedge a process that runs all day. This adds a stricter helper beside it; it does not replace it.

The retry numbers match the audit log's, which arrived at them first and for the same reason.

## Measured after

The same twenty-process probe, three runs running:

```
before: 493 / 478 / 474 of 500
after:  500 / 500 / 500
```

Zero process errors — under twenty-way contention the budget was never exhausted, so nobody meets the new exception in the workload that produced the loss.

## What the tests do

They drive the failure **deterministically**, by making the lock refuse on demand — the same approach `test_audit_lock_degrades` takes, and for the same reason: the Windows race is not reproducible on purpose, and a guard that needs one is not a guard.

| reverted | fails |
|---|---|
| no retry, one attempt only | the retry test, alone |
| run the body even when the lock was refused | five of six |
| never raise after the budget | five of six |

## Four measurements of mine that lied before this one

Worth recording, because each looked conclusive:

1. A probe whose import was wrong: all twenty processes died before writing, and it printed *"LOST WRITES"* over `0 of 500`.
2. Generated names that collided — `T1`+`12` and `T11`+`2` are both `T112` — so the store's dedup read as loss.
3. Events collected per-process and analysed without a common clock, inventing 228 "backwards reads".
4. *"Payload size is the factor"*, concluded from one run; the next run at the same size lost nothing.

The finding above is the one that survived instrumenting the actual yielded value.

ruff · mypy · **3924** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
