### PR TITLE
fix(runs): the reviewer judged a paragraph and called it judging the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,22 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — the rest
 
+- **The reviewer judged a paragraph and called it judging the work.** `Manager.review` receives
+  `(task, answer, context)` and had never seen the diff, the transcript or a single file — stated in
+  this repository's own test docstrings for months without the consequence being drawn. Measured on
+  the shipped rc39: four runs, five attempts, **five rejections**, every one for work the receipt
+  beside it proves was done. The cleanest reads *"the README.md must be physically created, not
+  merely described as created"* on an attempt whose receipt carries
+  `diff: +1 new (README.md)` and `diff_productive: true` — the refutation of the stated reason,
+  filed with the rejection. Under verify-or-revert the file was then deleted; and the failure was
+  distilled into a permanent anti-pattern skill card, so the hallucination outlived the run that
+  produced it. The reviewer is now shown what the attempt changed on disk, which meant moving the
+  diff computation ahead of the review — it used to run after every gate had already voted, so the
+  machine truth existed only as a description of a verdict already sealed. **Evidence, not
+  criterion**, and the distinction is load-bearing: a recalled fact from another project can make
+  something enforceable that nobody agreed to, which is the leak the previous release closed, while
+  a diff can only describe what the answer is a claim *about*. It cannot add a requirement; it can
+  only stop the reviewer being wrong about whether the work happened.
 - **A judge that could not read scored the work zero, and the work was deleted for it.**
   `model_judge` asks a model for a number in [0, 1] and returned `0.0` whenever the reply held
   none — a refusal, an empty completion, a provider error string, an answer in the wrong language.

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -297,6 +297,11 @@ class AutonomousResult:
     stopped_reason: str = ""  # why the loop ended early; "cancelled" on a cooperative stop, else ""
 
 
+#: Char budget for the diff bodies handed to the reviewer. Enough to show what a small edit did
+#: without turning every review into a second copy of the repository.
+_JUDGE_DIFF_CHARS = 4000
+
+
 class AutonomousAgent:
     """Runs a task autonomously with planning, supervision and verify-or-revert."""
 
@@ -741,13 +746,86 @@ class AutonomousAgent:
             # authoritative — treat this attempt as if there were no verifier, so the Manager review
             # and the coverage checklist still run instead of accepting on an empty non-block.
             verifier_active = self.verifier is not None and not abstained
