### PR TITLE
bench(fusion): the paired experiment, pre-registered and not yet run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ site/
 
 # Local benchmark run outputs (harness + tasks are tracked; per-run results are not)
 bench/local_lift/results/
+bench/fusion_paired/results/
 bench/llm_benchmarks/results/
 bench/llm_benchmarks/data/   # downloaded HumanEval/GSM8K (their own licences; fetched on demand)
 

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ site/
 # Local benchmark run outputs (harness + tasks are tracked; per-run results are not)
 bench/local_lift/results/
 bench/fusion_paired/results/
+bench/fusion_aggregate/results/
 bench/llm_benchmarks/results/
 bench/llm_benchmarks/data/   # downloaded HumanEval/GSM8K (their own licences; fetched on demand)
 

--- a/bench/fusion_aggregate/PREREGISTRATION.md
+++ b/bench/fusion_aggregate/PREREGISTRATION.md
@@ -1,0 +1,141 @@
+# Pre-registration — union + validator instead of the vote, on the fusion panel
+
+**Written and committed BEFORE a single model call of this experiment.** Nothing below may be edited
+after the first run; changes go in an addendum with a reason, as `local_lift`, `memory_graph` and
+`fusion_paired` do.
+
+## The question
+
+> When the panel has answered, the aggregator picks the answer. Today a logic-typed task with a
+> strict majority returns **the majority**. Does taking the **union of the distinct answers and
+> validating each one** beat that — and by how much, at what price?
+
+## Why, and what is already known
+
+`chimera/fusion/engine.py` aggregates a panel two ways. For a task typed `logic` with a strict
+majority it returns that majority and skips the judge and the synthesiser entirely
+(`_aggregate`, the `vote` branch). Everything else goes judge → synthesiser.
+
+Three things say the vote is the weaker half:
+
+- **The pool holds more than the selection takes.** Barrel of Monkeys, SWE-bench Verified n=500:
+  pool coverage **80.8%**, selected **66.2%**. Fourteen points sit in the pool and never get chosen.
+  A strict majority is the most brittle selector of all — it picks by popularity, and a correct
+  minority answer is discarded by construction.
+- **This project already has the mechanism and never wired it to the panel.**
+  `chimera/fusion/verifier_select.py` (`VerifierSelector`, Weaver-lite: *score each candidate, take
+  the top one*) is injected into `SelfConsistency` and reachable only through one CLI flag on
+  `best-of`. The panel — the place with the most candidates and the most to lose — votes.
+- **Our own judge is weak at ranking and was never asked to verify.** `bench/review_judge` measured
+  15.1% rejection recall against a registered 30% floor. Ranking several answers is a harder question
+  than checking one; the validator asks the easier one, once per candidate.
+
+**Measured free, before any of this: 856 of 1319 GSM8K test items (64.9%) classify as `logic`.**
+The vote path is not a rare branch on its own target corpus, so there is something here to change.
+
+## Design, fixed now
+
+**Corpus.** GSM8K test (`bench/llm_benchmarks/datasets.py`, pinned URL), restricted to the items
+`classify_task_type` calls `logic` — the vote branch's actual domain. A fixed-seed sample of N.
+Ground truth is the number after `####`; scoring is exact match after numeric normalisation.
+
+**The panel is generated ONCE and every aggregator reads the same answers.** That is the whole point
+of the design: panel sampling noise is removed by construction, so a difference between aggregators
+is a difference between aggregators. Same items, same ruler, same n.
+
+| stage | arm | cost |
+|---|---|---|
+| 1 | generate the panel, cache to `panel.jsonl` | paid once |
+| 2 | `oracle` — is the gold answer in ANY panel answer? | **free** |
+| 2 | `vote_text` — `majority()`, today's shipped logic path | **free** |
+| 2 | `vote_answer` — the same vote, counting the extracted NUMBER | **free** |
+| 2 | `member_i` — each panel member alone | **free** |
+| 3 | `judge_synth` — today's other path, on the cached panel | paid |
+| 3 | `union_validator` — the proposal, on the cached panel | paid |
+
+`oracle` is the ceiling and `member_i` is the floor. Between them is everything any aggregator could
+ever win, and both are free once the panel exists.
+
+### Why `vote_answer` exists, measured before this file was committed
+
+`majority()` clusters answers by **text similarity** (`difflib` over the whole answer) and returns
+the **longest** member of the winning cluster. On a logic task — where the answers differ by a
+single character — that is backwards in both directions, and both were reproduced in the shipped
+code before any of this ran:
+
+| panel | what the shipped vote returns |
+|---|---|
+| two panelists say **42**, one says **41**, same wording | **41** — the minority answer |
+| three panelists all reach **72** by different reasoning | **no majority** → pays judge + synthesiser |
+
+The first is the failure the branch was built to prevent: `chimera/fusion/task_type.py` opens by
+saying voting is used so *"a correct minority answer must not be averaged away"*, while the
+implementation can **elect** one. The second pays two extra model calls to re-derive an answer three
+models already agreed on.
+
+So `union_validator` **must not** be compared against `vote_text`. Fixing a clustering bug and
+adding a validator are two different interventions, and measuring them together would credit the
+validator with the fix — the `§2g` error, in the form where it flatters the thing being proposed.
+The registered baseline for criterion 1 is **`vote_answer`**, and `vote_text` is reported beside it
+as the size of the bug.
+
+## The stop, and why it is where it is
+
+**Stage 3 may not be paid for until stage 2 has printed the ceiling.** If `oracle` is close to
+`vote`, the pool holds nothing the vote is missing and no selector can help — the item closes at the
+price of the panel alone. This is the rule `§2k` was written for: before building a loop around a
+verifier, measure how much there is to reject.
+
+The gap `oracle − vote_answer` is registered here as the **headroom** — measured against the
+FIXED vote, never the broken one, and the decision rule is absolute:
+
+- **headroom < 3.0 pp** → stage 3 is not run. There is nothing left for a selector to find, and
+  the honest outcome of the item is the clustering fix alone.
+- **headroom ≥ 3.0 pp** → stage 3 runs, and the criterion below applies.
+
+## Adoption criterion — absolute, and fixed before the number exists
+
+`union_validator` replaces the vote for logic-typed tasks only if **all three** hold, measured
+against `vote_answer`:
+
+1. **union_validator − vote_answer ≥ +3.0 pp** — an absolute floor, never a multiplicative one;
+2. the **95% CI of the paired delta excludes zero**;
+3. **damage ≤ gain**: the count of items the vote got right and the validator got wrong is not
+   larger than the count it turned the other way.
+
+Criterion 3 is there because an aggregator that wins on net while destroying more than it saves is a
+different thing from one that only adds, and the net alone cannot tell them apart. This project has
+already shipped a decoding intervention that showed +12.9 pp on the headline metric while silently
+destroying 35 cases (`§2r`); the paired damage count is what caught it.
+
+## Activation — how much the change acted
+
+Printed beside the delta, never under it: **the share of items where `union_validator` and `vote_answer`
+return different answers**. If they differ on fewer than **5%** of items, the intervention barely
+acted and the delta is noise on a handful of cells, not a result. An intervention that does not
+report how much it acted reads "on and inert" as "did not help".
+
+## What would refute the bet
+
+- **vote_answer ≥ union_validator** ⇒ popularity beats verification on this corpus, and the Weaver result
+  does not transfer to a three-model panel of frontier models.
+- **union_validator ≈ oracle** ⇒ the validator is capturing the headroom and the vote was the
+  bottleneck — adopt.
+- **union_validator wins but damage > gain** ⇒ it is trading, not adding, and the honest outcome is
+  an opt-in with the trade written on it.
+
+## What this experiment CANNOT show — registered before it runs
+
+- **It is arithmetic with one numeric answer.** That is the vote branch's domain and nothing else.
+  It says nothing about the judge → synthesiser path on open-ended work, which is where most fused
+  turns actually go, and where "the union of the distinct answers" is not even well defined.
+- **The panel is cached**, deliberately. So this measures **aggregation** and cannot say whether a
+  different panel would do better — that is `fusion_paired`'s question, not this one.
+- **The validator is a model.** A validator that scores every candidate equally selects by tie-break
+  order, which is `member_0`. The report prints the score spread for exactly this reason: a flat
+  spread means the validator did not discriminate, and the arm must be read as `member_0` in disguise
+  rather than as verification that did not help.
+
+## Provenance
+
+Every row records the model slugs, the seed, the sample, and the SHA of this file.

--- a/bench/fusion_aggregate/RESULTS.md
+++ b/bench/fusion_aggregate/RESULTS.md
@@ -1,0 +1,92 @@
+# Results — stages 1–2, n=40. Stage 3 is not run, by the rule fixed in advance.
+
+Run 2026-08-28 · 40 logic-typed GSM8K items × a 3-model panel · seed 20260828 · prereg
+`59e4d76c60ce`.
+
+**Read `PREREGISTRATION.md` first.** The arms, the headroom gate, the adoption criterion and the
+conditions for calling the item closed were fixed there before the first model call.
+
+## The numbers
+
+| arm | |
+|---|---|
+| `oracle` — the gold answer is in **some** panel answer | **100.0%** (40/40) |
+| `member:gemini-3.1-pro-preview` | 100.0% (40/40) |
+| `member:gpt-5.5` | 97.5% (39/40) |
+| `member:claude-opus-5` | 95.0% (38/40) |
+| **`vote_answer`** — a strict majority over the extracted number | **97.5%** (39/40) |
+| **`vote_text`** — the shipped vote, a majority over prose similarity | **0.0%** (0/40) |
+
+Extraction: **100.0%** of panel answers carried the registered `ANSWER:` line, so the ruler read
+every arm the same way.
+
+## 1. The shipped logic vote fires on nothing
+
+`vote_text` **fired on 0 of 40 items** — and that number is reported separately from correctness on
+purpose, because 0% correct has two opposite readings and only the firing rate says which.
+
+`majority()` returning `None` does not mean the vote was wrong. It means the branch **declined**, and
+the turn fell through to judge → synthesiser. So the finding is **inert, not harmful**: the
+task-typed aggregation never does the thing it was built for, and every logic turn still pays for
+the two calls the branch exists to avoid.
+
+The mechanism is the one reproduced in the pre-registration before this ran: `majority()` clusters
+with `difflib` over the **whole answer**. Three panelists reasoning their way to the same number in
+their own words are three clusters of one, so no cluster ever holds a majority. The same clustering
+in the other direction can elect a minority answer, since three answers differing in one digit are
+one cluster whose representative is the **longest** member.
+
+`chimera/fusion/task_type.py` opens by saying the branch exists so *"a correct minority answer must
+not be averaged away by a synthesizer"*. Measured on its own target corpus, it neither prevents that
+nor does anything else.
+
+Counting the number instead of the prose takes it from 0.0% to **97.5%** — 39 discordant pairs to 0,
+CI [+80.0%, +97.5%]. That comparison is really "the branch fires" against "the branch never fires",
+and it should be read that way rather than as an accuracy improvement.
+
+## 2. Stage 3 is not run: the headroom is 2.5 pp, below the registered 3.0 pp gate
+
+**oracle − vote_answer = +2.5 pp**, 95% CI **[−1.5, +2.5]** — one item out of forty, not
+significant. One single item in this sample holds a correct answer that the fixed vote does not
+select, so there is nothing left for a validator to find.
+
+By the rule fixed in advance, **stage 3 is not paid for**, and the honest outcome of the item is the
+clustering fix alone. Union + validator is not warranted **on this corpus**.
+
+## What this does NOT say — and the part that limits it
+
+**The corpus is at ceiling.** `oracle` is 100.0% and one panel member is 100.0% on its own. The
+headroom could not have been large here whatever the aggregator did, so *"no headroom"* is a
+statement about **GSM8K against frontier models**, not about aggregation in general. The gate did
+what it was for — it refused to spend on a comparison that could not discriminate — but a null it
+produces is a null about the instrument as much as about the hypothesis.
+
+This is the second corpus in this session to saturate, after `local_lift`, and the third pattern of
+its kind in the project after the learning-lift series' three attempts at a 40–60% band. The
+constraint is consistent enough to plan around: **frontier models do not leave headroom on authored
+or classic suites**, and any experiment that needs headroom has to buy difficulty it did not choose.
+
+Narrower limits, also registered in advance: this is arithmetic with one numeric answer, which is
+the vote branch's whole domain and nothing else — it says nothing about the judge → synthesiser path
+on open-ended work, where most fused turns go and where "the union of the distinct answers" is not
+even well defined. And the panel is cached deliberately, so this measures **aggregation** and cannot
+say whether a different panel would do better.
+
+## An apparatus defect this run caught in itself
+
+The provenance stamp did its job on its own harness. The cached panel carries **three different
+`prereg` values** across 40 rows: `25087f1e96d0` (13 rows), `59e4d76c60ce` (24) and `MISSING` (2).
+Nothing about the design or the prompt changed between them — the pre-registration was amended
+mid-run to add `vote_answer`, and then a branch checkout removed the file from the working tree
+while the run was still going.
+
+The panel answers are unaffected: the prompt, the models and the sampling were identical throughout,
+and the amendment changed the analysis rather than the data collection. The rows are comparable, and
+the point is that this had to be **checked** rather than assumed — which is only possible because
+the stamp was there.
+
+Two smaller ones, fixed here: the report block still read a `free["vote"]` key that the `vote_text`
+/ `vote_answer` split had removed, and the patch that should have updated it asserted nothing and
+silently did nothing. The run reached the end of stage 2, printed every arm, and then raised
+`KeyError: 'vote'` — which is the good version of that failure. A test now reads the source for the
+stale key.

--- a/bench/fusion_aggregate/run_aggregate.py
+++ b/bench/fusion_aggregate/run_aggregate.py
@@ -65,6 +65,9 @@ _ANY_NUMBER = re.compile(r"-?\d[\d,]*\.?\d*")
 #: moment the model changes, and it stops silently.
 _MIN_EXTRACTION = 0.90
 
+#: The registered sample. A run with `--sample k < this` measures a PREFIX of it, never a new draw.
+_REGISTERED_SAMPLE = 120
+
 
 def prereg_sha() -> str:
     path = HERE / "PREREGISTRATION.md"
@@ -108,7 +111,12 @@ def logic_items(sample: int, seed: int) -> list[dict]:
         if classify_task_type([{"role": "user", "content": row["question"]}]) == "logic"
     ]
     rows.sort(key=lambda r: r["question"])  # a stable order before the seeded draw
-    return random.Random(seed).sample(rows, min(sample, len(rows)))
+    # Draw the FULL registered sample once and slice it, so a smaller run is a PREFIX of a larger
+    # one. Drawing `sample(rows, k)` directly gives a different set for every k, which would make
+    # the cache useless the moment the sample grew — and would let a re-draw quietly become a
+    # second roll of the same die.
+    drawn = random.Random(seed).sample(rows, min(_REGISTERED_SAMPLE, len(rows)))
+    return drawn[:sample]
 
 
 def gold(row: dict) -> str:

--- a/bench/fusion_aggregate/run_aggregate.py
+++ b/bench/fusion_aggregate/run_aggregate.py
@@ -249,6 +249,17 @@ def arms_free(rows: list[dict]) -> dict[str, list[bool]]:
     return out
 
 
+def fired_text(row: dict) -> bool:
+    """Did the shipped vote produce an answer at all on this item?
+
+    `majority` returning None does not mean the vote was wrong — it means the branch DECLINED and
+    the turn fell through to judge -> synthesiser. Scoring only correctness merges "inert" with
+    "harmful", which are opposite conclusions drawn from the same 0%.
+    """
+    texts = [a["content"] for a in row["answers"] if not a.get("error") and a["content"]]
+    return majority(texts) is not None if texts else False
+
+
 def extraction_rate(rows: list[dict]) -> float:
     """The share of live panel answers that carried the registered ANSWER: line."""
     total = ok = 0
