### PR TITLE
fix(runs): a successful run could leave no receipt, and say so only at debug

### DIFF
--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -1230,9 +1230,20 @@ class AutonomousAgent:
     def _persist_receipt(self, result: AutonomousResult, task: str) -> None:
         """Append a run receipt recording how this finished run PROVED its work (read-only evidence).
 
-        Best-effort: persisting a receipt must NEVER break or fail a run, so any error (disk,
-        serialization) is swallowed with a debug log. Reads the verify command off the verifier when
-        it exposes one (``CommandVerifier.command``); ``None`` for a run with no executable verifier.
+        Best-effort in the sense that it must NEVER break or fail a run — but not silent, and not
+        all-or-nothing. Both of those were true until a bench caught it: on one task, three runs in
+        a row wrote no row at all and TWO OF THEM HAD SUCCEEDED, with the work still on disk and its
+        test passing. A receipt that failed to serialise disappeared behind a `debug` line, which no
+        user and no bench ever sees, and it disappeared BY TASK rather than at random — so every
+        consumer of these rows, the Cost screen included, undercounted systematically and quietly.
+
+        So a failure now (a) logs at WARNING with the reason, and (b) falls back to a minimal row
+        that still carries the tokens and the workspace. A run whose full proof trail cannot be
+        serialised is still a run that cost money, and the cost is the part nothing else can
+        reconstruct.
+
+        Reads the verify command off the verifier when it exposes one (``CommandVerifier.command``);
+        ``None`` for a run with no executable verifier.
         """
         if self.run_log is None:
             return
@@ -1252,7 +1263,48 @@ class AutonomousAgent:
             )
             append_run(self.run_log, receipt)
         except Exception as exc:  # noqa: BLE001 — receipt persistence is best-effort, never fatal
