### PR TITLE
fix(desktop): the app hung forever on the first command the agent ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,26 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **The installed app stopped forever the first time the agent chose to run a command.** Not slow —
+  stopped: no frame, no error, no timeout, and `cancel` answering `{"ok": true}` indefinitely about a
+  run that could not be stopped. Three threads of the shipped build were parked in `typer.confirm`,
+  reading a stdin nobody was writing to. The host-exec gate decides between asking and refusing with
+  `sys.stdin.isatty()`, and the desktop shell spawns the frozen sidecar under `CREATE_NO_WINDOW` —
+  which Windows honours by giving the child a console **with no window**. stdin is a character
+  device, `isatty()` says yes, and there is no one there. So the gate drew a confirmation prompt
+  where no human could see it and waited for an answer that could never come. Reachable from the
+  Code screen, `/api/runs`, the lifecycle screen and every cron job. Present since the console was
+  hidden, roughly thirty-five releases ago, and the first thing a new user hits.
+  **`code_api.py` had already written the correct invariant down** — *"this surface has no terminal,
+  so its `ask` has always been a refusal"* — while the code went on inferring it from a file
+  descriptor and getting the opposite answer: a comment asserting what the code did not do. Three
+  things now hold instead. Serving HTTP declares that no human is present, once, at the top of
+  `build_api_app`, so no surface has to remember. The desktop shell hands the backend
+  `Stdio::null()`, so the file descriptor stops lying. And a prompt that is somehow still reached
+  can no longer block forever — `except Exception` never caught this, because blocking is not an
+  exception, so the wait is bounded and the waiter is a daemon. Unattended, the refusal is the
+  documented `ask` behaviour and says how to proceed; in the Code screen, choosing the
+  workspace-and-shell reach ungates it as it always did.
 - **The agent's root was the app's own install folder.** `read_file(".env")` returned
   `OPENROUTER_API_KEY=sk-or-v1-…` in full. Not a sandbox failure — a path outside the root is still
   refused — the root itself was the folder holding the key. `resolve_app_workspace` falls back to

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -366,6 +366,14 @@ fn start_sidecar(paths: &Paths, wanted: u16, budget: Budget) -> Result<Backend, 
         .arg(&port_file)
         .env("CHIMERA_HOME", data_dir.join("data"))
         .env("CHIMERA_WORKSPACE", &workspace_dir)
+        // The backend inherits no stdin, because there is nobody on the other end of it. Inherited,
+        // and combined with the CREATE_NO_WINDOW below, Windows hands the child a console with no
+        // window: `isatty()` reports a terminal, the host-exec gate believes it, and the first
+        // command the agent chose to run blocks on a confirmation prompt drawn where no human can
+        // see it — permanently, cancel included. The backend now also declares this for itself, and
+        // both halves stay: this one makes the file descriptor tell the truth, that one makes the
+        // answer independent of the file descriptor.
+        .stdin(Stdio::null())
         .stderr(Stdio::piped());
     hide_console(&mut cmd);
     let mut child = cmd

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -109,6 +109,7 @@ from chimera.core.agent import ToolActivity
 from chimera.core.events import AgentEvent, EventSink
 from chimera.interface import ChatSession
 from chimera.providers.gateway import SupportsComplete
+from chimera.sandbox.confirm import declare_no_human_here
 from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:
@@ -434,6 +435,14 @@ def build_api_app(
     ``solve_agent_factory`` builds the per-run autonomous agent; it defaults to the real LLM-backed
     builder and is injectable so the run endpoint is testable without a provider (see tests).
     """
+    # Serving HTTP means the caller is a client, not somebody watching this process's terminal.
+    # Asking that terminal to approve a command a remote request wants to run would be the wrong
+    # question even if a person were there — and in the packaged desktop nobody is: the sidecar is
+    # spawned with CREATE_NO_WINDOW, gets a console with no window, and `isatty()` cheerfully says
+    # there is a terminal. Every host command then blocked its request thread on a prompt drawn
+    # where no one could see it. Declared here, once, so no surface has to remember.
+    declare_no_human_here("http api")
+
     settings_override = settings
     settings = settings or get_settings()
     workspace = (workspace or Path.cwd()).expanduser().resolve()

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -447,8 +447,13 @@ def assemble_registry(
 
     # Whether a mounted shell tool may run on the host, decided per request rather than only per
     # install. `resolve_host_exec_confirm` answers None for "no gate", a refusal for `deny`, and a
-    # terminal prompt for `ask` — and this surface has no terminal, so its `ask` has always been a
-    # refusal. Passing None is what lets a project someone opened commands for actually run them.
+    # terminal prompt for `ask` — and this surface has no terminal, so its `ask` resolves to a
+    # refusal. That last clause used to be a claim rather than a fact: the resolver decided from
+    # `sys.stdin.isatty()`, which in the packaged desktop reports a terminal (a console with no
+    # window, courtesy of CREATE_NO_WINDOW), so `ask` drew a prompt nobody could see and blocked
+    # this request thread forever. `declare_no_human_here`, called once in `build_api_app`, is what
+    # makes the sentence true. Passing None is what lets a project someone opened commands for
+    # actually run them.
     #
     # BOTH locks, and never against the owner's `deny`. The reach lock is read from the resolved
     # posture rather than from the reach string: `deny_tools` is what actually removes the tools, so

--- a/chimera/sandbox/confirm.py
+++ b/chimera/sandbox/confirm.py
@@ -3,8 +3,9 @@
 When the sandbox is ``local`` (the default, because most ``pip install`` users have no Docker), a
 command the model chose to run executes on the host. ``CHIMERA_HOST_EXEC`` decides the posture:
 
-* ``ask`` (default) — interactive terminal: confirm each host command; headless: run with a one-time
-  warning (so cron / CI / the benchmark harness are not broken by a prompt nothing can answer).
+* ``ask`` (default) — interactive terminal: confirm each host command; headless: **refuse**, with a
+  one-time warning saying how to proceed deliberately (see :func:`_make_headless_deny`; this line
+  used to say "run with a one-time warning", which is what the code did before the refusal landed).
 * ``allow`` — run on the host without asking (the pre-2026-07 behaviour, now an explicit opt-in).
 * ``deny`` — never run on the host; the command is refused with a pointer to ``CHIMERA_SANDBOX=docker``.
 
@@ -15,7 +16,9 @@ the tool, from the real :func:`sandbox_is_isolated` (a docker *config* is not pr
 
 from __future__ import annotations
 
+import contextlib
 import sys
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -28,6 +31,45 @@ _log = get_logger("sandbox.confirm")
 
 # Given the command (shell) or a one-line summary (code), return True to run it on the host.
 HostExecConfirm = Callable[[str], bool]
+
+#: How long an interactive confirm may wait before it is treated as no answer. A backstop, not the
+#: mechanism: with the declaration below working, nothing should ever reach it. It exists because
+#: the failure it catches is unbounded — a prompt written to a console nobody can see blocks the
+#: request thread forever, cancel included — and a refusal after two minutes is recoverable where a
+#: permanent hang is not. Generous on purpose: a real person reading a command they were asked to
+#: approve should never lose the race.
+PROMPT_TIMEOUT_SECONDS = 120.0
+
+#: Set by a surface that KNOWS no human can answer, rather than inferred from the file descriptors.
+#: See :func:`declare_no_human_here`.
+_no_human_surface: str | None = None
+
+
+def declare_no_human_here(surface: str) -> None:
+    """Record that this process has no human who could answer a terminal prompt.
+
+    ``isatty()`` answers "is this a character device", which is not the same question. A frozen
+    sidecar launched by the desktop shell under ``CREATE_NO_WINDOW`` is given a console **with no
+    window**: stdin reports a terminal, and nobody is there. Every host command the agent chose then
+    blocked the request thread on a prompt drawn where no one could see it — no frame, no error, no
+    timeout, and cancel returning ok forever on a run that could not be stopped.
+
+    ``chimera/api/code_api.py`` already stated the invariant in a comment — *"this surface has no
+    terminal, so its `ask` has always been a refusal"* — while the code went on guessing from a file
+    descriptor and getting the opposite answer. This is that comment made executable: a surface that
+    knows says so, instead of leaving it to be inferred.
+    """
+    global _no_human_surface
+    if _no_human_surface is None:
+        _no_human_surface = surface
+        _log.debug("host-exec confirm: no human at the keyboard (%s)", surface)
+
+
+def _human_can_answer() -> bool:
+    """Whether a terminal prompt could actually reach a person. Declaration beats inference."""
+    if _no_human_surface is not None:
+        return False
+    return bool(getattr(sys.stdin, "isatty", lambda: False)())
 
 
 def sandbox_is_isolated(sandbox: object) -> bool:
@@ -71,10 +113,41 @@ def _prompt(command: str) -> bool:
             "⚠  The agent wants to run this on your machine (host, not a sandbox):", fg="yellow"
         )
         typer.secho(f"    {command}", fg="cyan")
-        return bool(typer.confirm("Run it?", default=False))
+        return _answer_or_refuse(lambda: bool(typer.confirm("Run it?", default=False)), command)
     except Exception:  # noqa: BLE001 — no TTY / typer missing: fail safe (do not run)
         _log.warning("host-exec confirm could not prompt; refusing. Command: %s", command[:200])
         return False
+
+
+def _answer_or_refuse(ask: Callable[[], bool], command: str) -> bool:
+    """Run ``ask`` on a side thread and refuse if it does not answer in time.
+
+    ``except Exception`` above cannot catch this failure, because blocking is not an exception: a
+    read from a console with no window never returns and never raises. The waiting thread is a
+    daemon, so a prompt left hanging cannot keep the process alive either — the request gets its
+    refusal and moves on, where before it got nothing at all, forever.
+    """
+    answer: list[bool] = []
+
+    def _run() -> None:
+        # A failure to ask is a refusal, same as the caller's rule — and it has to be swallowed
+        # HERE, because an exception on this thread never reaches the caller's `except`.
+        with contextlib.suppress(Exception):
+            answer.append(bool(ask()))
+
+    waiter = threading.Thread(target=_run, name="host-exec-confirm", daemon=True)
+    waiter.start()
+    waiter.join(PROMPT_TIMEOUT_SECONDS)
+    if not answer:
+        _log.warning(
+            "host-exec confirm went unanswered for %.0fs; refusing. If you are seeing no prompt, "
+            "this process has no usable terminal — set CHIMERA_HOST_EXEC=allow, or "
+            "CHIMERA_SANDBOX=docker to run isolated. Command: %s",
+            PROMPT_TIMEOUT_SECONDS,
+            command[:200],
+        )
+        return False
+    return answer[0]
 
 
 def _make_headless_deny() -> HostExecConfirm:
@@ -135,5 +208,5 @@ def resolve_host_exec_confirm(
 
     # posture == "ask" (or anything unrecognised → treat as ask, the safe default)
     if interactive is None:
-        interactive = bool(getattr(sys.stdin, "isatty", lambda: False)())
+        interactive = _human_can_answer()
     return _prompt if interactive else _make_headless_deny()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,23 @@ def _model_provider_keys() -> list[str]:
 
 
 @pytest.fixture(autouse=True)
+def _nobody_has_declared_the_terminal_dead() -> Iterator[None]:
+    """Clear the process-wide "no human here" flag between tests.
+
+    ``build_api_app`` sets it, and it is deliberately process-wide — the fact it records is a fact
+    about the process. That makes it leak across tests in one session, and the leak is silent and
+    directional: every test after the first API test would see the headless answer. The TTY
+    auto-detection tests assert the *interactive* one, so without this they pass or fail on
+    collection order, which is the kind of failure that shows up in CI and nowhere else.
+    """
+    import chimera.sandbox.confirm as confirm_mod
+
+    confirm_mod._no_human_surface = None
+    yield
+    confirm_mod._no_human_surface = None
+
+
+@pytest.fixture(autouse=True)
 def _no_dotenv(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     config = dict(Settings.model_config)
     config["env_file"] = None

--- a/tests/test_the_prompt_nobody_could_see.py
+++ b/tests/test_the_prompt_nobody_could_see.py
@@ -1,0 +1,200 @@
+"""The installed app hung forever the first time the agent chose to run a command.
+
+Not slow — stopped. No frame, no error, no timeout, and `POST /api/runs/{id}/cancel` answering
+`{"ok": true}` indefinitely about a run that could not be stopped. Three threads of the shipped
+build were parked in the same place:
+
+    confirm    (click/termui.py)        <- reading stdin, blocked
+    _prompt    (chimera/sandbox/confirm.py)
+    run        (chimera/tools/shell.py)
+    ...
+    work       (chimera/api/app.py)
+
+`resolve_host_exec_confirm` decided between prompting and refusing with
+``sys.stdin.isatty()``. The desktop shell spawns the frozen backend with ``CREATE_NO_WINDOW``, and
+Windows answers that by giving the child a console **with no window**: stdin is a character device,
+`isatty()` says True, and there is nobody there. So the gate drew a confirmation prompt somewhere
+no human could ever see and waited for an answer that could never come.
+
+`chimera/api/code_api.py` had already written the correct invariant down — *"this surface has no
+terminal, so its `ask` has always been a refusal"* — while the code went on inferring it from a file
+descriptor and getting the opposite answer. A comment asserting what the code does not do.
+
+Three things now hold, and each is tested below because each fails differently: the API declares
+that no human is present instead of leaving it to be guessed; the desktop shell hands the backend a
+stdin that tells the truth; and a prompt that is somehow still reached cannot block forever.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import chimera.sandbox.confirm as confirm_mod
+from chimera.sandbox.confirm import (
+    _answer_or_refuse,
+    _human_can_answer,
+    declare_no_human_here,
+    resolve_host_exec_confirm,
+)
+
+
+class _Settings:
+    def __init__(self, sandbox: str = "local", host_exec: str = "ask") -> None:
+        self.sandbox = sandbox
+        self.host_exec = host_exec
+
+
+class _FakeStdin:
+    """A stdin that claims to be a terminal — exactly what the packaged sidecar sees."""
+
+    def isatty(self) -> bool:
+        return True
+
+
+# --------------------------------------------------------------------------- the declaration
+
+
+def test_a_declared_surface_refuses_even_when_stdin_claims_a_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The defect, reproduced and closed. `isatty()` is True here, as it is in the shipped app."""
+    monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin())
+    assert _human_can_answer() is True  # the control: without the declaration, it would prompt
+
+    declare_no_human_here("test")
+    assert _human_can_answer() is False
+    gate = resolve_host_exec_confirm(_Settings("local", "ask"))
+    assert gate is not confirm_mod._prompt
+    assert gate is not None and gate("rm -rf /") is False
+
+
+def test_a_real_terminal_still_gets_its_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control. Someone running `chimera solve` in their own terminal is the case the gate was
+    written for, and a fix that refuses everywhere would be a different bug, not a fix."""
+    monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin())
+    assert resolve_host_exec_confirm(_Settings("local", "ask")) is confirm_mod._prompt
+
+
+def test_the_declaration_does_not_override_allow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`allow` is an explicit choice by the person who installed this; a headless surface is not a
+    reason to overrule it. Refusing here would break every unattended install that opted in."""
+    monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin())
+    declare_no_human_here("test")
+    assert resolve_host_exec_confirm(_Settings("local", "allow")) is None
+
+
+# --------------------------------------------------------------------------- the API declares it
+
+
+def test_building_the_api_declares_it(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Mechanism to wiring — the half that actually shipped broken. Serving HTTP means the caller is
+    a client, not somebody watching this process's terminal, and one declaration at the top of
+    `build_api_app` is what keeps every surface under it from having to remember."""
+    monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin())
+    assert _human_can_answer() is True
+
+    from chimera.api import build_api_app
+    from chimera.config import Settings
+
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"))  # type: ignore[call-arg]
+    build_api_app(lambda: None, settings=settings)  # type: ignore[arg-type,return-value]
+    assert _human_can_answer() is False
+
+
+# --------------------------------------------------------------------------- the prompt is bounded
+
+
+def test_a_prompt_that_never_answers_refuses_instead_of_hanging() -> None:
+    """The backstop, and the property that was missing: the old prompt could not fail, only stall.
+
+    `except Exception` cannot catch this — blocking is not an exception. A read from a console with
+    no window simply never returns.
+    """
+    started, release = threading.Event(), threading.Event()
+
+    def _never_answers() -> bool:
+        started.set()
+        # Bounded, and released in the `finally` below. A literal `sleep(3600)` would model the
+        # real hang more faithfully and leave an hour-long thread behind on every run — which is
+        # exactly the kind of debris that turns a sabotage run into a stall instead of a failure.
+        release.wait(30)
+        return True
+
+    original = confirm_mod.PROMPT_TIMEOUT_SECONDS
+    confirm_mod.PROMPT_TIMEOUT_SECONDS = 0.2
+    try:
+        began = time.monotonic()
+        assert _answer_or_refuse(_never_answers, "the prompt nobody could see") is False
+        elapsed = time.monotonic() - began
+    finally:
+        confirm_mod.PROMPT_TIMEOUT_SECONDS = original
+        release.set()
+
+    assert started.is_set(), "the prompt never ran, so this proved nothing about waiting for it"
+    assert elapsed < 15, f"refused, but only after {elapsed:.1f}s — that is still a hang"
+
+
+def test_the_waiting_thread_cannot_keep_the_process_alive() -> None:
+    """A daemon, deliberately. The stuck prompt is unkillable — nothing can interrupt a blocking
+    console read — so the only question left is whether it also prevents shutdown. It must not."""
+    release = threading.Event()
+    original = confirm_mod.PROMPT_TIMEOUT_SECONDS
+    confirm_mod.PROMPT_TIMEOUT_SECONDS = 0.1
+    try:
+        _answer_or_refuse(lambda: bool(release.wait(30)), "x")
+        stuck = [t for t in threading.enumerate() if t.name == "host-exec-confirm"]
+        assert stuck, "control failed: no waiting thread was left, so daemon-ness is untested here"
+        assert all(t.daemon for t in stuck)
+    finally:
+        confirm_mod.PROMPT_TIMEOUT_SECONDS = original
+        release.set()
+
+
+def test_an_answer_that_arrives_in_time_is_returned_faithfully() -> None:
+    """The control for the two above. A timeout that swallowed real answers would refuse everything
+    a human approved, which is the same class of harm pointing the other way."""
+    assert _answer_or_refuse(lambda: True, "ls") is True
+    assert _answer_or_refuse(lambda: False, "ls") is False
+
+
+def test_a_prompt_that_raises_still_refuses() -> None:
+    """Fail-safe survives being moved onto another thread — an exception there is invisible to the
+    caller's `except`, so the refusal has to be decided by the absence of an answer."""
+
+    def _explodes() -> bool:
+        raise RuntimeError("no console")
+
+    assert _answer_or_refuse(_explodes, "ls") is False
+
+
+# --------------------------------------------------------------------------- the launcher's half
+
+
+def test_the_desktop_shell_hands_the_backend_a_stdin_that_tells_the_truth() -> None:
+    """The other half, in the other language, and the reason it is asserted as text: this file
+    cannot spawn a Tauri shell, and leaving the Rust side untested would leave the fix depending on
+    a line nobody would notice being deleted. Read together with the comment above it, which says
+    why `CREATE_NO_WINDOW` and an inherited stdin cannot both stand.
+    """
+    main_rs = Path(__file__).resolve().parents[1] / "apps/desktop/src-tauri/src/main.rs"
+    source = main_rs.read_text(encoding="utf-8")
+    spawn = source[source.index("let mut cmd = Command::new(&exe);") :][:1500]
+    assert re.search(r"\.stdin\(Stdio::null\(\)\)", spawn), (
+        "the backend is spawned with an inherited stdin again; under CREATE_NO_WINDOW that is a "
+        "console with no window, and isatty() will lie to the host-exec gate"
+    )
+
+
+def test_the_code_surface_no_longer_asserts_what_it_cannot_enforce() -> None:
+    """The comment that was true as intent and false as description. It is allowed to say the ask
+    resolves to a refusal only because something now makes that so."""
+    code_api = Path(__file__).resolve().parents[1] / "chimera/api/code_api.py"
+    text = code_api.read_text(encoding="utf-8")
+    assert "declare_no_human_here" in text, (
+        "code_api still explains the refusal without naming whatever now produces it"
+    )