@@ -297,11 +308,31 @@ def main() -> None:
     for name, hits in sorted(free.items()):
         print(f"  {name:<34} {sum(hits) / len(hits):6.1%}  ({sum(hits)}/{len(hits)})")
 
-    headroom = (sum(free["oracle"]) - sum(free["vote"])) / len(rows) * 100
-    print(f"\nHEADROOM (oracle - vote) = {headroom:+.1f} pp")
+    # How often the shipped vote FIRED at all, kept apart from how often it was right. Merging the
+    # two would report "declined to vote, so synthesis decided" and "voted and got it wrong" as one
+    # number, and they are opposite facts about the branch: the first says the feature is inert,
+    # the second says it is harmful. Only this line says which of the two a 0% was.
+    fired = sum(fired_text(row) for row in rows)
+    print(f"\n  vote_text FIRED on {fired}/{len(rows)} = {fired / len(rows):.1%} of items")
+    print("  (a vote that does not fire falls through to judge -> synthesiser: inert rather "
+          "than harmful, and it pays for the two calls the branch exists to avoid)")
+
     print(
         format_report(
-            compare_paired(free["vote"], free["oracle"], baseline_name="vote", treatment_name="oracle")
+            compare_paired(
+                free["vote_text"], free["vote_answer"],
+                baseline_name="vote_text", treatment_name="vote_answer",
+            )
+        )
+    )
+    headroom = (sum(free["oracle"]) - sum(free["vote_answer"])) / len(rows) * 100
+    print(f"HEADROOM (oracle - vote_answer) = {headroom:+.1f} pp")
+    print(
+        format_report(
+            compare_paired(
+                free["vote_answer"], free["oracle"],
+                baseline_name="vote_answer", treatment_name="oracle",
+            )
         )
     )
 

--- a/bench/fusion_aggregate/run_aggregate.py
+++ b/bench/fusion_aggregate/run_aggregate.py
@@ -1,0 +1,316 @@
+"""Union + validator instead of the vote, on the fusion panel — the staged run.
+
+The design, the thresholds and the refutation criterion are fixed in PREREGISTRATION.md, which was
+committed before this file ran once. Read that first; this is only the apparatus.
+
+The panel is generated ONCE and cached; every aggregator reads the same answers. That is the whole
+design: panel sampling noise is removed by construction, so a difference between aggregators is a
+difference between aggregators and not between two draws of the same panel.
+
+    stage 1  generate the panel                                          paid once
+    stage 2  oracle / vote_text / vote_answer / member_i, from the cache  FREE, reruns forever
+    stage 3  judge_synth / union_validator, on the same cache             paid, GATED on stage 2
+
+`vote_text` is today's shipped vote, which clusters answers by PROSE similarity and returns the
+longest member of the winning cluster — so on a logic task it can elect the minority answer, and
+three panelists who agree on the number by different reasoning read as no majority at all. Both were
+reproduced in the shipped code before this file existed. `vote_answer` is the same rule counting the
+extracted number, and it is the baseline stage 3 is measured against: crediting a validator with a
+clustering fix would be measuring two interventions and reporting one.
+
+Stage 3 is gated because if `oracle` sits close to `vote_answer`, the pool holds nothing the fixed
+vote is missing and no selector can find it. Measuring how much there is to reject before building
+the thing that rejects is the rule this project wrote after paying for a retry loop around a
+verifier that accepted 95% of what it saw.
+
+Usage:
+    python bench/fusion_aggregate/run_aggregate.py --sample 120          # stages 1-2
+    python bench/fusion_aggregate/run_aggregate.py --sample 120 --stage3 # adds the paid arms
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "bench/llm_benchmarks"))
+
+from datasets import load_gsm8k  # noqa: E402
+
+from chimera.eval.paired import compare_paired, format_report  # noqa: E402
+from chimera.fusion.consistency import majority  # noqa: E402
+from chimera.fusion.task_type import classify_task_type  # noqa: E402
+
+RESULTS = HERE / "results"
+PANEL_CACHE = RESULTS / "panel.jsonl"
+
+#: The panel answers a question in the shape the ruler can read. Registered here rather than
+#: discovered later: an extractor that has to guess where the number is measures the extractor.
+_PROMPT = (
+    "Solve this problem. Think it through, then give the final numeric answer on the last line in "
+    "exactly this format:\n\nANSWER: <number>\n\nProblem: {question}"
+)
+_ANSWER_LINE = re.compile(r"ANSWER:\s*(-?[\d,]+(?:\.\d+)?)", re.I)
+_ANY_NUMBER = re.compile(r"-?\d[\d,]*\.?\d*")
+
+#: Below this share of panel answers yielding the registered line, the ruler is not reading the
+#: panel and no arm may be read. `§2e`: a harness written against one model stops reporting the
+#: moment the model changes, and it stops silently.
+_MIN_EXTRACTION = 0.90
+
+
+def prereg_sha() -> str:
+    path = HERE / "PREREGISTRATION.md"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12] if path.is_file() else "MISSING"
+
+
+def normalise(value: str) -> str:
+    """Canonical numeric form, so 1,000 / 1000 / 1000.0 compare equal. Same rule as gsm8k.py."""
+    text = str(value).strip().replace(",", "").replace("$", "").rstrip(".")
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+    return str(int(number)) if number == int(number) else str(number)
+
+
+def extract(answer: str) -> str | None:
+    """The number the panel meant, or None.
+
+    Prefers the registered `ANSWER:` line and falls back to the last number in the text. The
+    fallback is measured rather than silent: a run where most answers need it is a run where the
+    panel ignored the format, and that is a fact about the apparatus, not about the panel.
+    """
+    match = _ANSWER_LINE.search(answer)
+    if match:
+        return normalise(match.group(1))
+    numbers = _ANY_NUMBER.findall(answer)
+    return normalise(numbers[-1]) if numbers else None
+
+
+def logic_items(sample: int, seed: int) -> list[dict]:
+    """A fixed-seed sample of the GSM8K items the vote branch would actually see.
+
+    Restricted to `classify_task_type == "logic"` on purpose: the vote is what this experiment
+    replaces, and it only ever runs there. Measured free before any of this: 856 of 1319 test items
+    (64.9%) classify as logic, so the branch is not a rare one on its own corpus.
+    """
+    rows = [
+        row
+        for row in load_gsm8k()
+        if classify_task_type([{"role": "user", "content": row["question"]}]) == "logic"
+    ]
+    rows.sort(key=lambda r: r["question"])  # a stable order before the seeded draw
+    return random.Random(seed).sample(rows, min(sample, len(rows)))
+
+
+def gold(row: dict) -> str:
+    return normalise(str(row["answer"]).rsplit("####", 1)[-1])
+
+
+def _key(question: str) -> str:
+    return hashlib.sha256(question.encode("utf-8")).hexdigest()[:16]
+
+
+def _load_cache() -> list[dict]:
+    if not PANEL_CACHE.is_file():
+        return []
+    out = []
+    for line in PANEL_CACHE.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            out.append(json.loads(line))
+        except ValueError:
+            continue
+    return out
+
+
+def generate_panel(items: list[dict], models: list[str]) -> list[dict]:
+    """Stage 1, paid once. One call per (item, model), tool-free, cached to disk.
+
+    Resumable by construction: an item already in the cache is not re-asked, so an interrupted run
+    costs what it already spent and nothing more.
+    """
+    from chimera.providers.gateway import LLMGateway, Message
+
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    done = {row["id"] for row in _load_cache()}
+    gateway = LLMGateway()
+    with PANEL_CACHE.open("a", encoding="utf-8") as cache:
+        for index, item in enumerate(items):
+            key = _key(item["question"])
+            if key in done:
+                continue
+            answers: list[dict] = []
+            for model in models:
+                try:
+                    result = gateway.complete(
+                        [Message(role="user", content=_PROMPT.format(question=item["question"]))],
+                        model=model,
+                        temperature=0.3,
+                    )
+                    answers.append(
+                        {
+                            "model": model,
+                            "content": result.content,
+                            "prompt_tokens": result.prompt_tokens,
+                            "completion_tokens": result.completion_tokens,
+                        }
+                    )
+                except Exception as exc:  # noqa: BLE001 — a dead panelist is data, not a crash
+                    answers.append({"model": model, "content": "", "error": str(exc)})
+            row = {
+                "id": key,
+                "question": item["question"],
+                "gold": gold(item),
+                "answers": answers,
+                "prereg": prereg_sha(),
+            }
+            cache.write(json.dumps(row, ensure_ascii=False) + "\n")
+            cache.flush()
+            print(f"  [{index + 1}/{len(items)}] {key} gold={row['gold']}")
+    return _load_cache()
+
+
+def union(answers: list[str]) -> list[str]:
+    """The DISTINCT candidates: one representative per distinct EXTRACTED ANSWER.
+
+    This is the half the vote throws away, and the grouping is by the number rather than by the
+    prose for the reason measured in the pre-registration: `_cluster` compares whole answers with
+    difflib, so on a logic task "ANSWER: 41" and "ANSWER: 42" land in one cluster and one of them
+    disappears. Grouping by the extracted value is the only grouping that means anything here.
+
+    Order is first-seen, which makes the tie-break in any downstream selector deterministic.
+    """
+    seen: dict[str, str] = {}
+    for answer in answers:
+        key = extract(answer) or f"__unparsed_{len(seen)}"
+        seen.setdefault(key, answer)
+    return list(seen.values())
+
+
+def vote_answer(answers: list[str]) -> str | None:
+    """A strict majority over the extracted NUMBERS — the vote the logic branch was meant to be.
+
+    Same rule as `majority`: the winning group must hold MORE than half, so a plurality does not
+    win and there can be no tie. What changes is what is being counted.
+    """
+    picked = [extract(a) for a in answers]
+    live = [p for p in picked if p]
+    if not live:
+        return None
+    counts: dict[str, int] = {}
+    for value in live:
+        counts[value] = counts.get(value, 0) + 1
+    best, hits = max(counts.items(), key=lambda kv: kv[1])
+    return best if hits * 2 > len(picked) else None
+
+
+def arms_free(rows: list[dict]) -> dict[str, list[bool]]:
+    """Stage 2. Everything computable from the cache: the ceiling, the floor, and today's vote."""
+    out: dict[str, list[bool]] = {"oracle": [], "vote_text": [], "vote_answer": []}
+    models = [a["model"] for a in rows[0]["answers"]] if rows else []
+    for model in models:
+        out[f"member:{model.split('/')[-1]}"] = []
+    for row in rows:
+        golden = row["gold"]
+        texts = [a["content"] for a in row["answers"] if not a.get("error") and a["content"]]
+        picked = [p for p in (extract(t) for t in texts) if p]
+        # The ceiling: does ANY panel member hold the right answer? Everything an aggregator could
+        # ever win lives between this line and the best single member.
+        out["oracle"].append(golden in picked)
+        # Today's shipped behaviour, faithfully: a majority over TEXT similarity, whose winner is
+        # the longest member of the winning cluster. Reported so the size of the bug is visible
+        # beside the fix rather than folded into it.
+        winner = majority(texts) if texts else None
+        out["vote_text"].append(bool(winner) and extract(winner) == golden)
+        # The same rule, counting the number instead of the prose. This is the baseline criterion 1
+        # is measured against: crediting a validator with a clustering fix would be measuring two
+        # interventions and reporting one.
+        out["vote_answer"].append(vote_answer(texts) == golden)
+        for answer in row["answers"]:
+            key = f"member:{answer['model'].split('/')[-1]}"
+            got = extract(answer["content"]) if answer.get("content") else None
+            out[key].append(got == golden)
+    return out
+
+
+def extraction_rate(rows: list[dict]) -> float:
+    """The share of live panel answers that carried the registered ANSWER: line."""
+    total = ok = 0
+    for row in rows:
+        for answer in row["answers"]:
+            if answer.get("error"):
+                continue
+            total += 1
+            ok += int(_ANSWER_LINE.search(answer.get("content") or "") is not None)
+    return ok / total if total else 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sample", type=int, default=120)
+    parser.add_argument("--seed", type=int, default=20260828)
+    parser.add_argument("--stage3", action="store_true", help="Run the paid aggregators.")
+    args = parser.parse_args()
+
+    from chimera.config import get_settings
+
+    settings = get_settings()
+    models = list(settings.fusion_panel)
+    print(f"prereg={prereg_sha()}  sample={args.sample}  seed={args.seed}")
+    print(f"panel={models}")
+
+    items = logic_items(args.sample, args.seed)
+    print(f"logic-typed GSM8K items drawn: {len(items)}")
+    rows = generate_panel(items, models)
+    keys = {_key(item["question"]) for item in items}
+    rows = [row for row in rows if row["id"] in keys]
+    print(f"panel cached for {len(rows)} items")
+
+    rate = extraction_rate(rows)
+    print(f"extraction: {rate:.1%} of answers carried the registered ANSWER: line")
+    if rate < _MIN_EXTRACTION:
+        # A ruler that reads the wrong number reports the panel as wrong, and the arm that happens
+        # to phrase itself the ruler's way wins for a reason that has nothing to do with the panel.
+        raise SystemExit(
+            f"STOP: only {rate:.1%} of panel answers used the registered format (floor "
+            f"{_MIN_EXTRACTION:.0%}). The ruler is not reading the panel; fix it before reading arms."
+        )
+
+    free = arms_free(rows)
+    print()
+    for name, hits in sorted(free.items()):
+        print(f"  {name:<34} {sum(hits) / len(hits):6.1%}  ({sum(hits)}/{len(hits)})")
+
+    headroom = (sum(free["oracle"]) - sum(free["vote"])) / len(rows) * 100
+    print(f"\nHEADROOM (oracle - vote) = {headroom:+.1f} pp")
+    print(
+        format_report(
+            compare_paired(free["vote"], free["oracle"], baseline_name="vote", treatment_name="oracle")
+        )
+    )
+
+    if headroom < 3.0:
+        print("=" * 78)
+        print("STOP, by the rule fixed in the pre-registration: the pool holds nothing the FIXED")
+        print("vote is missing, so no selector can find it. Stage 3 is not run, and the honest")
+        print("outcome of this item is the clustering fix on its own.")
+        return
+    if not args.stage3:
+        print("=" * 78)
+        print(f"Headroom is {headroom:+.1f} pp, above the 3.0 pp gate. Re-run with --stage3 to pay")
+        print("for the two aggregators. Nothing above is a comparison between aggregators yet.")
+        return
+
+    raise SystemExit("stage 3 is not built yet: build it only if the headroom above justifies it")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/fusion_paired/ADDENDUM-01.md
+++ b/bench/fusion_paired/ADDENDUM-01.md
@@ -1,0 +1,83 @@
+# Addendum 01 — two apparatus defects found before the first model call
+
+**Written 2026-08-28, before any cell of this experiment ran.** The pre-registration says changes go
+in an addendum with a reason; this is that. Nothing in the question, the arms, the seeds or the
+adoption criterion moves. What moves is the apparatus, in two places where the runner as committed
+would have measured something other than what the design names.
+
+Both were found by reading the runner against `chimera/config.py` and against the runners of
+`bench/local_lift`, not by running anything.
+
+---
+
+## 1. "The best single model" was never operationalised — and the default would have been the cheap one
+
+The design says arms B and C spend the same budget on **the best single model**. The runner passed no
+`--model`, so those arms would have inherited `settings.default_model`, which is
+`openrouter/deepseek/deepseek-chat-v3.1` — while arm A convenes a panel of
+`claude-opus-5` / `gpt-5.5` / `gemini-3.1-pro-preview`.
+
+That is not the registered comparison. It is **frontier panel against a cheap model**, and it would
+have moved both criteria at once: criterion 1 (the +5.0 pp floor) would have measured model tier,
+and criterion 3 (the token ratio ≤ 2.0) would have compared prices of different classes of model.
+It is the same family as `§2g` — two things measured different ways, and the difference reports the
+apparatus.
+
+**Operationalised now, as a declaration and not as a selection:**
+
+> The single model for arms B and C is **`openrouter/anthropic/claude-opus-5`** — the model the
+> shipped configuration already trusts to write the final answer (`_DEFAULT_SYNTHESIZER`), and
+> `_DEFAULT_PANEL[0]`.
+
+It is a **declaration**, not a measurement, and the direction of the error is stated here rather than
+discovered later: if Opus 5 is not in fact the strongest panel member on this corpus, arm B is
+understated and the bias runs **in favour of fusion**. So a null (B ≥ A) would be conservative and
+survives the doubt; a **win for A is the outcome at risk**, and adopting on it requires the model
+choice to be measured first rather than declared.
+
+**A screen, not a selection, guards the gross case.** The pilot runs arm C once per panel member. A
+member that solves **zero** pilot tasks is excluded from ever being the single model — that is a
+broken ruler, not a weak model (`§2e`: the ruler written against one model that lies when the model
+changes). The screen may **not** promote a member on a good showing: five tasks at one seed cannot
+resolve a real difference, and letting it try would be a forking path. The rule is absolute and it
+is written here before the numbers exist.
+
+## 2. Nothing stopped one cell from teaching the next
+
+Every runner in `bench/local_lift` passes a hygiene set — `--no-remember --no-collect
+--no-evolve-skills --no-skill-cards` — and this one passed none of it. The loop runs
+`for task → for seed → for arm`, so arm A would solve a task, write a long-term memory fact and
+possibly propose a learned skill, and then arms B and C would solve **the same task** with that in
+reach.
+
+The contamination is not random. It runs **with the arm order**, so it would have credited whichever
+arm ran last — here B and C — and nothing in the recorded rows would have said so. This project has
+seen exactly this shape before: the wiring is what was untested, not the mechanism.
+
+Fixed: the same four flags, on every arm, plus a per-run `CHIMERA_HOME` so the usage receipts read
+back belong to this experiment and not to whatever else the machine did.
+
+---
+
+## Recorded, not changed: what arm A actually is
+
+Two facts about the shipped route, written down because a reader would otherwise assume otherwise,
+and because criterion 3 is a price ceiling:
+
+- `fusion_mode` defaults to **`selective`** — a probe of the first two panel members, escalating to
+  the full panel, judge and synthesiser only on disagreement. Arm A is therefore the **shipped**
+  fusion, not "every turn fused". That is the thing worth measuring: it is what a user gets.
+- `--fuse` routes **deep-reasoning turns**; the rest of arm A's turns run on `default_model`. Arm A
+  is a mixed route by construction, arm B is frontier throughout, and the token ratio is what keeps
+  the budgets comparable — not flag symmetry.
+
+`A vs B` remains well-posed and stays the primary comparison: roughly three frontier generations on
+each side, one arm spending them on a diverse panel with a judge, the other on repeated samples of
+one model with the test as the gate.
+
+## The pilot, restated
+
+One seed, not three. Seeds exist to separate a difference from a variance in the **result**; the
+pilot is not a result and its own output says so. It buys three things: the gross-failure screen
+above, a measured per-cell cost for every arm, and proof that the apparatus runs end to end before
+900 cells depend on it.