-            _log.debug("run receipt skipped: %s", exc)
+            _log.warning("run receipt failed to persist (%s: %s); writing a minimal row instead",
+                         type(exc).__name__, exc)
+            self._persist_minimal_receipt(result, task, exc)
+
+    def _persist_minimal_receipt(
+        self, result: AutonomousResult, task: str, cause: Exception
+    ) -> None:
+        """The fallback: the tokens and the outcome, with none of the fields that can fail.
+
+        Written by hand rather than through ``build_receipt`` on purpose — the builder is what just
+        raised, so re-entering it would lose the row for the same reason twice. Everything here is a
+        primitive, and the whole thing is wrapped again because a fallback that can itself throw is
+        not a fallback.
+        """
+        try:
+            import json as _json
+
+            row = {
+                "ts": datetime.now(UTC).isoformat(),
+                "task": str(task)[:2000],
+                "success": bool(getattr(result, "success", False)),
+                "workspace": str(self.workspace) if self.workspace else "",
+                "partial": True,
+                "partial_reason": f"{type(cause).__name__}: {cause}"[:500],
+                "attempts": [
+                    {
+                        "index": int(getattr(a, "index", 0) or 0),
+                        "success": bool(getattr(a, "success", False)),
+                        "prompt_tokens": int(getattr(a, "prompt_tokens", 0) or 0),
+                        "completion_tokens": int(getattr(a, "completion_tokens", 0) or 0),
+                        "usd": getattr(a, "usd", None),
+                        "model": str(getattr(a, "model", "") or ""),
+                    }
+                    for a in getattr(result, "attempts", None) or []
+                ],
+            }
+            assert self.run_log is not None
+            self.run_log.parent.mkdir(parents=True, exist_ok=True)
+            with self.run_log.open("a", encoding="utf-8") as handle:
+                handle.write(_json.dumps(row, ensure_ascii=True) + "\n")
+        except Exception as exc:  # noqa: BLE001 — still never fatal
+            _log.warning("minimal run receipt also failed: %s", exc)
 
     def _save_checkpoint(
         self,

--- a/tests/test_run_receipt_never_vanishes.py
+++ b/tests/test_run_receipt_never_vanishes.py
@@ -1,0 +1,149 @@
+"""A run that cost money must leave a row saying so, even when its proof trail cannot be serialised.
+
+Found by `bench/fusion_paired`: on one task, three solves in a row wrote **no row at all** to
+`runs.jsonl`, and two of them had SUCCEEDED — the workspace still held the written module and its
+test passed on a fresh check. `_persist_receipt` wrapped the whole write in `except Exception` and
+logged at `debug`, so the loss was invisible at every level a user or a bench would ever look at.
+
+It was also invisible in a way that biases: receipts vanished **by task** rather than at random, so
+every consumer of these rows — the Cost screen included — undercounted systematically. A cost that
+reads zero looks exactly like a cheap run.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.core.autonomous import AutonomousAgent
+
+
+@dataclass
+class _Attempt:
+    """The fields `build_receipt` reads. The ones it reads DIRECTLY rather than through `getattr`
+    are the interesting half: `verified`, `reverted`, `verify_output`, `diff_summary` and `feedback`
+    have no default there, so an attempt missing any of them takes the whole receipt down with it."""
+
+    index: int = 1
+    verified: bool = True
+    reverted: bool = False
+    verify_output: str = "1 passed"
+    diff_summary: str = "diff: +1 new"
+    feedback: str = ""
+    diffs: list = field(default_factory=list)
+    success: bool = True
+    prompt_tokens: int = 4321
+    completion_tokens: int = 210
+    usd: float | None = 0.05
+    model: str = "openrouter/anthropic/claude-opus-5"
+
+
+@dataclass
+class _Result:
+    """Likewise for the result: `paused` and `answer` are read directly by the builder."""
+
+    success: bool = True
+    paused: bool = False
+    answer: str = "done"
+    attempts: list[_Attempt] = field(default_factory=lambda: [_Attempt()])
+
+
+def _agent(tmp_path: Path) -> Any:
+    """An agent shell with only the fields `_persist_receipt` touches.
+
+    Built with `__new__` rather than a real constructor on purpose: this file is about one method's
+    failure path, and wiring a whole agent would make the test depend on everything else that method
+    does not use.
+    """
+    agent = AutonomousAgent.__new__(AutonomousAgent)
+    agent.run_log = tmp_path / "runs.jsonl"
+    agent.workspace = tmp_path / "ws"
+    agent.verifier = None
+    agent.run_profile = None
+    agent.verify_source = "user"
+    agent.profile_source = "user"
+    return agent
+
+
+def _rows(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_a_receipt_that_cannot_be_built_still_records_the_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The failure that actually happened. `build_receipt` raises, and the run vanished entirely.
+
+    The tokens are the part nothing else can reconstruct: the workspace survives a lost receipt and
+    so does the answer, but what the run COST exists only here.
+    """
+    import chimera.api.runs as runs_module
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        raise ValueError("a field would not serialise")
+
+    monkeypatch.setattr(runs_module, "build_receipt", _explode)
+    agent = _agent(tmp_path)
+
+    agent._persist_receipt(_Result(), "make the thing work")
+
+    rows = _rows(agent.run_log)
+    assert len(rows) == 1, "the run left no trace at all"
+    assert rows[0]["partial"] is True, "a fallback row must not pass for a complete one"
+    assert rows[0]["attempts"][0]["prompt_tokens"] == 4321
+    assert rows[0]["attempts"][0]["completion_tokens"] == 210
+    assert rows[0]["workspace"].endswith("ws"), "without this the row cannot be joined to a cell"
+
+
+def test_the_loss_is_reported_at_a_level_somebody_sees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`debug` is what made this invisible for as long as it was. A bench that reads receipts and a
+    user reading the Cost screen both see WARNING; neither sees debug."""
+    import chimera.api.runs as runs_module
+
+    monkeypatch.setattr(
+        runs_module, "build_receipt", lambda *a, **k: (_ for _ in ()).throw(ValueError("nope"))
+    )
+    agent = _agent(tmp_path)
+
+    with caplog.at_level("WARNING"):
+        agent._persist_receipt(_Result(), "task")
+
+    assert any("receipt" in record.message.lower() for record in caplog.records), caplog.text
+
+
+def test_a_working_receipt_is_untouched(tmp_path: Path) -> None:
+    """The fallback is a fallback. When the builder works, exactly one complete row is written and
+    it carries no `partial` marker — otherwise every consumer would have to learn a second shape."""
+    agent = _agent(tmp_path)
+
+    agent._persist_receipt(_Result(), "task")
+
+    rows = _rows(agent.run_log)
+    assert len(rows) == 1
+    assert "partial" not in rows[0]
+    assert rows[0]["attempts"][0]["prompt_tokens"] == 4321
+
+
+def test_a_fallback_that_itself_fails_does_not_break_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Persisting a receipt must never fail a run — that part of the original contract was right,
+    and a fallback that can throw is not a fallback."""
+    import chimera.api.runs as runs_module
+
+    monkeypatch.setattr(
+        runs_module, "build_receipt", lambda *a, **k: (_ for _ in ()).throw(ValueError("nope"))
+    )
+    agent = _agent(tmp_path)
+    agent.run_log = tmp_path / "nested" / "runs.jsonl"
+    monkeypatch.setattr(Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+
+    agent._persist_receipt(_Result(), "task")  # must not raise


### PR DESCRIPTION
Found by a bench pilot, not by a report — which is the point.

On one task, **three solves in a row wrote no row at all** to `runs.jsonl`, and **two of them had succeeded**. The workspace still held the written module and its test passed on a fresh check. What the bench saw was three cells with a cost of zero, which reads exactly like three cheap runs.

## The mechanism

`AutonomousAgent._persist_receipt` wrapped the whole write in `except Exception` and logged at **debug**.

- **Invisible.** No user and no bench reads debug, so the loss had no symptom anywhere.
- **Biased, not noisy.** Receipts vanish **by task** rather than at random — whatever about a particular run's attempts will not serialise will fail every time that run happens. So every consumer of these rows, the Cost screen included, undercounts *systematically*.

## The change

"Best effort" was right about one thing: persisting a receipt must never break a run. It was wrong to be silent, and wrong to be all-or-nothing. A failure now:

1. logs at **WARNING** with the exception type and message;
2. falls back to a **minimal row** carrying the tokens, the outcome and the workspace, marked `partial: true` so it can never pass for a complete one.

The fallback is written by hand rather than through `build_receipt` — the builder is what just raised, and re-entering it would lose the row twice for the same reason. Every field is a primitive, and the whole thing is wrapped again: a fallback that can itself throw is not a fallback.

**The tokens are the part nothing else can reconstruct.** The workspace survives a lost receipt and so does the answer; what the run *cost* exists only here.

## Tests

Four, and the doubles are deliberately explicit about which fields `build_receipt` reads **directly** rather than through `getattr` — `verified`, `reverted`, `verify_output`, `diff_summary`, `feedback` on the attempt, and `paused`, `answer` on the result. An object missing any one of them takes the whole receipt down, which is a plausible shape for what happened on the task that lost three. **The exact cause there is not established and is not claimed.**

Full suite 4258 passed, 14 skipped; `ruff` and `mypy` clean (325 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)