### PR TITLE
fix: two more found by using rc39 — a missing tool, and a spec that vouched for itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,31 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **`--gen-tests` threw the work away on any machine without pytest, and the receipt blamed a test.**
+  Asked for a file with a function in it, the run wrote the file, generated a test for it, and came
+  back `verified: false · reverted: true · evidence: "verifier"` over
+  `python.exe: No module named pytest`. `python -m pytest` with no pytest installed exits **1** —
+  the same code every runner uses for "your tests failed" — so the 5/127 no-verdict codes never saw
+  it, and `program_missing` correctly answered that the *binary* was there. It is the same class of
+  bug the 127 handling exists to prevent, arriving through the `-m` door. The message is matched
+  here, where it was rightly refused for `cmd.exe`, because it comes from Python's own runpy rather
+  than a localised shell — and only in its unquoted form, so a traceback from code under test
+  failing to import stays a failure. **A second defect sat on top of it:** `SpecTestVerifier` wrapped
+  the runner's result and dropped `abstained`, so fixing only the first would have turned a wrong
+  failure into a confident wrong pass, `evidence: "verifier"` and all. The audience is the point —
+  spec-test generation exists for the person who is not a Python developer, so "pytest is not
+  installed" is the expected state of their machine, not an edge case.
+- **Two specs in a folder, and the project passed with nothing built.** The drift gate searches every
+  `contains` regex across every text file, and a spec repeats in its own `text` and `target` fields
+  the words those regexes look for — so a spec sitting in the folder it judges is evidence for
+  itself. That was found and fixed by excluding the spec being checked. Only that one file: measured
+  on an empty folder, one spec reports **0/5 satisfied**, and the same spec copied to a second
+  filename reports **5/5, aligned**. Nor is the second file hypothetical — the drafting flow derives
+  the filename from the project slug, so changing your mind about the name produces it through the
+  ordinary path. Now a file that is itself a spec is never evidence that a spec is satisfied,
+  decided by shape rather than filename, because a rule that trusts the name is a rule a rename
+  defeats. Ordinary project YAML is still scanned: a gate that excluded too much would be
+  unsatisfiable, which is not a stricter gate but a broken one.
 - **The agent's root was the app's own install folder.** `read_file(".env")` returned
   `OPENROUTER_API_KEY=sk-or-v1-…` in full. Not a sandbox failure — a path outside the root is still
   refused — the root itself was the folder holding the key. `resolve_app_workspace` falls back to

--- a/chimera/core/spec_test.py
+++ b/chimera/core/spec_test.py
@@ -149,4 +149,14 @@ class SpecTestVerifier:
             return VerificationResult(True, f"spec-test: could not write tests ({exc})", abstained=True)
         runner = CommandVerifier(self.command.format(file=_TEST_FILE), self.workspace, timeout=self.timeout)
         result = runner.verify()
-        return VerificationResult(result.passed, f"spec-grounded tests ({_TEST_FILE}):\n{result.output}")
+        # `abstained` is carried, not dropped. Every other exit from this method decides carefully
+        # between passing and abstaining, and then this line — the one path where a real command
+        # ran — threw the distinction away: an abstention arrives here as `passed=True`, so a run
+        # that could not be checked came out as `evidence="verifier"`, a receipt naming a test that
+        # never reached a verdict. Fixing the runner without this line would have made that worse,
+        # by turning a wrong failure into a confident wrong pass.
+        return VerificationResult(
+            result.passed,
+            f"spec-grounded tests ({_TEST_FILE}):\n{result.output}",
+            abstained=result.abstained,
+        )

--- a/chimera/core/verify.py
+++ b/chimera/core/verify.py
@@ -8,6 +8,7 @@ runs a command (tests, a build, a linter) and treats exit code 0 as success — 
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -120,6 +121,38 @@ def program_missing(command: str, workspace: Path | str | None = None) -> bool:
     return shutil.which(program) is None and shutil.which(program, path=str(root)) is None
 
 