--- a/bench/fusion_paired/ADDENDUM-02.md
+++ b/bench/fusion_paired/ADDENDUM-02.md
@@ -1,0 +1,81 @@
+# Addendum 02 — what the smoke run found, and what it means for reading the result
+
+**Written 2026-08-28, after a one-task smoke run of six solves and before the pilot.** The smoke run
+existed to separate "the ruler does not work" from "the model does not solve". It found both a broken
+ruler and something more important about the mechanism.
+
+## What the smoke run proved
+
+Six solves ran end to end and all six passed. All three panel members are alive on this corpus
+(`claude-opus-5`, `gpt-5.5`, `gemini-3.1-pro-preview`, 1/1 each), so the ADDENDUM-01 screen finds
+nothing to exclude. The workspace fork, the pytest gate and `assert_discriminating` all work.
+
+## 1. The cost reader returned a confident zero for six paid runs
+
+`read_cost` read `usage.jsonl`, and printed `0 tokens, $0.00, ratio=inf` for six runs that cost real
+money. Two independent reasons, either of which alone was fatal:
+
+- **Wrong file.** `append_usage` is called only from the API layer (`chimera/api/app.py`,
+  `chimera/api/code_api.py`). A CLI `solve` writes nothing there — the newest row in that file was
+  three days old. The CLI's receipt lives on the **attempts** of `runs.jsonl`, one level below where
+  a reader naturally looks. This project has made that exact level error before.
+- **Wrong directory.** `settings.home` defaults to `Path(".chimera")` — **relative**, resolved
+  against the process's cwd, which for a solve is the repo root. The reader looked in
+  `~/.chimera`, which does not exist on this machine.
+
+Fixed by joining on the **workspace path** instead of a time window. The fork directory is unique per
+cell and is recorded on the row, so the join is exact. The window version compared an ISO timestamp
+against `str(time.time())` as strings — a comparison that cannot be right in either direction.
+
+**And a guard, because a zero that looks like a measurement is the thing that just happened:** a cell
+whose join finds no rows records tokens as **unknown**, never as zero, and the pilot refuses to print
+a full-run estimate when any arm reads unknown.
+
+## 2. The mechanism: on this corpus, fusion acts on the PLANNING turn only
+
+This is the finding, and it is read off the code rather than inferred from a number.
+
+`RoutedBackend.complete` (`chimera/fusion/router.py:173`) opens with:
+
+```python
+# Tool-calling turns must go to a single model (fusion doesn't tool-call).
+if tools:
+    return self.single.complete(...)
+```
+
+The `solve` worker is a tool-calling agent — it writes the files. So **every worker turn passes
+tools and therefore never fuses.** The editor is excluded a second time and deliberately, at
+`chimera/cli/main.py:3415`: *"The EDITOR's model. Never fused: synthesising three patches produces
+one that applies cleanly and means nothing."* What `--fuse` does add is the planner, wired straight
+to the engine at `main.py:3320`.
+
+The smoke run agrees: arm A's attempt recorded `model=openrouter/deepseek/deepseek-chat-v3.1` — the
+default worker model — while arms B and C recorded the pinned `claude-opus-5`.
+
+**So arm A is: fused planning, single-model tool-calling worker.** That is the shipped product and it
+is what a user gets; it is not "three models writing the patch".
+
+### What this does to the reading — the `§2q` statement, before the numbers
+
+The comparison stays exactly as registered. What changes is what a result may be said to mean:
+
+- **A loses to B** ⇒ *fusion as shipped does not beat spending the same budget on a better model, on
+  gated code tasks.* That is a decision about the default route, and it is the question worth having.
+  It is **not** evidence that panel aggregation fails — the panel never wrote a line of the patch
+  here, so this corpus cannot say anything about that.
+- **A matches B at a lower token ratio** ⇒ fused planning buys the same outcome more cheaply, which
+  is a stronger result for fusion than the design anticipated, and criterion 3 is what shows it.
+- **A wins** ⇒ a planning turn worth three models, with a cheap worker. Also worth knowing, and
+  narrower than the headline the design would otherwise invite.
+
+Nothing here can speak to fusion on prose, where turns are tool-free and the router fuses them —
+which is where `ADDENDUM-01`'s and the pre-registration's limits already pointed.
+
+## 3. An activation guard, because "on and inert" reads as "did not help"
+
+The pre-registration asks for a token ratio as a price ceiling. The same number doubles as proof the
+intervention acted: if arm A and arm C spend the **same** tokens, fusion did not fire and every
+comparison in the run is void rather than null.
+
+The runner now prints `A/C` beside the verdict and says so in words when the ratio sits inside
+±10% of 1.0. An intervention that reports how much it acted is the only kind whose null can be read.

--- a/bench/fusion_paired/PREREGISTRATION.md
+++ b/bench/fusion_paired/PREREGISTRATION.md
@@ -1,0 +1,112 @@
+# Pre-registration — does the fusion panel beat spending the same budget on one model?
+
+**Written and committed BEFORE a single model call of this experiment.** Nothing below may be
+edited after the first run; changes go in an addendum with a reason, as `local_lift` and
+`memory_graph` do. The commit that introduces this file is the timestamp that matters.
+
+## The question
+
+> Fusion routes a turn through a panel of three architecturally different models, a judge, and a
+> synthesiser. **Does that beat giving the same token budget to the best single model**, on the same
+> tasks, from the same starting state, judged by the same executable gate?
+
+This is the project's central bet, and it has never been measured against the obvious alternative.
+
+## Why now, and why this shape
+
+The comparative study found the literature split down the middle of our own architecture:
+
+| stage | verdict in the literature | source |
+|---|---|---|
+| **panel** — generate N diverse candidates | **supported** | Barrel of Monkeys, SWE-bench Verified n=500: pool coverage 80.8%, selected 66.2% vs 62.8% for the best single member |
+| **judge** — an LLM deciding code correctness | **contradicted** | 8 judges, n=374: agreement with test execution κ = 0.21 (Java) / 0.10 (Python); GPT-4 misses half the wrong programs |
+| **synthesiser** — aggregating models of unequal quality | **contradicted at equal cost** | Self-MoA, CRUX (code) n=800: six samples of the *best* model beat six mixed by **+5.6 pp**; quality coefficient 4.55 vs diversity 1.42 |
+
+And two more findings point the same way. Aider measured, in 2024, that adding Claude 3 Opus to
+GPT-4o **lowered** GPT-4o's contribution from 17.0% to 15.3%, because plausible-and-wrong answers
+eclipse implausible-and-right ones. Our own `bench/review_judge` **failed our own judge**: 15.1%
+against a registered threshold of 30%.
+
+**The experiment the literature has not run** is the one with the budget held equal. Barrel of
+Monkeys pooled candidates that already existed and never paid to generate them; Self-MoA controls
+cost but is not SWE-bench and has no executable gate. Nobody has asked our question.
+
+## Design, fixed now
+
+**Corpus.** `bench/local_lift/tasks.py` — the existing **100** tasks, unchanged, reused deliberately
+rather than authored for this. Each has a pytest that must fail on the untouched workspace, and
+`assert_discriminating` proves that **before any model call**: a task whose test already passes
+scores a hit for an arm that did nothing.
+
+**Arms.** All three run the same loop, the same workspace fork and the same pytest gate. They differ
+only in what produces the candidate.
+
+| arm | what it is |
+|---|---|
+| **A — fusion** | the shipped panel → judge → synthesiser, one attempt |
+| **B — repeat** | the best single model, **three** samples, the gate keeps the first that passes |
+| **C — single** | the best single model, one sample |
+
+**C is not decoration.** A vs B alone cannot separate *more diversity* from *more computation*;
+B vs C is what says whether repetition helps at all on this corpus. It is the same control Self-MoA
+used, and without it a win for A would be unattributable.
+
+**Primary comparison: A vs B.** Secondary: A vs C, and B vs C.
+
+**Seeds: three.** Two alert, three decide. Reported with the dispersion beside the sampling error of
+the difference (`SE·√2`), so a spread that is ordinary sampling is not read as instability.
+
+**Statistics.** McNemar on the discordant pairs, Wilson interval, via `chimera/eval/paired.py`.
+Aligned per task and per seed; a task both arms pass carries no signal and is reported as such.
+
+## Adoption criterion — absolute, and fixed before the number exists
+
+Fusion stays the recommended route for this task class **only if all three hold**:
+
+1. **A − B ≥ +5.0 pp** — an absolute floor, never a multiplicative one;
+2. the **95% CI of the paired delta excludes zero**;
+3. the **measured token ratio A/B ≤ 2.0**.
+
+Criterion 3 exists because a win bought at four times the price is not the same finding as a win,
+and this project has been burned by a multiplicative criterion before (`§2c #5`: `pass@k > pass@1 ×
+1.5` printed "no useful tail" for 52.3% → 72.9%).
+
+## What would refute the bet, stated now
+
+- **B ≥ A** at the point estimate across three seeds ⇒ the panel's diversity does not pay on this
+  corpus, and the Barrel-of-Monkeys result does not transfer to a setting where the budget is paid
+  rather than pooled.
+- **B ≈ C** ⇒ repetition is not the mechanism either, and any A-vs-C gap is about the panel rather
+  than about sampling.
+- **A > B but ratio > 2.0** ⇒ the panel works and is not worth its price as a default; the honest
+  outcome is a documented opt-in, not a default.
+
+## What this experiment CANNOT show — registered before it runs
+
+Every task here has an **executable gate**. That is what makes the comparison clean, and it is also
+the condition under which the literature says the judge matters least: when a test decides, an LLM
+judge has little left to do. So a null result here is a null **for gated code tasks** and says
+nothing about fusion on prose, where no gate exists and where the panel may be earning its keep.
+
+Refuting the bet on this corpus would not refute it in general, and this file says so *before* the
+number arrives rather than after — the failure mode named in `§2q`.
+
+Secondarily: the judge is measured here only through its effect on the final answer. This is not a
+replacement for `bench/review_judge`, which measures the judge directly and already failed it.
+
+## Cost, and the stop
+
+The harness runs a **pilot** first — a handful of tasks across all arms and seeds — reports the
+**measured** tokens and dollars, and **stops**. The full run requires `--full` and an explicit
+decision by a person.
+
+The pilot exists because the alternative is an estimate, and an estimate of this is a guess: the
+prior bench's journal records outcomes and not cost, so there is no measured tokens-per-solve to
+extrapolate from. Measuring five is cheaper than being wrong about nine hundred.
+
+**Full run size:** 100 tasks × 3 arms × 3 seeds = **900 solves**.
+
+## Provenance
+
+Every row records the Chimera version, the model slugs of every arm, the seed, and the SHA of this
+file — so a result can never be read against a design it was not run under.

