### PR TITLE
fix(runs): the coverage checklist graded prose too, and reverted the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,20 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **The coverage checklist graded prose too, and deleted the file that satisfied the requirement.**
+  Found by driving the release that had just fixed the same blindness one gate over. A run with
+  `--gen-tests` on a machine without pytest: the requirement was *"somar(a, b) devolve a + b"*, the
+  diff was `+def somar(a, b):` / `+    return a + b`, and the feedback was **"Requirements not
+  covered"**. Three things had to line up and they did — the spec-test verifier **abstained**
+  correctly because pytest was missing, abstention demotes the attempt to the no-verifier path,
+  and that is exactly what makes this gate decisive. It was still reading the answer's prose, which
+  said only "Pronto.", so verify-or-revert removed the two lines that met the requirement. The
+  reviewer had been given the diff one release earlier; this gate had not, and the two fixes met
+  here. Same evidence, same terms: it describes what the answer is a claim about and cannot add a
+  requirement — the list stays the one the person kept. The grader's instruction changed with it,
+  because *"judge only what the answer actually shows"* is the rule that produced the miss, and
+  handing the model a diff while still telling it to ignore everything but the prose would have
+  shipped as a fix and changed nothing.
 - **The installed app stopped forever the first time the agent chose to run a command.** Not slow —
   stopped: no frame, no error, no timeout, and `cancel` answering `{"ok": true}` indefinitely about a
   run that could not be stopped. Three threads of the shipped build were parked in `typer.confirm`,

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -883,7 +883,11 @@ class AutonomousAgent:
             # opinion on top of them. (Requirements are still injected up front, so the worker targets
             # them from attempt 1 regardless.)
             if ok and self.checklist is not None and requirements and not verifier_active:
-                misses = self.checklist.grade(task, answer, requirements)
+                # The same evidence the reviewer gets, for the same reason. This gate runs only
+                # when there is no active verifier — which is exactly what an abstaining one
+                # produces — so it inherits the decisive vote precisely when the tests could not
+                # speak, and grading prose there deletes work the diff proves was done.
+                misses = self.checklist.grade(task, answer, requirements, evidence=evidence_ctx)
                 if misses:
                     ok = False
                     detail = "Requirements not covered:\n" + "\n".join(f"- {m}" for m in misses)

--- a/chimera/core/checklist.py
+++ b/chimera/core/checklist.py
@@ -39,10 +39,13 @@ _EXTRACT_SYSTEM = (
     "correct. Do NOT solve the task. Output ONLY the JSON object."
 )
 _GRADE_SYSTEM = (
-    "You grade whether an answer meets each requirement. Given the requirements and the answer, "
+    "You grade whether an answer meets each requirement. Given the requirements, the answer, and — "
+    "when it is present — a section showing what the work changed on disk, "
     'output {"items": [{"text": "<requirement>", "met": true|false}]} with one entry per '
-    "requirement, in order. Judge only what the answer actually shows; if a requirement is not "
-    "clearly satisfied, mark it false. Output ONLY the JSON object."
+    "requirement, in order. Judge what the WORK shows, not only what the answer says: a requirement "
+    "satisfied by the changed files is met even when the answer does not restate it. If neither the "
+    "answer nor the changes clearly satisfy a requirement, mark it false. Output ONLY the JSON "
+    "object."
 )
 
 
@@ -92,12 +95,38 @@ class RequirementChecklist:
             _log.warning("checklist extract failed, continuing without it: %s", exc)
             return []
 
-    def grade(self, task: str, answer: str, requirements: list[Requirement]) -> list[str]:
-        """Return the texts of the requirements the answer does NOT meet (empty on failure)."""
+    def grade(
+        self,
+        task: str,
+        answer: str,
+        requirements: list[Requirement],
+        *,
+        evidence: str = "",
+    ) -> list[str]:
+        """Return the texts of the requirements the work does NOT meet (empty on failure).
+
+        ``evidence`` is what the attempt changed on disk. Without it this graded the answer's
+        **prose**, which is the same blindness the reviewer had and it cost the same thing:
+        measured on the installed rc40, a run wrote
+
+            +def somar(a, b):
+            +    return a + b
+
+        against the requirement *"somar(a, b) devolve a + b"*, and this grader returned
+        "Requirements not covered". Under verify-or-revert the file was deleted. The reviewer had
+        just been given the diff; this gate had not, and it runs precisely when the reviewer's
+        verdict is no longer decisive — with no active verifier — so the two fixes met here.
+
+        Evidence, not criterion, on the same terms as the reviewer's: the diff describes what the
+        answer is a claim about. It cannot add a requirement to the list, which is the whole point
+        of the list being the one the person kept.
+        """
         if not requirements:
             return []
         listing = "\n".join(f"- [{r.kind}] {r.text}" for r in requirements)
         prompt = f"Requirements:\n{listing}\n\n<<answer>>\n{answer}\n<<end-answer>>"