+def module_missing(command: str, output: str) -> bool:
+    """True when ``command`` ran a module with ``-m`` and the interpreter said it does not exist.
+
+    :func:`program_missing` asks whether the *binary* is there. This is the same question one level
+    in: ``python -m pytest`` on a machine without pytest finds the binary perfectly well, exits **1**
+    — indistinguishable from "your tests failed" — and prints ``No module named pytest``. Spec-test
+    generation hard-codes exactly that command, and its audience is the person who is not a Python
+    developer, so on their machine the generated test "failed", the attempt was reverted, and the
+    receipt recorded a test failure that never ran. The same class of bug the 127 handling exists to
+    prevent, arriving through the ``-m`` door.
+
+    Matching the message is sound HERE where it was not sound for ``cmd.exe``: this text comes from
+    Python's own runpy, not from a localised shell, and it is the same string on every platform.
+
+    Two discriminations keep a real failure from being reinterpreted, which is the dangerous
+    direction. The module name must be the one the command actually asked for. And the interpreter's
+    unquoted ``No module named pytest`` is required — a traceback from code *under test* failing to
+    import says ``No module named 'pytest'``, with quotes, and must stay a failure.
+    """
+    try:
+        tokens = shlex.split(command, posix=False)
+    except ValueError:
+        return False
+    try:
+        module = tokens[tokens.index("-m") + 1].strip("\"'")
+    except (ValueError, IndexError):
+        return False
+    if not module:
+        return False
+    return re.search(rf"No module named {re.escape(module)}(?![\w'\"])", output) is not None
+
+
 
 @dataclass
 class VerificationResult:
@@ -179,6 +212,12 @@ class CommandVerifier:
             # autonomous loop already demotes an abstention to the no-verifier path, so `evidence`
             # correctly stops being "verifier". We could not check it; we do not claim we did, and we
             # do not punish the work for our own inability.
+            return VerificationResult(True, output, abstained=True)
+        if proc.returncode != 0 and module_missing(self.command, output):
+            # `python -m <tool>` where the tool is not installed: the binary exists, the exit code is
+            # 1, and only the message distinguishes it from a test that failed. Checked after a
+            # non-zero exit for the same reason as the Windows arm below — a command that ran and
+            # genuinely failed must never be reinterpreted as an abstention.
             return VerificationResult(True, output, abstained=True)
         if proc.returncode != 0 and os.name == "nt" and program_missing(self.command, self.workspace):
             # The Windows half of the same abstention. Checked only after a non-zero exit, so a

--- a/chimera/governance/drift.py
+++ b/chimera/governance/drift.py
@@ -16,6 +16,7 @@ a verifier: pass it to ``solve --verify`` to make the spec the executable ground
 
 from __future__ import annotations
 
+import contextlib
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -71,26 +72,80 @@ class DriftReport:
     results: list[RequirementResult]
 
 
