### PR TITLE
feat(cron): a scheduled job can finally tell you what it found

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -2352,6 +2352,17 @@
             "title": "Action",
             "type": "string"
           },
+          "deliver_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deliver To"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -2394,6 +2405,17 @@
           "created_by": {
             "title": "Created By",
             "type": "string"
+          },
+          "deliver_to": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deliver To"
           },
           "enabled": {
             "title": "Enabled",

--- a/apps/desktop/src/components/Cron.deliver.test.tsx
+++ b/apps/desktop/src/components/Cron.deliver.test.tsx
@@ -1,0 +1,111 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Cron, hostOf } from "@/components/Cron";
+import { createCron, getCron } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", () => ({
+  getCron: vi.fn(),
+  createCron: vi.fn(),
+  enableCron: vi.fn(),
+  disableCron: vi.fn(),
+  deleteCron: vi.fn(),
+}));
+
+const WEBHOOK = "https://discord.com/api/webhooks/123456789/segredo-que-nao-pode-vazar";
+
+function job(over: Record<string, unknown> = {}) {
+  return {
+    id: "j1",
+    name: "resumo do site",
+    trigger: "cron",
+    schedule: "0 7 * * *",
+    action: "liste os arquivos",
+    enabled: true,
+    next_run: null,
+    last_run: null,
+    last_status: null,
+    last_error: null,
+    consecutive_failures: 0,
+    created_by: "human",
+    workspace: null,
+    deliver_to: null,
+    ...over,
+  };
+}
+
+/**
+ * Where a scheduled answer goes.
+ *
+ * `deliver_to` was on the model from the start and appeared in exactly two places in the codebase:
+ * its own declaration, and a line copying it into the result file. Nothing read it to send
+ * anything, and no screen offered to set it — so every answer a schedule ever produced went into a
+ * JSONL nobody opens.
+ *
+ * A webhook URL rather than a bot token, because a bot needs an application, an invite and a server
+ * you administer, and a webhook is a URL you copy out of a channel's settings.
+ */
+describe("a schedule can deliver its answer to chat", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(getCron).mockReset().mockResolvedValue([]);
+    vi.mocked(createCron).mockReset().mockResolvedValue({} as never);
+  });
+
+  async function preencher(webhook?: string) {
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/name/i), "resumo");
+    await user.type(screen.getByPlaceholderText(/what should Chimera do/i), "liste os arquivos");
+    if (webhook) await user.type(screen.getByLabelText(/webhook/i), webhook);
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+  }
+
+  it("sends the webhook the user pasted", async () => {
+    renderWithProviders(<Cron />);
+    await preencher(WEBHOOK);
+
+    expect(vi.mocked(createCron).mock.calls[0]?.[0]).toMatchObject({ deliver_to: WEBHOOK });
+  });
+
+  it("sends null when the field is left empty", async () => {
+    // The control: delivery is optional, and `""` would round-trip as "deliver to nowhere in
+    // particular" rather than as "do not deliver".
+    renderWithProviders(<Cron />);
+    await preencher();
+
+    expect(vi.mocked(createCron).mock.calls[0]?.[0]).toMatchObject({ deliver_to: null });
+  });
+
+  it("shows the host on a job that delivers, and never the URL", async () => {
+    // A webhook URL is a credential — whoever reads it off a screen can post in that channel.
+    vi.mocked(getCron).mockResolvedValue([job({ deliver_to: WEBHOOK })] as never);
+    renderWithProviders(<Cron />);
+
+    expect(await screen.findByText(/discord\.com/)).toBeTruthy();
+    expect(screen.queryByText(/segredo-que-nao-pode-vazar/)).toBeNull();
+    expect(screen.queryByText(/123456789/)).toBeNull();
+  });
+
+  it("says nothing about delivery on a job that has none", async () => {
+    vi.mocked(getCron).mockResolvedValue([job()] as never);
+    renderWithProviders(<Cron />);
+
+    await screen.findByText("resumo do site");
+    expect(screen.queryByText(/delivers to/i)).toBeNull();
+  });
+});
+
+describe("hostOf", () => {
+  it("keeps the host and drops the secret path", () => {
+    expect(hostOf(WEBHOOK)).toBe("discord.com");
+    expect(hostOf("https://hooks.slack.com/services/T/B/x")).toBe("hooks.slack.com");
+  });
+
+  it("shows a malformed value back rather than hiding it", () => {
+    // Something the user typed wrong. Hiding it leaves them staring at a row that says nothing,
+    // with no way to see what needs fixing.
+    expect(hostOf("nao-e-uma-url")).toBe("nao-e-uma-url");
+  });
+});