+
+            # MOVED UP, ahead of the review. It used to be computed after every gate had already
+            # voted, which left the reviewer judging the answer's PROSE with no way to know what
+            # the attempt did to the disk. Nothing between here and the old position writes to the
+            # workspace — the contract, the coverage checklist and the strong verifier all read
+            # text — so the numbers are identical. They are simply available in time to be
+            # evidence instead of only a description.
+            # Diff-gate (nanobot "Dream"): certify what the attempt *actually* changed from the
+            # real workspace snapshot, BEFORE any revert — the machine truth, not the model's claim.
+            # Computed BEFORE the Attempt is finalized so --require-diff can act on it: the gate has to
+            # be able to fail the attempt, not just describe it after the verdict is already sealed.
+            diff_productive: bool | None = None
+            diff_summary: str | None = None
+            diffs: list[FileDiff] = []
+            if snapshot is not None and self.guard is not None:
+                from chimera.evolution.diff_gate import diff_snapshots, unified_diffs
+
+                after = self.guard.snapshot()  # one capture feeds both the summary and the per-file diffs
+                last_after = after  # remember for --keep-workspace (restored after the loop if it fails)
+                # `--gen-tests` writes its test file INTO the workspace, and it does so between the
+                # two snapshots (`_verify()` runs above). Left in, the verifier's own artifact counts
+                # as the run's work: `is_productive` becomes True on every attempt, so `--require-diff`
+                # — the gate that exists because SWE-bench run 1 returned 11/19 empty patches — can
+                # never fire while tests are being generated. With `--diff-feedback` it is worse than
+                # inert: the retry is handed the test file under "you already tried this and FAILED",
+                # feedback about an edit the model did not make.
+                after = _without_verifier_artifacts(after)
+                pdiff = diff_snapshots(snapshot, after)
+                diff_productive = pdiff.is_productive
+                diff_summary = pdiff.audit_summary()
+                diffs = unified_diffs(snapshot, after)  # real diffs, BEFORE any revert below
+
+            # What the attempt actually did, handed to the reviewer as EVIDENCE.
+            #
+            # The reviewer receives `(task, answer, context)` and has never seen the diff, the
+            # transcript or a single file — a fact tests/test_success_gate.py had already written
+            # down without drawing the consequence. Measured on rc39: four runs, five attempts,
+            # five rejections, every one for work the receipt's own `diff_summary` proves was done.
+            # One verbatim, "the README.md must be physically created, not merely described as
+            # created", on an attempt whose receipt reads `diff: +1 new (README.md)` and
+            # `diff_productive: true`. Under verify-or-revert the file was then deleted, and the
+            # failure was distilled into a permanent anti-pattern card — so the hallucination
+            # outlived the run that produced it.
+            #
+            # This is evidence, NOT a criterion, and that distinction is the whole point of the
+            # narrowing above: a recalled fact from another project can make something enforceable
+            # that nobody agreed to, while a diff can only describe what the answer is a claim
+            # ABOUT. It cannot add a requirement; it can only stop the reviewer being wrong about
+            # whether the work happened.
+            evidence_ctx = ""
+            if diff_summary:
+                bodies: list[str] = []
+                budget = _JUDGE_DIFF_CHARS
+                for file_diff in diffs:
+                    if budget <= 0:
+                        break
+                    body = file_diff.patch[:budget]
+                    budget -= len(body)
+                    bodies.append("--- " + file_diff.path + "\n" + body)
+                evidence_ctx = (
+                    "<<what-this-attempt-changed-on-disk>>\n"
+                    + diff_summary
+                    + "\n"
+                    + "\n".join(bodies)
+                    + "\n<<end>>"
+                )
+            # No branch for "measured and nothing changed": `audit_summary()` already says
+            # `diff: no productive change`, so that case arrives through the line above with the
+            # distinction intact. A second branch for it would have been dead code — written, and
+            # caught by the test that asserted the wrong sentence.
+            attempt_judge_context = (
+                (judge_context + "\n\n" + evidence_ctx).strip() if evidence_ctx else judge_context
+            )
             # PROBE proxy (M18-5): in probe mode compute the cheap manager judgment even on a passing
             # attempt, so the logged (proxy, reward) pair is unbiased; reused below → no extra call.
             probe_proxy: bool | None = None
             proxy_fb = ""
             proxy_abstained = False
             if self.probe_log is not None and self.manager is not None:
-                probe_proxy, proxy_fb, proxy_abstained = self._review(task, answer, judge_context)
+                probe_proxy, proxy_fb, proxy_abstained = self._review(task, answer, attempt_judge_context)
             # Whether a manager actually judged THIS attempt, as opposed to being configured. Only
             # a real judgment may be named as one in the receipt below.
             review_abstained = True
@@ -760,9 +838,9 @@ class AutonomousAgent:
                 elif probe_proxy is not None:
                     approved, fb, review_abstained = probe_proxy, proxy_fb, proxy_abstained
                 else:
-                    approved, fb, review_abstained = self._review(task, answer, judge_context)
+                    approved, fb, review_abstained = self._review(task, answer, attempt_judge_context)
             else:
-                approved, fb, review_abstained = self._review(task, answer, judge_context)
+                approved, fb, review_abstained = self._review(task, answer, attempt_judge_context)
                 # An abstaining reviewer is the only gate here and just declined to be one. Letting
                 # `ok` ride on it would decide the attempt on a non-answer; the contract, coverage
                 # and diff gates below still run and can still fail it.
@@ -824,31 +902,6 @@ class AutonomousAgent:
                         "result is likely wrong or incomplete. Reconsider and fix it."
                     )
                     fb = f"{fb}\n\n{detail}" if fb else detail
