### PR TITLE
fix(runs): the judge held work to things nobody agreed to

### DIFF
--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -589,6 +589,21 @@ class AutonomousAgent:
             for part in (spine, repo_ctx, lessons, card_ctx, facts_ctx, playbook_ctx, requirements_ctx)
             if part
         )
+        #: What the JUDGE is allowed to hold the work to — the agreed criteria, and nothing else.
+        #:
+        #: The worker's context and the reviewer's used to be the same string, and that turned
+        #: everything advisory into something enforceable. Measured on a real run: a globally-scoped
+        #: memory fact naming another project's path ("the Cafe Aurora test project lives in
+        #: Desktop/teste-chimera/…") reached the reviewer, which then failed a run for not putting
+        #: that path in a README nobody had asked to contain it. The attempt's own diff proves the
+        #: file was written; verify-or-revert then deleted it, and with one attempt there was no
+        #: retry. Correct work destroyed on a criterion nobody agreed to.
+        #:
+        #: `requirements_ctx` stays because it IS the agreement — a checklist somebody read and
+        #: edited before the run. Everything else is material for the worker to USE: recalled facts,
+        #: distilled lessons, skill cards, the playbook, the repository map, file bodies read before
+        #: the work. Useful to think with; not a contract to be judged against.
+        judge_context = requirements_ctx
         # how many times this task pattern has already succeeded / failed (before this
         # run) — the recurrence signals that gate auto-skill-evolution (a pattern card on
         # recurring success, an anti-pattern card on recurring failure)
@@ -731,7 +746,7 @@ class AutonomousAgent:
             probe_proxy: bool | None = None
             proxy_fb = ""
             if self.probe_log is not None and self.manager is not None:
-                probe_proxy, proxy_fb = self._review(task, answer, context)
+                probe_proxy, proxy_fb = self._review(task, answer, judge_context)
             if verifier_active:
                 ok = verified
                 if verified:
@@ -739,9 +754,9 @@ class AutonomousAgent:
                 elif probe_proxy is not None:
                     approved, fb = probe_proxy, proxy_fb
                 else:
-                    approved, fb = self._review(task, answer, context)
+                    approved, fb = self._review(task, answer, judge_context)
             else:
-                approved, fb = self._review(task, answer, context)
+                approved, fb = self._review(task, answer, judge_context)
                 ok = approved
             # Record the paired observation for PROBE: arm = which worker ran, proxy = the cheap
             # manager verdict, reward = the verified outcome (only with a real verifier + manager).

