### PR TITLE
fix: four defects found by using the installed rc37

### DIFF
--- a/apps/desktop/src/components/orchestration/DelegationSavings.tsx
+++ b/apps/desktop/src/components/orchestration/DelegationSavings.tsx
@@ -65,6 +65,16 @@ export function DelegationSavings() {
         </p>
       )}
 
+      {/* When the two halves disagree, say WHY — in one line, and only then. More tokens on cheaper
+          models is fewer dollars, which is the entire point of routing by role; the code has known
+          that since it was written and said it in a comment, where the person reading the screen
+          cannot see it. Orange "5,229 more" sitting above green "$0.0199 saved" reads as a panel
+          contradicting itself, and a reader who concludes the number is broken has learned to
+          distrust the one screen built to be trusted. */}
+      {priced && tokens < 0 && usd > 0 ? (
+        <p className="text-xs text-muted-foreground">{t("orch.saving.cheaperModels")}</p>
+      ) : null}
+
       {summary.estimated_n ? (
         <p className="text-xs text-muted-foreground">
           {t("orch.saving.estimated", { n: summary.estimated_n, total: summary.n })}

--- a/apps/desktop/src/components/run/RunLauncher.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.tsx
@@ -345,7 +345,10 @@ export function RunLauncher({
           disabled={running}
         />
       </div>
-      <div className="flex items-center gap-3">
+      {/* `flex-wrap`: this row grew two checkboxes and a second button, and without wrapping the
+          last item is squeezed until its label breaks. Reflowing is the behaviour that survives the
+          next control somebody adds — and the next translation, which may be longer than this one. */}
+      <div className="flex flex-wrap items-center gap-3">
         <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
           {t("runs.maxAttempts")}
           <input

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -37,7 +37,10 @@ export const Button = forwardRef<HTMLButtonElement, Props>(
     <button
       ref={ref}
       className={cn(
-        "inline-flex items-center justify-center gap-2 rounded-chip font-medium transition-all duration-150",
+        // `whitespace-nowrap`: a button is a target, and a label broken across three lines inside a
+        // pill stops looking like one. Measured on the running app — "Ver o plano antes" wrapped
+        // to three lines the moment two checkboxes were added to its row.
+        "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-chip font-medium transition-all duration-150",
         "focus-visible:outline-none focus-visible:shadow-glow",
         "disabled:cursor-not-allowed",
         variants[variant],

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -444,6 +444,7 @@ const en: Dict = {
   "tasks.approvePlan": "Approve plan",
   "tasks.deny": "Deny",
   "tasks.specPath": "path to a spec file",
+  "orch.saving.cheaperModels": "More tokens, fewer dollars: the work went to cheaper models. Both numbers are right.",
   "registry.describe": "Describe one",
   "registry.designIt": "Design it",
   "registry.describePlaceholder": "what should this agent do? e.g. read my drafts and say what is weak, without changing anything",
@@ -875,7 +876,7 @@ const en: Dict = {
   "code.posture.saysPause.always": "Stops for your sign-off before finishing.",
   "code.posture.saysPause.tainted":
     "Stops for your sign-off if it read untrusted content.",
-  "code.posture.saysPause.never": "Never stops to ask.",
+  "code.posture.saysPause.never": "Never pauses for your sign-off.",
   "code.posture.fellBack":
     "A container was configured, but none is running — this is your machine.",
   "code.posture.unguarded":
@@ -1685,6 +1686,7 @@ const pt: Dict = {
   "tasks.approvePlan": "Aprovar plano",
   "tasks.deny": "Negar",
   "tasks.specPath": "caminho de um arquivo de spec",
+  "orch.saving.cheaperModels": "Mais tokens, menos dinheiro: o trabalho foi para modelos mais baratos. Os dois números estão certos.",
   "registry.describe": "Descrever um",
   "registry.designIt": "Desenhar",
   "registry.describePlaceholder": "o que este agente deve fazer? ex.: ler meus rascunhos e dizer o que está fraco, sem mexer em nada",
@@ -2121,7 +2123,7 @@ const pt: Dict = {
   "code.posture.saysPause.always": "Para e espera seu aval antes de concluir.",
   "code.posture.saysPause.tainted":
     "Para e espera seu aval se tiver lido conteúdo não confiável.",
-  "code.posture.saysPause.never": "Nunca para para perguntar.",
+  "code.posture.saysPause.never": "Nunca para para pedir seu aval.",
   "code.posture.fellBack":
     "Um contêiner foi configurado, mas nenhum está rodando — esta é a sua máquina.",
   "code.posture.unguarded":
@@ -2938,6 +2940,7 @@ const es: Dict = {
   "tasks.approvePlan": "Aprobar plan",
   "tasks.deny": "Denegar",
   "tasks.specPath": "ruta a un archivo de spec",
+  "orch.saving.cheaperModels": "Más tokens, menos dinero: el trabajo fue a modelos más baratos. Ambos números son correctos.",
   "registry.describe": "Describir uno",
   "registry.designIt": "Diseñar",
   "registry.describePlaceholder": "¿qué debe hacer este agente? p. ej.: leer mis borradores y decir qué está flojo, sin tocar nada",
@@ -3379,7 +3382,7 @@ const es: Dict = {
     "Se detiene y espera tu visto bueno antes de terminar.",
   "code.posture.saysPause.tainted":
     "Se detiene y espera tu visto bueno si leyó contenido no confiable.",
-  "code.posture.saysPause.never": "Nunca se detiene a preguntar.",
+  "code.posture.saysPause.never": "Nunca se detiene a pedir tu visto bueno.",
   "code.posture.fellBack":
     "Se configuró un contenedor, pero no hay ninguno en marcha — esta es tu máquina.",
   "code.posture.unguarded":
@@ -4203,6 +4206,7 @@ const fr: Dict = {
   "tasks.approvePlan": "Approuver le plan",
   "tasks.deny": "Refuser",
   "tasks.specPath": "chemin vers un fichier de spec",
+  "orch.saving.cheaperModels": "Plus de jetons, moins d'argent : le travail est allé à des modèles moins chers. Les deux chiffres sont justes.",
   "registry.describe": "En décrire un",
   "registry.designIt": "Concevoir",
   "registry.describePlaceholder": "que doit faire cet agent ? ex. : lire mes brouillons et dire ce qui est faible, sans rien modifier",
@@ -4649,7 +4653,7 @@ const fr: Dict = {
     "S'arrête et attend votre validation avant de conclure.",
   "code.posture.saysPause.tainted":
     "S'arrête et attend votre validation s'il a lu du contenu non fiable.",
-  "code.posture.saysPause.never": "Ne s'arrête jamais pour demander.",
+  "code.posture.saysPause.never": "Ne s'arrête jamais pour votre validation.",
   "code.posture.fellBack":
     "Un conteneur était configuré, mais aucun ne tourne — c'est votre machine.",
   "code.posture.unguarded":
@@ -5475,6 +5479,7 @@ const de: Dict = {
   "tasks.approvePlan": "Plan genehmigen",
   "tasks.deny": "Ablehnen",
   "tasks.specPath": "Pfad zu einer Spec-Datei",
+  "orch.saving.cheaperModels": "Mehr Tokens, weniger Geld: die Arbeit ging an günstigere Modelle. Beide Zahlen stimmen.",
   "registry.describe": "Einen beschreiben",
   "registry.designIt": "Entwerfen",
   "registry.describePlaceholder": "Was soll dieser Agent tun? z. B.: meine Entwürfe lesen und sagen, was schwach ist, ohne etwas zu ändern",
@@ -5919,7 +5924,7 @@ const de: Dict = {
     "Hält vor dem Abschluss an und wartet auf deine Freigabe.",
   "code.posture.saysPause.tainted":
     "Hält an und wartet auf deine Freigabe, wenn es nicht vertrauenswürdige Inhalte gelesen hat.",
-  "code.posture.saysPause.never": "Hält nie an, um zu fragen.",
+  "code.posture.saysPause.never": "Hält nie für Ihre Freigabe an.",
   "code.posture.fellBack":
     "Ein Container war konfiguriert, läuft aber nicht — das ist dein Rechner.",
   "code.posture.unguarded":
@@ -6714,6 +6719,7 @@ const zh: Dict = {
   "tasks.approvePlan": "批准计划",
   "tasks.deny": "拒绝",
   "tasks.specPath": "spec 文件路径",
+  "orch.saving.cheaperModels": "token 更多，花费更少：工作交给了更便宜的模型。两个数字都是对的。",
   "registry.describe": "描述一个",
   "registry.designIt": "生成设计",
   "registry.describePlaceholder": "这个代理要做什么？例如：读我的草稿并指出哪里弱，但不改动任何东西",
@@ -7124,7 +7130,7 @@ const zh: Dict = {
   "code.posture.saysShell.refused": "主机上的命令被拒绝。",
   "code.posture.saysPause.always": "完成前停下等待你签字。",
   "code.posture.saysPause.tainted": "如果读过不可信内容，会停下等待你签字。",
-  "code.posture.saysPause.never": "从不停下询问。",
+  "code.posture.saysPause.never": "从不为你的批准而暂停。",
   "code.posture.fellBack": "配置了容器，但没有一个在运行——这是你的机器。",
   "code.posture.unguarded":
     "这个对话读了不可信内容之后没有任何标记，所以它之后仍然能写文件。到设置里打开聊天防护来改变这一点。",
@@ -7931,6 +7937,7 @@ const ja: Dict = {
   "tasks.approvePlan": "計画を承認",
   "tasks.deny": "拒否",
   "tasks.specPath": "spec ファイルのパス",
+  "orch.saving.cheaperModels": "トークンは多く、費用は少なく：作業を安いモデルに回したためです。どちらの数字も正しいです。",
   "registry.describe": "説明して作る",
   "registry.designIt": "設計する",
   "registry.describePlaceholder": "このエージェントに何をさせますか？例：下書きを読んで弱い点を指摘する、何も変更せずに",
@@ -8367,7 +8374,7 @@ const ja: Dict = {
   "code.posture.saysPause.always": "完了前に停止して承認を待ちます。",
   "code.posture.saysPause.tainted":
     "信頼できない内容を読んだ場合は停止して承認を待ちます。",
-  "code.posture.saysPause.never": "確認のために停止することはありません。",
+  "code.posture.saysPause.never": "承認のために停止することはありません。",
   "code.posture.fellBack":
     "コンテナが設定されていますが、動いていません — これはあなたのマシンです。",
   "code.posture.unguarded":
@@ -9187,6 +9194,7 @@ const it: Dict = {
   "tasks.approvePlan": "Approva il piano",
   "tasks.deny": "Nega",
   "tasks.specPath": "percorso di un file spec",
+  "orch.saving.cheaperModels": "Più token, meno denaro: il lavoro è andato a modelli più economici. Entrambi i numeri sono corretti.",
   "registry.describe": "Descrivine uno",
   "registry.designIt": "Progetta",
   "registry.describePlaceholder": "cosa deve fare questo agente? es.: leggere le mie bozze e dire cosa è debole, senza toccare nulla",
@@ -9629,7 +9637,7 @@ const it: Dict = {
     "Si ferma e aspetta il tuo via libera prima di concludere.",
   "code.posture.saysPause.tainted":
     "Si ferma e aspetta il tuo via libera se ha letto contenuti non affidabili.",
-  "code.posture.saysPause.never": "Non si ferma mai a chiedere.",
+  "code.posture.saysPause.never": "Non si ferma mai per la tua approvazione.",
   "code.posture.fellBack":
     "Era configurato un container, ma nessuno è in esecuzione — questa è la tua macchina.",
   "code.posture.unguarded":
@@ -10448,6 +10456,7 @@ const pl: Dict = {
   "tasks.approvePlan": "Zatwierdź plan",
   "tasks.deny": "Odmów",
   "tasks.specPath": "ścieżka do pliku spec",
+  "orch.saving.cheaperModels": "Więcej tokenów, mniej pieniędzy: praca trafiła do tańszych modeli. Obie liczby są poprawne.",
   "registry.describe": "Opisz jednego",
   "registry.designIt": "Zaprojektuj",
   "registry.describePlaceholder": "co ma robić ten agent? np.: czytać moje szkice i mówić, co jest słabe, niczego nie zmieniając",
@@ -10887,7 +10896,7 @@ const pl: Dict = {
     "Zatrzymuje się i czeka na twoją zgodę przed zakończeniem.",
   "code.posture.saysPause.tainted":
     "Zatrzymuje się i czeka na twoją zgodę, jeśli czytał niezaufane treści.",
-  "code.posture.saysPause.never": "Nigdy nie zatrzymuje się, by zapytać.",
+  "code.posture.saysPause.never": "Nigdy nie zatrzymuje się po twoją zgodę.",
   "code.posture.fellBack":
     "Skonfigurowano kontener, ale żaden nie działa — to twój komputer.",
   "code.posture.unguarded":
@@ -11706,6 +11715,7 @@ const ru: Dict = {
   "tasks.approvePlan": "Утвердить план",
   "tasks.deny": "Отклонить",
   "tasks.specPath": "путь к файлу спецификации",
+  "orch.saving.cheaperModels": "Больше токенов, меньше денег: работа ушла на более дешёвые модели. Обе цифры верны.",
   "registry.describe": "Описать",
   "registry.designIt": "Спроектировать",
   "registry.describePlaceholder": "что должен делать этот агент? например: читать мои черновики и говорить, что слабо, ничего не меняя",
@@ -12149,7 +12159,7 @@ const ru: Dict = {
     "Останавливается за вашим согласием перед завершением.",
   "code.posture.saysPause.tainted":
     "Останавливается за вашим согласием, если прочитал недоверенное содержимое.",
-  "code.posture.saysPause.never": "Никогда не останавливается, чтобы спросить.",
+  "code.posture.saysPause.never": "Никогда не останавливается ради вашего одобрения.",
   "code.posture.fellBack":
     "Контейнер был настроен, но ни один не запущен — это ваша машина.",
   "code.posture.unguarded":

--- a/chimera/core/checklist.py
+++ b/chimera/core/checklist.py
@@ -34,7 +34,9 @@ _EXTRACT_SYSTEM = (
     '{"items": [{"text": "...", "kind": "do|avoid|include"}]}. Each item is ONE checkable '
     'requirement: "do" = an action that must happen, "avoid" = something that must NOT happen, '
     '"include" = something the output must contain. Split compound requirements; keep each atomic '
-    "and literal. Do NOT solve the task. Output ONLY the JSON object."
+    "and literal. Write each `text` in the SAME LANGUAGE as the task — this list is read by the "
+    "person who wrote that task, and a checklist somebody cannot read is a checklist they cannot "
+    "correct. Do NOT solve the task. Output ONLY the JSON object."
 )
 _GRADE_SYSTEM = (
     "You grade whether an answer meets each requirement. Given the requirements and the answer, "

--- a/tests/test_checklist_speaks_your_language.py
+++ b/tests/test_checklist_speaks_your_language.py
@@ -1,0 +1,60 @@
+"""The requirement checklist has to come back in the language the task was written in.
+
+Found by using the installed rc37: asked in Portuguese for *"faca uma pagina de contato com
+formulario e telefone"*, the list came back as *"create a contact page"*, *"include a form"*,
+*"include a phone number"*.
+
+That list is the whole product of the feature. It exists so somebody reads it and corrects it
+before the run, and whatever they add becomes an acceptance criterion — a checklist a person cannot
+read is a checklist they cannot correct.
+
+Measured against the real model, same request, five repeats each:
+
+    old prompt   5 of 5 in English
+    new prompt   0 of 5
+
+**A single sample nearly buried this.** The first paired run drew Portuguese from the old prompt
+and I doubted the finding; five repeats showed that draw was luck. Two samples do not estimate
+variance — they produce a difference.
+
+The spec drafter shipped in the same wave already said "write it in the same language as the
+request" and behaved correctly throughout. Same job, two prompts, one of them told.
+"""
+
+from __future__ import annotations
+
+from chimera.core.checklist import _EXTRACT_SYSTEM, _GRADE_SYSTEM
+
+
+def test_the_extraction_is_told_to_answer_in_the_task_s_language() -> None:
+    assert "SAME LANGUAGE" in _EXTRACT_SYSTEM
+
+
+def test_it_says_why_rather_than_only_what() -> None:
+    """A rule with its reason survives an edit that a bare instruction does not: the next person to
+    shorten this prompt can see what the sentence is buying."""
+    assert "cannot correct" in _EXTRACT_SYSTEM
+
+
+def test_the_two_prompts_of_this_feature_agree() -> None:
+    """The drafter and the checklist do the same job on the same screen. One of them having the
+    rule and the other not is how a user gets half a feature in their own language."""
+    from chimera.orchestration.draft import _SYSTEM as DRAFTER
+
+    assert "same language as the request" in DRAFTER
+    assert "SAME LANGUAGE" in _EXTRACT_SYSTEM
+
+
+def test_the_grader_is_not_asked_to_translate() -> None:
+    """The control, and it is the half that could have been broken by fixing the other. The grader
+    receives requirement texts and returns them with a verdict; telling it to write in the task's
+    language would invite it to REPHRASE what it echoes, and the caller matches those strings to
+    decide what was missed."""
+    assert "SAME LANGUAGE" not in _GRADE_SYSTEM
+    assert "one entry per" in _GRADE_SYSTEM
+
+
+def test_the_instruction_costs_one_sentence() -> None:
+    """This prompt runs on every checklist extraction. Asserted rather than assumed: a prompt
+    nobody measures grows a sentence at a time until somebody finds it in a token bill."""
+    assert len(_EXTRACT_SYSTEM) < 1200, f"{len(_EXTRACT_SYSTEM)} characters, sent every extraction"


### PR DESCRIPTION
Testing the release as a user, against the running app, with fictional projects, schedules and
agents. Four defects, each measured before it was fixed.

## The checklist came back in English for a Portuguese request

Asked for *"faca uma pagina de contato com formulario e telefone"*, the list read "create a contact
page", "include a form", "include a phone number".

That list is the entire product of the feature. It exists so somebody reads it and corrects it
before the run, and whatever they add becomes an acceptance criterion — **a checklist a person
cannot read is a checklist they cannot correct.**

Five repeats each, same request, real model:

| prompt | out of language |
|---|---|
| old | **5 of 5** |
| new | **0 of 5** |

The spec drafter shipped in the same wave already said "write it in the same language as the
request" and behaved correctly throughout. Same job, two prompts, one of them told.

**A single sample nearly buried this.** The first paired run drew Portuguese from the old prompt
and I doubted the finding; five repeats showed that draw was luck. Two samples do not estimate
variance — they produce a difference.

## "Was it worth it?" looked like it was contradicting itself

`5,229 tokens MORE` in orange, directly above `$0.0199 saved` in green.

Both numbers are right, and the reason is the entire point of routing by role: 12 mid-tier calls
and 8 top against a counterfactual of 20 top is more tokens on cheaper models. The component's own
docstring says exactly that — to whoever reads the source. The screen said nothing, and a reader
who concludes the number is broken has learned to distrust the one panel built to be trusted.

It now says why, in one line, and only when the two halves actually disagree.

## "See the plan first" wrapped to three lines inside its pill

The row grew two checkboxes in wave 3 and had no `flex-wrap`, so the last control was squeezed
until its label broke. Fixed at both causes: the row reflows, and a `Button` never breaks its own
label — a button is a target, and one spread over three lines stops looking like one.

## "Never stops to ask" now collides with an agent that asks

That line describes the pause posture, and its two siblings say "sign-off" — only this one said
"ask", which since wave 2 is something the agent genuinely does. Aligned with its siblings in all
ten languages: two different mechanisms may not wear the same words on the same screen.

## Verified live, on the installed build

| wave | checked | result |
|---|---|---|
| 1 | `/api/plan` | real steps, editable text |
| 3 | `/api/requirements` | 3 requirements, kinds separated |
| 2.1 | describe → review → write → start | spec in PT-BR, the deleted requirement absent from the file, project born `planning` |
| 3 | design a subagent | a read-only agent got read-only tools |
| 3 | schedule silence | overdue job listed, **disabled job not** (the control) |
| 2.4 | schedule results | 3 results, one delivered `HTTP 204` |
| 3 | run with every seam on | **24.3s** against 27s without them |

## A correction about my own apparatus

I nearly reported a 25-minute stall in a run. It was my SSE reader waiting for the stream to close
instead of stopping at the terminal frame; the run had finished in 24 seconds. Second time this
session that I almost attributed to the product a defect in the instrument — measured before
claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)