-
-            # Diff-gate (nanobot "Dream"): certify what the attempt *actually* changed from the
-            # real workspace snapshot, BEFORE any revert — the machine truth, not the model's claim.
-            # Computed BEFORE the Attempt is finalized so --require-diff can act on it: the gate has to
-            # be able to fail the attempt, not just describe it after the verdict is already sealed.
-            diff_productive: bool | None = None
-            diff_summary: str | None = None
-            diffs: list[FileDiff] = []
-            if snapshot is not None and self.guard is not None:
-                from chimera.evolution.diff_gate import diff_snapshots, unified_diffs
-
-                after = self.guard.snapshot()  # one capture feeds both the summary and the per-file diffs
-                last_after = after  # remember for --keep-workspace (restored after the loop if it fails)
-                # `--gen-tests` writes its test file INTO the workspace, and it does so between the
-                # two snapshots (`_verify()` runs above). Left in, the verifier's own artifact counts
-                # as the run's work: `is_productive` becomes True on every attempt, so `--require-diff`
-                # — the gate that exists because SWE-bench run 1 returned 11/19 empty patches — can
-                # never fire while tests are being generated. With `--diff-feedback` it is worse than
-                # inert: the retry is handed the test file under "you already tried this and FAILED",
-                # feedback about an edit the model did not make.
-                after = _without_verifier_artifacts(after)
-                pdiff = diff_snapshots(snapshot, after)
-                diff_productive = pdiff.is_productive
-                diff_summary = pdiff.audit_summary()
-                diffs = unified_diffs(snapshot, after)  # real diffs, BEFORE any revert below
 
             # --require-diff: for a code task, an answer that changed nothing is not a success, however
             # convincing its prose. Without this the diff-gate is a passive observer — with no verifier

