### PR TITLE
feat(sandbox): the kernel holds the boundary, where there is a kernel that will

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,9 +42,12 @@ CHIMERA_API_BASE=
 # e.g. CHIMERA_FALLBACK_MODELS=openrouter/openai/gpt-4o-mini,ollama/llama3
 CHIMERA_FALLBACK_MODELS=
 
-# Execution sandbox for the shell tool: local (host, default) or docker (isolated).
-# docker runs each command in an ephemeral, network-off container; see docker/README.md.
-CHIMERA_SANDBOX=local
+# Execution sandbox for the shell tool: auto (default) | os | local | docker.
+# auto = the platform's kernel sandbox where there is one (Seatbelt on macOS, bubblewrap on Linux;
+#        network off, writes confined to the workspace), and the host with a startup warning where
+#        there is not — Windows, and any Linux whose kernel refuses unprivileged user namespaces.
+# local = the host, deliberately. docker = ephemeral network-off container; see docker/README.md.
+CHIMERA_SANDBOX=auto
 CHIMERA_SANDBOX_IMAGE=python:3.12-slim
 # Optional hardened OCI runtime for the docker sandbox. Set to runsc to run under gVisor
 # (userspace kernel; intercepts syscalls, shrinks host-kernel attack surface). Requires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ and the engineering were both high and verifiable. Almost nothing that was built
 
 Most of this release is doors. The rest is what testing each release candidate as a user turned up.
 
+### Added — the kernel holds the boundary now, where there is a kernel that will
+
+- **The default sandbox is no longer the host.** `SECURITY.md` said it plainly — the `local`
+  sandbox is not isolated — so the shipped boundary between a command the model chose and the
+  machine was the governance kernel plus a confirmation prompt. A prompt is a boundary a tired
+  person waves through and an injected instruction routes around. The default is now `auto`:
+  **Seatbelt** on macOS with a `(deny default)` profile, **bubblewrap** on Linux with
+  `--unshare-net --unshare-pid --unshare-ipc --cap-drop ALL` over a read-only bind of `/`. Network
+  off, writes confined to the working directory and the temp dir.
+  **Windows gets nothing, and says so.** The mechanism there is a restricted token plus network
+  filters — native work this does not attempt, and approximating it would be worse than its
+  absence, because a boundary that is believed and missing is more dangerous than one known to be
+  missing. Same for a Linux kernel that refuses unprivileged user namespaces: the binary is
+  installed, the syscall fails, and the honest report is *unavailable*.
+  Two properties carry the weight. **Availability is probed with the same command line the sandbox
+  actually uses**, so a rejected flag set reports unavailable instead of certifying a sandbox that
+  then fails every command. And **`is_isolated()` is true only where the wrapper really applied** —
+  it is what the host-exec gate reads, so a machine without a boundary keeps its confirmation
+  prompt rather than losing it to a claim nothing enforces.
+  ⚠️ Stated rather than implied: the machine this was written on has neither `bwrap` nor
+  `sandbox-exec` and no permission to install one, so the flag set and the profile are asserted by
+  content and not by execution. That is exactly why the probe runs the real argv.
+- **And the change caught a second bug on its way in.** `run_streamed` decided whether to stream
+  live output by reading `settings.sandbox != "local"` — correct only while `local` was the
+  default. Flipping the default sent every machine down the one-shot path and cost live output and
+  Stop. Fixing it by loosening the check would have been worse than the regression: streaming
+  spawns its *own* process, so on a machine that does have a kernel sandbox it would have run the
+  command around the wrapper while every screen still said "sandboxed". The branch now asks the
+  resolved backend, with an exact type check rather than `isinstance`, because `OsSandbox`
+  subclasses `LocalSandbox` to reuse its process handling.
+
 ### Added — the app can reach what it was built on
 
 - **The step budget was the one configuration this project's own bench published as sterile.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,9 +122,21 @@ environment** when you grant autonomy:
 - **Human-in-the-loop** — agent-proposed crons are created **disabled**, pending approval.
 - **Audit log** — governance decisions and evolution changes are recorded.
 
