### PR TITLE
fix(catalog): four prices had drifted, and one of them by seven times

### DIFF
--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -69,18 +69,18 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- weak: near-free probes. Cheap first drafts, k-sample agreement. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-v4-flash", "weak", "DeepSeek",
-        0.074, 0.148, tools=True, context_k=1048,
+        0.0886, 0.1772, tools=True, context_k=1048,
         notes="cheapest capable probe here, with a frontier-sized window; unmeasured in this repo",
     ),
     CatalogEntry(
         "openrouter/mistralai/mistral-small-3.2-24b-instruct", "weak", "Mistral",
-        0.094, 0.25, tools=True, context_k=256,
+        0.075, 0.20, tools=True, context_k=256,
         notes="the local-lift goldilocks model; cheap paid weak with usable tools",
     ),
     CatalogEntry(
         "openrouter/meta-llama/llama-3.3-70b-instruct", "weak", "Meta",
-        0.10, 0.32, tools=True, context_k=131,
-        notes="the paid variant; the :free one was withdrawn on 2026-08-18",
+        0.71, 0.71, tools=True, context_k=131,
+        notes="the paid variant; the :free one was withdrawn on 2026-08-18. Input and output\n        cost the same here, which is unusual and is what the provider charges",
     ),
     CatalogEntry(
         "openrouter/openai/gpt-oss-20b", "weak", "OpenAI",
@@ -90,7 +90,7 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
-        0.25, 0.95, tools=True, context_k=163,
+        0.55, 1.65, tools=True, context_k=163,
         notes="proven in this repo's benches; the product default",
     ),
     CatalogEntry(


### PR DESCRIPTION
CI on `main` went red on the live-provider job, which checks the shipped price catalogue against what OpenRouter actually charges:

```
meta-llama/llama-3.3-70b-instruct: catalogue 0.10, live 0.71
```

Confirmed at the source rather than taken from the test's word: **0.71 in and 0.71 out**, which is unusual enough to be worth a note in the entry.

## The direction matters

The catalogue **understates**. So every estimate and every `max_usd` ceiling built on it is low — a cap set to bite at a dollar lets seven through. That is precisely the failure a price catalogue exists to prevent.

## Checked all of it, not the one the test named

A catalogue with many entries adrift is a catalogue nobody maintains, which would be a different problem worth knowing about:

| | |
|---|---:|
| entries | 15 |
| within 15% of live | 11 |
| drifted | 4 |
| withdrawn upstream | 0 |

So it **is** maintained, and four had moved:

| model | catalogue | live | |
|---|---:|---:|---|
| `meta-llama/llama-3.3-70b-instruct` | 0.10 | **0.71** | 7.1× — what the test caught |
| `deepseek/deepseek-chat-v3.1` | 0.25 | **0.55** | 2.2× |
| `deepseek/deepseek-v4-flash` | 0.074 | 0.0886 | 1.2× |
| `mistralai/mistral-small-3.2-24b-instruct` | 0.094 | 0.075 | 0.8× |

Only the llama entry breaks the order-of-magnitude guard. But `deepseek-chat-v3.1` is the product's **default edit model** — the ceiling on the surface people use most was wrong by more than half. Fixing only the one the test named would be reading the guard as the requirement rather than as the alarm.

All four now match the provider, input and output. Re-measured against the live API afterwards: **15 of 15 within 15%, none adrift.**

ruff · mypy · **3923** Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)