--- a/apps/desktop/src/components/Cron.test.tsx
+++ b/apps/desktop/src/components/Cron.test.tsx
@@ -41,6 +41,9 @@ describe("Cron — create a schedule from the UI", () => {
           // Which folder the job will work in — null here because this test chose no project.
           // Sent on creation rather than read when it fires: see Cron.workspace.test.tsx.
           workspace: null,
+          // And where its answer goes. Null is "only the result file", which is what every
+          // schedule did before this field was wired to anything: see Cron.deliver.test.tsx.
+          deliver_to: null,
         },
         expect.anything(), // react-query passes a context object as the 2nd arg
       ),

--- a/apps/desktop/src/components/Cron.tsx
+++ b/apps/desktop/src/components/Cron.tsx
@@ -15,18 +15,34 @@ const PRESETS: { key: string; cron: string }[] = [
   { key: "cron.preset.weekdays", cron: "0 9 * * 1-5" },
 ];
 
+/** The host of a webhook URL, for showing where a job delivers without showing the secret.
+ *
+ * Falls back to the raw value only when it does not parse as a URL: an unparseable `deliver_to` is
+ * something the user typed and needs to see to fix, and hiding it would leave them staring at a row
+ * that says nothing.
+ */
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 function AddSchedule() {
   const t = useT();
   const qc = useQueryClient();
   const [name, setName] = useState("");
   const [schedule, setSchedule] = useState("0 7 * * *");
   const [action, setAction] = useState("");
+  const [deliverTo, setDeliverTo] = useState("");
   const create = useMutation({
     mutationFn: createCron,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["cron"] });
       setName("");
       setAction("");
+      setDeliverTo("");
     },
   });
   const canSubmit = name.trim() && schedule.trim() && action.trim() && !create.isPending;