### PR DESCRIPTION
## What happens

The installed app **stops permanently** the first time the agent chooses to run a command. Not slow — stopped. No frame, no error, no timeout, and `POST /api/runs/{id}/cancel` answering `{"ok": true}` indefinitely about a run that cannot be stopped. Found by driving the shipped rc39 build; deterministic, 3/3.

Three threads of the running build, from a live stack dump:

```
confirm    (click/termui.py)          <- reading stdin, blocked
_prompt    (chimera/sandbox/confirm.py)
run        (chimera/tools/shell.py)
_run_tool  (chimera/core/agent.py)
...
work       (chimera/api/app.py)
```

Blast radius: the Code screen, `/api/runs`, the lifecycle screen, every cron job. Present since the console was hidden (#130), about thirty-five releases ago, and it is the first thing a new user hits.

## Why

`resolve_host_exec_confirm` chose between prompting and refusing with `sys.stdin.isatty()`.

The desktop shell spawns the frozen sidecar under `CREATE_NO_WINDOW`, and Windows honours that by giving the child a console **with no window**. stdin is a character device, `isatty()` says yes, and there is nobody there. So the gate drew a confirmation prompt somewhere no human could ever see and waited for an answer that could never come. `except Exception` around it does not help: blocking is not an exception.

The control isolates the apparatus — same model, same folder, same tool loop, with the shell tools denied: **12.6 s**. Without: never returns.

**And the invariant was already written down.** `chimera/api/code_api.py` says, in a comment beside the call:

> `resolve_host_exec_confirm` answers None for "no gate", a refusal for `deny`, and a terminal prompt for `ask` — and this surface has no terminal, so its `ask` has always been a refusal.

True as intent, false as description. The code went on inferring it from a file descriptor and getting the opposite answer.

## What changed

Three things, each failing differently, each tested:

| | |
|---|---|
| **Declaration beats inference** | `build_api_app` calls `declare_no_human_here("http api")` once. Serving HTTP means the caller is a client, not somebody watching this process's terminal — and asking that terminal to approve a command a *remote request* wants to run would be the wrong question even if a person were there. One place, so no surface has to remember. |
| **The file descriptor stops lying** | The Tauri launcher hands the backend `Stdio::null()`. Inherited stdin plus `CREATE_NO_WINDOW` is what produces the console with no window; both halves stay, because one makes the descriptor truthful and the other makes the answer independent of it. |
| **The prompt is bounded** | A confirm that is somehow still reached runs on a daemon thread with a deadline. A refusal after two minutes is recoverable; a permanent hang is not — and a stuck prompt can no longer hold the process open either. |

**Behaviour after the fix is the documented behaviour**: unattended `ask` refuses and says how to proceed deliberately (`CHIMERA_HOST_EXEC=allow`, or `CHIMERA_SANDBOX=docker` to run isolated), and the Code screen's workspace-and-shell reach ungates host execution exactly as it did before. Nothing that worked stops working; what hung now answers.

Also corrects the module docstring, which still described the pre-refusal headless behaviour ("run with a one-time warning") that the code stopped doing when the refusal landed.

## Verification

- **7 sabotages, 7 caught**, each confirmed present in the file on disk before the run was read. Two of them initially came back with **no verdict at all** rather than a failure: sabotaging the deadline or the daemon flag made the *test* hang, which is a stall, not a signal. The tests were rewritten to use a released `Event` instead of a long sleep, and both then caught their sabotage properly.
- The Rust half is asserted from Python, deliberately: this suite cannot spawn a Tauri shell, and leaving it untested would leave the fix depending on a line nobody would notice being deleted.
- Full suite **4138 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces identically on pristine `origin/main` — environmental, the WSL venv lagging a release cut.
- `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)