+        if evidence:
+            prompt = f"{prompt}\n\n{evidence}"
         try:
             result = self.backend.complete(
                 [Message(role="system", content=_GRADE_SYSTEM), Message(role="user", content=prompt)],

--- a/tests/test_checklist.py
+++ b/tests/test_checklist.py
@@ -74,7 +74,7 @@ class _RecordingChecklist:
     def extract(self, task: str) -> list[Requirement]:
         return [Requirement(text="include the error code")]
 
-    def grade(self, task: str, answer: str, requirements: list[Requirement]) -> list[str]:
+    def grade(self, task: str, answer: str, requirements: list[Requirement], *, evidence: str = "") -> list[str]:
         self.graded += 1
         return ["include the error code"] if self.graded == 1 else []
 
@@ -115,7 +115,7 @@ class _TwoReqChecklist:
     def extract(self, task: str) -> list[Requirement]:
         return [Requirement(text="support lowercase input"), Requirement(text="raise on empty")]
 
-    def grade(self, task: str, answer: str, requirements: list[Requirement]) -> list[str]:
+    def grade(self, task: str, answer: str, requirements: list[Requirement], *, evidence: str = "") -> list[str]:
         return []  # everything covered, so the run succeeds on attempt 1
 
 
@@ -126,7 +126,7 @@ class _GradeCountingChecklist:
     def extract(self, task: str) -> list[Requirement]:
         return [Requirement(text="do the thing")]
 
-    def grade(self, task: str, answer: str, requirements: list[Requirement]) -> list[str]:
+    def grade(self, task: str, answer: str, requirements: list[Requirement], *, evidence: str = "") -> list[str]:
         self.grades += 1
         return []
 

--- a/tests/test_the_checklist_can_see_the_work.py
+++ b/tests/test_the_checklist_can_see_the_work.py
@@ -1,0 +1,160 @@
+"""The coverage checklist graded prose too, and deleted the file that satisfied the requirement.
+
+Found by driving the installed rc40 — that is, by testing the release that had just fixed the same
+blindness one gate over. A run with `--gen-tests` on a machine with no pytest:
+
+    requirement:  "somar(a, b) devolve a + b"
+    diff:         +def somar(a, b):
+                  +    return a + b
+    feedback:     "Requirements not covered: - somar(a, b) devolve a + b"
+    receipt:      verified: true · reverted: true · evidence: diff+manager
+
+Three things had to line up, and they did. The spec-test verifier **abstained**, correctly, because
+pytest was not installed. Abstention demotes the attempt to the no-verifier path — which is what
+makes the coverage checklist the decisive gate. And that gate was still reading the answer's prose,
+so it did not see the two lines that met the requirement, and verify-or-revert removed them.
+
+The reviewer had been given the diff one release earlier. This gate had not. The fix is the same
+evidence, on the same terms: it describes what the answer is a claim about, and it cannot add a
+requirement — the list stays the one the person kept.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.core import AutonomousAgent, AutonomousConfig, WorkspaceGuard
+from chimera.core.agent import AgentResult
+from chimera.core.checklist import Requirement, RequirementChecklist
+from chimera.core.supervisor import Review
+
+
+class _Backend:
+    """Records the prompt it was graded with, and answers however the case needs."""
+
+    def __init__(self, reply: str) -> None:
+        self.reply = reply
+        self.prompts: list[str] = []
+
+    def complete(self, messages: Any, model: Any = None, **kwargs: Any) -> Any:
+        self.prompts.append(messages[-1].content)
+
+        class _R:
+            content = self.reply
+
+        return _R()
+
+
+class _Worker:
+    def __init__(self, workspace: Path) -> None:
+        self.workspace = workspace
+        self.runs = 0
+
+    def run(self, task: str) -> AgentResult:
+        self.runs += 1
+        (self.workspace / "soma.py").write_text(
+            "def somar(a, b):\n    return a + b\n", encoding="utf-8"
+        )
+        return AgentResult(answer="Pronto.", steps=1, stopped_reason="final")
+
+
+class _Approving:
+    def review(self, task: str, answer: str, context: str) -> Review:
+        return Review(approved=True)
+
+
+# --------------------------------------------------------------------------- the grader itself
+
+
+def test_the_diff_reaches_the_grader() -> None:
+    """Mechanism. The prompt is what the model reads, so this is where the evidence is or is not."""
+    backend = _Backend('{"items": [{"text": "somar(a, b) devolve a + b", "met": true}]}')
+    checklist = RequirementChecklist(backend)  # type: ignore[arg-type]
+
+    checklist.grade(
+        "build it",
+        "Pronto.",
+        [Requirement(text="somar(a, b) devolve a + b")],
+        evidence="<<what-this-attempt-changed-on-disk>>\n+def somar(a, b):\n<<end>>",
+    )
+    assert "def somar" in backend.prompts[-1], "the grader still sees only the prose"
+
+
+def test_without_evidence_the_prompt_is_byte_identical_to_before() -> None:
+    """The control, and asserted on the whole string rather than on the absence of a heading.
+
+    A sabotage run proved the weaker version worthless: making the append unconditional passed it,
+    because appending an empty string adds no heading — only two blank lines. Harmless there,
+    but the assertion was not measuring what it claimed to, and the next change might not be.
+    """
+    backend = _Backend('{"items": [{"text": "x", "met": true}]}')
+    RequirementChecklist(backend).grade("t", "a", [Requirement(text="x")])  # type: ignore[arg-type]
+    assert backend.prompts[-1] == "Requirements:\n- [do] x\n\n<<answer>>\na\n<<end-answer>>"
+
+
+def test_the_grader_is_told_the_changed_files_count_as_evidence() -> None:
+    """The instruction is half the fix, and a fake backend cannot notice it changing.
+
+    The old system prompt said to judge *only what the answer actually shows* — which is exactly
+    the rule that made a satisfied requirement read as unmet. Handing the model a diff while still
+    telling it to ignore everything but the prose would have shipped as a fix and changed nothing.
+    Pinned as a clause, not as prose: the wording may move, the permission may not.
+    """
+    from chimera.core.checklist import _GRADE_SYSTEM
+
+    assert "changed files is met even when the answer does not restate it" in _GRADE_SYSTEM
+    assert "only what the answer actually shows" not in _GRADE_SYSTEM
+
+
+def test_the_grader_still_reports_a_genuine_miss() -> None:
+    """The control that matters: showing the work must not become a way of passing everything."""
+    backend = _Backend('{"items": [{"text": "x", "met": false}]}')
+    misses = RequirementChecklist(backend).grade(  # type: ignore[arg-type]
+        "t", "a", [Requirement(text="x")], evidence="<<what-this-attempt-changed-on-disk>>\n<<end>>"
+    )
+    assert misses == ["x"]
+
+
+# --------------------------------------------------------------------------- the wiring
+
+
+class _GradesOnProseOnly:
+    """A grader that marks the requirement met only if it can see the code — which is exactly what
+    the real one was being asked to do without being shown it."""
+
+    def __init__(self) -> None:
+        self.evidence_seen = ""
+
+    def extract(self, task: str) -> list[Requirement]:
+        return [Requirement(text="somar(a, b) devolve a + b")]
+
+    def grade(
+        self,
+        task: str,
+        answer: str,
+        requirements: list[Requirement],
+        *,
+        evidence: str = "",
+    ) -> list[str]:
+        self.evidence_seen = evidence
+        return [] if "def somar" in (answer + evidence) else ["somar(a, b) devolve a + b"]
+
+
+def test_the_work_survives_a_requirement_its_diff_satisfies(tmp_path: Path) -> None:
+    """Mechanism to wiring, and the rc40 case end to end: the answer says only "Pronto." and the
+    requirement is met by the file. Before, the attempt failed here and the file was reverted."""
+    checklist = _GradesOnProseOnly()
+    result = AutonomousAgent(
+        worker=_Worker(tmp_path),
+        manager=_Approving(),
+        planner=None,
+        verifier=None,
+        guard=WorkspaceGuard(tmp_path),
+        config=AutonomousConfig(max_attempts=1, use_planner=False),
+        checklist=checklist,  # type: ignore[arg-type]
+    ).run("crie soma.py com somar(a, b)")
+
+    assert "def somar" in checklist.evidence_seen, "the loop never handed the grader the diff"
+    assert result.success is True
+    assert (tmp_path / "soma.py").is_file(), "the file that met the requirement was reverted again"

--- a/tests/test_the_judge_only_holds_you_to_the_agreement.py
+++ b/tests/test_the_judge_only_holds_you_to_the_agreement.py
@@ -88,11 +88,28 @@ def test_recalled_facts_never_reach_the_judge() -> None:
 def test_the_checklist_grader_could_not_have_written_that_feedback() -> None:
     """Pinned because it is what makes the diagnosis a conclusion rather than a guess: the grader's
     prompt is built from the requirement list and the answer, so a path present in neither could
-    not have come from it. If this prompt ever grows a context argument, the elimination above
-    stops holding and this file's reasoning needs redoing."""
+    not have come from it.
+
+    The prompt has since grown one more input, which the docstring here warned would happen and
+    said would need re-doing. Re-done: it takes the attempt's **diff** and nothing else. The
+    elimination therefore still holds for the class of leak this file is about — a fact recalled
+    from another project cannot reach this grader, because the only thing added is a description of
+    what this attempt wrote. What would break it is `context`, or anything derived from it, and the
+    call site is asserted below.
+    """
     from chimera.core.checklist import RequirementChecklist
 
     grade = inspect.getsource(RequirementChecklist.grade)
     assert 'prompt = f"Requirements:\\n{listing}\\n\\n<<answer>>\\n{answer}\\n<<end-answer>>"' in grade
+    assert 'prompt = f"{prompt}\\n\\n{evidence}"' in grade
     # `task` is a parameter it accepts and deliberately does not put in the prompt.
     assert "{task}" not in grade
+
+
+def test_the_grader_is_handed_the_diff_and_nothing_else() -> None:
+    """The other half of the elimination above, at the call site rather than in the prompt."""
+    source = _run_source()
+    call = next(ln for ln in source.splitlines() if "self.checklist.grade(" in ln)
+    assert "evidence=evidence_ctx" in call
+    for advisory in ("context", "facts_ctx", "card_ctx", "playbook_ctx", "repo_ctx", "lessons"):
+        assert f"evidence={advisory}" not in call, f"{advisory} became enforceable through the grader"


### PR DESCRIPTION
Found by driving the **installed rc40** — the release that had just fixed the same blindness one gate over.

## What happens

A run with `--gen-tests` on a machine without pytest:

```
requirement:  "somar(a, b) devolve a + b"
diff:         +def somar(a, b):
              +    return a + b
answer:       "Pronto."
feedback:     "Requirements not covered: - somar(a, b) devolve a + b"
receipt:      verified: true · reverted: true · evidence: diff+manager
```

The file that met the requirement was deleted.

**Three things had to line up, and they did.** The spec-test verifier **abstained** — correctly, because pytest was not installed, which is itself a fix from the last release. Abstention demotes the attempt to the no-verifier path. And that is exactly what makes the coverage checklist the decisive gate. It was still grading the answer's prose, so it never saw the two lines.

The reviewer had been handed the diff one release earlier. This gate had not. The two fixes met here.

## What changed

`RequirementChecklist.grade` takes the attempt's diff, on the same terms the reviewer's does: **evidence, not criterion** — it describes what the answer is a claim *about*, and it cannot add a requirement. The list stays the one the person kept and edited.

**The system instruction changed with it**, and that half matters as much. The old text said *"judge only what the answer actually shows"* — which is precisely the rule that turned a satisfied requirement into a miss. Handing the model a diff while still telling it to ignore everything but the prose would have shipped as a fix and changed nothing.

## API change, and the signal it gave

`grade` gains a keyword-only `evidence`. Three test doubles implementing the old signature broke immediately — which is the correct outcome, not an inconvenience: the checklist is an injected collaborator, and every implementer has to be updated. The failure said so, by name.

## Verification

- **5 sabotages, 5 caught** — but only after two of them **failed to catch on the first pass**, and both were findings about my tests rather than about the code:
  - nothing pinned the **system instruction**. A fake backend cannot notice it changing, so reverting the permission back to "judge only the answer" passed the whole suite. Now pinned as a clause — the wording may move, the permission may not.
  - the no-evidence control asserted the *absence of a heading*, which an unconditional append also satisfies, because appending an empty string adds no heading. It now asserts the prompt byte for byte.
- Full suite **4213 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces on pristine `origin/main` — environmental.
- `ruff` and `mypy` clean.

## Still open from the same test session

- **A global memory fact still hijacks the write path.** In this session's run the README landed at `<workspace>/Desktop/teste-chimera/site-institucional/README.md` — a ghost tree mirroring another project's path. Formally the designed behaviour of a globally-scoped fact; in practice the agent writing in the wrong place every time.
- **A question-shaped task fails for not changing a file**, with feedback asserting "this task requires editing code" about a task that asked nothing of the sort.

Neither is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)