--- a/tests/test_the_judge_only_holds_you_to_the_agreement.py
+++ b/tests/test_the_judge_only_holds_you_to_the_agreement.py
@@ -37,13 +37,34 @@ def test_the_reviewer_is_given_the_judge_context() -> None:
     verifier-failed path and the no-verifier path — and one left on the worker's context is a leak
     that only shows up on whichever branch nobody exercised."""
     source = _run_source()
-    assert source.count("self._review(task, answer, judge_context)") == 3
+    # `attempt_judge_context` is `judge_context` plus what THIS attempt changed on disk — the
+    # agreement, plus evidence about the answer. The name changed when the diff was added; the
+    # property did not, and the assertion that matters is the negative one below.
+    assert source.count("self._review(task, answer, attempt_judge_context)") == 3
     assert "self._review(task, answer, context)" not in source
+    assert "self._review(task, answer, judge_context)" not in source
 
 
 def test_the_judge_context_is_the_agreement_and_nothing_else() -> None:
     source = _run_source()
     assert "judge_context = requirements_ctx" in source
+
+
+def test_what_the_attempt_changed_is_added_as_evidence_not_as_a_criterion() -> None:
+    """The one thing allowed to join the agreement, and why it is not a widening of it.
+
+    A recalled fact from another project can make something enforceable that nobody agreed to —
+    that is the leak this file exists for. A diff cannot: it describes what the answer is a claim
+    ABOUT, so it can only stop the reviewer being wrong about whether the work happened. Which it
+    was, on the shipped build, five times out of five, while the receipt beside it read
+    ``diff_productive: true``.
+    """
+    source = _run_source()
+    assert "attempt_judge_context = (" in source
+    line = source[source.index("attempt_judge_context = (") :][:400]
+    assert "judge_context" in line and "evidence_ctx" in line
+    for advisory in ("facts_ctx", "card_ctx", "playbook_ctx", "repo_ctx", "lessons"):
+        assert advisory not in line, f"{advisory} rejoined the judge through the evidence line"
 
 
 def test_the_worker_still_gets_everything() -> None:

--- a/tests/test_the_reviewer_can_see_the_work.py
+++ b/tests/test_the_reviewer_can_see_the_work.py
@@ -1,0 +1,142 @@
+"""The reviewer judged a paragraph and called it judging the work.
+
+`Manager.review` receives `(task, answer, context)` and had never seen the diff, the transcript or
+a single file — a fact `tests/test_success_gate.py` states in its own module docstring without
+drawing the consequence. Measured on the shipped rc39: four runs, five attempts, **five
+rejections**, every one of them for work the receipt's own summary proves was done. The cleanest:
+
+    tool: write_file ok  {"path": "README.md"}  -> "wrote 33 chars to README.md"
+    tool: list_dir   ok  {"path": "."}          -> "README.md"
+    result: attempt 1 failed
+            "the README.md must be physically created, not merely described as created"
+
+and the receipt for that same attempt:
+
+    {"diff_summary": "diff: +1 new, ~0 changed, -0 removed (README.md)",
+     "diff_productive": true, "reverted": true, "success": false}
+
+The receipt carries the refutation of the stated reason and reverts anyway. Then the failure is
+distilled into an anti-pattern skill card — `phantom_file_creation`, "assuming a file exists
+because you described creating it" — so the hallucination is written to disk and outlives the run
+that produced it.
+
+The fix is not a new rule. It is showing the reviewer what the attempt did, which required moving
+the diff computation ahead of the review; it used to run after every gate had already voted.
+
+**Evidence, not criterion.** The narrowing in
+`test_the_judge_only_holds_you_to_the_agreement.py` exists because a recalled fact from another
+project made something enforceable that nobody agreed to. A diff cannot do that: it describes what
+the answer is a claim *about*, so it can only stop the reviewer being wrong about whether the work
+happened.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.core import AutonomousAgent, AutonomousConfig, WorkspaceGuard
+from chimera.core.agent import AgentResult
+from chimera.core.supervisor import Review
+
+
+class _WritingWorker:
+    """Writes a real file and says so — the shape every one of the five rejections had."""
+
+    def __init__(self, workspace: Path, name: str = "README.md") -> None:
+        self.workspace = workspace
+        self.name = name
+
+    def run(self, task: str) -> AgentResult:
+        (self.workspace / self.name).write_text("# Padaria Aurora\n", encoding="utf-8")
+        return AgentResult(answer="I created the README.", steps=1, stopped_reason="final")
+
+
+class _SilentWorker:
+    """Touches nothing, and says it did the work anyway."""
+
+    def run(self, task: str) -> AgentResult:
+        return AgentResult(answer="I created the README.", steps=1, stopped_reason="final")
+
+
+class _RecordingManager:
+    """Approves everything and keeps what it was told, which is the thing under test."""
+
+    def __init__(self) -> None:
+        self.contexts: list[str] = []
+
+    def review(self, task: str, answer: str, context: str) -> Review:
+        self.contexts.append(context)
+        return Review(approved=True)
+
+
+def _run(workspace: Path, worker: Any, manager: Any) -> Any:
+    return AutonomousAgent(
+        worker=worker,
+        manager=manager,
+        planner=None,
+        verifier=None,
+        guard=WorkspaceGuard(workspace),
+        config=AutonomousConfig(max_attempts=1, use_planner=False),
+    ).run("create a README describing the project")
+
+
+def test_the_reviewer_is_told_which_file_the_attempt_wrote(tmp_path: Path) -> None:
+    """Mechanism to wiring. Everything else here is unreachable if the reviewer is still handed
+    the answer's prose and nothing about the disk."""
+    manager = _RecordingManager()
+    _run(tmp_path, _WritingWorker(tmp_path), manager)
+
+    assert manager.contexts, "the reviewer was never called, so this proved nothing"
+    context = manager.contexts[-1]
+    assert "README.md" in context, "the reviewer still cannot see what the attempt wrote"
+    assert "what-this-attempt-changed-on-disk" in context
+
+
+def test_the_reviewer_is_told_when_nothing_changed(tmp_path: Path) -> None:
+    """The other half, and the one that keeps this from being a way to approve anything: measured
+    and empty is not the same as unmeasured. A reviewer told nothing goes on assuming, and the
+    empty-patch failure this project has measured before is the assumption going the other way."""
+    manager = _RecordingManager()
+    _run(tmp_path, _SilentWorker(), manager)
+
+    assert manager.contexts
+    context = manager.contexts[-1]
+    assert "what-this-attempt-changed-on-disk" in context
+    assert "no productive change" in context, (
+        "the reviewer is left to guess whether the silence means nothing happened or nothing "
+        "was looked at"
+    )
+
+
+def test_the_evidence_carries_the_diff_body_not_only_the_filename(tmp_path: Path) -> None:
+    """A filename answers "did anything happen"; the body is what lets a reviewer judge whether
+    what happened is the thing that was asked for."""
+    manager = _RecordingManager()
+    _run(tmp_path, _WritingWorker(tmp_path), manager)
+
+    assert "Padaria Aurora" in manager.contexts[-1]
+
+
+def test_the_agreement_is_still_all_that_can_be_enforced(tmp_path: Path) -> None:
+    """The control for the narrowing this sits on top of. Adding evidence must not smuggle the
+    worker's context back in: no recalled fact, no skill card, no repository map."""
+    manager = _RecordingManager()
+    _run(tmp_path, _WritingWorker(tmp_path), manager)
+
+    context = manager.contexts[-1]
+    # The spine the WORKER gets always names the workspace root; the reviewer's must not.
+    assert str(tmp_path) not in context
+    assert "Repository map" not in context
+
+
+def test_the_diff_is_measured_before_the_review_runs(tmp_path: Path) -> None:
+    """Ordering, asserted where it is decided, because this is the part a later refactor would
+    undo without noticing: the diff block used to sit after every gate had voted, and a reviewer
+    cannot be shown a number that has not been computed yet."""
+    import inspect
+
+    source = inspect.getsource(AutonomousAgent.run)
+    assert source.index("diffs = unified_diffs(") < source.index(
+        "self._review(task, answer, attempt_judge_context)"
+    ), "the diff is computed after the review again, so the evidence is always empty"