--- a/bench/fusion_paired/RESULTS.md
+++ b/bench/fusion_paired/RESULTS.md
@@ -1,0 +1,107 @@
+# Results — pilot only. The registered run must not be paid for on this corpus.
+
+Run 2026-08-28 · 5 tasks × 3 arms × 1 seed, plus a 15-solve screen · prereg `PREREGISTRATION.md`
+with `ADDENDUM-01` and `ADDENDUM-02`.
+
+**Read the pre-registration first.** The arms, the seeds, the adoption criterion and the conditions
+for calling a run void were fixed there before the first model call. This file reports what the
+pilot bought, and the pilot bought a decision: **do not run the registered 900 cells on this
+corpus.**
+
+## What the pilot measured
+
+| | |
+|---|---|
+| screen — `claude-opus-5` / `gpt-5.5` / `gemini-3.1-pro-preview` | **5/5 each**, 15/15 |
+| `B_repeat` (opus ×3, gate keeps the first pass) | **5/5** |
+| `C_single` (opus ×1) | **5/5** |
+| `A_fusion` (the shipped `--fuse` route) | **3/5** — and both misses are the clock |
+
+## Three reasons the registered run would not have meant anything
+
+### 1. The corpus is at ceiling, so there is nothing for an aggregator to win
+
+Twenty-five single-model solves, twenty-five passes. `local_lift` was authored to discriminate a
+**weak** model; against frontier models its first five tasks are trivial. A comparison whose control
+arm sits at 100% cannot show a lift or a loss in either direction — the instrument cannot exhibit
+the effect, which is the `§2q` condition for a result that says nothing while looking like one.
+
+This is the **third** time this project has run into an authored suite's ceiling. The learning-lift
+series tried three times to land a control arm in a 40–60% band and got 84–92% every time, and
+closed with the sentence that applies here word for word: *"we cannot build a synthetic suite that
+can measure it."*
+
+### 2. At ceiling, arm B collapses into arm C — the equal-budget comparison degenerates
+
+Arm B is three samples with the gate keeping the first that passes. Every first sample passed, so
+`samples_paid` was **1** in all five cells and arm B never bought samples two and three. Measured
+cost confirms it: on the three tasks where every arm left a receipt, B spent 178,098 tokens against
+C's 165,899.
+
+So the primary comparison A-vs-B, which the design chose precisely because it holds the budget
+equal, is on this corpus a comparison against a **single** sample. The equal-budget arm only exists
+when the model sometimes fails — which is another way of saying the same thing as §1.
+
+### 3. Both of arm A's misses are the timeout, not the model
+
+`path_get` and `eval_expr` failed at **300.1s** against a `--timeout 300`. Fusion runs 3–4× slower
+than the single arms (164–234s where they take 34–88s), so the wall lands on one arm and not the
+others.
+
+A full run at this timeout would have reported a large A-vs-B deficit that is a **clock artifact**,
+and nothing in the pass/fail column would have said so. This is exactly the conflation the
+learning-lift series had to separate after run 7a: *"the agent could not do it"* and *"the clock ran
+out"* were the same number.
+
+## What the tokens say, on the part that is readable
+
+Only three of five tasks left a receipt in **every** arm, so only those three can be compared:
+
+| arm | tokens, paired-complete subset (3 tasks) |
+|---|---|
+| `A_fusion` | 190,549 |
+| `B_repeat` | 178,098 |
+| `C_single` | 165,899 |
+
+**A/C = 1.15** — fusion moved the spend by +15%, which is the activation reading `ADDENDUM-02`
+registered: the fused planning turn fired. **A/B = 1.07**, and criterion 3's ceiling is 2.0, so cost
+was never going to be what disqualified fusion here.
+
+There is no accuracy signal to put beside these numbers: every arm passed all three.
+
+## An apparatus finding worth more than the run: a successful solve can leave no receipt
+
+On `eval_expr`, **all three arms wrote no row to `runs.jsonl` at all** — and two of them succeeded.
+The workspace still holds the written `calc.py`, and its test passes on a fresh check. Two more
+cells lost their receipt to the timeout kill. Four of fifteen cells therefore have a cost that is
+**unknown, not zero**, and the pilot's `NO ESTIMATE` guard refused to print a full-run projection
+built on them.
+
+The mechanism is in the product, not in the bench. `AutonomousAgent._persist_receipt`
+(`chimera/core/autonomous.py:1230`) wraps the whole write in `except Exception` and logs at **debug**.
+A receipt that fails to serialise disappears with no trace at any level a user or a bench would see,
+and it disappears **by task** rather than at random — so every consumer of those receipts, the Cost
+screen included, undercounts systematically and silently.
+
+## Two defects in this harness, caught by its own output
+
+- The token counts printed by the run **double-count an earlier run of the same cell**. The
+  workspace path repeats between runs, and the process had already loaded its code when the scoping
+  fix landed. Every number in this file is recomputed from `runs.jsonl` scoped to the pilot window;
+  the fix is committed and tested.
+- The harness discards the solve's exit code and output, so a cell that joins no receipt leaves
+  **no evidence of what happened**. That is why the `eval_expr` diagnosis had to be done from disk.
+
+## What would have to change before the registered run is worth paying for
+
+1. **A corpus whose single-model arm lands in a measurable band.** Not authored to be hard — chosen
+   because it already is. SWE-bench Verified is the one this project has already registered for
+   exactly this reason: difficulty nobody here authored, and a grader nobody here owns.
+2. **A timeout that does not truncate the slowest arm**, with timeouts recorded and audited per arm
+   and an asymmetric timeout invalidating the run outright — the rule the learning-lift series
+   already had to write.
+3. **A receipt that cannot vanish**, or a cost source that does not depend on one.
+
+Until then the honest statement is that fusion-as-shipped and a frontier model both solve these
+tasks every time, fusion costs 15% more than one frontier pass to do it, and **this corpus cannot
+tell them apart** — which is a fact about the corpus and not about fusion.

--- a/bench/fusion_paired/run_paired.py
+++ b/bench/fusion_paired/run_paired.py
@@ -32,6 +32,7 @@ import shutil
 import subprocess
 import sys
 import time
+from datetime import UTC, datetime
 from importlib.metadata import version
 from pathlib import Path
 
@@ -188,7 +189,7 @@ def run_solve(task: dict, ws: Path, flags: list[str], seed: int, timeout: int) -
     return {"exit": code, "tail": tail, "seconds": round(time.monotonic() - began, 1)}
 
 
-def read_cost(home: Path, workspace: Path) -> dict[str, float | None]:
+def read_cost(home: Path, workspace: Path, since: str = "") -> dict[str, float | None]:
     """What this cell spent, joined by WORKSPACE rather than by a window of time.
 
     Two things were wrong before, and the smoke run made both visible at once by printing
@@ -202,6 +203,13 @@ def read_cost(home: Path, workspace: Path) -> dict[str, float | None]:
     The window itself was the third: it compared an ISO timestamp against `str(time.time())` as
     strings. The workspace path is unique per cell and is recorded on the row, so the join is exact
     and no clock is involved.
+
+    ``since`` is the ISO-UTC instant this run began, and it is not optional in practice. The
+    workspace path repeats between runs — the pilot reuses `screen_<model>/<task>` — so the join
+    alone silently ADDS every earlier run of the same cell. It was caught by the pilot itself: a
+    screen cell read 86,983 prompt tokens where the smoke run of the same cell had measured 43,219,
+    which is the smoke plus the pilot. ISO-UTC timestamps compare correctly as strings, and the
+    earlier version's bug was comparing one against ``str(time.time())``, not the comparison itself.
 
     ``usd`` follows the all-or-nothing rule and is None when any joined attempt is unpriced — here
     that is the frontier models, which the local catalogue does not price. ``tokens_known`` is False
@@ -224,6 +232,8 @@ def read_cost(home: Path, workspace: Path) -> dict[str, float | None]:
             continue
         if str(row.get("workspace", "")).replace(chr(92), "/").split("workspaces/")[-1] != needle:
             continue
+        if since and str(row.get("ts", "")) < since:
+            continue  # an earlier run of the SAME cell: its cost is not this run's
         for attempt in row.get("attempts") or []:
             joined += 1
             prompt += int(attempt.get("prompt_tokens") or 0)
@@ -240,9 +250,9 @@ def read_cost(home: Path, workspace: Path) -> dict[str, float | None]:
     }
 
 
-def _sum_costs(home: Path, forks: list[Path]) -> dict:
+def _sum_costs(home: Path, forks: list[Path], since: str) -> dict:
     """Arm B pays for every sample it took, so a cell's cost is the sum over its forks."""
-    parts = [read_cost(home, fork) for fork in forks]
+    parts = [read_cost(home, fork, since) for fork in forks]
     usd: float | None = 0.0
     for part in parts:
         if part["usd"] is None:
@@ -261,7 +271,9 @@ def _sum_costs(home: Path, forks: list[Path]) -> dict:
     }
 
 
-def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Path) -> dict:
+def run_cell(
+    task: dict, arm: str, seed: int, root: Path, timeout: int, home: Path, since: str
+) -> dict:
     """One (task, arm, seed). Arm B is N solves from the SAME fork; the gate keeps the first pass.
 
     Each sample starts from a fresh workspace on purpose. Letting sample 2 inherit sample 1's edits
@@ -281,7 +293,7 @@ def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Pa
         if independent_pytest(task, ws):
             passed = True
             break  # the gate keeps the first that passes; the rest are not paid for
-    cost = _sum_costs(home, forks)
+    cost = _sum_costs(home, forks, since)
     return {
         "task": task["id"],
         "arm": arm,
@@ -298,7 +310,7 @@ def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Pa
 
 
 def run_screen(
-    tasks: list[dict], seed: int, root: Path, timeout: int, home: Path, journal
+    tasks: list[dict], seed: int, root: Path, timeout: int, home: Path, journal, since: str
 ) -> dict[str, int]:
     """The gross-failure screen from ADDENDUM-01: one pass of arm C per panel member.
 
@@ -320,7 +332,7 @@ def run_screen(
             hits += int(ok)
             row = {
                 "task": task["id"], "arm": f"screen:{model}", "seed": seed, "passed": ok,
-                "samples_paid": 1, "seconds": outcome["seconds"], **read_cost(home, ws),
+                "samples_paid": 1, "seconds": outcome["seconds"], **read_cost(home, ws, since),
                 "prereg": prereg_sha(), "chimera_version": version("chimera-agent"), "model": model,
             }
             journal.write(json.dumps(row, ensure_ascii=False) + "\n")
@@ -415,11 +427,16 @@ def main() -> None:
     ])
     print("apparatus: every task's test fails on the untouched workspace")
 
+    # The instant this run began, in the same ISO-UTC shape the receipts carry. Every cost join is
+    # scoped by it, because the workspace path repeats between runs and the join alone would add the
+    # previous run of the same cell to this one.
+    since = datetime.now(UTC).isoformat()
+
     rows: list[dict] = []
     with JOURNAL.open("a", encoding="utf-8") as journal:
         if not args.full:
             print("\nscreen (ADDENDUM-01): one pass of arm C per panel member")