--- a/tests/test_the_judge_only_holds_you_to_the_agreement.py
+++ b/tests/test_the_judge_only_holds_you_to_the_agreement.py
@@ -1,0 +1,77 @@
+"""What the reviewer may hold the work to, and what it may not.
+
+Found by using the installed rc37. A run whose own diff proves `README.md` was written was failed
+with this feedback, and verify-or-revert then deleted the file:
+
+    "O arquivo README.md deve existir e conter uma linha descrevendo o projeto, mas a localização
+     do projeto no caminho 'Desktop/teste-chimera/site-institucional' não foi incluída na descrição."
+
+The agreed requirement was *"o README.md deve existir"*. That path appears in neither the
+requirement nor the answer — it exists only as a globally-scoped memory fact, about a different
+project entirely.
+
+**Which gate wrote it is decidable from the evidence.** `RequirementChecklist.grade` builds its
+prompt from the requirement list and the answer and nothing else — it never sees the path. The
+reviewer receives `context`, and `context` contained the recalled facts. Only one gate could have
+produced that sentence.
+
+So: the worker's context and the reviewer's were the same string, and that made every advisory
+thing enforceable. `requirements_ctx` stays, because it IS the agreement — a checklist somebody
+read and edited before the run. Recalled facts, distilled lessons, skill cards, the playbook, the
+repository map and file bodies are material for the worker to think with, not a contract.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from chimera.core.autonomous import AutonomousAgent
+
+
+def _run_source() -> str:
+    return inspect.getsource(AutonomousAgent.run)
+
+
+def test_the_reviewer_is_given_the_judge_context() -> None:
+    """Every review call, not most of them. There are three — a passing attempt's PROBE proxy, the
+    verifier-failed path and the no-verifier path — and one left on the worker's context is a leak
+    that only shows up on whichever branch nobody exercised."""
+    source = _run_source()
+    assert source.count("self._review(task, answer, judge_context)") == 3
+    assert "self._review(task, answer, context)" not in source
+
+
+def test_the_judge_context_is_the_agreement_and_nothing_else() -> None:
+    source = _run_source()
+    assert "judge_context = requirements_ctx" in source
+
+
+def test_the_worker_still_gets_everything() -> None:
+    """The control, and the half that could have been broken by fixing the other. Narrowing what
+    the JUDGE sees must not narrow what the worker can think with — recalled facts and learned
+    cards are why the loop improves at all."""
+    source = _run_source()
+    assert "(spine, repo_ctx, lessons, card_ctx, facts_ctx, playbook_ctx, requirements_ctx)" in source
+
+
+def test_recalled_facts_never_reach_the_judge() -> None:
+    """The specific leak, named. `facts_ctx` is memory recall — including facts scoped to every
+    project — and a judge holding work to a fact recalled from somewhere else is a judge enforcing
+    a criterion nobody agreed to."""
+    source = _run_source()
+    judge_line = next(ln for ln in source.splitlines() if "judge_context =" in ln)
+    for advisory in ("facts_ctx", "lessons", "card_ctx", "playbook_ctx", "repo_ctx", "spine"):
+        assert advisory not in judge_line, f"{advisory} became enforceable again"
+
+
+def test_the_checklist_grader_could_not_have_written_that_feedback() -> None:
+    """Pinned because it is what makes the diagnosis a conclusion rather than a guess: the grader's
+    prompt is built from the requirement list and the answer, so a path present in neither could
+    not have come from it. If this prompt ever grows a context argument, the elimination above
+    stops holding and this file's reasoning needs redoing."""
+    from chimera.core.checklist import RequirementChecklist
+
+    grade = inspect.getsource(RequirementChecklist.grade)
+    assert 'prompt = f"Requirements:\\n{listing}\\n\\n<<answer>>\\n{answer}\\n<<end-answer>>"' in grade
+    # `task` is a parameter it accepts and deliberately does not put in the prompt.
+    assert "{task}" not in grade


### PR DESCRIPTION
Found by installing rc37 and using it. A run whose own diff proves `README.md` was written was
failed, and verify-or-revert then deleted the file:

```
verified : True                      <- nothing failed verification
reverted : True                      <- the work was undone anyway
diff     : +1 new (README.md)        <- the file WAS written
feedback : "...mas a localização do projeto no caminho
            'Desktop/teste-chimera/site-institucional'
            não foi incluída na descrição."
```

The agreed requirement was **"o README.md deve existir"**. That path appears in neither the
requirement nor the answer. It exists as exactly one thing: a globally-scoped memory fact, about a
different project.

## Which gate wrote it — decided from evidence, not reproduction

| where the path could have come from | present? |
|---|---|
| the requirement I sent | no |
| the agent's answer | no |
| the recalled memory fact | **yes, verbatim** |

```python
# the checklist grader receives ONLY this — `task` is not even in the prompt:
prompt = f"Requirements:\n{listing}\n\n<<answer>>\n{answer}\n<<end-answer>>"

# the reviewer receives the whole context:
manager.review(task, answer, context=context)   # context includes facts_ctx
```

The grader could not have written that sentence. One gate had the path.

## The fix

The worker's context and the reviewer's were the same string, which made everything advisory
enforceable. They are separate now:

- **the judge** sees `requirements_ctx` — the agreement, a checklist somebody read and edited
  before the run — and nothing else;
- **the worker** still sees everything: recalled facts, distilled lessons, skill cards, the
  playbook, the repository map, file bodies. Useful to think with; not a contract.

All three review call sites take it, not two — the PROBE proxy on a passing attempt, the
verifier-failed path, and the no-verifier path. One left behind is a leak that only surfaces on
whichever branch nobody exercised.

The control is pinned as well: narrowing what the judge sees must not narrow what the worker can
think with, since recalled facts and learned cards are why the loop improves at all.

## Verification

4129 Python tests, ruff and mypy clean. Sabotage: restoring `judge_context = context` fails the
test that names the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)