-def _scannable(workspace: Path, skip: Path | None) -> Iterator[Path]:
+#: Extensions a spec can be written in. ``yaml.safe_load`` reads JSON too, so both are candidates.
+_SPEC_SUFFIXES = frozenset({".yaml", ".yml", ".json"})
+
+
+def _is_spec_shaped(data: object) -> bool:
+    """Whether a parsed document is a spec — decided by shape, not by filename.
+
+    Deliberately narrow: a name, a non-empty requirement list, and every entry carrying the two
+    fields the drift gate actually reads. A project's ordinary YAML does not look like this, and
+    excluding a file that is not a spec would weaken the scan rather than correct it.
+    """
+    if not isinstance(data, dict) or not isinstance(data.get("name"), str):
+        return False
+    requirements = data.get("requirements")
+    if not isinstance(requirements, list) or not requirements:
+        return False
+    return all(isinstance(r, dict) and "check" in r and "target" in r for r in requirements)
+
+
+def _spec_files(workspace: Path, source: Path | None) -> frozenset[Path]:
+    """Every file under ``workspace`` that is ITSELF a spec, plus ``source`` wherever it lives.
+
+    Skipping only the spec being checked was half a fix. A spec repeats, in its ``text`` and
+    ``target`` fields, the very words its ``contains`` regexes look for, so any spec left in the
+    folder is evidence for itself. Measured: with one spec the guard reports 0/5 satisfied on an
+    empty project, and **copying that spec to a second filename takes it to 5/5, aligned**, with
+    still not a line of code written. That second file is not hypothetical — the drafting flow
+    derives the filename from the project slug, so redrafting with a slightly different name
+    produces it through the ordinary path.
+
+    Shape, not filename, because a rule that trusts the name is a rule an unlucky rename defeats.
+    """
+    import yaml
+
+    found: set[Path] = set()
+    if source is not None:
+        with contextlib.suppress(OSError):
+            found.add(source.resolve())
+    for path in workspace.rglob("*"):
+        if path.is_dir() or path.suffix.lower() not in _SPEC_SUFFIXES:
+            continue
+        if any(part in _IGNORE_DIRS for part in path.relative_to(workspace).parts):
+            continue
+        try:
+            if path.stat().st_size > _MAX_FILE_BYTES:
+                continue
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, yaml.YAMLError):
+            continue
+        if _is_spec_shaped(data):
+            with contextlib.suppress(OSError):
+                found.add(path.resolve())
+    return frozenset(found)
+
+
+def _scannable(workspace: Path, skip: frozenset[Path]) -> Iterator[Path]:
     """Every file the checks are allowed to read. One place, so ``skip`` cannot be honoured by one
     check and forgotten by another — the positive and negative scans disagreeing about what counts
     as evidence would be worse than either rule alone."""
-    ignore = skip.resolve() if skip else None
     for path in workspace.rglob("*"):
         if path.is_dir():
             continue
         if any(part in _IGNORE_DIRS for part in path.relative_to(workspace).parts):
             continue
-        if ignore is not None:
+        if skip:
             try:
-                if path.resolve() == ignore:
+                if path.resolve() in skip:
                     continue
             except OSError:
                 pass
         yield path
 
 
-def _iter_text(workspace: Path, skip: Path | None = None) -> Iterator[str]:
+def _iter_text(workspace: Path, skip: frozenset[Path] = frozenset()) -> Iterator[str]:
     for path in _scannable(workspace, skip):
         try:
             if path.stat().st_size > _MAX_FILE_BYTES:
@@ -100,12 +155,12 @@ def _iter_text(workspace: Path, skip: Path | None = None) -> Iterator[str]:
             continue
 
 
-def _present(workspace: Path, pattern: str, skip: Path | None = None) -> bool:
+def _present(workspace: Path, pattern: str, skip: frozenset[Path] = frozenset()) -> bool:
     regex = re.compile(pattern)
     return any(regex.search(text) for text in _iter_text(workspace, skip))
 
 