-Treat secrets as server-only. **The default `local` sandbox is not isolated** — for untrusted
-or autonomous work run with `CHIMERA_SANDBOX=docker` (ephemeral, network-off by default),
-ideally in a throwaway account or VM rather than your main one.
+Treat secrets as server-only. **The default `auto` sandbox asks the kernel to hold the boundary**
+— Seatbelt on macOS, bubblewrap on Linux — with the network off and writes confined to the working
+directory and the temp dir. Where the platform offers nothing it says so once, at startup, and runs
+on the host: **Windows has no OS sandbox here** (the mechanism there is a restricted token plus
+network filters, which is native work this does not attempt), and a Linux kernel that refuses
+unprivileged user namespaces cannot run bubblewrap even when the binary is installed.
+
+Availability is probed with the same command line the sandbox actually uses, so a rejected flag set
+reports *unavailable* rather than certifying a sandbox that then fails every command. And
+`is_isolated()` — which is what the host-exec gate reads — is true only where the wrapper really
+applied, so a machine without a boundary keeps its confirmation prompt instead of losing it to a
+claim nothing enforces.
+
+For untrusted or autonomous work on a machine with no OS sandbox, run with `CHIMERA_SANDBOX=docker`
+(ephemeral, network-off by default), ideally in a throwaway account or VM rather than your main one.
 
 **Host execution is gated by default, including unattended.** Because most installs have no Docker, a
 command the model chooses to run would otherwise execute on your machine. `CHIMERA_HOST_EXEC=ask` (the

--- a/chimera/api/exec_stream.py
+++ b/chimera/api/exec_stream.py
@@ -105,14 +105,26 @@ def run_streamed(
     root = Path(workspace).resolve()
     resolved = resolve_exec_cwd(root, cwd)  # raises ValueError on escape — before any process starts
 
-    mode = (settings.sandbox or "local").lower()
-    if mode != "local":
-        # Honor isolation: don't host-exec. Run one-shot in the configured sandbox and deliver the
-        # whole output at once — no line streaming (that's the local-only path).
-        from chimera.sandbox import get_sandbox
+    # Decided from the RESOLVED backend, not from the setting string. Streaming spawns its own
+    # process, which is equivalent to the configured sandbox only when that sandbox adds nothing to
+    # a plain host process. `type(...) is` and not `isinstance`, deliberately: `OsSandbox` subclasses
+    # `LocalSandbox` to reuse its process handling, and an `isinstance` check would stream — running
+    # the command with this function's own Popen and quietly stepping around the kernel wrapper the
+    # user is relying on.
+    #
+    # This branch used to read `settings.sandbox != "local"`. That was correct only while `local`
+    # was the default; the day the default became `auto`, every machine took the one-shot path and
+    # lost live output and Stop — which is how these lines came to be rewritten.
+    from chimera.sandbox import get_sandbox
+    from chimera.sandbox.local import LocalSandbox
 
-        result = get_sandbox(settings).run(command, timeout=int(max(1, timeout)), cwd=resolved)
-        on_line(f"(sandbox={mode}: output shown on completion)")
+    backend = get_sandbox(settings)
+    if type(backend) is not LocalSandbox:
+        # Honor isolation: don't host-exec. Run one-shot in the configured sandbox and deliver the
+        # whole output at once — no line streaming (that's the unsandboxed-host path only).
+        result = backend.run(command, timeout=int(max(1, timeout)), cwd=resolved)
+        label = "docker" if type(backend).__name__ == "DockerSandbox" else "os"
+        on_line(f"(sandbox={label}: output shown on completion)")
         out = result.output
         if len(out) > _MAX_STREAM_CHARS:
             out = out[:_MAX_STREAM_CHARS] + "\n[output truncated]"

--- a/chimera/api/posture.py
+++ b/chimera/api/posture.py
@@ -216,7 +216,10 @@ def describe(
         if isolated:
             shell = "isolated"
         else:
-            fell_back = (settings.sandbox or "local").lower() != "local"
+            # Anything but an explicit `local` asked for a boundary and did not get one. Under the
+            # `auto` default this is how a Windows user — where no OS sandbox exists — is told that
+            # their commands run on the host, on every posture read rather than once at startup.
+            fell_back = (settings.sandbox or "auto").lower() != "local"
             posture_env = (settings.host_exec or "ask").lower()
             # `ask` is honest about being unanswerable here: the server has no terminal, so the
             # confirm resolves to a refusal rather than to a prompt nobody will ever see.

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -386,8 +386,15 @@ class Settings(BaseSettings):
     # --- Default iCalendar feed for the calendar_events reference tool ---
     calendar_ics_url: str | None = Field(default=None, validation_alias="CHIMERA_CALENDAR_ICS_URL")
 
-    # --- Execution sandbox for the shell tool (local = host, docker = isolated) ---
-    sandbox: str = Field(default="local", validation_alias="CHIMERA_SANDBOX")
+    # --- Execution sandbox for the shell tool ---
+    # `auto` (default): the platform's kernel sandbox where there is one — Seatbelt on macOS,
+    # bubblewrap on Linux — and the host with a warning where there is not (Windows, and any Linux
+    # whose kernel refuses the user namespace). `local` is the explicit opt-out to the host, `os`
+    # forces the attempt, `docker` is the isolated container.
+    #
+    # This default used to be `local`. That meant the shipped boundary was a confirmation prompt,
+    # which is a boundary a person can wave through and an injected instruction cannot be stopped by.
+    sandbox: str = Field(default="auto", validation_alias="CHIMERA_SANDBOX")
     sandbox_image: str = Field(
         default="python:3.12-slim", validation_alias="CHIMERA_SANDBOX_IMAGE"
     )

--- a/chimera/sandbox/__init__.py
+++ b/chimera/sandbox/__init__.py
@@ -1,10 +1,14 @@
 """Execution sandboxes: pluggable backends for running shell commands.
 
-* :class:`LocalSandbox` — runs on the host (timeout + working dir); the default.
+* :class:`~chimera.sandbox.os_sandbox.OsSandbox` — the platform's kernel sandbox (Seatbelt on
+  macOS, bubblewrap on Linux), network off, writes confined to the working directory. **The
+  default**, via ``auto``.
+* :class:`LocalSandbox` — runs on the host (timeout + working dir). What ``auto`` falls back to
+  where no kernel sandbox is available, and what ``local`` selects deliberately.
 * :class:`DockerSandbox` — runs in an ephemeral, network-isolated container, with a
   graceful fallback to local when Docker is absent.
 
-Select the backend with ``CHIMERA_SANDBOX=local|docker`` (image via
+Select the backend with ``CHIMERA_SANDBOX=auto|os|local|docker`` (image via
 ``CHIMERA_SANDBOX_IMAGE``, hardened OCI runtime via ``CHIMERA_SANDBOX_RUNTIME=runsc``
 for gVisor); :func:`get_sandbox` reads the settings.
 """
@@ -16,17 +20,50 @@ from typing import TYPE_CHECKING
 from chimera.sandbox.base import Sandbox, SandboxResult
 from chimera.sandbox.docker import DockerSandbox
 from chimera.sandbox.local import LocalSandbox
+from chimera.sandbox.os_sandbox import OsSandbox, os_sandbox_available, unavailable_reason
+from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:
     from chimera.config import Settings
 
+_log = get_logger("sandbox")
+_warned = False
+
+
+def _warn_unsandboxed(reason: str) -> None:
+    """Say it once per process. Repeated per command it becomes noise nobody reads; said once it is
+    the difference between a user who knows the boundary is absent and one who assumes it is there."""
+    global _warned
+    if not _warned:
+        _warned = True
+        _log.warning("commands run WITHOUT an OS sandbox: %s", reason)
+
 
 def get_sandbox(settings: Settings | None = None) -> Sandbox:
-    """Return the configured sandbox backend (local by default)."""
+    """Return the configured sandbox backend.
+
+    The default is ``auto``: use the platform's kernel sandbox where there is one, and say out loud
+    when there is not. It used to be ``local`` — the host, with a timeout and a working directory —
+    which meant the shipped default had no boundary at all and the only thing in front of a command
+    was a confirmation prompt.
+
+    ``auto`` resolves to :class:`LocalSandbox` on a machine with no usable sandbox rather than to an
+    :class:`OsSandbox` that would fall through to the same place. Both run the command identically;
+    the difference is that this way the warning is emitted once, here, instead of once per command,
+    and ``is_isolated()`` is False for the plain structural reason that the object cannot isolate.
+    """
     from chimera.config import get_settings
 
     settings = settings or get_settings()
-    if (settings.sandbox or "local").lower() == "docker":
+    choice = (settings.sandbox or "auto").lower()
+    if choice in {"auto", "os"}:
+        from chimera.sandbox.os_sandbox import OsSandbox, os_sandbox_available, unavailable_reason
+
+        if os_sandbox_available():
+            return OsSandbox()
+        _warn_unsandboxed(unavailable_reason())
+        return LocalSandbox()
+    if choice == "docker":
         # Every one of these was a constructor parameter the factory never passed. `network` and
         # `memory` in particular were accepted, documented, and dead: no caller could reach them, so
         # the container was hard-wired to no-network/512m whatever the settings said.
@@ -41,4 +78,13 @@ def get_sandbox(settings: Settings | None = None) -> Sandbox:
     return LocalSandbox()
 
 
-__all__ = ["Sandbox", "SandboxResult", "LocalSandbox", "DockerSandbox", "get_sandbox"]
+__all__ = [
+    "Sandbox",
+    "SandboxResult",
+    "LocalSandbox",
+    "DockerSandbox",
+    "OsSandbox",
+    "get_sandbox",
+    "os_sandbox_available",
+    "unavailable_reason",
+]

--- a/chimera/sandbox/local.py
+++ b/chimera/sandbox/local.py
@@ -50,14 +50,26 @@ class LocalSandbox:
         """The local sandbox runs on the host — no isolation from it."""
         return False
 
+    def _command_argv(self, command: str, cwd: Path | None) -> tuple[list[str] | str, bool]:
+        """What to hand ``Popen``, and whether it needs a shell. Runs the command as typed.
+
+        The seam :class:`~chimera.sandbox.os_sandbox.OsSandbox` overrides to wrap the same command
+        in the platform's kernel sandbox. It exists so that everything below — the timeout that
+        kills the whole process tree, the secret-scrubbed environment, the non-interactive
+        overrides — is written once. Each of those is a correctness fix with its own history, and a
+        sandbox backend that copied them would be a second place for that history to rot.
+        """
+        return (command, True)
+
     def run(self, command: str, *, timeout: int = 60, cwd: Path | None = None) -> SandboxResult:
         posix = os.name == "posix"
+        target, use_shell = self._command_argv(command, cwd)
         # start_new_session puts the command in its own process GROUP so a timeout can kill the whole
         # tree (killpg), not just the shell — otherwise a forked grandchild survives the timeout and
         # can even hold the stdout pipe open, hanging the reap past the deadline.
         proc = subprocess.Popen(
-            command,
-            shell=True,
+            target,
+            shell=use_shell,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/chimera/sandbox/os_sandbox.py
+++ b/chimera/sandbox/os_sandbox.py
@@ -1,0 +1,214 @@
+"""OS-level sandbox — the kernel enforces the boundary, not a prompt and not a promise.
+
+Until now the shipped default was ``local``: the agent's commands ran on the host with a timeout
+and a working directory, and the only thing between a chosen command and the machine was the
+governance kernel plus a confirmation the user had to answer. ``SECURITY.md`` said so out loud.
+Both comparable products enforce a kernel boundary **per command** with the network off by default,
+and one of them refuses to run at all rather than degrade to unsandboxed.
+
+This module is that boundary where the platform offers one:
+
+* **macOS** — Seatbelt (``/usr/bin/sandbox-exec``) with a ``(deny default)`` profile: read anywhere,
+  write only under the declared roots, no network.
+* **Linux** — bubblewrap: read-only bind of ``/``, read-write bind of the declared roots,
+  ``--unshare-net``, ``--unshare-pid``, ``--unshare-ipc``, ``--cap-drop ALL``, ``--die-with-parent``.
+* **Windows** — **nothing**. The mechanism Codex uses there is a restricted token plus WFP filters,
+  which is native work this cannot honestly approximate, and approximating it is worse than not
+  having it: a boundary that is believed and absent is more dangerous than one known to be absent.
+
+That last point is the design rule for the whole module: :meth:`OsSandbox.is_isolated` answers True
+**only** when the wrapper really applied. It is what the host-exec gate consults, so a machine
+without a usable sandbox keeps its confirmation prompt and a machine with one may skip it — the
+claim and the enforcement move together, and neither can drift from the other.
+
+Availability is **probed, not guessed**. `bwrap` on PATH is not the question; whether this kernel
+lets it unshare a user namespace is. Containers, hardened distributions and WSL1 all ship the binary
+and refuse the syscall.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+from chimera.sandbox.local import LocalSandbox
+from chimera.telemetry import get_logger
+
+_log = get_logger("sandbox.os")
+
+#: How long the availability probe may take. A probe that hangs is a probe that answers "no".
+_PROBE_TIMEOUT = 10
+
+_SEATBELT = "/usr/bin/sandbox-exec"
+
+
+def _probe(argv: list[str], what: str) -> bool:
+    """Run ``argv`` and report whether it succeeded, treating any failure to launch as a no.
+
+    The probe runs the **same argv builder** the real command will use, differing only in the
+    program at the end. Probing a simpler invocation than the one that ships is how a machine ends
+    up reporting an available sandbox and then failing every command with a flag error — the check
+    would pass and the thing it certified would not exist.
+    """
+    try:
+        result = subprocess.run(argv, capture_output=True, timeout=_PROBE_TIMEOUT, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        _log.debug("%s probe could not run: %s", what, exc)
+        return False
+    if result.returncode != 0:
+        _log.debug("%s present but unusable: %s", what, (result.stderr or b"")[:300])
+    return result.returncode == 0
+
+
+@lru_cache(maxsize=1)
+def seatbelt_available() -> bool:
+    """macOS with a sandbox binary that accepts the profile this module actually generates.
+
+    The absolute path is deliberate, and it is the same reasoning Chrome and Codex use: resolving
+    ``sandbox-exec`` through PATH would let anything earlier on PATH become the thing that decides
+    whether the sandbox exists.
+    """
+    if platform.system() != "Darwin" or not Path(_SEATBELT).is_file():
+        return False
+    profile = _seatbelt_profile(_writable_roots(None))
+    return _probe([_SEATBELT, "-p", profile, "/usr/bin/true"], "seatbelt")
+
+
+@lru_cache(maxsize=1)
+def bubblewrap_available() -> bool:
+    """Linux with a `bwrap` that this kernel lets run the exact flag set used below.
+
+    Probed rather than assumed. Unprivileged user namespaces are disabled by default on several
+    distributions and inside many container runtimes, and WSL1 has no support at all — in every one
+    of those the binary is present and the call fails. Asking `shutil.which` would report a sandbox
+    that cannot start.
+    """
+    if platform.system() != "Linux" or shutil.which("bwrap") is None:
+        return False
+    return _probe(_bwrap_argv(_writable_roots(None), None) + ["--", "/bin/true"], "bubblewrap")
+
+
+def os_sandbox_available() -> bool:
+    """Whether this machine can enforce a kernel boundary for the agent's commands."""
+    return seatbelt_available() or bubblewrap_available()
+
+
+def unavailable_reason() -> str:
+    """Why not, in one sentence a person can act on. Empty when a sandbox IS available."""
+    if os_sandbox_available():
+        return ""
+    system = platform.system()
+    if system == "Windows":
+        return (
+            "Windows has no OS sandbox in Chimera: the mechanism there is a restricted token plus "
+            "network filters, which is native work this does not attempt. Use CHIMERA_SANDBOX=docker "
+            "for a real boundary."
+        )
+    if system == "Linux":
+        if shutil.which("bwrap") is None:
+            return "bubblewrap is not installed (apt install bubblewrap), so commands run on the host."
+        return (
+            "bubblewrap is installed but this kernel refuses to unshare a user namespace "
+            "(common in containers and on hardened kernels), so commands run on the host."
+        )
+    if system == "Darwin":
+        return f"{_SEATBELT} is missing, so commands run on the host."
+    return f"no OS sandbox is implemented for {system!r}, so commands run on the host."
+
+
+def _writable_roots(cwd: Path | None) -> list[Path]:
+    """Where the command may write: the directory it runs in, plus the temp dir it will reach for.
+
+    Temp is not a convenience. Compilers, package managers and test runners all write there, and a
+    sandbox that forbids it turns into a sandbox nobody leaves switched on.
+    """
+    roots: list[Path] = []
+    if cwd is not None:
+        roots.append(Path(cwd))
+    tmp = os.environ.get("TMPDIR") or "/tmp"
+    roots.append(Path(tmp))
+    resolved: list[Path] = []
+    for root in roots:
+        try:
+            candidate = root.resolve()
+        except OSError:
+            continue
+        if candidate.is_dir() and candidate not in resolved:
+            resolved.append(candidate)
+    return resolved
+
+
+def _seatbelt_profile(roots: list[Path]) -> str:
+    """A closed-by-default SBPL profile: read anywhere, write only under ``roots``, no network.
+
+    ``(deny default)`` is what makes the omissions safe — network is denied because nothing allows
+    it, not because a rule turned it off, so a rule that fails to render cannot open it by accident.
+    """
+    lines = [
+        "(version 1)",
+        "(deny default)",
+        "(allow process-exec)",
+        "(allow process-fork)",
+        "(allow signal (target same-sandbox))",
+        "(allow sysctl-read)",
+        "(allow file-read*)",
+        # /dev/null must stay writable or almost every shell pipeline fails on its own redirection.
+        '(allow file-write-data (require-all (path "/dev/null") (vnode-type CHARACTER-DEVICE)))',
+    ]
+    for root in roots:
+        lines.append(f'(allow file-write* (subpath "{root.as_posix()}"))')
+    return "\n".join(lines) + "\n"
+
+
+def _bwrap_argv(roots: list[Path], cwd: Path | None) -> list[str]:
+    argv = ["bwrap", "--ro-bind", "/", "/"]
+    for root in roots:
+        argv += ["--bind", str(root), str(root)]
+    argv += [
+        "--dev",
+        "/dev",
+        "--proc",
+        "/proc",
+        "--unshare-net",
+        "--unshare-pid",
+        "--unshare-ipc",
+        "--die-with-parent",
+        "--new-session",
+        "--cap-drop",
+        "ALL",
+    ]
+    if cwd is not None:
+        argv += ["--chdir", str(cwd)]
+    return argv
+
+
+class OsSandbox(LocalSandbox):
+    """Runs the command under the platform's kernel sandbox.
+
+    Subclasses :class:`LocalSandbox` for its process handling rather than copying it: the timeout
+    that kills the whole process tree, the secret-scrubbed environment and the non-interactive
+    overrides are all correctness fixes with their own history, and a second copy of them is a
+    second place for that history to be forgotten. Only the argv changes.
+    """
+
+    @staticmethod
+    def is_isolated() -> bool:
+        """True only where the wrapper genuinely applies. This is the claim the host-exec gate
+        reads, so it must never be more optimistic than the enforcement."""
+        return os_sandbox_available()
+
+    def _command_argv(self, command: str, cwd: Path | None) -> tuple[list[str] | str, bool]:
+        roots = _writable_roots(cwd)
+        if seatbelt_available():
+            return ([_SEATBELT, "-p", _seatbelt_profile(roots), "/bin/sh", "-c", command], False)
+        if bubblewrap_available():
+            return (_bwrap_argv(roots, cwd) + ["--", "/bin/sh", "-c", command], False)
+        # No boundary to apply. Falling through to the host would be the silent degradation this
+        # module exists to prevent, so say it and run gated instead — `is_isolated` is already False,
+        # which keeps the host-exec confirmation in front of this command.
+        _log.warning("os sandbox unavailable, running on the host: %s", unavailable_reason())
+        return (command, True)

--- a/tests/test_posture.py
+++ b/tests/test_posture.py
@@ -420,7 +420,24 @@ def test_a_host_exec_deny_is_reported_as_refused_not_as_running(tmp_path: Any, m
 
     facts = describe(Posture(reach="workspace_shell", approval="never"), tmp_path, settings)
     assert facts.shell == "refused"
-    assert not facts.fell_back_to_host  # nothing fell back — local was what was asked for
+    # Under the `auto` default something DID fall back: a boundary was intended and this machine
+    # has none. That is the fact a Windows user most needs on the screen, so it is reported.
+    assert facts.fell_back_to_host
+
+
+def test_choosing_the_host_on_purpose_is_not_a_fallback(tmp_path: Any, monkeypatch: Any) -> None:
+    """The control for the line above. `fell_back_to_host` means "a boundary was intended and is
+    missing"; someone who selected `local` intended the host and should not be told they lost
+    something they never asked for."""
+    monkeypatch.setattr(
+        "chimera.sandbox.confirm.sandbox_is_isolated", lambda _s: False, raising=True
+    )
+    settings = Settings(  # type: ignore[call-arg]
+        CHIMERA_HOME=str(tmp_path), CHIMERA_HOST_EXEC="deny", CHIMERA_SANDBOX="local"
+    )
+
+    facts = describe(Posture(reach="workspace_shell", approval="never"), tmp_path, settings)
+    assert not facts.fell_back_to_host
 
 
 def test_a_conversation_turn_reports_that_it_cannot_pause(tmp_path: Any) -> None:

--- a/tests/test_the_kernel_holds_the_boundary.py
+++ b/tests/test_the_kernel_holds_the_boundary.py
@@ -1,0 +1,301 @@
+"""The shipped default used to be the host, and the only thing in front of it was a question.
+
+`SECURITY.md` said it plainly: the `local` sandbox is not isolated. So the boundary between a
+command the model chose and the machine was the governance kernel plus a confirmation prompt — and
+a prompt is a boundary a tired person waves through and an injected instruction routes around.
+
+Both comparable products enforce a *kernel* boundary per command, with the network off by default.
+This is that boundary where the platform offers one, and an explicit, loud absence where it does
+not.
+
+**The rule the whole module is built on:** `is_isolated()` is what the host-exec gate reads, so it
+may never be more optimistic than the enforcement. A machine that cannot sandbox keeps its prompt.
+A machine that can may skip it. The claim and the enforcement move together or the claim is a lie.
+
+⚠️ **Coverage stated rather than implied.** These tests run everywhere, but neither `bwrap` nor
+`sandbox-exec` exists on the machine this was written on — no sudo to install one. So the argv and
+the profile are asserted by **content**, not by execution, and the seam is exercised with a real
+wrapper that does exist. What is NOT proven here: that bubblewrap and Seatbelt accept these exact
+flags. The mitigation is in the code rather than in a promise — availability is probed with the
+*same* argv builder the real command uses, so a rejected flag set reports unavailable instead of
+reporting a sandbox that then fails every command.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import chimera.sandbox as sandbox_pkg
+from chimera.sandbox import LocalSandbox, get_sandbox
+from chimera.sandbox.os_sandbox import (
+    OsSandbox,
+    _bwrap_argv,
+    _seatbelt_profile,
+    _writable_roots,
+    bubblewrap_available,
+    os_sandbox_available,
+    seatbelt_available,
+    unavailable_reason,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_probe_cache() -> Any:
+    """The availability probes are cached for the process; a test that fakes one must not leak."""
+    for fn in (seatbelt_available, bubblewrap_available):
+        fn.cache_clear()
+    sandbox_pkg._warned = False
+    yield
+    for fn in (seatbelt_available, bubblewrap_available):
+        fn.cache_clear()
+    sandbox_pkg._warned = False
+
+
+class _Settings:
+    def __init__(self, sandbox: str) -> None:
+        self.sandbox = sandbox
+
+
+# --------------------------------------------------------------------------- the claim
+
+
+def test_an_unavailable_sandbox_never_claims_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The invariant the host-exec gate depends on. If this is ever True while the wrapper does not
+    apply, the confirmation prompt disappears in front of a command running on the bare host."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+
+    assert os_sandbox_available() is False
+    assert OsSandbox.is_isolated() is False
+    assert unavailable_reason() != ""
+
+
+def test_an_available_sandbox_claims_isolation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control. A module that always answered False would pass the test above and be useless."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: True)
+
+    assert os_sandbox_available() is True
+    assert OsSandbox.is_isolated() is True
+    assert unavailable_reason() == ""
+
+
+def test_the_reason_names_the_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A refusal a person cannot act on is a refusal they will switch off. Each platform gets its
+    own sentence with the next step in it."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.platform.system", lambda: "Windows")
+    assert "docker" in unavailable_reason().lower()
+
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.platform.system", lambda: "Linux")
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.shutil.which", lambda _: None)
+    assert "bubblewrap" in unavailable_reason().lower()
+
+
+# --------------------------------------------------------------------------- the factory
+
+
+def test_auto_is_the_default_and_prefers_the_kernel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: True)
+    assert isinstance(get_sandbox(_Settings("auto")), OsSandbox)  # type: ignore[arg-type]
+
+
+def test_the_shipped_default_is_auto_not_the_host() -> None:
+    """The whole point of this change is the value a user gets without choosing anything. Every
+    test above passes `auto` explicitly, so none of them would notice the default going back."""
+    from chimera.config import Settings
+
+    assert Settings.model_fields["sandbox"].default == "auto"
+
+
+def test_auto_falls_back_to_the_host_and_says_so(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Falling back is allowed. Falling back quietly is what this replaces."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+
+    with caplog.at_level("WARNING"):
+        chosen = get_sandbox(_Settings("auto"))  # type: ignore[arg-type]
+
+    assert type(chosen) is LocalSandbox
+    assert chosen.is_isolated() is False
+    assert "WITHOUT an OS sandbox" in caplog.text
+
+
+def test_the_warning_is_said_once_not_once_per_command(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+
+    with caplog.at_level("WARNING"):
+        for _ in range(5):
+            get_sandbox(_Settings("auto"))  # type: ignore[arg-type]
+
+    assert caplog.text.count("WITHOUT an OS sandbox") == 1
+
+
+def test_local_is_still_reachable_deliberately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Someone who wants the host must still be able to say so — and get no warning for choosing
+    it on purpose, which is different from being given it by default."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: True)
+    assert type(get_sandbox(_Settings("local"))) is LocalSandbox  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- what gets built
+
+
+def test_bubblewrap_argv_carries_every_isolation_flag() -> None:
+    """Asserted by content because this machine has no bwrap to run it against — and named as such
+    in the module docstring. Each flag below is load-bearing: without `--unshare-net` the sandbox
+    still reaches the network, without `--cap-drop ALL` it keeps capabilities, and `--ro-bind / /`
+    before the writable binds is what makes the rest of the disk read-only."""
+    ws = Path.cwd()
+    argv = _bwrap_argv([ws], ws)
+    joined = " ".join(argv)
+
+    assert argv[0] == "bwrap"
+    assert "--ro-bind / /" in joined
+    assert f"--bind {ws} {ws}" in joined
+    for flag in ("--unshare-net", "--unshare-pid", "--unshare-ipc", "--die-with-parent"):
+        assert flag in argv, flag
+    assert argv[argv.index("--cap-drop") + 1] == "ALL"
+    # The read-only bind must come before the writable one, or it would mount over it.
+    assert joined.index("--ro-bind / /") < joined.index(f"--bind {ws} {ws}")
+
+
+def test_the_seatbelt_profile_is_closed_by_default() -> None:
+    """`(deny default)` is what makes the omissions safe: the network is denied because nothing
+    allows it, so a rule that fails to render cannot open it by accident."""
+    ws = Path.cwd()
+    profile = _seatbelt_profile([ws])
+
+    assert "(deny default)" in profile
+    assert f'(allow file-write* (subpath "{ws.as_posix()}"))' in profile
+    assert "network" not in profile, "a network allowance appeared in a profile that must have none"
+
+
+def test_writes_are_confined_to_the_workspace_and_temp() -> None:
+    """Temp is deliberate, not a leak: compilers, package managers and test runners all write
+    there, and a sandbox that forbids it is a sandbox people switch off."""
+    ws = Path.cwd()
+    roots = _writable_roots(ws)
+
+    assert ws.resolve() in roots
+    assert len(roots) >= 1
+    assert all(r.is_dir() for r in roots)
+
+
+# --------------------------------------------------------------------------- the seam
+
+
+def test_the_wrapper_actually_reaches_the_process(tmp_path: Path) -> None:
+    """Mechanism to wiring, and the half that would rot silently: every assertion above is about a
+    string that no one runs unless `LocalSandbox.run` consults the hook. Exercised with a wrapper
+    that exists on every platform — the interpreter running these tests — so this is a real
+    execution, not a mock."""
+
+    class _WrappedSandbox(OsSandbox):
+        def _command_argv(self, command: str, cwd: Path | None) -> tuple[list[str] | str, bool]:
+            return ([sys.executable, "-c", "print('through-the-wrapper')"], False)
+
+    result = _WrappedSandbox().run("echo this-string-must-not-appear", cwd=tmp_path)
+
+    assert result.exit_code == 0
+    assert "through-the-wrapper" in result.stdout
+    assert "this-string-must-not-appear" not in result.output
+
+
+def test_streaming_never_steps_around_the_wrapper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The most dangerous line in this change, pinned.
+
+    `run_streamed` spawns its OWN process to deliver output line by line. That is equivalent to the
+    configured sandbox only when the sandbox adds nothing to a plain host process. `OsSandbox`
+    subclasses `LocalSandbox` to reuse its process handling, so an `isinstance` check there would
+    stream — running the command outside the kernel wrapper the user is relying on, silently, while
+    every screen still says "sandboxed".
+    """
+    from chimera.api.exec_stream import run_streamed
+    from chimera.config import Settings
+
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: True)
+    # The wrapper is faked to something harmless that exists, so the branch is exercised for real.
+    monkeypatch.setattr(
+        OsSandbox,
+        "_command_argv",
+        lambda self, command, cwd: ([sys.executable, "-c", "print('via-the-backend')"], False),
+    )
+    settings = Settings(CHIMERA_HOME=str(tmp_path), CHIMERA_SANDBOX="auto")  # type: ignore[call-arg]
+
+    lines: list[str] = []
+    code = run_streamed(
+        "echo must-not-be-streamed-directly",
+        workspace=tmp_path,
+        cwd=None,
+        timeout=30,
+        on_line=lines.append,
+        settings=settings,
+    )
+    joined = "\n".join(lines)
+
+    assert code == 0
+    assert "via-the-backend" in joined, "the sandbox backend was bypassed"
+    assert "must-not-be-streamed-directly" not in joined
+    assert "output shown on completion" in joined
+
+
+def test_streaming_still_streams_on_an_unsandboxed_host(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The control, and the regression this change caused once already: flipping the default to
+    `auto` sent every machine down the one-shot path and cost live output and Stop."""
+    from chimera.api.exec_stream import run_streamed
+    from chimera.config import Settings
+
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+    settings = Settings(CHIMERA_HOME=str(tmp_path), CHIMERA_SANDBOX="auto")  # type: ignore[call-arg]
+
+    lines: list[str] = []
+    code = run_streamed(
+        f'{sys.executable} -c "print(1); print(2)"',
+        workspace=tmp_path,
+        cwd=None,
+        timeout=30,
+        on_line=lines.append,
+        settings=settings,
+    )
+
+    assert code == 0
+    assert "output shown on completion" not in "\n".join(lines)
+    assert any("1" in ln for ln in lines)
+
+
+def test_the_plain_sandbox_still_runs_the_command_as_typed(tmp_path: Path) -> None:
+    """The control for the seam. Adding the hook must not change what `local` does."""
+    result = LocalSandbox().run("echo hello-from-the-host", cwd=tmp_path)
+
+    assert result.exit_code == 0
+    assert "hello-from-the-host" in result.stdout
+
+
+def test_an_unsandboxable_host_runs_the_command_gated_rather_than_wrapped(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The pair that must hold together: no wrapper AND no claim. Wrapping with something that is
+    not there would break every command; claiming isolation without it would remove the prompt."""
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.seatbelt_available", lambda: False)
+    monkeypatch.setattr("chimera.sandbox.os_sandbox.bubblewrap_available", lambda: False)
+
+    target, use_shell = OsSandbox()._command_argv("echo x", tmp_path)
+
+    assert (target, use_shell) == ("echo x", True)
+    assert OsSandbox.is_isolated() is False


### PR DESCRIPTION
Item 1 of 6 from the comparative study. The one gap a user feels as **risk** rather than as a missing feature.

## What was shipping

`SECURITY.md` said it plainly: the `local` sandbox is not isolated. So the boundary between a command the model chose and the machine was the governance kernel plus a confirmation prompt — and a prompt is a boundary a tired person waves through and an injected instruction routes around. Both comparable products enforce a **kernel** boundary per command, with the network off by default; one of them refuses to run at all rather than degrade to unsandboxed.

## What the default is now

| platform | mechanism |
|---|---|
| **macOS** | Seatbelt, `(deny default)` profile — read anywhere, write only under the working directory and temp, **no network** |
| **Linux** | bubblewrap over a read-only bind of `/`, `--unshare-net --unshare-pid --unshare-ipc --cap-drop ALL --die-with-parent` |
| **Windows** | **nothing — and it says so** |

Windows is not an oversight. The mechanism there is a restricted token plus WFP filters, which is native work this does not attempt, and **approximating it would be worse than its absence: a boundary that is believed and missing is more dangerous than one known to be missing.** Same for a Linux kernel that refuses unprivileged user namespaces — the binary is installed, the syscall fails, and the honest report is *unavailable*.

## The two properties that carry the weight

**Availability is probed with the same argv the sandbox actually uses.** My first version probed a simpler invocation, which is exactly how a machine reports an available sandbox and then fails every command with a flag error — the check would pass and the thing it certified would not exist.

**`is_isolated()` is true only where the wrapper really applied.** It is what the host-exec gate reads, so a machine without a boundary keeps its confirmation prompt instead of losing it to a claim nothing enforces. The claim and the enforcement move together, or the claim is a lie.

`OsSandbox` subclasses `LocalSandbox` for its process handling rather than copying it — the timeout that kills the whole tree, the secret-scrubbed environment and the non-interactive overrides are each correctness fixes with their own history, and a second copy is a second place for that history to rot.

## The change caught a second bug on its way in

`run_streamed` decided between live streaming and one-shot by reading `settings.sandbox != "local"` — correct only while `local` was the default. Flipping the default sent **every** machine down the one-shot path and cost live output and Stop. Four tests caught it.

**And loosening the check would have been worse than the regression.** Streaming spawns its *own* process, so on a machine that does have a kernel sandbox it would have run the command around the wrapper while every screen still said "sandboxed". The branch now asks the resolved backend, with an exact type check and **not** `isinstance`, because `OsSandbox` subclasses `LocalSandbox`. That line has its own test and its own sabotage.

## Verification

- **9 sabotages, 9 caught**, each confirmed present in the file on disk before the run was read — including the `isinstance` one.
- Full suite **4230 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces on pristine `origin/main` — environmental.
- `ruff` and `mypy` clean.

## ⚠️ Coverage stated rather than implied

The machine this was written on has **neither `bwrap` nor `sandbox-exec`**, and no sudo to install one. So the flag set and the SBPL profile are asserted by **content**, not by execution. What is *not* proven here is that bubblewrap and Seatbelt accept these exact flags.

The mitigation is in the code rather than in a promise: the probe runs the real argv, so a rejected flag set reports *unavailable* — the machine keeps its prompt and runs on the host, which is where it already was — rather than certifying a sandbox that then fails everything.

**And the honest note for this repository's own maintainer: on Windows this changes nothing but a startup warning.** The users who gain a boundary are on macOS and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)