-            scored = run_screen(tasks, seeds[0], work, args.timeout, home, journal)
+            scored = run_screen(tasks, seeds[0], work, args.timeout, home, journal, since)
             dead = [m for m, hits in scored.items() if hits == 0]
             if SINGLE_MODEL in dead:
                 print(f"\nSTOP: {SINGLE_MODEL} solved 0/{len(tasks)}. That is a broken ruler, not a "
@@ -431,7 +448,7 @@ def main() -> None:
         for task in tasks:
             for seed in seeds:
                 for arm in ARMS:
-                    row = run_cell(task, arm, seed, work, args.timeout, home)
+                    row = run_cell(task, arm, seed, work, args.timeout, home, since)
                     rows.append(row)
                     journal.write(json.dumps(row, ensure_ascii=False) + "\n")
                     journal.flush()

--- a/bench/fusion_paired/run_paired.py
+++ b/bench/fusion_paired/run_paired.py
@@ -1,0 +1,301 @@
+"""Does the fusion panel beat spending the same budget on one model? — the paired run.
+
+Design, thresholds and the refutation criterion are fixed in PREREGISTRATION.md, which was committed
+before this file ran once. Read that first; this is only the apparatus.
+
+Three arms over the SAME 100 tasks, the same workspace fork and the same pytest gate:
+
+    A  fusion   the shipped panel -> judge -> synthesiser, one attempt
+    B  repeat   the best single model, three samples, the gate keeps the first that passes
+    C  single   the best single model, one sample
+
+C is the control that separates *more diversity* from *more computation*. Without it a win for A is
+unattributable, which is the mistake the MoA paper made and Self-MoA corrected.
+
+**It stops.** The first invocation runs a PILOT — a few tasks across all arms and seeds — prints the
+MEASURED tokens and dollars, and exits. The full 900-solve run needs `--full` and a person deciding.
+The alternative would be an estimate, and there is nothing to estimate from: the prior bench's
+journal records outcomes and not cost. Measuring five is cheaper than being wrong about nine hundred.
+
+Usage:
+    uv run --no-sync python bench/fusion_paired/run_paired.py            # pilot, then stop
+    uv run --no-sync python bench/fusion_paired/run_paired.py --full     # the registered run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from importlib.metadata import version
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+sys.path.insert(0, str(HERE.parent / "local_lift"))
+from tasks import TASKS  # noqa: E402
+
+from chimera.eval.paired import compare_paired, format_report  # noqa: E402
+from chimera.eval.selftest import TaskCheck, assert_discriminating  # noqa: E402
+
+RESULTS = HERE / "results"
+JOURNAL = RESULTS / "journal.jsonl"
+_PY = sys.executable
+_CHIMERA = str(Path(_PY).parent / "chimera")
+
+#: Fixed in the pre-registration. Two alert, three decide.
+SEEDS = (42, 43, 44)
+
+#: How many tasks the pilot pays for before it stops and asks. Enough to measure the per-solve cost
+#: of the most expensive arm, few enough that being wrong about it costs pocket change.
+PILOT_TASKS = 5
+
+#: The arms, and the ONLY thing that differs between them.
+#:
+#: `--samples` does not exist as a solve flag; arm B is N independent solves of the same task from
+#: the same fork, and the gate keeps the first that passes. Written as a count here so the runner,
+#: not a flag, is what makes the arms comparable.
+ARMS: dict[str, dict[str, object]] = {
+    "A_fusion": {"flags": ["--fuse", "--max-attempts", "1"], "samples": 1},
+    "B_repeat": {"flags": ["--max-attempts", "1"], "samples": 3},
+    "C_single": {"flags": ["--max-attempts", "1"], "samples": 1},
+}
+
+
+def _load_dotenv() -> dict[str, str]:
+    """Parse the repo .env so the solve subprocess (run from a temp cwd) keeps the provider key."""
+    env: dict[str, str] = {}
+    dotenv = REPO_ROOT / ".env"
+    if dotenv.exists():
+        for line in dotenv.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, value = line.partition("=")
+                env[key.strip()] = value.strip()
+    return env
+
+
+_DOTENV = _load_dotenv()
+
+
+def prereg_sha() -> str:
+    """The design this row was run under, stamped on the row.
+
+    A result read against a design it was not run under is worse than no result, and an edited
+    pre-registration is exactly how that happens without anybody lying.
+    """
+    path = HERE / "PREREGISTRATION.md"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12] if path.is_file() else "MISSING"
+
+
+def setup_workspace(task: dict, root: Path) -> Path:
+    ws = root / task["id"]
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    for rel, content in task.get("files", {}).items():
+        target = ws / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    (ws / task["test"]).write_text(task["test_src"], encoding="utf-8")
+    return ws
+
+
+def independent_pytest(task: dict, ws: Path) -> bool:
+    """The authoritative verdict: run the test ourselves, ignore what solve claimed.
+
+    The whole comparison rests on this line. An arm that self-reports success is an arm grading its
+    own homework, and the fusion arm has a judge inside it whose entire job is to say things went
+    well.
+    """
+    proc = subprocess.run(
+        [_PY, "-m", "pytest", "-q", task["test"]],
+        cwd=str(ws), capture_output=True, text=True,
+        encoding="utf-8", errors="replace", check=False,
+    )
+    return proc.returncode == 0
+
+
+def run_solve(task: dict, ws: Path, flags: list[str], seed: int, timeout: int) -> dict:
+    """One solve. Returns the outcome plus what it cost, read from the run receipt."""
+    verify = f'"{_PY}" -m pytest -q {task["test"]}'
+    argv = [
+        _CHIMERA, "solve", task["prompt"],
+        "--workspace", str(ws),
+        "--verify", verify,
+        *flags,
+    ]
+    env = {**os.environ, **_DOTENV, "CHIMERA_SEED": str(seed), "PYTHONHASHSEED": str(seed)}
+    began = time.monotonic()
+    try:
+        proc = subprocess.run(
+            argv, cwd=str(REPO_ROOT), capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=timeout, check=False, env=env,
+        )
+        code, tail = proc.returncode, ((proc.stdout or "")[-400:] + (proc.stderr or "")[-400:])
+    except subprocess.TimeoutExpired:
+        code, tail = 124, "solve timed out"
+    return {"exit": code, "tail": tail, "seconds": round(time.monotonic() - began, 1)}
+
+
+def read_cost(home: Path, since: float) -> dict[str, float | None]:
+    """Tokens and dollars this solve added to the usage log.
+
+    Read from the receipt rather than parsed from stdout: the log is what the Cost screen reads, and
+    a number taken from a different place than the product's own would be a second accounting.
+
+    ``usd`` is None when ANY row in the window is unpriced — the all-or-nothing rule this project
+    uses everywhere. A partial sum presented as the total flatters whichever arm used the unpriced
+    model, and here that would be the fusion panel.
+    """
+    log = home / "usage.jsonl"
+    if not log.is_file():
+        return {"prompt_tokens": 0, "completion_tokens": 0, "usd": None}
+    prompt = completion = 0
+    usd: float | None = 0.0
+    for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        stamp = row.get("ts") or ""
+        if not stamp or stamp < str(since):
+            continue
+        prompt += int(row.get("prompt_tokens") or 0)
+        completion += int(row.get("completion_tokens") or 0)
+        if row.get("usd") is None:
+            usd = None
+        elif usd is not None:
+            usd += float(row["usd"])
+    return {"prompt_tokens": prompt, "completion_tokens": completion, "usd": usd}
+
+
+def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Path) -> dict:
+    """One (task, arm, seed). Arm B is N solves from the SAME fork; the gate keeps the first pass.
+
+    Each sample starts from a fresh workspace on purpose. Letting sample 2 inherit sample 1's edits
+    would make B a three-attempt loop, which is a different experiment — and one this project has
+    already run under the name `local_lift`.
+    """
+    spec = ARMS[arm]
+    flags = list(spec["flags"])  # type: ignore[arg-type]
+    samples = int(spec["samples"])  # type: ignore[arg-type]
+    started = time.time()
+    attempts: list[dict] = []
+    passed = False
+    for index in range(samples):
+        ws = setup_workspace(task, root / f"{arm}_s{seed}_{index}")
+        attempts.append(run_solve(task, ws, flags, seed + index, timeout))
+        if independent_pytest(task, ws):
+            passed = True
+            break  # the gate keeps the first that passes; the rest are not paid for
+    return {
+        "task": task["id"],
+        "arm": arm,
+        "seed": seed,
+        "passed": passed,
+        "samples_paid": len(attempts),
+        "seconds": sum(a["seconds"] for a in attempts),
+        **read_cost(home, started),
+        "prereg": prereg_sha(),
+        "chimera_version": version("chimera-agent"),
+        "model": os.environ.get("CHIMERA_DEFAULT_MODEL", "?"),
+    }
+
+
+def report(rows: list[dict]) -> str:
+    """The three comparisons, each paired per (task, seed), plus the token ratio the criterion needs."""
+    out: list[str] = []
+    keyed = {(r["task"], r["arm"], r["seed"]): r for r in rows}
+    tasks = sorted({r["task"] for r in rows})
+    seeds = sorted({r["seed"] for r in rows})
+    pairs = [(t, s) for t in tasks for s in seeds]
+
+    def outcomes(arm: str) -> list[bool] | None:
+        got = [keyed.get((t, arm, s)) for t, s in pairs]
+        return None if any(g is None for g in got) else [bool(g["passed"]) for g in got if g]
+
+    def tokens(arm: str) -> int:
+        return sum(
+            int(r["prompt_tokens"] or 0) + int(r["completion_tokens"] or 0)
+            for r in rows if r["arm"] == arm
+        )
+
+    for base, treat in (("B_repeat", "A_fusion"), ("C_single", "A_fusion"), ("C_single", "B_repeat")):
+        b, t = outcomes(base), outcomes(treat)
+        if b is None or t is None:
+            out.append(f"{treat} vs {base}: incomplete — some cells did not run")
+            continue
+        out.append(format_report(compare_paired(b, t, baseline_name=base, treatment_name=treat)))
+        base_tokens, treat_tokens = tokens(base), tokens(treat)
+        ratio = (treat_tokens / base_tokens) if base_tokens else float("inf")
+        # Printed beside every delta, never under it: criterion 3 of the pre-registration is a cost
+        # ceiling, and a lift reported without its price cannot be checked against it.
+        out.append(f"  tokens {treat}={treat_tokens:,} {base}={base_tokens:,} ratio={ratio:.2f}\n")
+    return "\n".join(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--full", action="store_true", help="Run the registered 900 solves.")
+    parser.add_argument("--timeout", type=int, default=300)
+    parser.add_argument("--pilot-tasks", type=int, default=PILOT_TASKS)
+    args = parser.parse_args()
+
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    home = Path(os.environ.get("CHIMERA_HOME") or (Path.home() / ".chimera"))
+    tasks = TASKS if args.full else TASKS[: args.pilot_tasks]
+    work = RESULTS / "workspaces"
+    work.mkdir(exist_ok=True)
+
+    print(f"prereg={prereg_sha()}  tasks={len(tasks)}  arms={list(ARMS)}  seeds={SEEDS}")
+    print(f"cells={len(tasks) * len(ARMS) * len(SEEDS)}  ({'FULL' if args.full else 'PILOT'})")
+
+    # Prove the apparatus before paying for the phenomenon. A task whose test already passes on the
+    # untouched workspace scores a hit for an arm that did nothing, and nothing downstream would
+    # ever say so. Costs no model call and aborts before the first one.
+    assert_discriminating([
+        TaskCheck(
+            task_id=str(task["id"]),
+            setup=lambda task=task: setup_workspace(task, work / "_selftest"),
+            verify=f'"{_PY}" -m pytest -q {task["test"]}',
+        )
+        for task in tasks
+    ])
+    print("apparatus: every task's test fails on the untouched workspace")
+
+    rows: list[dict] = []
+    with JOURNAL.open("a", encoding="utf-8") as journal:
+        for task in tasks:
+            for seed in SEEDS:
+                for arm in ARMS:
+                    row = run_cell(task, arm, seed, work, args.timeout, home)
+                    rows.append(row)
+                    journal.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    journal.flush()
+                    print(f"  {task['id']:<28} {arm:<9} seed={seed} "
+                          f"{'PASS' if row['passed'] else 'fail'} "
+                          f"{row['seconds']:>6.1f}s  ${row['usd'] if row['usd'] is not None else '?'}")
+
+    print("\n" + report(rows))
+
+    if not args.full:
+        spent = sum(r["usd"] or 0.0 for r in rows)
+        unpriced = any(r["usd"] is None for r in rows)
+        per_cell = spent / len(rows) if rows else 0.0
+        full_cells = len(TASKS) * len(ARMS) * len(SEEDS)
+        print("=" * 78)
+        print(f"PILOT ONLY. {len(rows)} cells cost ${spent:.2f}"
+              + (" (some rows unpriced — treat the total as a floor)" if unpriced else ""))
+        print(f"The registered run is {full_cells} cells "
+              f"→ roughly ${per_cell * full_cells:.2f} at the measured rate.")
+        print("Nothing here is a result. Re-run with --full to pay for one.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/fusion_paired/run_paired.py
+++ b/bench/fusion_paired/run_paired.py
@@ -55,15 +55,53 @@ SEEDS = (42, 43, 44)
 #: of the most expensive arm, few enough that being wrong about it costs pocket change.
 PILOT_TASKS = 5
 
+#: What no arm may carry in from a previous cell. Added in ADDENDUM-01, and missing before it: the
+#: loop is `for task -> for seed -> for arm`, so arm A would solve a task, write a long-term memory
+#: fact and possibly a learned skill, and arms B and C would then solve THE SAME TASK with that in
+#: reach. The contamination runs with the arm order, so it credits whichever arm ran last, and
+#: nothing in the recorded rows would have said so. Every other runner in `bench/local_lift` has
+#: carried this set since it was written; this one did not.
+_HYGIENE = ["--no-remember", "--no-collect", "--no-evolve-skills", "--no-skill-cards"]
+
+#: The single model arms B and C spend their budget on. DECLARED, not measured — it is the model the
+#: shipped configuration already trusts to write the final answer (`_DEFAULT_SYNTHESIZER`) and is
+#: `_DEFAULT_PANEL[0]`. ADDENDUM-01 states the direction of the residual error: if this is not the
+#: strongest panel member on this corpus, arm B is understated and the bias favours FUSION, so a
+#: null survives the doubt and a win for A is the outcome that would need the choice measured first.
+#:
+#: Without this pin both arms inherited `settings.default_model` — `deepseek-chat-v3.1`, a cheap
+#: model — against a frontier panel, which would have made criterion 1 a measurement of model tier
+#: and criterion 3 a comparison between price classes.
+SINGLE_MODEL = "openrouter/anthropic/claude-opus-5"
+
+#: Screened, never selected. A panel member that solves ZERO pilot tasks is excluded from being the
+#: single model, because that is a broken ruler rather than a weak model. A good showing may NOT
+#: promote one: five tasks at one seed cannot resolve a real difference, and letting it try would be
+#: a forking path. The rule is absolute and predates the numbers.
+SCREEN_MODELS = (
+    "openrouter/anthropic/claude-opus-5",
+    "openrouter/openai/gpt-5.5",
+    "openrouter/google/gemini-3.1-pro-preview",
+)
+
 #: The arms, and the ONLY thing that differs between them.
 #:
 #: `--samples` does not exist as a solve flag; arm B is N independent solves of the same task from
 #: the same fork, and the gate keeps the first that passes. Written as a count here so the runner,
 #: not a flag, is what makes the arms comparable.
+#:
+#: Arm A pins no model on purpose. `--fuse` routes deep-reasoning turns through the panel and leaves
+#: the rest on `default_model`; that mixed route IS the shipped product, and pinning it would
+#: measure something no user gets. The budgets are held comparable by criterion 3's token ratio,
+#: which is measured, rather than by making the flags look symmetric.
 ARMS: dict[str, dict[str, object]] = {
-    "A_fusion": {"flags": ["--fuse", "--max-attempts", "1"], "samples": 1},
-    "B_repeat": {"flags": ["--max-attempts", "1"], "samples": 3},
-    "C_single": {"flags": ["--max-attempts", "1"], "samples": 1},
+    "A_fusion": {"flags": ["--fuse", "--max-attempts", "1", *_HYGIENE], "samples": 1},
+    "B_repeat": {
+        "flags": ["--model", SINGLE_MODEL, "--max-attempts", "1", *_HYGIENE], "samples": 3
+    },
+    "C_single": {
+        "flags": ["--model", SINGLE_MODEL, "--max-attempts", "1", *_HYGIENE], "samples": 1
+    },
 }
 
 
@@ -90,6 +128,13 @@ def prereg_sha() -> str:
     pre-registration is exactly how that happens without anybody lying.
     """
     path = HERE / "PREREGISTRATION.md"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12] if path.is_file() else "MISSING"
+
+
+def addendum_sha() -> str:
+    """Stamped beside the pre-registration's. The addendum changed the apparatus, not the design, and
+    a row that does not say which apparatus produced it cannot be compared with one that does."""
+    path = HERE / "ADDENDUM-01.md"
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12] if path.is_file() else "MISSING"
 
 
@@ -143,36 +188,77 @@ def run_solve(task: dict, ws: Path, flags: list[str], seed: int, timeout: int) -
     return {"exit": code, "tail": tail, "seconds": round(time.monotonic() - began, 1)}
 
 
-def read_cost(home: Path, since: float) -> dict[str, float | None]:
-    """Tokens and dollars this solve added to the usage log.
+def read_cost(home: Path, workspace: Path) -> dict[str, float | None]:
+    """What this cell spent, joined by WORKSPACE rather than by a window of time.
 
-    Read from the receipt rather than parsed from stdout: the log is what the Cost screen reads, and
-    a number taken from a different place than the product's own would be a second accounting.
+    Two things were wrong before, and the smoke run made both visible at once by printing
+    `0 tokens, $0.00, ratio=inf` for six runs that cost real money (ADDENDUM-02):
 
-    ``usd`` is None when ANY row in the window is unpriced — the all-or-nothing rule this project
-    uses everywhere. A partial sum presented as the total flatters whichever arm used the unpriced
-    model, and here that would be the fusion panel.
+    - it read `usage.jsonl`, which only the API layer writes. A CLI solve records nothing there; its
+      receipt lives on the ATTEMPTS of `runs.jsonl`, one level below where a reader looks.
+    - it resolved `~/.chimera`, but `settings.home` defaults to the RELATIVE `Path(".chimera")`, so
+      a solve run from the repo root writes to the repo, not to the user's home.
+
+    The window itself was the third: it compared an ISO timestamp against `str(time.time())` as
+    strings. The workspace path is unique per cell and is recorded on the row, so the join is exact
+    and no clock is involved.
+
+    ``usd`` follows the all-or-nothing rule and is None when any joined attempt is unpriced — here
+    that is the frontier models, which the local catalogue does not price. ``tokens_known`` is False
+    when the join found nothing at all: a paid cell that reads zero is the failure this docstring
+    describes, and the caller refuses to estimate from it rather than reporting a confident zero.
     """
-    log = home / "usage.jsonl"
+    log = home / "runs.jsonl"
     if not log.is_file():
-        return {"prompt_tokens": 0, "completion_tokens": 0, "usd": None}
-    prompt = completion = 0
+        return {"prompt_tokens": 0, "completion_tokens": 0, "usd": None, "tokens_known": False}
+    needle = workspace.as_posix().split("workspaces/")[-1]
+    prompt = completion = joined = 0
     usd: float | None = 0.0
+    models: set[str] = set()
     for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        if needle not in line:
+            continue  # cheap prefilter; the json parse below is what decides
         try:
             row = json.loads(line)
         except ValueError:
             continue
-        stamp = row.get("ts") or ""
-        if not stamp or stamp < str(since):
+        if str(row.get("workspace", "")).replace(chr(92), "/").split("workspaces/")[-1] != needle:
             continue
-        prompt += int(row.get("prompt_tokens") or 0)
-        completion += int(row.get("completion_tokens") or 0)
-        if row.get("usd") is None:
+        for attempt in row.get("attempts") or []:
+            joined += 1
+            prompt += int(attempt.get("prompt_tokens") or 0)
+            completion += int(attempt.get("completion_tokens") or 0)
+            models.add(str(attempt.get("model") or "?"))
+            if attempt.get("usd") is None:
+                usd = None
+            elif usd is not None:
+                usd += float(attempt["usd"])
+    return {
+        "prompt_tokens": prompt, "completion_tokens": completion,
+        "usd": usd if joined else None, "tokens_known": joined > 0,
+        "worker_models": sorted(models),
+    }
+
+
+def _sum_costs(home: Path, forks: list[Path]) -> dict:
+    """Arm B pays for every sample it took, so a cell's cost is the sum over its forks."""
+    parts = [read_cost(home, fork) for fork in forks]
+    usd: float | None = 0.0
+    for part in parts:
+        if part["usd"] is None:
             usd = None
         elif usd is not None:
-            usd += float(row["usd"])
-    return {"prompt_tokens": prompt, "completion_tokens": completion, "usd": usd}
+            usd += float(part["usd"])
+    models: set[str] = set()
+    for part in parts:
+        models.update(part.get("worker_models") or [])
+    return {
+        "prompt_tokens": sum(int(p["prompt_tokens"] or 0) for p in parts),
+        "completion_tokens": sum(int(p["completion_tokens"] or 0) for p in parts),
+        "usd": usd,
+        "tokens_known": all(p["tokens_known"] for p in parts),
+        "worker_models": sorted(models),
+    }
 
 
 def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Path) -> dict:
@@ -185,15 +271,17 @@ def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Pa
     spec = ARMS[arm]
     flags = list(spec["flags"])  # type: ignore[arg-type]
     samples = int(spec["samples"])  # type: ignore[arg-type]
-    started = time.time()
     attempts: list[dict] = []
+    forks: list[Path] = []
     passed = False
     for index in range(samples):
         ws = setup_workspace(task, root / f"{arm}_s{seed}_{index}")