-def _scan_absent(workspace: Path, pattern: str, skip: Path | None = None) -> tuple[bool, list[str]]:
+def _scan_absent(workspace: Path, pattern: str, skip: frozenset[Path] = frozenset()) -> tuple[bool, list[str]]:
     """For a negative (``absent``) check: return (pattern_found, unscannable_files).
 
     ``_iter_text`` silently skips oversized (> 1 MB) and undecodable files. For a POSITIVE check
@@ -166,12 +221,12 @@ def _defines_pattern(name: str) -> re.Pattern[str]:
     )
 
 
-def _defined(workspace: Path, name: str, skip: Path | None = None) -> bool:
+def _defined(workspace: Path, name: str, skip: frozenset[Path] = frozenset()) -> bool:
     regex = _defines_pattern(name)
     return any(regex.search(text) for text in _iter_text(workspace, skip))
 
 
-def _check(requirement: Requirement, workspace: Path, skip: Path | None = None) -> tuple[bool, str]:
+def _check(requirement: Requirement, workspace: Path, skip: frozenset[Path] = frozenset()) -> tuple[bool, str]:
     if requirement.check == "defines":
         ok = _defined(workspace, requirement.target, skip)
         return ok, "" if ok else f"'{requirement.target}' is not defined"
@@ -200,10 +255,13 @@ def _check(requirement: Requirement, workspace: Path, skip: Path | None = None) 
 def check_drift(spec: Spec, workspace: Path) -> DriftReport:
     """Check the workspace against the spec; ``aligned`` is False if anything drifted."""
     root = Path(workspace).resolve()
+    # Computed ONCE per report, not per requirement: it walks the tree and parses candidates, and
+    # every check below asks the same question about the same files.
+    skip = _spec_files(root, spec.source)
     results: list[RequirementResult] = []
     aligned = True
     for requirement in spec.requirements:
-        ok, detail = _check(requirement, root, spec.source)
+        ok, detail = _check(requirement, root, skip)
         results.append(RequirementResult(requirement.id, ok, detail))
         if requirement.required and not ok:
             aligned = False

--- a/tests/test_a_second_spec_is_not_evidence_either.py
+++ b/tests/test_a_second_spec_is_not_evidence_either.py
@@ -1,0 +1,116 @@
+"""One spec was excluded from its own scan. Two specs, and the project passed with nothing built.
+
+The drift gate searches every `contains` regex across every text file in the workspace. A spec
+repeats, in its `text` and `target` fields, the very words those regexes look for — so a spec
+sitting in the folder it judges is evidence for itself. That was found and fixed by excluding
+`spec.source`: the exact file being checked.
+
+Measured on the shipped rc39, in an empty folder:
+
+    one spec  ................. 0/5 satisfied, aligned=False   <- the fix working
+    the same spec, copied ..... 5/5 satisfied, aligned=True    <- with no code written
+
+Only the file being checked was skipped, so any *other* spec in the folder was still scanned and
+still contained the answers. And the second file is not hypothetical: the drafting flow derives the
+filename from the project slug, so redrafting a project with a slightly different name produces it
+through the ordinary path — no unusual act required, just changing your mind about the name.
+
+The rule is now "a file that is itself a spec is not evidence that a spec is satisfied", decided by
+shape rather than filename, because a rule that trusts the name is a rule a rename defeats.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from chimera.governance.drift import Spec, check_drift, load_spec
+
+_SPEC = {
+    "name": "padaria aurora",
+    "requirements": [
+        {"id": "r1", "text": "a página inicial existe", "check": "contains", "target": "Padaria Aurora"},
+        {"id": "r2", "text": "há um cardápio", "check": "contains", "target": "cardapio"},
+        {"id": "r3", "text": "há um formulário de contato", "check": "contains", "target": "contato"},
+    ],
+}
+
+
+def _write(path: Path, data: object) -> Path:
+    path.write_text(yaml.safe_dump(data, allow_unicode=True), encoding="utf-8")
+    return path
+
+
+def test_one_spec_does_not_satisfy_itself(tmp_path: Path) -> None:
+    """The control, and the fix that already existed: an empty project satisfies nothing."""
+    spec = load_spec(_write(tmp_path / "padaria.spec.yaml", _SPEC))
+    report = check_drift(spec, tmp_path)
+    assert report.aligned is False
+    assert [r.satisfied for r in report.results] == [False, False, False]
+
+
+def test_a_second_spec_does_not_satisfy_the_first(tmp_path: Path) -> None:
+    """The defect. Same empty project, one extra file, and it used to report 3/3 aligned."""
+    spec = load_spec(_write(tmp_path / "padaria.spec.yaml", _SPEC))
+    _write(tmp_path / "padaria-aurora-doces.spec.yaml", _SPEC)  # what redrafting produces
+
+    report = check_drift(spec, tmp_path)
+    assert report.aligned is False, "a copy of the spec is still being read as the work"
+    assert [r.satisfied for r in report.results] == [False, False, False]
+
+
+def test_a_spec_under_any_name_is_still_a_spec(tmp_path: Path) -> None:
+    """Shape, not filename. Excluding `*.spec.yaml` would have been the easy rule and an
+    unlucky rename would walk straight through it."""
+    spec = load_spec(_write(tmp_path / "padaria.spec.yaml", _SPEC))
+    _write(tmp_path / "notes.yml", _SPEC)
+
+    assert check_drift(spec, tmp_path).aligned is False
+
+
+def test_the_spec_being_checked_need_not_live_in_the_workspace(tmp_path: Path) -> None:
+    """The original guard still holds when the spec is kept outside the folder it judges."""
+    elsewhere, project = tmp_path / "elsewhere", tmp_path / "project"
+    elsewhere.mkdir()
+    project.mkdir()
+    spec = load_spec(_write(elsewhere / "s.yaml", _SPEC))
+
+    assert check_drift(spec, project).aligned is False
+
+
+def test_real_work_still_satisfies_the_spec(tmp_path: Path) -> None:
+    """The control that matters most: a rule which excluded too much would make the gate
+    unsatisfiable, and an unsatisfiable gate is not a stricter gate — it is a broken one."""
+    spec = load_spec(_write(tmp_path / "padaria.spec.yaml", _SPEC))
+    (tmp_path / "index.html").write_text(
+        "<h1>Padaria Aurora</h1><a href='#cardapio'>cardapio</a><form id='contato'></form>",
+        encoding="utf-8",
+    )
+    report = check_drift(spec, tmp_path)
+    assert report.aligned is True
+    assert all(r.satisfied for r in report.results)
+
+
+def test_ordinary_project_yaml_is_still_scanned(tmp_path: Path) -> None:
+    """The other side of the same risk. Only a document shaped like a spec leaves the scan; a
+    config file that happens to be YAML is still evidence, or the gate would quietly stop
+    reading half of a real project."""
+    spec = Spec(
+        name="s",
+        requirements=[{"id": "r1", "check": "contains", "target": "postgres"}],  # type: ignore[list-item]
+    )
+    _write(tmp_path / "docker-compose.yml", {"services": {"db": {"image": "postgres:16"}}})
+
+    assert check_drift(spec, tmp_path).aligned is True
+
+
+def test_a_yaml_that_is_not_a_spec_is_not_mistaken_for_one(tmp_path: Path) -> None:
+    """`name` plus a `requirements` list is not enough — the entries must carry what the gate
+    reads. A python project's own metadata should never be silently excluded."""
+    from chimera.governance.drift import _is_spec_shaped
+
+    assert _is_spec_shaped({"name": "pkg", "requirements": ["fastapi>=0.1", "pydantic"]}) is False
+    assert _is_spec_shaped({"name": "pkg", "requirements": []}) is False
+    assert _is_spec_shaped({"requirements": [{"check": "contains", "target": "x"}]}) is False
+    assert _is_spec_shaped({"name": "s", "requirements": [{"check": "contains", "target": "x"}]}) is True

