### PR TITLE
fix(orchestration): the crew's bill never reached the Cost screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -265,6 +265,19 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — the rest
 
+- **The most expensive route in the app reported nothing on the Cost screen.** `_record_run_spend`
+  reads `outcome.receipts` and returns immediately when that list is empty; `IsolatedCrewResult` had
+  `transcript`, `conflicts`, `merged`, `failures`, `rejected` and `summary`, and no `receipts`. So
+  every crew run took the early return, and the screen that answers "what has this cost me" showed
+  zero for the one route that starts N tool-using agents at once. Two things kept it alive: the
+  comment beside the call said the opposite — that the route now appears on the screen — and the
+  test covering the recorder used a stand-in class **with** a `receipts` attribute, so it exercised
+  a contract the shipped object did not fulfil. A fake more capable than the real thing tests the
+  fake. The crew now meters **per worker**, because a crew is justified by "N attempts, the test
+  picks the winner" and that trade is only accountable if you can see what each attempt cost —
+  including the rejected and the crashed ones, which cost exactly as much as the one that won. A
+  worker that never called a model is left out rather than filed at 0.00, and a model the pricer
+  does not know arrives as *unknown* rather than as free.
 - **The reviewer judged a paragraph and called it judging the work.** `Manager.review` receives
   `(task, answer, context)` and had never seen the diff, the transcript or a single file — stated in
   this repository's own test docstrings for months without the consequence being drawn. Measured on

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -983,6 +983,12 @@ def register_orchestration_api(
                 # worker loops plus an optional synthesis and wrote nothing to the usage log, so the
                 # screen that answers "what has this cost me" left out the more expensive of the two
                 # orchestration routes entirely.
+                #
+                # And this comment described the intention for months while the call did nothing:
+                # `_record_run_spend` reads `outcome.receipts` and returns early when it is empty,
+                # and `IsolatedCrewResult` had no such field. The recorder was correct, the call was
+                # correct, and between them there was no receipt to pass. It is filled now, one per
+                # worker, by `IsolatedCrew.run`.
                 _record_run_spend(live.home, run_id, outcome)
             except SpendExceeded as exc:
                 # The one failure the caller ASKED for. Reported with the numbers rather than as

--- a/chimera/orchestration/crew.py
+++ b/chimera/orchestration/crew.py
@@ -26,6 +26,8 @@ from chimera.memory.manager import MemoryManager
 from chimera.orchestration.comms import AgentMessage, consolidate, render
 from chimera.orchestration.events import OrchEvent, OrchEventSink
 from chimera.orchestration.isolation import run_isolated
+from chimera.orchestration.metering import MeteredBackend
+from chimera.orchestration.receipts import DelegationReceipt
 from chimera.orchestration.roles import Role, RoleAgent
 from chimera.providers.gateway import SupportsComplete
 from chimera.telemetry import get_logger
@@ -157,10 +159,45 @@ class IsolatedCrewResult:
     failures: dict[str, str] = field(default_factory=dict)  # worker crashed
     rejected: dict[str, str] = field(default_factory=dict)  # ran but failed verification -> not merged
     summary: str = ""  # supervisor's unified report (empty unless a supervisor is set)
+    #: One priced receipt per worker. The API's spend recorder reads ``outcome.receipts`` and this
+    #: field did not exist, so it took its early return on every crew run and the most expensive
+    #: route in the app reported nothing on the Cost screen — while the comment beside the call
+    #: said the opposite. Present for rejected and failed workers too: a discarded attempt cost
+    #: exactly as much as a kept one, and a cost report that only counts successes is an advert.
+    receipts: list[DelegationReceipt] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
         return not self.failures and not self.rejected and not self.conflicts
+
+
+def _receipts_from(metered: list[tuple[str, MeteredBackend]]) -> list[DelegationReceipt]:
+    """One receipt per worker that actually called a model.
+
+    A worker with no calls is left out rather than filed as a zero: it was cancelled before it
+    started or crashed on its way in, and a zero-dollar row invites the reader to conclude that a
+    worker ran for free.
+
+    ``usd`` is carried through as ``None`` when the meter could not price a call, never as 0.0.
+    That is the meter's own rule and it matters more here than anywhere: the spend recorder sums
+    these into the Cost screen, and an unpriced model silently counted as free would understate the
+    total in exactly the direction that flatters the configuration which used it.
+    """
+    receipts: list[DelegationReceipt] = []
+    for name, meter in metered:
+        if meter.calls == 0:
+            continue
+        receipts.append(
+            DelegationReceipt(
+                task_id=name,
+                tier="mid",
+                model=meter.last_model,
+                prompt_tokens=meter.prompt_tokens,
+                completion_tokens=meter.completion_tokens,
+                usd=meter.usd,
+            )
+        )
+    return receipts
 
 
 class IsolatedCrew:
@@ -231,7 +268,16 @@ class IsolatedCrew:
         worker that didn't crash merges (subject to conflict detection).
         """
 
+        # One meter per worker, built HERE — `make_unit` runs on this thread while the units are
+        # assembled, so nothing below ever mutates this list concurrently. A single shared meter
+        # would total the crew correctly and lose which worker spent what, which is the number that
+        # makes "N attempts, the test picks the winner" an accountable trade rather than a slogan.
+        metered: list[tuple[str, MeteredBackend]] = []
+
         def make_unit(worker: IsolatedWorker) -> Callable[[Path], WorkerOutcome]:
+            meter = MeteredBackend(worker.backend or self.backend, label=worker.role.name)
+            metered.append((worker.role.name, meter))
+
             def run_worker(ws: Path) -> WorkerOutcome:
                 name = worker.role.name
                 if self.should_stop is not None and self.should_stop():
@@ -251,7 +297,7 @@ class IsolatedCrew:
                 try:
                     agent = RoleAgent(
                         worker.role,
-                        worker.backend or self.backend,
+                        meter,
                         tools=worker.tools(ws),
                         max_steps=worker.max_steps,
                         identity=self.identity,
@@ -346,6 +392,7 @@ class IsolatedCrew:
             merged=batch.merged,
             failures=failures,
             rejected=rejected,
+            receipts=_receipts_from(metered),
         )
         # What each worker actually produced, emitted here and not from inside `run_worker`,
         # because here is where it exists: `run_isolated` reads each worktree's changed files as

--- a/chimera/orchestration/metering.py
+++ b/chimera/orchestration/metering.py
@@ -49,6 +49,10 @@ class MeteredBackend:
         self.calls = 0
         self.prompt_tokens = 0
         self.completion_tokens = 0
+        #: The model that most recently ANSWERED through this meter, for callers that have to name
+        #: one on a receipt. Recorded here because here is the only place it is known: the caller
+        #: asks for a slug and a cascade, a failover or a fusion panel may answer on another.
+        self.last_model = ""
         self._usd = 0.0
         self._unpriced = 0
         self._lock = threading.Lock()
@@ -112,6 +116,8 @@ class MeteredBackend:
             self.calls += 1
             self.prompt_tokens += prompt
             self.completion_tokens += completion
+            if model:
+                self.last_model = model
             if usd is None:
                 self._unpriced += 1
             else:

--- a/tests/test_the_crew_bill_arrives.py
+++ b/tests/test_the_crew_bill_arrives.py
@@ -1,0 +1,145 @@
+"""The most expensive route in the app reported nothing on the Cost screen.
+
+`_record_run_spend` reads `outcome.receipts` and returns immediately when the list is empty.
+`IsolatedCrewResult` had `transcript`, `conflicts`, `merged`, `failures`, `rejected` and `summary`
+— and no `receipts`. So `getattr(outcome, "receipts", None)` answered `None` on every crew run, the
+recorder took its early return, and the screen that answers "what has this cost me" showed zero for
+the one route that starts N tool-using agents at once.
+
+Two things kept it alive. The comment beside the call said the opposite — that the route now
+appears on the Cost screen — so anyone reading the code was told the fix was in. And the test that
+covered the recorder used a stand-in class **with** a `receipts` attribute, so it exercised a
+contract the shipped object did not fulfil: a fake that is more capable than the real thing tests
+the fake.
+
+The fix is per-worker metering rather than one crew total. A crew is justified by "N attempts, the
+test picks the winner", and that trade is only accountable if you can see what each attempt cost —
+including the ones that were rejected or crashed, which cost exactly as much as the one that won.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.orchestration.crew import IsolatedCrew, IsolatedCrewResult, IsolatedWorker
+from chimera.orchestration.roles import Role
+from chimera.tools.registry import ToolRegistry
+
+
+class _Result:
+    def __init__(self, content: str, model: str, prompt: int, completion: int) -> None:
+        self.content = content
+        self.model = model
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.tool_calls: list[Any] = []
+
+
+class _Backend:
+    """Answers once per call, reporting usage the way a provider does."""
+
+    def __init__(self, model: str = "openai/gpt-4o-mini") -> None:
+        self.model = model
+        self.calls = 0
+
+    def complete(self, messages: Any, **kwargs: Any) -> _Result:
+        self.calls += 1
+        return _Result("done", self.model, 100, 20)
+
+
+def _worker(name: str, backend: Any = None) -> IsolatedWorker:
+    return IsolatedWorker(
+        role=Role(name=name, system_prompt=f"you are {name}"),
+        tools=lambda _ws: ToolRegistry(),
+        backend=backend,
+        max_steps=1,
+    )
+
+
+# --------------------------------------------------------------------------- the contract
+
+
+def test_the_result_type_carries_receipts() -> None:
+    """Pinned on the type itself, because the whole defect was a field that was not there while
+    everything around it assumed it was."""
+    assert "receipts" in IsolatedCrewResult.__dataclass_fields__
+    assert IsolatedCrewResult().receipts == []
+
+
+def test_a_crew_run_produces_one_receipt_per_worker(tmp_path: Path) -> None:
+    """Mechanism to wiring. Declaring the field changes nothing until the run fills it."""
+    crew = IsolatedCrew(_Backend(), [_worker("alice"), _worker("bob")], max_workers=2)
+
+    result = crew.run("do the thing", tmp_path)
+
+    assert {r.task_id for r in result.receipts} == {"alice", "bob"}
+    assert all(r.prompt_tokens == 100 and r.completion_tokens == 20 for r in result.receipts)
+    assert all(r.model == "openai/gpt-4o-mini" for r in result.receipts)
+    assert all(r.usd is not None and r.usd > 0 for r in result.receipts)
+
+
+def test_each_worker_is_billed_to_itself(tmp_path: Path) -> None:
+    """One shared meter would total the crew correctly and lose which worker spent what — which is
+    the number that makes "N attempts, the test picks the winner" an accountable trade."""
+    cheap, dear = _Backend("openai/gpt-4o-mini"), _Backend("openai/gpt-4o")
+    crew = IsolatedCrew(
+        _Backend(), [_worker("cheap", cheap), _worker("dear", dear)], max_workers=2
+    )
+
+    result = crew.run("do the thing", tmp_path)
+    by_name = {r.task_id: r for r in result.receipts}
+
+    assert by_name["cheap"].model == "openai/gpt-4o-mini"
+    assert by_name["dear"].model == "openai/gpt-4o"
+    assert by_name["dear"].usd is not None and by_name["cheap"].usd is not None
+    assert by_name["dear"].usd > by_name["cheap"].usd
+
+
+def test_an_unpriced_worker_costs_unknown_not_zero(tmp_path: Path) -> None:
+    """The dangerous direction, and a sabotage run found nothing was holding it.
+
+    `usd or 0.0` reads as a harmless default and is not one: it turns "we cannot price this model"
+    into "this model was free", which understates the total in exactly the direction that flatters
+    whichever configuration used the unpriced one. The recorder downstream already refuses to sum a
+    partial total — it can only do that if the unknown arrives as an unknown.
+    """
+    crew = IsolatedCrew(
+        _Backend(), [_worker("mystery", _Backend("nobody/prices-this-one"))], max_workers=1
+    )
+
+    result = crew.run("do the thing", tmp_path)
+
+    assert len(result.receipts) == 1
+    assert result.receipts[0].usd is None
+    assert result.receipts[0].prompt_tokens == 100  # the tokens are known even when the price is not
+
+
+def test_a_worker_that_never_called_a_model_is_not_billed_zero(tmp_path: Path) -> None:
+    """Left out rather than filed at 0.00. A zero-dollar row invites the reader to conclude a
+    worker ran for free; absence says it did not run."""
+    from chimera.orchestration.crew import _receipts_from
+    from chimera.orchestration.metering import MeteredBackend
+
+    idle = MeteredBackend(_Backend(), label="idle")
+
+    assert _receipts_from([("idle", idle)]) == []
+
+
+# --------------------------------------------------------------------------- the wiring
+
+
+def test_the_bill_reaches_the_cost_screen(tmp_path: Path) -> None:
+    """End to end over the real objects: a crew run, its real result, the real recorder, the real
+    log. Every hop between them was individually fine, and the sum of them recorded nothing."""
+    from chimera.api.orchestration_api import _record_run_spend
+    from chimera.api.usage import load_usage
+
+    result = IsolatedCrew(_Backend(), [_worker("alice")], max_workers=1).run("go", tmp_path)
+    _record_run_spend(tmp_path, "crew_run_1", result)
+
+    rows = load_usage(tmp_path / "usage.jsonl")
+    assert len(rows) == 1, "the crew route is still invisible to the Cost screen"
+    assert rows[0].session_id == "orchestration:crew_run_1"
+    assert rows[0].prompt_tokens == 100 and rows[0].completion_tokens == 20
+    assert rows[0].usd is not None and rows[0].usd > 0

--- a/tests/test_usage_covers_what_spends.py
+++ b/tests/test_usage_covers_what_spends.py
@@ -69,15 +69,31 @@ def test_a_failure_to_log_never_takes_the_run_down(tmp_path: Path) -> None:
 
 
 def test_an_orchestration_run_lands_on_the_cost_screen(tmp_path: Path) -> None:
+    """Asserted against the REAL result type, not a stand-in.
+
+    This test passed for months while the crew route recorded nothing, because the `_Outcome` it
+    used had a `receipts` attribute and `IsolatedCrewResult` did not. The fake satisfied a contract
+    the shipped object could not, so the test measured the fake. Using the real class is what makes
+    the contract binding: delete the field and this stops compiling into a passing run.
+    """
     from chimera.api.orchestration_api import _record_run_spend
+    from chimera.orchestration.crew import IsolatedCrewResult
+    from chimera.orchestration.receipts import DelegationReceipt
 
-    class _Outcome:
-        receipts = [
-            _Receipt("t/model", 1000, 200, 0.01),
-            _Receipt("m/model", 500, 300, 0.002),
+    outcome = IsolatedCrewResult(
+        receipts=[
+            DelegationReceipt(
+                task_id="a", tier="mid", model="t/model",
+                prompt_tokens=1000, completion_tokens=200, usd=0.01,
+            ),
+            DelegationReceipt(
+                task_id="b", tier="mid", model="m/model",
+                prompt_tokens=500, completion_tokens=300, usd=0.002,
+            ),
         ]
+    )
 
-    _record_run_spend(tmp_path, "run_7", _Outcome())
+    _record_run_spend(tmp_path, "run_7", outcome)
 
     rows = load_usage(tmp_path / "usage.jsonl")
     assert len(rows) == 1


### PR DESCRIPTION
## What happens

`_record_run_spend` reads `outcome.receipts` and returns immediately when that list is empty. `IsolatedCrewResult` had `transcript`, `conflicts`, `merged`, `failures`, `rejected` and `summary` — **and no `receipts`**.

So every crew run took the early return, and the screen that answers *"what has this cost me"* showed **zero** for the one route that starts N tool-using agents at once.

## Two things kept it alive, and both are worth naming

**The comment beside the call said the opposite.** It explained that the route now appears on the Cost screen "for the same reason the hierarchy path is". Anyone reading the code was told the fix was already in.

**The test used a fake more capable than the real thing.** `test_an_orchestration_run_lands_on_the_cost_screen` built a stand-in class *with* a `receipts` attribute, so it exercised a contract the shipped object could not fulfil. It passed for months over a route that recorded nothing. That test now builds a real `IsolatedCrewResult`, which is what makes the contract binding.

## What changed

The crew meters **per worker**, not one crew total. A crew is justified by *"N attempts, the test picks the winner"*, and that trade is only accountable if you can see what each attempt cost — **including the rejected and the crashed ones, which cost exactly as much as the one that won**.

Two honesty rules carry from the meter into the receipt:

- a worker that never called a model is **left out**, not filed at `0.00` — a zero-dollar row invites the reader to conclude a worker ran for free;
- a model the pricer does not know arrives as `usd=None`, **not as free** — the recorder downstream refuses to sum a partial total, and it can only do that if the unknown reaches it as an unknown.

`MeteredBackend` gains `last_model`. The receipt has to name a model, and the meter is the only place it is known: a cascade or a failover can answer on a different model than the caller asked for.

## Verification

**6 sabotages, 6 caught — but only after the battery itself was fixed twice**, and both fixes are the finding:

1. The first run reported the control **green over a pytest invocation that collected nothing** — I had pointed it at a filename that does not exist, and `"no tests ran"` contains neither `"failed"` nor `"error"`. The battery reported six clean catches over a suite that never ran. It now refuses to proceed unless the control actually executed tests, and prints how many.
2. The sabotage `usd or 0.0` — turning *"we cannot price this"* into *"this was free"* — **caught nothing**, because no test held that direction. That is the dangerous direction: it understates the total in exactly the way that flatters whichever configuration used the unpriced model. There is a test for it now.

Full suite **4219 passed**. The single failure, `test_cli_schema_dump::test_the_committed_snapshot_is_current`, reproduces on pristine `origin/main` — environmental. `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)