@@ -68,6 +84,19 @@ function AddSchedule() {
           value={schedule}
           onChange={(e) => setSchedule(e.target.value)}
         />
+        {/* Optional, and a webhook URL rather than a bot token: a bot needs an application, an
+            invite and a server you administer, while a webhook is a URL you copy out of a channel's
+            settings. That is the difference between something every user can switch on and
+            something only the author of the app has set up. Left empty, the answer still lands in
+            the result file — which is what happened to EVERY answer before this field did
+            anything at all. */}
+        <input
+          className="field w-full px-3 py-2 font-mono text-xs"
+          placeholder={t("cron.add.deliver")}
+          aria-label={t("cron.add.deliver")}
+          value={deliverTo}
+          onChange={(e) => setDeliverTo(e.target.value)}
+        />
         <div className="flex items-center justify-between gap-3 pt-0.5">
           <span className="text-xs text-muted-foreground">{t("cron.add.hint")}</span>
           <Button
@@ -75,7 +104,14 @@ function AddSchedule() {
               // The folder the job will work in, fixed at the moment it is written rather than
               // read when it fires: a schedule runs for months, and "whichever project was open
               // at 7am" is not a root anybody chose.
-              canSubmit && create.mutate({ name, schedule, action, workspace: readWorkspace() || null })
+              canSubmit &&
+              create.mutate({
+                name,
+                schedule,
+                action,
+                workspace: readWorkspace() || null,
+                deliver_to: deliverTo.trim() || null,
+              })
             }
             disabled={!canSubmit}
           >
@@ -138,6 +174,14 @@ export function Cron({ embedded = false }: { embedded?: boolean } = {}) {
                 {j.workspace && (
                   <div className="mt-0.5 truncate font-mono text-xs text-muted-foreground" title={j.workspace}>
                     {j.workspace}
+                  </div>
+                )}
+                {/* The HOST, never the URL. A webhook URL is a credential — anyone who reads it off
+                    a shared screen can post into that channel — and the host is what answers the
+                    question the row is asking: where does this end up? */}
+                {j.deliver_to && (
+                  <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {t("cron.deliversTo", { host: hostOf(j.deliver_to) })}
                   </div>
                 )}
                 {/* Inline, not a tooltip. WHY it failed is the whole reason to look at this row, and

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -3333,6 +3333,8 @@ export interface components {
         CronCreateIn: {
             /** Action */
             action: string;
+            /** Deliver To */
+            deliver_to?: string | null;
             /** Name */
             name: string;
             /** Schedule */
@@ -3351,6 +3353,8 @@ export interface components {
             consecutive_failures: number;
             /** Created By */
             created_by: string;
+            /** Deliver To */
+            deliver_to?: string | null;
             /** Enabled */
             enabled: boolean;
             /** Id */

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -429,7 +429,13 @@ export const stopMessaging = (platform: string) =>
 // --- Cron ---
 export const getCron = () => json<CronJob[]>("/api/cron");
 export const createCron = (
-  body: { name: string; schedule: string; action: string; workspace?: string | null },
+  body: {
+    name: string;
+    schedule: string;
+    action: string;
+    workspace?: string | null;
+    deliver_to?: string | null;
+  },
 ) =>
   json<CronJob>("/api/cron", { method: "POST", body: JSON.stringify(body) });
 export const enableCron = (id: string) => json<CronJob>(`/api/cron/${id}/enable`, { method: "POST" });

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -406,6 +406,8 @@ const en: Dict = {
   "cron.add.name": "name (e.g. morning brief)",
   "cron.add.action": "what should Chimera do? (e.g. summarise my unread email)",
   "cron.add.when": "when — cron: minute hour day month weekday",
+  "cron.add.deliver": "Discord or Slack webhook URL (optional)",
+  "cron.deliversTo": "delivers to {host}",
   "cron.add.submit": "Schedule",
   "cron.add.error": "Couldn't schedule — check the time expression.",
   "cron.add.presets": "Quick pick:",
@@ -1567,6 +1569,8 @@ const pt: Dict = {
   "cron.add.action":
     "o que o Chimera deve fazer? (ex.: resumir meus e-mails não lidos)",
   "cron.add.when": "quando — cron: minuto hora dia mês dia-da-semana",
+  "cron.add.deliver": "URL de webhook do Discord ou Slack (opcional)",
+  "cron.deliversTo": "entrega em {host}",
   "cron.add.submit": "Agendar",
   "cron.add.error":
     "Não foi possível agendar — verifique a expressão de horário.",
@@ -2406,6 +2410,8 @@ const es: Dict = {
   "cron.add.action":
     "¿qué debería hacer Chimera? (p. ej. resume mis correos sin leer)",
   "cron.add.when": "cuándo — cron: minuto hora día mes día-semana",
+  "cron.add.deliver": "URL de webhook de Discord o Slack (opcional)",
+  "cron.deliversTo": "entrega en {host}",
   "cron.add.submit": "Programar",
   "cron.add.error": "No se pudo programar — revisa la expresión de tiempo.",
   "cron.add.presets": "Elección rápida:",
@@ -3588,6 +3594,8 @@ const fr: Dict = {
   "cron.add.action":
     "que doit faire Chimera ? (par ex. résume mes e-mails non lus)",
   "cron.add.when": "quand — cron : minute heure jour mois jour-semaine",
+  "cron.add.deliver": "URL de webhook Discord ou Slack (facultatif)",
+  "cron.deliversTo": "livre sur {host}",
   "cron.add.submit": "Planifier",
   "cron.add.error":
     "Impossible de planifier — vérifiez l'expression temporelle.",
@@ -4781,6 +4789,8 @@ const de: Dict = {
   "cron.add.action":
     "Was soll Chimera tun? (z. B. fasse meine ungelesenen E-Mails zusammen)",
   "cron.add.when": "wann — cron: Minute Stunde Tag Monat Wochentag",
+  "cron.add.deliver": "Discord- oder Slack-Webhook-URL (optional)",
+  "cron.deliversTo": "liefert an {host}",
   "cron.add.submit": "Planen",
   "cron.add.error": "Konnte nicht geplant werden — prüfe den Zeitausdruck.",
   "cron.add.presets": "Schnellauswahl:",
@@ -5968,6 +5978,8 @@ const zh: Dict = {
   "cron.add.name": "名称（例如：早间简报）",
   "cron.add.action": "要 Chimera 做什么？（例如：总结我的未读邮件）",
   "cron.add.when": "何时 —— cron：分 时 日 月 周",
+  "cron.add.deliver": "Discord 或 Slack 的 webhook 链接（可选）",
+  "cron.deliversTo": "发送到 {host}",
   "cron.add.submit": "排程",
   "cron.add.error": "排程失败——请检查时间表达式。",
   "cron.add.presets": "快速选择：",
@@ -7085,6 +7097,8 @@ const ja: Dict = {
   "cron.add.name": "名前（例：朝のブリーフィング）",
   "cron.add.action": "Chimera に何をさせますか？（例：未読メールを要約して）",
   "cron.add.when": "いつ — cron: 分 時 日 月 曜日",
+  "cron.add.deliver": "Discord または Slack の webhook URL（任意）",
+  "cron.deliversTo": "{host} に届けます",
   "cron.add.submit": "スケジュール",
   "cron.add.error":
     "スケジュールできませんでした — 時刻の書式を確認してください。",
@@ -8594,6 +8608,8 @@ const it: Dict = {
   "cron.add.action":
     "cosa dovrebbe fare Chimera? (es. riassumi le mie email non lette)",
   "cron.add.when": "quando — cron: minuto ora giorno mese giorno-settimana",
+  "cron.add.deliver": "URL webhook di Discord o Slack (facoltativo)",
+  "cron.deliversTo": "consegna su {host}",
   "cron.add.submit": "Pianifica",
   "cron.add.error":
     "Non è stato possibile pianificare — controlla l'espressione temporale.",
@@ -9778,6 +9794,8 @@ const pl: Dict = {
   "cron.add.action":
     "co Chimera ma zrobić? (np. streść moje nieprzeczytane maile)",
   "cron.add.when": "kiedy — cron: minuta godzina dzień miesiąc dzień-tygodnia",
+  "cron.add.deliver": "Adres webhooka Discord lub Slack (opcjonalnie)",
+  "cron.deliversTo": "wysyła na {host}",
   "cron.add.submit": "Zaplanuj",
   "cron.add.error": "Nie udało się zaplanować — sprawdź wyrażenie czasowe.",
   "cron.add.presets": "Szybki wybór:",
@@ -10957,6 +10975,8 @@ const ru: Dict = {
   "cron.add.action":
     "что должна сделать Chimera? (например, кратко изложить непрочитанную почту)",
   "cron.add.when": "когда — cron: минута час день месяц день_недели",
+  "cron.add.deliver": "URL вебхука Discord или Slack (необязательно)",
+  "cron.deliversTo": "отправляет в {host}",
   "cron.add.submit": "Запланировать",
   "cron.add.error": "Не удалось запланировать — проверьте выражение времени.",
   "cron.add.presets": "Быстрый выбор:",

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -74,6 +74,7 @@ def _job_dict(job: Any) -> dict[str, Any]:
         "consecutive_failures": job.consecutive_failures,
         "created_by": job.created_by,
         "workspace": job.workspace,
+        "deliver_to": job.deliver_to,
     }
 
 
@@ -469,6 +470,7 @@ def register_features(
                 now=time.time(),
                 created_by="human",
                 workspace=body.workspace,
+                deliver_to=body.deliver_to,
             )
         except ValueError as exc:  # an invalid cron expression is a client error, not a 500
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -835,6 +835,8 @@ class CronJobOut(BaseModel):
     workspace: str | None = None
     """The folder this job works in. None means the root the process was started with — which on a
     packaged build is the install directory, so the screen says so rather than leaving it blank."""
+    deliver_to: str | None = None
+    """A chat webhook URL the answer is posted to, or None to only write it to the result file."""
 
 
 class MessagingPlatformOut(BaseModel):
@@ -854,6 +856,8 @@ class CronCreateIn(BaseModel):
     workspace: str | None = None
     """The folder the job works in. Sent by the screen from the project the user chose; a client
     that omits it gets the process root, which is the previous behaviour."""
+    deliver_to: str | None = None
+    """Optional chat webhook (Discord or Slack) the answer is posted to when the job fires."""
 
 
 # --- tasks (kanban + projects) --------------------------------------------------------------------

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1885,8 +1885,6 @@ def _start_cron_daemon(
     backend: SupportsComplete, model: str | None, max_steps: int, workspace: Path, tick: int
 ) -> Any:
     """Start the cron daemon in a background thread; return its stop event."""
-    import json
-    import time
     from datetime import UTC, datetime
 
     from chimera.api.usage import UsageRecord, append_usage, spent_today
@@ -1895,6 +1893,7 @@ def _start_cron_daemon(
     from chimera.core.instructions import render as render_identity
     from chimera.orchestration.budget import BudgetExceeded
     from chimera.scheduler import CronDaemon, CronJob, Scheduler, make_agent_dispatch
+    from chimera.scheduler.delivery import make_deliver
     from chimera.tools import default_registry
 
     scheduler = Scheduler(_cron_store())
@@ -2004,19 +2003,13 @@ def _start_cron_daemon(
 
     results_path = get_settings().home / "scheduler" / "cron_results.jsonl"
 
-    def deliver(job: CronJob, answer: str) -> None:
-        """Durable sink: append every cron result so nothing is silently lost."""
-        results_path.parent.mkdir(parents=True, exist_ok=True)
-        record = {
-            "at": time.time(),
-            "id": job.id,
-            "name": job.name,
-            "action": job.action,
-            "deliver_to": job.deliver_to,
-            "answer": answer,
-        }
-        with results_path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    # The result file always, and the job's chat webhook when it names one. Built by
+    # `make_deliver` rather than written here: the defect it replaces was in the wiring rather than
+    # in any mechanism — `deliver_to` was declared, copied into the record, and read by nothing —
+    # and a sink that lives in a module is one a test can reach.
+    deliver = make_deliver(
+        results_path, warn=lambda linha: console.print(f"[yellow]{linha}[/yellow]")
+    )
 
     daemon = CronDaemon(
         scheduler, make_agent_dispatch(run_task, deliver, run_job=run_job), tick_seconds=tick

--- a/chimera/scheduler/delivery.py
+++ b/chimera/scheduler/delivery.py
@@ -1,0 +1,166 @@
+"""Sending a scheduled job's answer somewhere a person will actually see it.
+
+``CronJob.deliver_to`` has existed since the model did, and until now it appeared in exactly two
+places in the codebase: its own field declaration, and a line copying it into the result file. No
+code read it to deliver anything. A schedule wrote its answer to a JSONL nobody opens and that was
+the whole of "delivery" — which is why an install could run a job every night for a week and its
+owner never see one word of the output.
+
+A webhook URL rather than a bot token, deliberately. A bot needs an application, a token, an invite
+and a server the user administers; a webhook is a URL you copy out of a channel's settings, and it
+is the difference between a feature every user of a desktop app can turn on and one only the author
+of the app has set up.
+
+**The URL is a credential.** Whoever holds it can post into that channel, so it is never logged in
+full — :func:`redact` is used on every path that reports a failure.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from chimera.scheduler.models import CronJob
+from chimera.telemetry import get_logger
+
+_log = get_logger("scheduler.delivery")
+
+#: Discord rejects a message body over 2000 characters outright. Slack truncates around 4000 and
+#: keeps going. Cutting at the smaller of the two means one rule for every destination, and a
+#: refused delivery is worse than a shortened one — the answer is in the result file either way.
+MAX_CHARS = 1900
+
+#: A delivery must not hold the scheduler. Dispatch is sequential: a webhook host that hangs would
+#: delay every other job that is due, which is the failure `job_timeout` exists to prevent and this
+#: has no business reintroducing.
+TIMEOUT_S = 10.0
+
+
+@dataclass(frozen=True)
+class Delivered:
+    """What happened when we tried. ``ok=False`` is a report, never an exception upwards.
+
+    The job already ran and its answer is already on disk; failing the job because a chat service
+    was down would throw away work that succeeded, and would count against
+    ``consecutive_failures`` as though the schedule itself were broken.
+    """
+
+    ok: bool
+    detail: str = ""
+
+
+def make_deliver(
+    results_path: Path,
+    *,
+    warn: Callable[[str], None] | None = None,
+    send: Callable[[str, str], Delivered] | None = None,
+) -> Callable[[CronJob, str], None]:
+    """The sink a cron daemon hands its answers to: the file always, the webhook when there is one.
+
+    A module function rather than a closure inside the ``chimera app`` command, because the defect
+    this replaces was never in a mechanism — it was in the WIRING. ``deliver_to`` was declared,
+    copied into the result record, and read by nothing. A test of the sending mechanism would have
+    passed the whole time. So this is reachable, and there is a test asserting it actually sends.
+
+    ``warn`` receives one line when a delivery fails; ``send`` exists so a test can drive the
+    failure path without a socket.
+    """
+    enviar = send or deliver_to_webhook
+
+    def deliver(job: CronJob, answer: str) -> None:
+        entrega: Delivered | None = None
+        if job.deliver_to:
+            entrega = enviar(job.deliver_to, f"**{job.name}**\n{answer}")
+            if not entrega.ok and warn is not None:
+                # Said out loud rather than swallowed: a delivery that fails silently is
+                # indistinguishable from a job that never ran.
+                warn(f"cron '{job.name}': delivery failed — {entrega.detail}")
+
+        results_path.parent.mkdir(parents=True, exist_ok=True)
+        record: dict[str, object] = {
+            "at": time.time(),
+            "id": job.id,
+            "name": job.name,
+            "action": job.action,
+            "deliver_to": job.deliver_to,
+            "answer": answer,
+        }
+        if entrega is not None:
+            record["delivered"] = entrega.ok
+            record["delivery_detail"] = entrega.detail
+        with results_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    return deliver
+
+
+def redact(url: str) -> str:
+    """A webhook URL with its secret path removed, safe to put in a log or an error message."""
+    try:
+        parts = urllib.parse.urlparse(url)
+    except ValueError:
+        return "<unparseable url>"
+    if not parts.hostname:
+        return "<no host>"
+    return f"{parts.scheme}://{parts.hostname}/…"
+
+
+def payload_for(url: str, text: str) -> dict[str, str]:
+    """The body each service expects.
+
+    Slack reads ``text``; Discord reads ``content``. They are otherwise the same shape, so one
+    function covers both and anything Discord-compatible (which most self-hosted chat webhooks are).
+    """
+    host = (urllib.parse.urlparse(url).hostname or "").lower()
+    if host.endswith("slack.com"):
+        return {"text": text}
+    return {"content": text}
+
+
+def clip(text: str, limit: int = MAX_CHARS) -> str:
+    """Shorten to ``limit`` characters and say so, rather than being cut off mid-sentence.
+
+    The marker matters more than the saved characters: a message that simply stops looks like the
+    agent stopped, and that is a different thing to go and investigate.
+    """
+    if len(text) <= limit:
+        return text
+    marca = "\n… (truncated — the full answer is in cron_results.jsonl)"
+    return text[: limit - len(marca)] + marca
+
+
+def deliver_to_webhook(url: str, text: str, *, timeout: float = TIMEOUT_S) -> Delivered:
+    """POST ``text`` to a chat webhook. Returns what happened; never raises.
+
+    Only http(s): the field is a plain string on a job that an agent can propose, and a scheme like
+    ``file:`` would turn a delivery address into a local read. Agent-proposed jobs already arrive
+    disabled, so this is the second lock rather than the first.
+    """
+    parts = urllib.parse.urlparse(url)
+    if parts.scheme not in ("http", "https"):
+        return Delivered(False, f"refusing scheme {parts.scheme!r}: only http and https are sent to")
+    if not parts.hostname:
+        return Delivered(False, "no host in the delivery URL")
+
+    corpo = json.dumps(payload_for(url, clip(text))).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=corpo, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return Delivered(True, f"HTTP {resp.status}")
+    except urllib.error.HTTPError as exc:
+        # The body carries the reason (bad token, unknown channel, rate limit) and is worth keeping,
+        # but it is written by a remote service — bounded before it goes anywhere near a log line.
+        detalhe = (exc.read().decode("utf-8", "replace") or "")[:200].strip()
+        _log.warning("delivery to %s refused: HTTP %s", redact(url), exc.code)
+        return Delivered(False, f"HTTP {exc.code}: {detalhe}" if detalhe else f"HTTP {exc.code}")
+    except Exception as exc:  # noqa: BLE001 — a chat outage must not fail a job that worked
+        _log.warning("delivery to %s failed: %s", redact(url), type(exc).__name__)
+        return Delivered(False, f"{type(exc).__name__}: {exc}")

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -75,6 +75,7 @@ class Scheduler:
         now: float,
         created_by: CreatedBy = "human",
         workspace: str | None = None,
+        deliver_to: str | None = None,
     ) -> CronJob:
         if not croniter.is_valid(cron_expr):
             raise ValueError(f"invalid cron expression: {cron_expr!r}")
@@ -90,6 +91,7 @@ class Scheduler:
             enabled=created_by != "agent",
             next_run=_next_after(cron_expr, now),
             workspace=workspace,
+            deliver_to=deliver_to,
         )
         self.store.add(job)
         return job

--- a/tests/test_cron_delivery.py
+++ b/tests/test_cron_delivery.py
@@ -1,0 +1,228 @@
+"""Getting a scheduled job's answer to a person.
+
+``deliver_to`` existed on the model from the beginning and appeared in exactly two places in the
+whole codebase: its own declaration, and a line copying it into the result file. Nothing read it to
+send anything. So a schedule wrote its answer into a JSONL nobody opens, and that was delivery — an
+install could run a job every night for a week and its owner never see a word of the output.
+
+These tests run against a real local HTTP server rather than a mocked `urlopen`. The thing under
+test is what goes on the wire: the body shape each service expects, the status handling, and the
+promise that a chat outage cannot fail a job that already did its work.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from chimera.scheduler.delivery import (
+    MAX_CHARS,
+    clip,
+    deliver_to_webhook,
+    payload_for,
+    redact,
+)
+
+
+class _Recebedor(BaseHTTPRequestHandler):
+    """Records what arrived, and answers with whatever the test asked for."""
+
+    status = 204
+    recebidos: list[dict] = []
+
+    def do_POST(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's spelling
+        n = int(self.headers.get("Content-Length", 0))
+        corpo = self.rfile.read(n).decode("utf-8")
+        type(self).recebidos.append(
+            {"path": self.path, "body": json.loads(corpo), "ctype": self.headers.get("Content-Type")}
+        )
+        self.send_response(type(self).status)
+        self.end_headers()
+        if type(self).status >= 400:
+            self.wfile.write(b"unknown webhook")
+
+    def log_message(self, *_args) -> None:  # keep pytest output readable
+        pass
+
+
+@pytest.fixture
+def servidor():
+    """A webhook endpoint on a real socket, for the duration of one test."""
+    _Recebedor.recebidos = []
+    _Recebedor.status = 204
+    httpd = HTTPServer(("127.0.0.1", 0), _Recebedor)
+    t = threading.Thread(target=httpd.serve_forever, daemon=True)
+    t.start()
+    yield httpd, f"http://127.0.0.1:{httpd.server_address[1]}/api/webhooks/1/abc"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def test_the_answer_reaches_the_webhook(servidor) -> None:
+    _, url = servidor
+    r = deliver_to_webhook(url, "o site tem 3 arquivos")
+
+    assert r.ok, r.detail
+    assert len(_Recebedor.recebidos) == 1
+    enviado = _Recebedor.recebidos[0]
+    assert enviado["body"] == {"content": "o site tem 3 arquivos"}
+    assert enviado["ctype"] == "application/json"
+
+
+def test_slack_gets_the_field_slack_reads(servidor) -> None:
+    """Discord reads `content`, Slack reads `text`. Sending the wrong one is a silent 400."""
+    assert payload_for("https://hooks.slack.com/services/T/B/x", "oi") == {"text": "oi"}
+    assert payload_for("https://discord.com/api/webhooks/1/x", "oi") == {"content": "oi"}
+    # Anything else is treated as Discord-compatible, which most self-hosted chat webhooks are.
+    assert payload_for("https://chat.exemplo.com/hook/1", "oi") == {"content": "oi"}
+
+
+def test_a_refused_delivery_is_reported_not_raised(servidor) -> None:
+    """The job already ran. Throwing here would discard work that succeeded and would count
+    against `consecutive_failures` as though the schedule itself were broken."""
+    _, url = servidor
+    _Recebedor.status = 404
+
+    r = deliver_to_webhook(url, "texto")
+
+    assert not r.ok
+    assert "404" in r.detail
+    assert "unknown webhook" in r.detail, "the service's own reason is worth keeping"
+
+
+def test_an_unreachable_host_is_reported_not_raised() -> None:
+    # Port 1 on localhost: nothing listens, and the connection is refused immediately rather than
+    # hanging, so this stays a fast test.
+    r = deliver_to_webhook("http://127.0.0.1:1/hook", "texto", timeout=2.0)
+    assert not r.ok
+    assert r.detail
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://x/y", "javascript:alert(1)", "/hook"])
+def test_only_http_is_ever_fetched(url: str) -> None:
+    """`deliver_to` is a free-text field on a job an agent can propose. Agent-proposed jobs already
+    arrive disabled; this is the second lock, not the first."""
+    r = deliver_to_webhook(url, "texto")
+    assert not r.ok
+    assert "http" in r.detail.lower()
+
+
+def test_a_long_answer_is_shortened_and_says_so(servidor) -> None:
+    """Discord refuses a body over 2000 characters outright — a refused delivery would be worse
+    than a shortened one, since the full answer is in the result file either way."""
+    _, url = servidor
+    r = deliver_to_webhook(url, "x" * 5000)
+
+    assert r.ok
+    enviado = _Recebedor.recebidos[0]["body"]["content"]
+    assert len(enviado) <= MAX_CHARS
+    assert "truncated" in enviado, "a message that merely stops looks like an agent that stopped"
+
+
+def test_a_short_answer_is_left_exactly_alone() -> None:
+    # The control for the test above: a clip that always clips would pass it and mangle every
+    # ordinary message.
+    assert clip("três linhas curtas") == "três linhas curtas"
+
+
+# --------------------------------------------------------------------- the sink, and its wiring
+
+
+def _job(**over):
+    from chimera.scheduler import CronJob
+
+    base = {"id": "j1", "name": "resumo do site", "schedule": "0 7 * * *", "action": "liste"}
+    return CronJob(**{**base, **over})
+
+
+def test_the_sink_writes_the_file_even_with_no_webhook(tmp_path) -> None:
+    """The file is the record that survives a chat outage, a revoked webhook and a sleeping laptop."""
+    from chimera.scheduler.delivery import make_deliver
+
+    alvo = tmp_path / "scheduler" / "cron_results.jsonl"
+    make_deliver(alvo)(_job(), "três arquivos")
+
+    linha = json.loads(alvo.read_text(encoding="utf-8").strip())
+    assert linha["answer"] == "três arquivos"
+    assert linha["deliver_to"] is None
+    assert "delivered" not in linha, "a job that asked for no delivery has no delivery to report on"
+
+
+def test_the_sink_actually_sends_when_the_job_names_a_webhook(tmp_path) -> None:
+    """The test the original defect would have survived.
+
+    `deliver_to` was declared on the model and copied into the result record, and nothing ever read
+    it to send. Every test of the SENDING mechanism would have passed the whole time — the hole was
+    that nobody called it. So this asserts the call.
+    """
+    from chimera.scheduler.delivery import Delivered, make_deliver
+
+    enviados = []
+
+    def falso_envio(url, texto):
+        enviados.append((url, texto))
+        return Delivered(True, "HTTP 204")
+
+    alvo = tmp_path / "cron_results.jsonl"
+    make_deliver(alvo, send=falso_envio)(_job(deliver_to="https://discord.com/api/webhooks/1/x"), "ok")
+
+    assert len(enviados) == 1, "the sink did not send anything"
+    url, texto = enviados[0]
+    assert url == "https://discord.com/api/webhooks/1/x"
+    assert "resumo do site" in texto, "the job's name tells the reader which schedule spoke"
+    assert "ok" in texto
+
+    linha = json.loads(alvo.read_text(encoding="utf-8").strip())
+    assert linha["delivered"] is True
+
+
+def test_a_failed_delivery_is_recorded_and_announced_not_swallowed(tmp_path) -> None:
+    """A delivery that fails silently is indistinguishable from a job that never ran — which is the
+    confusion this whole area has been producing."""
+    from chimera.scheduler.delivery import Delivered, make_deliver
+
+    avisos = []
+    alvo = tmp_path / "cron_results.jsonl"
+    sink = make_deliver(
+        alvo, warn=avisos.append, send=lambda _u, _t: Delivered(False, "HTTP 401: bad token")
+    )
+    sink(_job(deliver_to="https://discord.com/api/webhooks/1/x"), "a resposta")
+
+    linha = json.loads(alvo.read_text(encoding="utf-8").strip())
+    assert linha["delivered"] is False
+    assert "401" in linha["delivery_detail"]
+    # And the answer is still on disk: the job worked, only the chat service did not.
+    assert linha["answer"] == "a resposta"
+    assert avisos and "401" in avisos[0]
+
+
+def test_the_app_uses_this_sink_rather_than_one_of_its_own() -> None:
+    """The wiring, asserted at the only place it can be: the command that builds the daemon.
+
+    Read from the module's own source — via `inspect`, not a relative path, which depends on the
+    directory pytest was started from — because the sink is built inside a Typer command that needs
+    a provider, a workspace and a bound port to run. So this guards the line against being dropped;
+    the tests above are what cover the behaviour.
+    """
+    import inspect
+
+    import chimera.cli.main as cli
+
+    fonte = inspect.getsource(cli)
+    assert "make_deliver(" in fonte, "the app no longer builds its sink from this module"
+    assert "from chimera.scheduler.delivery import make_deliver" in fonte
+    # And it has not grown a second sink of its own beside it, which is how the two would drift.
+    assert 'results_path.open("a"' not in fonte, "the app is writing the result file itself again"
+
+
+def test_the_url_is_never_repeated_in_full() -> None:
+    """A webhook URL is a credential: whoever holds it can post in that channel."""
+    url = "https://discord.com/api/webhooks/123456789/segredo-que-nao-pode-vazar"
+    escondida = redact(url)
+
+    assert "segredo-que-nao-pode-vazar" not in escondida
+    assert "123456789" not in escondida
+    assert "discord.com" in escondida, "and it still has to be useful for telling hosts apart"


### PR DESCRIPTION
A scheduled job could not tell anyone what it found.

`CronJob.deliver_to` has been on the model since the model existed. Grepping the whole codebase for
it returns **two** hits: its own field declaration, and a line copying it into the result record.
Nothing ever read it to send anything.

So "delivery" was a line appended to `cron_results.jsonl` — a file no screen opens. An install can
run a job every night for a week and its owner never see a word of the output. This one did: six
nights, and the result file did not exist at all because every run had timed out first.

## Webhook, not bot

A bot needs an application, a token, an invite, and a server the user administers. A webhook is a
URL you copy out of a channel's settings. For an app other people install, that is the difference
between a feature they can switch on and one only its author has set up.

Discord and Slack, told apart by host: Discord reads `content`, Slack reads `text`, and sending the
wrong field is a silent 400. Anything else is treated as Discord-compatible, which most self-hosted
chat webhooks are.

## What the delivery promises, and what it refuses to do

**It cannot fail the job.** The work already happened and the answer is already on disk. Throwing
because a chat service was down would discard a run that succeeded, and would climb
`consecutive_failures` as though the schedule itself were broken.

**It cannot be silent about failing.** `delivered` and `delivery_detail` go into the result record,
and a line is printed. A delivery that fails quietly is indistinguishable from a job that never ran
— the exact confusion this area has been producing.

**It cannot hold the scheduler.** Dispatch is sequential, so a hanging webhook host would delay
every other due job. Ten-second timeout.

**It cannot fetch a scheme that is not http(s).** `deliver_to` is a free-text field on a job an
agent can propose; `file:` would turn a delivery address into a local read. Agent-proposed jobs
already arrive disabled, so this is the second lock rather than the first.

**It cannot show the URL.** A webhook URL is a credential — whoever reads it off a shared screen
can post in that channel. The job row shows `delivers to discord.com`; failures are logged through
`redact()`.

## The test the original defect would have survived

Every test of a *sending mechanism* would have passed the entire time this was broken, because the
mechanism was never the problem — nothing called it. So `make_deliver` is a module function rather
than a closure inside the `chimera app` command, and there is a test asserting the sink actually
sends, plus one asserting the app builds its sink from this module rather than growing a second one
beside it.

Reverted, the sink that does not send drops two tests and the app that builds its own drops one.

## Verified

15 Python tests against a real local HTTP server rather than a mocked `urlopen` — the thing under
test is what goes on the wire. 6 desktop tests for the field, the host-only display, and the
control that an empty field sends `null` rather than `""`.

ruff · mypy · tsc · Python suite · 855 desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