--- a/tests/test_the_tool_that_was_not_installed.py
+++ b/tests/test_the_tool_that_was_not_installed.py
@@ -1,0 +1,141 @@
+"""`python -m pytest` on a machine without pytest is not a failing test.
+
+Found by driving the shipped rc39 build. Asked for a file with a function in it, with
+``gen_tests`` on, the run wrote the file, generated a test for it, and came back:
+
+    verified: false · reverted: true · evidence: "verifier"
+    diff: +1 new (soma.py)
+    verify_output: spec-grounded tests (test_chimera_spec.py):
+                   C:\\...\\python.exe: No module named pytest
+
+The work was correct. The generator worked. Nothing ran the tests, and the attempt was reverted
+for it — with `evidence: "verifier"` in the receipt, naming a verdict that was never reached.
+
+Two independent defects, and either one alone still loses the work:
+
+1. `python -m pytest` with no pytest installed exits **1** — the same code every runner uses for
+   "your tests failed" — so `_NO_VERDICT` (5, 127) never saw it and `program_missing` answered
+   "the program is there", which is true and beside the point. It is the same class of bug the 127
+   handling exists to prevent, arriving through the `-m` door.
+2. `SpecTestVerifier.verify` wrapped the runner's result and **dropped `abstained`**. Every other
+   exit in that method chooses carefully between passing and abstaining; the one path where a real
+   command ran threw the distinction away. Fixing only (1) would have turned a wrong failure into a
+   confident wrong pass, which is worse.
+
+And the audience is the point. `gen_tests` exists for the person who is not a Python developer —
+the same person the app invites to describe a project instead of writing its YAML — so "pytest is
+not installed" is the *expected* state of their machine, not an edge case.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from chimera.core.checklist import Requirement
+from chimera.core.spec_test import SpecTestVerifier
+from chimera.core.verify import CommandVerifier, module_missing
+
+#: A module name no environment will ever have installed, so the interpreter really does print the
+#: message rather than us pretending it did.
+ABSENT = "chimera_module_that_does_not_exist"
+
+
+class _Generator:
+    """Stands in for the LLM: returns whatever test source the case needs."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+
+    def generate(self, task: str, requirements: list[Requirement], code_context: str = "") -> str:
+        return self.code
+
+
+# --------------------------------------------------------------------------- the predicate
+
+
+def test_the_interpreter_saying_the_module_is_absent_is_recognised() -> None:
+    out = f"C:\\Python\\python.exe: No module named {ABSENT}\n"
+    assert module_missing(f"python -m {ABSENT} -q file.py", out) is True
+
+
+def test_a_traceback_from_the_code_under_test_is_not() -> None:
+    """The discrimination that keeps a real failure a failure. Python's own message is unquoted;
+    an `import pytest` failing inside the tests raises `ModuleNotFoundError: No module named
+    'pytest'`, with quotes. Reading the second as "the tool is absent" would abstain on a genuine
+    error, and abstention KEEPS the work — the dangerous direction of this bug."""
+    quoted = f"ModuleNotFoundError: No module named '{ABSENT}'\n"
+    assert module_missing(f"python -m {ABSENT} -q file.py", quoted) is False
+
+
+def test_a_different_module_does_not_count() -> None:
+    out = "python: No module named something_else\n"
+    assert module_missing(f"python -m {ABSENT}", out) is False
+
+
+def test_a_command_without_dash_m_never_matches() -> None:
+    out = f"No module named {ABSENT}\n"
+    assert module_missing("pytest -q", out) is False
+    assert module_missing("", out) is False
+
+
+def test_a_prefix_of_the_module_name_does_not_count() -> None:
+    """`-m pytest` must not be satisfied by `No module named pytest_asyncio`."""
+    assert module_missing("python -m pytest", "No module named pytest_asyncio\n") is False
+
+
+# --------------------------------------------------------------------------- the verifier
+
+
+def test_a_missing_module_abstains_instead_of_failing(tmp_path: Path) -> None:
+    """Run for real, no mocking: the interpreter is asked for a module that does not exist, and its
+    actual exit code and actual message are what the verifier sees."""
+    result = CommandVerifier(f"{sys.executable} -m {ABSENT}", tmp_path).verify()
+    assert result.abstained is True
+    assert result.passed is True  # abstention keeps the work; the other gates decide
+
+
+def test_a_command_that_really_failed_still_fails(tmp_path: Path) -> None:
+    """The control. A verifier that abstained on everything would keep every change ever made."""
+    result = CommandVerifier(f'{sys.executable} -c "import sys; sys.exit(1)"', tmp_path).verify()
+    assert result.abstained is False
+    assert result.passed is False
+
+
+def test_a_command_that_passed_still_passes(tmp_path: Path) -> None:
+    result = CommandVerifier(f'{sys.executable} -c "pass"', tmp_path).verify()
+    assert result.passed is True
+    assert result.abstained is False
+
+
+# --------------------------------------------------------------------------- the wrapper
+
+
+def test_the_spec_verifier_carries_the_abstention_out(tmp_path: Path) -> None:
+    """The second defect, and the one that would have made fixing the first actively harmful: an
+    abstention arrives with `passed=True`, so dropping the flag reports a confident pass and writes
+    `evidence="verifier"` about a test that never reached a verdict."""
+    verifier = SpecTestVerifier(
+        _Generator("def test_ok() -> None:\n    assert True\n"),  # type: ignore[arg-type]
+        "build soma.py",
+        [Requirement(text="soma(a, b) returns a + b")],
+        tmp_path,
+        command=f"{sys.executable} -m {ABSENT} " + "{file}",
+    )
+    result = verifier.verify()
+    assert result.abstained is True, "the abstention was swallowed on the way out again"
+
+
+def test_the_spec_verifier_still_reports_a_real_failure(tmp_path: Path) -> None:
+    """The control for the wrapper: a generated test that genuinely fails is a true negative the
+    gate must heed, and carrying `abstained` must not turn every result into an abstention."""
+    verifier = SpecTestVerifier(
+        _Generator("def test_no() -> None:\n    assert False\n"),  # type: ignore[arg-type]
+        "build soma.py",
+        [Requirement(text="soma(a, b) returns a + b")],
+        tmp_path,
+        command=f"{sys.executable} -m pytest -q " + "{file}",
+    )
+    result = verifier.verify()
+    assert result.abstained is False
+    assert result.passed is False