+        forks.append(ws)
         attempts.append(run_solve(task, ws, flags, seed + index, timeout))
         if independent_pytest(task, ws):
             passed = True
             break  # the gate keeps the first that passes; the rest are not paid for
+    cost = _sum_costs(home, forks)
     return {
         "task": task["id"],
         "arm": arm,
@@ -201,11 +289,47 @@ def run_cell(task: dict, arm: str, seed: int, root: Path, timeout: int, home: Pa
         "passed": passed,
         "samples_paid": len(attempts),
         "seconds": sum(a["seconds"] for a in attempts),
-        **read_cost(home, started),
+        **cost,
         "prereg": prereg_sha(),
+        "addendum": addendum_sha(),
         "chimera_version": version("chimera-agent"),
-        "model": os.environ.get("CHIMERA_DEFAULT_MODEL", "?"),
+        "model": SINGLE_MODEL if arm != "A_fusion" else "shipped-fusion-route",
     }
+
+
+def run_screen(
+    tasks: list[dict], seed: int, root: Path, timeout: int, home: Path, journal
+) -> dict[str, int]:
+    """The gross-failure screen from ADDENDUM-01: one pass of arm C per panel member.
+
+    It may EXCLUDE and may never PROMOTE. A member that solves zero tasks is a broken ruler rather
+    than a weak model — the failure `§2e` describes, where a harness written against one model stops
+    reporting the moment the model changes — and the experiment needs to know that before 900 cells
+    depend on it. A good showing may not pick the model: five tasks at one seed cannot resolve a real
+    difference, and letting it try would turn a declaration into a forking path.
+    """
+    scored: dict[str, int] = {}
+    for model in SCREEN_MODELS:
+        short = model.split("/")[-1]
+        flags = ["--model", model, "--max-attempts", "1", *_HYGIENE]
+        hits = 0
+        for task in tasks:
+            ws = setup_workspace(task, root / f"screen_{short}")
+            outcome = run_solve(task, ws, flags, seed, timeout)
+            ok = independent_pytest(task, ws)
+            hits += int(ok)
+            row = {
+                "task": task["id"], "arm": f"screen:{model}", "seed": seed, "passed": ok,
+                "samples_paid": 1, "seconds": outcome["seconds"], **read_cost(home, ws),
+                "prereg": prereg_sha(), "chimera_version": version("chimera-agent"), "model": model,
+            }
+            journal.write(json.dumps(row, ensure_ascii=False) + "\n")
+            journal.flush()
+            print(f"  {task['id']:<28} screen {short:<26} "
+                  f"{'PASS' if ok else 'fail'} {outcome['seconds']:>6.1f}s")
+        scored[model] = hits
+        print(f"  -> {short}: {hits}/{len(tasks)}")
+    return scored
 
 
 def report(rows: list[dict]) -> str:
@@ -236,7 +360,18 @@ def report(rows: list[dict]) -> str:
         ratio = (treat_tokens / base_tokens) if base_tokens else float("inf")
         # Printed beside every delta, never under it: criterion 3 of the pre-registration is a cost
         # ceiling, and a lift reported without its price cannot be checked against it.
-        out.append(f"  tokens {treat}={treat_tokens:,} {base}={base_tokens:,} ratio={ratio:.2f}\n")
+        out.append(f"  tokens {treat}={treat_tokens:,} {base}={base_tokens:,} ratio={ratio:.2f}")
+        if base == "C_single" and treat == "A_fusion":
+            # ADDENDUM-02: the same number that serves as criterion 3's price ceiling is also the
+            # proof the intervention ACTED. Arm A adds a fused planning turn over arm C and nothing
+            # else; if the two spend the same tokens, fusion did not fire and every comparison in
+            # this run is VOID rather than null. "On and inert" reads exactly like "did not help".
+            if 0.90 <= ratio <= 1.10:
+                out.append("  ACTIVATION: A and C spent the same tokens (ratio "
+                           f"{ratio:.2f}). Fusion did not act — this run is void, not null.")
+            else:
+                out.append(f"  activation: fusion moved the spend by {(ratio - 1) * 100:+.0f}%")
+        out.append("")
     return "\n".join(out)
 
 
@@ -245,16 +380,27 @@ def main() -> None:
     parser.add_argument("--full", action="store_true", help="Run the registered 900 solves.")
     parser.add_argument("--timeout", type=int, default=300)
     parser.add_argument("--pilot-tasks", type=int, default=PILOT_TASKS)
+    # One seed in the pilot. Seeds separate a difference from a variance in the RESULT; the pilot is
+    # not a result and says so in its own last line. Three would triple the bill for nothing.
+    parser.add_argument("--pilot-seeds", type=int, default=1)
     args = parser.parse_args()
 
     RESULTS.mkdir(parents=True, exist_ok=True)
-    home = Path(os.environ.get("CHIMERA_HOME") or (Path.home() / ".chimera"))
+    # `settings.home` defaults to the RELATIVE `Path(".chimera")` and a solve runs with cwd=repo
+    # root, so the receipts land in the REPO, not in the user's home. Reading `~/.chimera` is what
+    # made the smoke run report $0.00 for six paid solves.
+    raw = os.environ.get("CHIMERA_HOME")
+    home = Path(raw) if raw else REPO_ROOT / ".chimera"
+    if not home.is_absolute():
+        home = REPO_ROOT / home
     tasks = TASKS if args.full else TASKS[: args.pilot_tasks]
+    seeds = SEEDS if args.full else SEEDS[: max(1, args.pilot_seeds)]
     work = RESULTS / "workspaces"
     work.mkdir(exist_ok=True)
 
-    print(f"prereg={prereg_sha()}  tasks={len(tasks)}  arms={list(ARMS)}  seeds={SEEDS}")
-    print(f"cells={len(tasks) * len(ARMS) * len(SEEDS)}  ({'FULL' if args.full else 'PILOT'})")
+    print(f"prereg={prereg_sha()}  addendum={addendum_sha()}")
+    print(f"tasks={len(tasks)}  arms={list(ARMS)}  seeds={seeds}  single={SINGLE_MODEL}")
+    print(f"cells={len(tasks) * len(ARMS) * len(seeds)}  ({'FULL' if args.full else 'PILOT'})")
 
     # Prove the apparatus before paying for the phenomenon. A task whose test already passes on the
     # untouched workspace scores a hit for an arm that did nothing, and nothing downstream would
@@ -271,8 +417,19 @@ def main() -> None:
 
     rows: list[dict] = []
     with JOURNAL.open("a", encoding="utf-8") as journal:
+        if not args.full:
+            print("\nscreen (ADDENDUM-01): one pass of arm C per panel member")
+            scored = run_screen(tasks, seeds[0], work, args.timeout, home, journal)
+            dead = [m for m, hits in scored.items() if hits == 0]
+            if SINGLE_MODEL in dead:
+                print(f"\nSTOP: {SINGLE_MODEL} solved 0/{len(tasks)}. That is a broken ruler, not a "
+                      "weak model, and arms B and C would measure it instead of the question.")
+                raise SystemExit(2)
+            if dead:
+                print(f"  excluded from ever being the single model: {dead}")
+
         for task in tasks:
-            for seed in SEEDS:
+            for seed in seeds:
                 for arm in ARMS:
                     row = run_cell(task, arm, seed, work, args.timeout, home)
                     rows.append(row)
@@ -288,12 +445,31 @@ def main() -> None:
         spent = sum(r["usd"] or 0.0 for r in rows)
         unpriced = any(r["usd"] is None for r in rows)
         per_cell = spent / len(rows) if rows else 0.0
+        for arm in ARMS:
+            cells = [r for r in rows if r["arm"] == arm]
+            if not cells:
+                continue
+            tok = sum(int(r["prompt_tokens"] or 0) + int(r["completion_tokens"] or 0) for r in cells)
+            paid = sum(int(r["samples_paid"]) for r in cells)
+            money = sum(r["usd"] or 0.0 for r in cells)
+            print(f"  {arm:<9} {len(cells)} cells, {paid} solves, {tok:,} tokens, ${money:.2f}"
+                  + (" (floor)" if any(r["usd"] is None for r in cells) else ""))
+        blind = [r["arm"] for r in rows if not r.get("tokens_known", True)]
         full_cells = len(TASKS) * len(ARMS) * len(SEEDS)
+        # Per-cell rate from the ARMS rows only. The screen is pilot-only scaffolding and charging
+        # the full run for it would overstate the estimate by roughly half.
         print("=" * 78)
         print(f"PILOT ONLY. {len(rows)} cells cost ${spent:.2f}"
               + (" (some rows unpriced — treat the total as a floor)" if unpriced else ""))
-        print(f"The registered run is {full_cells} cells "
-              f"→ roughly ${per_cell * full_cells:.2f} at the measured rate.")
+        if blind:
+            # A cell that read nothing is not a cheap cell. Estimating from it would repeat, one
+            # level up, the confident zero that ADDENDUM-02 exists because of.
+            print(f"NO ESTIMATE: {len(blind)} cells joined no receipt at all ({sorted(set(blind))}). "
+                  "Their cost is unknown, not zero, and a rate built on them would understate the "
+                  "registered run by however much they actually cost.")
+        else:
+            print(f"The registered run is {full_cells} cells "
+                  f"→ roughly ${per_cell * full_cells:.2f} at the measured rate.")
         print("Nothing here is a result. Re-run with --full to pay for one.")
 
 

--- a/bench/fusion_paired/run_paired.py
+++ b/bench/fusion_paired/run_paired.py
@@ -300,6 +300,13 @@ def run_cell(
         "seed": seed,
         "passed": passed,
         "samples_paid": len(attempts),
+        # Kept because the pilot needed them and did not have them: on one task all three arms
+        # joined no receipt, two of them after SUCCEEDING, and the diagnosis had to be done by
+        # reading the workspace off disk. A cell whose cost is unknown must at least say what it
+        # did — 124 is the timeout, and a tail is the difference between "the model failed" and
+        # "the clock ran out".
+        "exits": [a["exit"] for a in attempts],
+        "tail": (attempts[-1]["tail"] if attempts else "")[-600:],
         "seconds": sum(a["seconds"] for a in attempts),
         **cost,
         "prereg": prereg_sha(),
@@ -466,6 +473,12 @@ def main() -> None:
             cells = [r for r in rows if r["arm"] == arm]
             if not cells:
                 continue
+            timeouts = sum(1 for r in cells if 124 in (r.get("exits") or []))
+            if timeouts:
+                # An asymmetric timeout does not lower an arm's score, it invalidates the
+                # comparison: "could not do it" and "ran out of clock" become one number.
+                print(f"  {arm:<9} TIMEOUTS: {timeouts} of {len(cells)} cells hit the wall. Any "
+                      "delta against this arm is a clock artifact until the wall moves.")
             tok = sum(int(r["prompt_tokens"] or 0) + int(r["completion_tokens"] or 0) for r in cells)
             paid = sum(int(r["samples_paid"]) for r in cells)
             money = sum(r["usd"] or 0.0 for r in cells)

--- a/tests/test_fusion_aggregate_harness.py
+++ b/tests/test_fusion_aggregate_harness.py
@@ -202,6 +202,33 @@ def test_the_union_keeps_the_cluster_of_one() -> None:
     assert any("42" in candidate for candidate in kept)
 
 
+def test_the_report_reads_no_arm_that_no_longer_exists() -> None:
+    """The `vote` key survived the `vote_text` / `vote_answer` split in the report block, and the
+    patch that should have removed it asserted nothing and silently did nothing.
+
+    The run got all the way to the end of stage 2, printed every arm, and then raised
+    `KeyError: 'vote'`. That is the GOOD version of the failure — a stale key that still resolved
+    would have reported one arm under the other's name.
+    """
+    source = (REPO / "bench/fusion_aggregate/run_aggregate.py").read_text(encoding="utf-8")
+
+    assert 'free["vote"]' not in source, "the report reads an arm that arms_free no longer produces"
+    assert 'free["vote_answer"]' in source and 'free["vote_text"]' in source
+
+
+def test_how_often_the_vote_fired_is_reported_apart_from_how_often_it_was_right() -> None:
+    """0% correct has two opposite readings. `majority` returning None means the branch DECLINED and
+    the turn fell through to judge -> synthesiser — inert. Voting and being wrong would be harmful.
+    Only the firing rate separates them, and the measured answer was 0/40: inert."""
+    run = _runner()
+    agreeing = _row("72", "One way: 72.\nANSWER: 72", "Another way entirely: 72.\nANSWER: 72")
+
+    assert run.fired_text(agreeing) is False, "the shipped vote fired where it never does"
+    assert "FIRED on" in (REPO / "bench/fusion_aggregate/run_aggregate.py").read_text(
+        encoding="utf-8"
+    )
+
+
 def test_the_paid_arm_is_measured_against_the_FIXED_vote() -> None:
     """Fixing the clustering and adding a validator are two interventions. Measuring them together
     would credit the validator with the fix — `§2g` in the form that flatters the proposal."""

--- a/tests/test_fusion_aggregate_harness.py
+++ b/tests/test_fusion_aggregate_harness.py
@@ -1,0 +1,217 @@
+"""The apparatus for the aggregation experiment, checked before it is allowed to cost anything.
+
+The experiment is registered in `bench/fusion_aggregate/PREREGISTRATION.md`. What these tests hold is
+the machinery — the ruler that reads a number out of a panel answer, the ceiling arm that decides
+whether the paid stage may run at all, and the union that is the whole proposal.
+
+Everything here is deterministic and free: no model call, no network, no dataset download.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PREREG = REPO / "bench/fusion_aggregate/PREREGISTRATION.md"
+
+
+def _runner() -> Any:
+    """Load the runner without running the bench. It lives under `bench/`, not in the package."""
+    sys.path.insert(0, str(REPO / "bench/llm_benchmarks"))
+    spec = importlib.util.spec_from_file_location(
+        "fusion_aggregate_runner", REPO / "bench/fusion_aggregate/run_aggregate.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(gold: str, *answers: str) -> dict:
+    return {
+        "id": "x",
+        "gold": gold,
+        "question": "q",
+        "answers": [{"model": f"m/{i}", "content": a} for i, a in enumerate(answers)],
+    }
+
+
+# --------------------------------------------------------------------------- the design
+
+
+def test_the_paid_stage_is_gated_on_a_free_measurement() -> None:
+    """The rule this project wrote after paying for a retry loop around a verifier that accepted
+    95% of what it saw: measure how much there is to reject before building the rejecter.
+
+    Here that is free — the ceiling and the vote both come out of the cached panel — so a headroom
+    below the registered floor closes the item at the price of the panel alone.
+    """
+    text = PREREG.read_text(encoding="utf-8")
+    source = (REPO / "bench/fusion_aggregate/run_aggregate.py").read_text(encoding="utf-8")
+
+    assert "headroom < 3.0 pp" in text and "stage 3 is not run" in text
+    assert "if headroom < 3.0:" in source, "the gate is written down but not enforced"
+    assert "--stage3" in source, "the paid stage must be opt-in"
+
+
+def test_the_criterion_is_absolute_and_counts_the_damage() -> None:
+    """A net win that destroys more than it saves is a different thing from one that only adds, and
+    the net alone cannot tell them apart — the failure that shipped a +12.9 pp headline while
+    silently breaking 35 cases."""
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "≥ +3.0 pp" in text and "absolute floor, never a multiplicative one" in text
+    assert "damage ≤ gain" in text
+    assert "CANNOT show" in text
+
+
+def test_the_corpus_is_the_branch_the_experiment_replaces() -> None:
+    """The vote only ever runs on a logic-typed task. Measuring it on anything else would compare
+    an aggregator against a branch that never fires."""
+    source = (REPO / "bench/fusion_aggregate/run_aggregate.py").read_text(encoding="utf-8")
+
+    assert 'classify_task_type([{"role": "user", "content": row["question"]}]) == "logic"' in source
+    assert "random.Random(seed).sample" in source, "the draw must be seeded, not incidental"
+
+
+# --------------------------------------------------------------------------- the ruler
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("blah blah\nANSWER: 42", "42"),
+        ("ANSWER: 1,000", "1000"),
+        ("ANSWER: 18.0", "18"),
+        ("ANSWER: -7", "-7"),
+        ("no marker here, so the last number wins: 13", "13"),
+        ("nothing numeric at all", None),
+    ],
+)
+def test_the_number_is_read_the_same_way_for_every_arm(text: str, expected: str | None) -> None:
+    """Every arm is scored by this one function. A ruler that reads one arm's phrasing better than
+    another's decides the experiment by formatting."""
+    assert _runner().extract(text) == expected
+
+
+def test_a_panel_that_ignored_the_format_stops_the_run(tmp_path: Path) -> None:
+    """`§2e`: a harness written against one model stops reporting the moment the model changes, and
+    it stops silently. Here the symptom would be every arm looking wrong at once."""
+    run = _runner()
+    rows = [_row("42", "the answer is 42", "42 obviously", "I think 42")]
+
+    assert run.extraction_rate(rows) == 0.0
+    assert run._MIN_EXTRACTION == 0.90
+    source = (REPO / "bench/fusion_aggregate/run_aggregate.py").read_text(encoding="utf-8")
+    assert "raise SystemExit(" in source and "_MIN_EXTRACTION" in source
+
+
+def test_a_dead_panelist_is_data_and_not_a_crash() -> None:
+    run = _runner()
+    rows = [_row("42", "ANSWER: 42", "ANSWER: 42")]
+    rows[0]["answers"].append({"model": "m/2", "content": "", "error": "429"})
+
+    free = run.arms_free(rows)
+
+    assert free["oracle"] == [True]
+    assert free["member:2"] == [False], "a panelist that never answered did not get the answer right"
+
+
+# --------------------------------------------------------------------------- the arms
+
+
+def test_the_ceiling_finds_a_correct_answer_the_vote_throws_away() -> None:
+    """The whole hypothesis in one row: two panelists agree on the wrong number, one holds the right
+    one. Both votes return the majority — wrong — and the pool held the answer the entire time.
+
+    This is the Barrel-of-Monkeys gap made local: pool coverage 80.8% against 66.2% selected.
+    """
+    run = _runner()
+    rows = [_row("42", "ANSWER: 41", "ANSWER: 41", "ANSWER: 42")]
+
+    free = run.arms_free(rows)
+
+    assert free["oracle"] == [True], "the correct answer was in the pool"
+    assert free["vote_answer"] == [False], "and the majority discarded it"
+
+
+def test_the_shipped_vote_can_elect_the_minority_answer() -> None:
+    """Measured in the shipped code before this bench existed, and kept here as the size of the bug.
+
+    `majority` clusters by difflib over the WHOLE answer, so three answers that differ in one digit
+    are one cluster, and its representative is the LONGEST member rather than the most common one.
+    Two panelists said 42; the vote returns 41. `chimera/fusion/task_type.py` opens by saying the
+    branch exists so "a correct minority answer must not be averaged away" — and it can elect one.
+    """
+    run = _runner()
+    rows = [_row(
+        "42",
+        "Work: 48 + 24 = 72 clips altogether in the two months here.\nANSWER: 41",
+        "Work: 48 + 24 = 72 clips altogether in the two months.\nANSWER: 42",
+        "Work: 48 + 24 = 72 clips altogether in the two months.\nANSWER: 42",
+    )]
+
+    free = run.arms_free(rows)
+
+    assert free["vote_text"] == [False], "the shipped vote stopped electing the minority"
+    assert free["vote_answer"] == [True], "counting the number does not recover the majority"
+
+
+def test_agreement_reached_by_different_reasoning_is_a_majority() -> None:
+    """The other direction of the same bug: three panelists all reach 72 and the shipped vote sees
+    no majority, so a logic task with unanimous agreement pays for a judge and a synthesiser."""
+    run = _runner()
+    rows = [_row(
+        "72",
+        "April: 48. May: half of that, 24. Total 72.\nANSWER: 72",
+        "She sold forty-eight the first month and half as many the second, so seventy-two.\nANSWER: 72",
+        "Let x = 48. May = x/2 = 24. x + x/2 = 72.\nANSWER: 72",
+    )]
+
+    free = run.arms_free(rows)
+
+    assert free["vote_text"] == [False], "the shipped vote started seeing this majority"
+    assert free["vote_answer"] == [True]
+
+
+def test_the_vote_and_the_ceiling_agree_when_there_is_nothing_to_win() -> None:
+    """The other side of the same guard: if the ceiling never rises above the vote, the headroom is
+    zero and the pre-registration closes the item without paying for stage 3."""
+    run = _runner()
+    rows = [_row("42", "ANSWER: 42", "ANSWER: 42", "ANSWER: 42")]
+
+    free = run.arms_free(rows)
+
+    assert free["oracle"] == [True] and free["vote_answer"] == [True]
+
+
+def test_the_union_keeps_the_cluster_of_one() -> None:
+    """`majority` returns one cluster and only when it holds more than half. The union keeps every
+    cluster — including the single-member one, which is exactly where a correct minority answer
+    lives and the only reason this experiment exists."""
+    run = _runner()
+
+    kept = run.union(["ANSWER: 41", "ANSWER: 41", "ANSWER: 42"])
+
+    assert len(kept) == 2, f"the minority answer was merged away: {kept}"
+    assert any("42" in candidate for candidate in kept)
+
+
+def test_the_paid_arm_is_measured_against_the_FIXED_vote() -> None:
+    """Fixing the clustering and adding a validator are two interventions. Measuring them together
+    would credit the validator with the fix — `§2g` in the form that flatters the proposal."""
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "union_validator − vote_answer ≥ +3.0 pp" in text
+    assert "oracle − vote_answer" in text, "the headroom gate must use the fixed vote too"
+
+
+def test_the_union_of_one_agreeing_panel_is_one_candidate() -> None:
+    """A validator handed three copies of the same answer has nothing to select, and the arm must
+    reduce to the vote rather than pretend to have chosen."""
+    assert len(_runner().union(["ANSWER: 42", "ANSWER: 42", "ANSWER: 42"])) == 1

--- a/tests/test_fusion_paired_harness.py
+++ b/tests/test_fusion_paired_harness.py
@@ -11,6 +11,7 @@ of the comparison, not its outcome.
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from typing import Any
@@ -68,39 +69,175 @@ def test_three_seeds_not_two() -> None:
     assert len(_runner().SEEDS) == 3
 
 
+def test_no_arm_can_carry_anything_in_from_the_cell_before_it() -> None:
+    """The loop is `for task -> for seed -> for arm`, so without this every cell teaches the next.
+
+    Arm A solves a task, writes a long-term memory fact and may propose a learned skill; arms B and C
+    then solve THE SAME TASK with it in reach. The contamination runs WITH the arm order, so it
+    credits whichever arm ran last, and no recorded field would have shown it. Every other runner in
+    `bench/local_lift` has carried these four flags for exactly this reason; this one did not until
+    ADDENDUM-01.
+    """
+    arms = _runner().ARMS
+    required = {"--no-remember", "--no-collect", "--no-evolve-skills", "--no-skill-cards"}
+
+    for name, spec in arms.items():
+        missing = required - set(spec["flags"])
+        assert not missing, f"{name} can carry state between cells: missing {sorted(missing)}"
+
+
+def test_the_single_model_arms_are_pinned_to_a_panel_grade_model() -> None:
+    """Unpinned, arms B and C inherited `settings.default_model` — a cheap model — against a frontier
+    panel. That would have made criterion 1 a measurement of model tier and criterion 3 a comparison
+    between price classes, which is the failure `§2g` names: two things measured different ways.
+
+    Arm A stays unpinned on purpose: `--fuse` leaves non-deep turns on the default model, and that
+    mixed route IS the shipped product. Pinning it would measure something no user gets.
+    """
+    run = _runner()
+
+    for arm in ("B_repeat", "C_single"):
+        flags = run.ARMS[arm]["flags"]
+        assert "--model" in flags, f"{arm} would inherit the cheap default model"
+        assert flags[flags.index("--model") + 1] == run.SINGLE_MODEL
+    assert "--model" not in run.ARMS["A_fusion"]["flags"], "arm A must be the shipped route"
+    assert run.SINGLE_MODEL in run.SCREEN_MODELS, "the declared single model is not a panel member"
+
+
+def test_the_screen_can_exclude_a_model_and_can_never_promote_one() -> None:
+    """Five tasks at one seed cannot resolve a real difference between frontier models. The screen
+    exists to catch a BROKEN one — zero solved is a ruler that stopped reporting, `§2e` — and letting
+    a good showing pick the model instead would turn a declaration into a forking path.
+
+    Asserted on the source because the promotion that must not exist is an absence, and an absence
+    has no behaviour to call.
+    """
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert "hits == 0" in source, "nothing excludes a model that solved nothing"
+    assert "SINGLE_MODEL =" in source and source.count("SINGLE_MODEL =") == 1, (
+        "SINGLE_MODEL is assigned more than once: the screen may be promoting"
+    )
+    assert "raise SystemExit(2)" in source, "a dead single model must stop the run, not run it"
+
+
+def test_the_addendum_is_stamped_beside_the_preregistration() -> None:
+    """It changed the apparatus rather than the design, and a row that does not say which apparatus
+    produced it cannot be compared with one that does."""
+    run = _runner()
+    addendum = REPO / "bench/fusion_paired/ADDENDUM-01.md"
+
+    assert addendum.is_file()
+    assert run.addendum_sha() != "MISSING"
+    text = addendum.read_text(encoding="utf-8")
+    # The direction of the residual bias, written before the number exists rather than after.
+    assert "favour of fusion" in text
+    assert "declaration" in text and "not a selection" in text
+
+
 # --------------------------------------------------------------------------- the accounting
 
-def test_one_unpriced_row_makes_the_total_unknown_not_smaller(tmp_path: Path) -> None:
-    """The direction that matters: a partial sum flatters whichever arm used the unpriced model,
-    and here that would be the fusion panel."""
-    run = _runner()
-    (tmp_path / "usage.jsonl").write_text(
-        '{"ts": "9", "prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02}\n'
-        '{"ts": "9", "prompt_tokens": 50, "completion_tokens": 5, "usd": null}\n',
+def _runs_log(tmp_path: Path, *attempts: dict, workspace: str = "w/A_fusion_s42_0/t1") -> Path:
+    """A `runs.jsonl` shaped like the one a CLI solve writes: the receipt is on the ATTEMPT."""
+    (tmp_path / "runs.jsonl").write_text(
+        json.dumps({"workspace": f"/tmp/workspaces/{workspace}", "attempts": list(attempts)}) + "\n",
         encoding="utf-8",
     )
+    return tmp_path
 
-    cost = run.read_cost(tmp_path, 0)
+
+def test_the_cost_comes_from_the_run_receipt_and_not_from_the_api_usage_log(tmp_path: Path) -> None:
+    """The reader looked in `usage.jsonl`, which only the API layer writes, and in `~/.chimera`, when
+    `settings.home` is the RELATIVE `.chimera`. It returned `0 tokens, $0.00` for six paid solves and
+    the token ratio — criterion 3 — printed `inf`. A confident zero is worse than a missing number.
+    """
+    run = _runner()
+    home = _runs_log(
+        tmp_path, {"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02, "model": "m"}
+    )
+    # An `usage.jsonl` beside it, holding the wrong answer, so the test fails if the old path returns.
+    (tmp_path / "usage.jsonl").write_text(
+        '{"ts": "9", "prompt_tokens": 999, "completion_tokens": 999, "usd": 9.99}\n', encoding="utf-8"
+    )
+
+    cost = run.read_cost(home, Path("/tmp/workspaces/w/A_fusion_s42_0/t1"))
+
+    assert cost["prompt_tokens"] == 100 and cost["completion_tokens"] == 10
+    assert cost["usd"] == 0.02
+    assert cost["tokens_known"] is True
+
+
+def test_a_cell_that_joins_no_receipt_is_unknown_and_never_zero(tmp_path: Path) -> None:
+    """The failure that actually happened, kept as a test: a paid run whose cost reads zero looks
+    exactly like a cheap run, and the full-run estimate is built on that rate."""
+    run = _runner()
+    home = _runs_log(tmp_path, {"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02})
+
+    cost = run.read_cost(home, Path("/tmp/workspaces/w/SOMETHING_ELSE/t1"))
+
+    assert cost["tokens_known"] is False
+    assert cost["usd"] is None, "an unjoined cell must not report a price"
+
+
+def test_one_unpriced_attempt_makes_the_total_unknown_not_smaller(tmp_path: Path) -> None:
+    """The direction that matters: a partial sum flatters whichever arm used the unpriced model, and
+    the frontier models are exactly the ones the local catalogue does not price."""
+    run = _runner()
+    home = _runs_log(
+        tmp_path,
+        {"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02},
+        {"prompt_tokens": 50, "completion_tokens": 5, "usd": None},
+    )
+
+    cost = run.read_cost(home, Path("/tmp/workspaces/w/A_fusion_s42_0/t1"))
 
     assert cost["usd"] is None
     assert cost["prompt_tokens"] == 150, "the tokens are known even when the price is not"
 
 
-def test_cost_outside_the_window_is_not_charged_to_this_solve(tmp_path: Path) -> None:
+def test_a_missing_run_log_is_unknown_not_a_crash(tmp_path: Path) -> None:
+    cost = _runner().read_cost(tmp_path, Path("/tmp/workspaces/w/x/t1"))
+    assert cost["tokens_known"] is False and cost["usd"] is None
+
+
+def test_arm_b_pays_for_every_sample_it_took(tmp_path: Path) -> None:
+    """Arm B is three solves in three forks. Charging it for one would halve the denominator of the
+    token ratio and hand fusion a ceiling it never had to clear."""
     run = _runner()
-    (tmp_path / "usage.jsonl").write_text(
-        '{"ts": "1", "prompt_tokens": 999, "completion_tokens": 0, "usd": 9.99}\n'
-        '{"ts": "9", "prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02}\n',
-        encoding="utf-8",
-    )
+    log = tmp_path / "runs.jsonl"
+    log.write_text("".join(
+        json.dumps({
+            "workspace": f"/tmp/workspaces/B_repeat_s42_{i}/t1",
+            "attempts": [{"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.01}],
+        }) + "\n" for i in range(3)
+    ), encoding="utf-8")
 
-    assert run.read_cost(tmp_path, 5)["prompt_tokens"] == 100
+    cost = run._sum_costs(tmp_path, [Path(f"/tmp/workspaces/B_repeat_s42_{i}/t1") for i in range(3)])
+
+    assert cost["prompt_tokens"] == 300 and cost["completion_tokens"] == 30
+    assert cost["usd"] == pytest.approx(0.03)
 
 
-def test_a_missing_usage_log_is_zero_and_unknown_not_a_crash(tmp_path: Path) -> None:
-    assert _runner().read_cost(tmp_path, 0) == {
-        "prompt_tokens": 0, "completion_tokens": 0, "usd": None
-    }
+def test_a_fusion_that_spent_what_the_control_spent_is_void_not_null() -> None:
+    """ADDENDUM-02. Arm A adds a fused planning turn over arm C and nothing else, so an A/C ratio of
+    1.0 says the intervention never fired. Without this line an inert run reads as a clean null —
+    the strongest conclusion the experiment could produce, drawn from nothing happening.
+    """
+    run = _runner()
+    rows = _rows(A_fusion=[True, False], B_repeat=[True, False], C_single=[True, False])
+
+    text = run.report(rows)
+
+    assert "ACTIVATION" in text and "void, not null" in text
+
+
+def test_an_arm_that_read_no_receipt_blocks_the_full_run_estimate() -> None:
+    """The confident zero, one level up: a rate built on cells that joined nothing understates the
+    registered run by however much those cells actually cost."""
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert "NO ESTIMATE:" in source
+    assert 'r.get("tokens_known", True)' in source
 
 
 # --------------------------------------------------------------------------- the report

--- a/tests/test_fusion_paired_harness.py
+++ b/tests/test_fusion_paired_harness.py
@@ -1,0 +1,186 @@
+"""The apparatus for the fusion experiment, checked before it is allowed to cost anything.
+
+The experiment itself is registered in `bench/fusion_paired/PREREGISTRATION.md` and has not run. What
+these tests hold is the machinery, because an experiment whose harness is wrong produces a number
+that looks exactly like a result — and this one is meant to decide the project's central bet.
+
+Everything here is deterministic and free: no model call, no network. What is asserted is the shape
+of the comparison, not its outcome.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PREREG = REPO / "bench/fusion_paired/PREREGISTRATION.md"
+
+
+def _runner() -> Any:
+    """Load the runner without executing the bench. It lives under `bench/`, not in the package."""
+    sys.path.insert(0, str(REPO / "bench/local_lift"))
+    spec = importlib.util.spec_from_file_location(
+        "fusion_paired_runner", REPO / "bench/fusion_paired/run_paired.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- the design
+
+def test_the_preregistration_exists_and_binds_before_the_run() -> None:
+    """It is committed before the first model call or it is not a pre-registration — it is a summary
+    written afterwards, which is the thing this practice exists to make impossible."""
+    assert PREREG.is_file()
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "BEFORE a single model call" in text
+    # The criterion must be absolute. A multiplicative one has already misfired in this project:
+    # `pass@k > pass@1 × 1.5` printed "no useful tail" for 52.3% → 72.9%.
+    assert "A − B ≥ +5.0 pp" in text
+    assert "absolute floor, never a multiplicative one" in text
+    # And what would refute the bet, written before the number exists.
+    assert "What would refute the bet" in text
+    assert "CANNOT show" in text
+
+
+def test_the_design_has_the_control_that_makes_a_win_attributable() -> None:
+    """A vs B alone cannot separate *more diversity* from *more computation*. C is what does, and it
+    is the control the MoA paper omitted and Self-MoA had to add."""
+    arms = _runner().ARMS
+
+    assert set(arms) == {"A_fusion", "B_repeat", "C_single"}
+    assert "--fuse" in arms["A_fusion"]["flags"]
+    assert "--fuse" not in arms["B_repeat"]["flags"]
+    assert arms["B_repeat"]["samples"] == 3, "equal sample count to the panel, or it is not a control"
+    assert arms["C_single"]["samples"] == 1
+
+
+def test_three_seeds_not_two() -> None:
+    """Two alert, three decide. At two, a difference and a variance are indistinguishable."""
+    assert len(_runner().SEEDS) == 3
+
+
+# --------------------------------------------------------------------------- the accounting
+
+def test_one_unpriced_row_makes_the_total_unknown_not_smaller(tmp_path: Path) -> None:
+    """The direction that matters: a partial sum flatters whichever arm used the unpriced model,
+    and here that would be the fusion panel."""
+    run = _runner()
+    (tmp_path / "usage.jsonl").write_text(
+        '{"ts": "9", "prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02}\n'
+        '{"ts": "9", "prompt_tokens": 50, "completion_tokens": 5, "usd": null}\n',
+        encoding="utf-8",
+    )
+
+    cost = run.read_cost(tmp_path, 0)
+
+    assert cost["usd"] is None
+    assert cost["prompt_tokens"] == 150, "the tokens are known even when the price is not"
+
+
+def test_cost_outside_the_window_is_not_charged_to_this_solve(tmp_path: Path) -> None:
+    run = _runner()
+    (tmp_path / "usage.jsonl").write_text(
+        '{"ts": "1", "prompt_tokens": 999, "completion_tokens": 0, "usd": 9.99}\n'
+        '{"ts": "9", "prompt_tokens": 100, "completion_tokens": 10, "usd": 0.02}\n',
+        encoding="utf-8",
+    )
+
+    assert run.read_cost(tmp_path, 5)["prompt_tokens"] == 100
+
+
+def test_a_missing_usage_log_is_zero_and_unknown_not_a_crash(tmp_path: Path) -> None:
+    assert _runner().read_cost(tmp_path, 0) == {
+        "prompt_tokens": 0, "completion_tokens": 0, "usd": None
+    }
+
+
+# --------------------------------------------------------------------------- the report
+
+def _rows(**passes: list[bool]) -> list[dict]:
+    out = []
+    for arm, results in passes.items():
+        for index, ok in enumerate(results):
+            out.append({
+                "task": f"t{index}", "arm": arm, "seed": 42, "passed": ok,
+                "prompt_tokens": 100, "completion_tokens": 10,
+            })
+    return out
+
+
+def test_the_report_pairs_every_comparison_and_prints_the_price() -> None:
+    """Criterion 3 is a cost ceiling, so a lift reported without its price cannot be checked
+    against the design at all."""
+    run = _runner()
+    rows = _rows(
+        A_fusion=[True, True, False], B_repeat=[True, False, False], C_single=[False, False, False]
+    )
+
+    text = run.report(rows)
+
+    assert "A_fusion" in text and "B_repeat" in text and "C_single" in text
+    assert text.count("ratio=") == 3
+
+
+def test_an_incomplete_grid_says_so_instead_of_reporting_a_number() -> None:
+    """A missing cell silently dropped is a comparison over a different task set than the one it
+    names — and it reads exactly like a complete result."""
+    run = _runner()
+    rows = _rows(A_fusion=[True, True], B_repeat=[True])
+
+    assert "incomplete" in run.report(rows)
+
+
+def test_the_prereg_sha_is_stamped_so_a_result_cannot_be_read_against_another_design() -> None:
+    run = _runner()
+
+    assert run.prereg_sha() != "MISSING"
+    assert len(run.prereg_sha()) == 12
+
+
+# --------------------------------------------------------------------------- the stop
+
+def test_the_runner_pilots_before_it_can_spend_the_full_budget() -> None:
+    """The registered run is 900 solves. The first invocation pays for a handful, prints what they
+    measured, and exits — because the alternative is an estimate, and there is nothing to estimate
+    from: the prior bench's journal records outcomes and not cost."""
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert '"--full", action="store_true"' in source
+    assert "tasks = TASKS if args.full else TASKS[: args.pilot_tasks]" in source
+    assert "Nothing here is a result. Re-run with --full to pay for one." in source
+
+
+def test_the_verdict_is_the_test_and_never_the_arm_self_report() -> None:
+    """The fusion arm contains a judge whose whole job is to say things went well. The verdict is
+    an independent pytest run, and this is the line that keeps it that way."""
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert "def independent_pytest" in source
+    assert "ignore what solve claimed" in source
+    assert "assert_discriminating" in source, "the apparatus must prove itself before it is paid for"
+
+
+def test_each_repeat_sample_starts_from_a_fresh_fork() -> None:
+    """Letting sample 2 inherit sample 1's edits would make arm B a three-attempt loop — a different
+    experiment, and one this project has already run under the name `local_lift`."""
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert "ws = setup_workspace(task, root / f\"{arm}_s{seed}_{index}\")" in source
+
+
+@pytest.mark.parametrize("phrase", [
+    "panel", "judge", "synthesiser", "Self-MoA", "Barrel of Monkeys", "review_judge",
+])
+def test_the_preregistration_states_the_evidence_it_is_testing_against(phrase: str) -> None:
+    """Each arm of the split the literature found, named in the design — so the result is read
+    against what was already known rather than against whatever is remembered afterwards."""
+    assert phrase in PREREG.read_text(encoding="utf-8")

--- a/tests/test_fusion_paired_harness.py
+++ b/tests/test_fusion_paired_harness.py
@@ -269,6 +269,22 @@ def test_an_arm_that_read_no_receipt_blocks_the_full_run_estimate() -> None:
     assert 'r.get("tokens_known", True)' in source
 
 
+def test_a_cell_records_what_it_did_so_a_blank_receipt_is_diagnosable() -> None:
+    """The pilot needed this and did not have it: on one task all three arms joined no receipt, two
+    of them after SUCCEEDING, and the diagnosis had to be done by reading the workspace off disk.
+
+    Exit 124 is the timeout, and it is a different outcome from a wrong answer. The learning-lift
+    series had to write this rule after run 7a, when "the agent could not do it" and "the clock ran
+    out" were still the same number.
+    """
+    source = (REPO / "bench/fusion_paired/run_paired.py").read_text(encoding="utf-8")
+
+    assert '"exits": [a["exit"] for a in attempts]' in source
+    assert '"tail":' in source
+    assert "TIMEOUTS:" in source, "an arm that hit the wall must say so beside its score"
+    assert "clock artifact" in source
+
+
 # --------------------------------------------------------------------------- the report
 
 def _rows(**passes: list[bool]) -> list[dict]:

--- a/tests/test_fusion_paired_harness.py
+++ b/tests/test_fusion_paired_harness.py
@@ -137,6 +137,33 @@ def test_the_addendum_is_stamped_beside_the_preregistration() -> None:
 
 # --------------------------------------------------------------------------- the accounting
 
+def test_an_earlier_run_of_the_same_cell_is_not_charged_to_this_one(tmp_path: Path) -> None:
+    """The workspace path repeats between runs — the pilot reuses `screen_<model>/<task>` — so the
+    join alone ADDS every earlier run of the same cell to this one.
+
+    Caught by the pilot itself: a screen cell read 86,983 prompt tokens where the smoke run of the
+    same cell had measured 43,219, which is the smoke plus the pilot. A cost that grows every time
+    you re-run is the kind of number that looks like a measurement.
+    """
+    run = _runner()
+    (tmp_path / "runs.jsonl").write_text(
+        json.dumps({"ts": "2026-08-01T00:00:00+00:00",
+                    "workspace": "/tmp/workspaces/w/C_single_s42_0/t1",
+                    "attempts": [{"prompt_tokens": 900, "completion_tokens": 90, "usd": 0.9}]}) + chr(10)
+        + json.dumps({"ts": "2026-08-28T00:00:00+00:00",
+                      "workspace": "/tmp/workspaces/w/C_single_s42_0/t1",
+                      "attempts": [{"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.1}]}) + chr(10),
+        encoding="utf-8",
+    )
+    where = Path("/tmp/workspaces/w/C_single_s42_0/t1")
+
+    scoped = run.read_cost(tmp_path, where, "2026-08-27T00:00:00+00:00")
+    unscoped = run.read_cost(tmp_path, where)
+
+    assert scoped["prompt_tokens"] == 100, "an earlier run of the same cell was charged to this one"
+    assert unscoped["prompt_tokens"] == 1000, "the guard is the scope, not a change of file"
+
+
 def _runs_log(tmp_path: Path, *attempts: dict, workspace: str = "w/A_fusion_s42_0/t1") -> Path:
     """A `runs.jsonl` shaped like the one a CLI solve writes: the receipt is on the ATTEMPT."""
     (tmp_path / "runs.jsonl").write_text(
@@ -212,7 +239,9 @@ def test_arm_b_pays_for_every_sample_it_took(tmp_path: Path) -> None:
         }) + "\n" for i in range(3)
     ), encoding="utf-8")
 
-    cost = run._sum_costs(tmp_path, [Path(f"/tmp/workspaces/B_repeat_s42_{i}/t1") for i in range(3)])
+    cost = run._sum_costs(
+        tmp_path, [Path(f"/tmp/workspaces/B_repeat_s42_{i}/t1") for i in range(3)], ""
+    )
 
     assert cost["prompt_tokens"] == 300 and cost["completion_tokens"] == 30
     assert cost["usd"] == pytest.approx(0.03)


### PR DESCRIPTION
Item 4 of 6, **built and stopped before spending**, as asked.

## The question, and why nobody has answered it

Fusion routes a turn through three architecturally different models, a judge and a synthesiser. **Does that beat giving the same token budget to the best single model?**

The comparative study found the literature split down the middle of our own architecture:

| stage | verdict | evidence |
|---|---|---|
| **panel** | **supported** | Barrel of Monkeys, SWE-bench Verified n=500: pool coverage 80.8%, selected **66.2%** vs **62.8%** for the best single member |
| **judge** | **contradicted** | 8 judges, n=374: agreement with test execution **κ = 0.21** (Java) / **0.10** (Python) |
| **synthesiser** | **contradicted at equal cost** | Self-MoA, CRUX (code) n=800: six samples of the *best* model beat six mixed by **+5.6 pp** |

Two more point the same way. Aider measured in 2024 that adding Opus to GPT-4o **lowered** GPT-4o's contribution, because plausible-and-wrong eclipses implausible-and-right. And `bench/review_judge` already **failed our own judge**: 15.1% against a registered threshold of 30%.

**The experiment nobody has run is the one with the budget held equal.** Barrel of Monkeys pooled candidates that already existed and never paid to generate them; Self-MoA controls cost but has no executable gate.

## The design

Three arms over the existing **100-task `local_lift` corpus** — reused deliberately rather than authored for this — same fork, same pytest gate:

| arm | |
|---|---|
| **A — fusion** | the shipped panel → judge → synthesiser, one attempt |
| **B — repeat** | the best single model, **three** samples, the gate keeps the first that passes |
| **C — single** | the best single model, one sample |

**C is not decoration.** A vs B alone cannot separate *more diversity* from *more computation*. It is the control MoA omitted and Self-MoA had to add.

**Three seeds** — two alert, three decide.

## The criterion, fixed before any number exists

Fusion stays the recommended route only if **all three** hold: **A − B ≥ +5.0 pp**, the 95% CI excludes zero, and the **measured token ratio A/B ≤ 2.0**.

Absolute, never multiplicative. A multiplicative criterion has already misfired in this repo: `pass@k > pass@1 × 1.5` printed *"no useful tail"* for 52.3% → 72.9%.

## What would refute the bet, and what this cannot show

Both written **before** the run, not after:

- **B ≥ A** ⇒ the panel's diversity does not pay when the budget is paid rather than pooled.
- **B ≈ C** ⇒ repetition is not the mechanism either.
- **A > B but ratio > 2.0** ⇒ it works and is not worth being the default; the honest outcome is a documented opt-in.

And the limit: **every task here has an executable gate**, which is exactly the condition under which the literature says a judge matters least. A null result here is a null **for gated code tasks** and says nothing about fusion on prose, where no gate exists and where the panel may be earning its keep.

## It does not run

The first invocation pays for a **five-task pilot**, prints the **measured** tokens and dollars, and exits. The registered **900 solves** need `--full` and a person deciding.

There is nothing to estimate from — the prior bench's journal records outcomes and not cost — and measuring five is cheaper than being wrong about nine hundred.

## Apparatus

- The verdict is an **independent pytest run**, never the arm's self-report. The fusion arm contains a judge whose entire job is to say things went well.
- `assert_discriminating` proves every task's test **fails on the untouched workspace** before the first model call — a task that already passes scores a hit for an arm that did nothing.
- Each repeat sample starts from a **fresh fork**; letting sample 2 inherit sample 1's edits would make B a three-attempt loop, which is a different experiment and one already run here as `local_lift`.
- Cost follows the all-or-nothing rule: one unpriced row makes the total **unknown**, never smaller — the direction that would otherwise flatter the fusion arm.
- The pre-registration's SHA is stamped on every row, so a result cannot be read against a design it was not run under.

**18 tests hold the apparatus**, all deterministic and free. Full suite 4231 passed; `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)