### PR DESCRIPTION
> **Stacked on #240** — it edits the same lines of `autonomous.py`, so its base is that branch, not `main`. Merge #240 first and this retargets cleanly.

## What happens

`Manager.review` receives `(task, answer, context)` and has **never seen the diff, the transcript, or a single file**. This repository's own test docstrings say so; nobody drew the consequence.

Measured on the shipped rc39: four runs, five attempts, **five rejections**, every one of them for work the receipt beside it proves was done. The cleanest case:

```
tool: write_file ok  {"path": "README.md"}  -> "wrote 33 chars to README.md"
tool: list_dir   ok  {"path": "."}          -> "README.md"
result: attempt 1 failed
        "the README.md must be physically created, not merely described as created"
```

and the receipt for that same attempt:

```json
{"diff_summary": "diff: +1 new, ~0 changed, -0 removed (README.md)",
 "diff_productive": true, "verified": true, "reverted": true, "success": false}
```

**The receipt carries the refutation of the stated reason, and reverts anyway.** Under verify-or-revert the file is deleted. Then the failure is distilled into a permanent anti-pattern skill card — `phantom_file_creation`, *"assuming a file exists because you described creating it"* — so the hallucination is written to disk and outlives the run that produced it.

## What changed

The reviewer is shown what the attempt changed on disk: the diff summary and a bounded slice of the real per-file patches.

That required **moving the diff computation ahead of the review**. It used to run after every gate had already voted, so the machine truth existed only as a description of a verdict that was already sealed. Nothing between the two positions writes to the workspace — the completion contract, the coverage checklist and the strong verifier all read text — so the numbers are identical; they are simply available in time to be evidence. A test asserts that ordering where it is decided, because it is exactly what a later refactor would undo without noticing.

## Why this does not reopen what #240 closed

#240 narrowed the reviewer to *the agreement* because a globally-scoped memory fact — the path of an unrelated project — became an enforceable criterion and destroyed correct work.

A diff cannot do that. It is not a criterion; it is **evidence about the answer** — a description of what the claim is a claim *about*. It cannot add a requirement, it can only stop the reviewer being wrong about whether the work happened. The test guarding the narrowing now also asserts that nothing else rejoined through this line, and a behavioural test asserts the reviewer's context still contains no repository map and not even the workspace path.

The `Nothing changed` case is carried too — measured-and-empty is not the same as unmeasured, and a reviewer told nothing goes on assuming, which is the empty-patch failure this project has already measured, pointing the other way.

## Verification

- **5 sabotages, 5 caught**, each confirmed present in the file on disk before the run was read — including the one that matters most, handing the reviewer the *worker's* full context again.
- **A dead branch was written and caught here.** `audit_summary()` already says `no productive change`, so a second branch for "measured and empty" could never run. The test found it by asserting a sentence the code would never emit; the branch is gone and the test now pins the real one.
- Full suite **4180 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces on pristine `origin/main` — environmental.
- `ruff` and `mypy` clean.

## Residue, stated rather than implied

Fixing the reviewer's blindness removes the *source* of those five rejections. It does **not** add a rule preventing an anti-pattern card from being distilled out of a wrong rejection in general — a card written from a false failure is still a card. That is a separate question about what the flywheel is allowed to learn, and it is not answered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)