### PR DESCRIPTION
Two independent defects found by driving the shipped rc39 build, one commit each. Neither touches `chimera/core/autonomous.py`, so this is conflict-free against #240 and #241.

## 1. A tool that is not installed is not a failing test

With `--gen-tests` on, a run that did the work correctly came back:

```
verified: false · reverted: true · evidence: "verifier"
diff: +1 new (soma.py)
verify_output: spec-grounded tests (test_chimera_spec.py):
               C:\...\python.exe: No module named pytest
```

The work was thrown away and the receipt blamed a test that never ran.

`python -m pytest` with no pytest installed exits **1** — the same code every runner uses for "your tests failed" — so `_NO_VERDICT` (5, 127) never saw it, and `program_missing` correctly answered that the *binary* was there. It is the same class of bug the 127 handling exists to prevent, arriving through the `-m` door.

Matching the message is sound here where it was rightly refused for `cmd.exe`: this text comes from Python's own runpy, not from a localised shell. Two discriminations keep a genuine failure from being reinterpreted, which is the dangerous direction — the module must be the one the command asked for, and the interpreter's **unquoted** `No module named pytest` is required, because a traceback from code *under test* says `No module named 'pytest'`, with quotes, and must stay a failure.

**A second defect sat on top of it.** `SpecTestVerifier.verify` wrapped the runner's result and **dropped `abstained`**. Every other exit in that method chooses carefully between passing and abstaining; the one path where a real command ran threw the distinction away, so an abstention arrived as `passed=True` and wrote `evidence: "verifier"`. Fixing only the first would have turned a wrong failure into a confident wrong pass.

The audience is the point: spec-test generation exists for the person who is *not* a Python developer — the same person the app invites to describe a project instead of writing its YAML — so "pytest is not installed" is the expected state of their machine, not an edge case.

## 2. A second spec in the folder was still evidence for the first

The drift gate searches every `contains` regex across every text file, and a spec repeats in its own `text` and `target` fields the words those regexes look for. A spec sitting in the folder it judges is evidence for itself. That was found and fixed by excluding `spec.source` — the exact file being checked, and only that one.

Measured on an empty folder:

| | satisfied | aligned |
|---|---|---|
| one spec | **0/5** | False |
| the same spec, copied to a second name | **5/5** | **True** |

with not a line of code written. And the second file is not hypothetical: the drafting flow derives the filename from the project slug, so changing your mind about a project's name produces it through the ordinary path.

A file that is itself a spec is now never evidence that a spec is satisfied — decided by **shape** rather than filename, because a rule that trusts the name is a rule a rename defeats. Deliberately narrow: a name, a non-empty requirement list, and entries carrying the two fields the gate actually reads. **Ordinary project YAML is still scanned**, and there is a test for it: a gate that excluded too much would be unsatisfiable, which is not a stricter gate but a broken one.

## Verification

- **7 sabotages, 7 caught**, each confirmed present in the file on disk before the run was read — including one for each direction of the risk (the check never firing, and the check firing on a real failure).
- Full suite **4145 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces identically on pristine `origin/main` — environmental.
- `ruff` and `mypy` clean.

## Still open from the same testing session

The third defect — **the reviewer never sees the artifact**, so it fails work the run's own diff proves was done — touches `autonomous.py` and therefore collides with #240. It is being done on top of that branch rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)