### PR TITLE
feat(evolution): a black-box holdout for auto-evolution

### DIFF
--- a/chimera/evolution/auto_evolve.py
+++ b/chimera/evolution/auto_evolve.py
@@ -16,11 +16,13 @@ non-destructive; the gates above keep it honest rather than guarding against har
 
 from __future__ import annotations
 
+import hashlib
 import string
 from typing import TYPE_CHECKING
 
 from chimera.eval.anytime import best_possible_wilson, wilson_lower_best_of
 from chimera.evolution.evolver import SkillEvolver
+from chimera.evolution.holdout import HoldoutGate, HoldoutVerdict
 from chimera.evolution.learned_skill import LearnedSkill
 from chimera.evolution.skill_store import SkillStore
 from chimera.governance.validator import SkillValidator
@@ -31,6 +33,17 @@ if TYPE_CHECKING:
     from chimera.governance.audit import AuditLog
 
 _log = get_logger("evolution.auto")
+
+
+def _task_id(task: str) -> str:
+    """A stable identity for a TASK, so the holdout can exclude the one the skill came from.
+
+    Hashed rather than slugged: a slug of the first few words collides across tasks that open the
+    same way ("fix the failing test in ..."), and a collision here does not fail loudly — it
+    silently excludes a case that should have been scored, shrinking the holdout toward the
+    unmeasured verdict without anything saying so.
+    """
+    return hashlib.sha256(" ".join(task.split()).encode("utf-8")).hexdigest()[:16]
 
 
 def _placeholders(template: str) -> list[str]:
@@ -52,6 +65,7 @@ class AutoSkillEvolver:
         accept_mode: str = "point",
         provisional: bool = False,
         audit: AuditLog | None = None,
+        holdout: HoldoutGate | None = None,
     ) -> None:
         self.evolver = evolver
         self.store = store
@@ -66,6 +80,12 @@ class AutoSkillEvolver:
         # single-model proposal. Falls back to single-model when unset.
         self.collective = collective
         self.min_transfer = min_transfer
+        # Opt-in, and off changes nothing: without a gate this class behaves exactly as it did.
+        # What it adds is the axis the other two gates do not have — the smoke test runs the
+        # candidate on its OWN task and checks the output is non-empty, and `min_transfer` varies
+        # the MODEL while holding that same task fixed. Neither asks whether the skill works on a
+        # task it has never seen. See `chimera/evolution/holdout.py`.
+        self.holdout = holdout
         # "point" (raw pass fraction) or "wilson" (lower confidence bound on the
         # fraction) — the honesty upgrade that stops a lucky small-sample pass counting.
         self.accept_mode = accept_mode
@@ -114,6 +134,53 @@ class AutoSkillEvolver:
             _log.debug("skill %s born PROVISIONAL (on measured probation)", skill.name)
         self.store.add(skill)
         return skill
+
+    def _clears_holdout(self, candidate: LearnedSkill, task: str) -> bool:
+        """False only when the holdout RAN and the candidate failed it.
+
+        An unmeasured holdout does not reject — there is nothing to reject on — but it does not pass
+        silently either: the skill is stored with its status recorded so "checked and cleared" and
+        "never checked" stay different facts. `chimera/eval/transfer.py` set the same rule for the
+        promotion path: an honest "promoted without a transfer check", never a silent pass.
+        """
+        if self.holdout is None:
+            return True
+        verdict = self.holdout.evaluate(candidate, minted_from=_task_id(task))
+        if not verdict.measured:
+            _log.info("auto-skill %s stored WITHOUT a holdout check: %s",
+                      candidate.name, verdict.reason)
+            self._record_holdout(candidate, verdict, kept=True)
+            return True
+        if not self.holdout.accepts(verdict):
+            _log.info("discarded auto-skill %s: %s", candidate.name, verdict.summary())
+            self._record_holdout(candidate, verdict, kept=False)
+            return False
+        self._record_holdout(candidate, verdict, kept=True)
+        return True
+
+    def _record_holdout(
+        self, candidate: LearnedSkill, verdict: HoldoutVerdict, *, kept: bool
+    ) -> None:
+        """Write the verdict to the audit log, kept or not.
+
+        The REJECTED ones are the half worth keeping: a gate whose rejection rate is zero is a gate
+        that supports nothing built on top of it, and there is no way to notice that from the skills
+        that survived it.
+        """
+        if self.audit is None:
+            return
+        self.audit.record(
+            "skill_holdout",
+            {
+                "name": candidate.name,
+                "kept": kept,
+                "measured": verdict.measured,
+                "passed": verdict.passed,
+                "total": verdict.total,
+                "excluded": verdict.excluded,
+                "errors": len(verdict.errors),
+            },
+        )
 
     def maybe_evolve(
         self, task: str, solution: str, prior_successes: int, *, tainted: bool = False
@@ -194,6 +261,10 @@ class AutoSkillEvolver:
             _log.debug("discarded auto-skill %s (failed smoke test)", candidate.name)
             return None
 
+        # Gate 3 — black-box holdout: does it work on a task it was not minted from?
+        if not self._clears_holdout(candidate, task):
+            return None
+
         self._mark_and_store(candidate, tainted=tainted)
         _log.debug("kept auto-skill %s", candidate.name)
         return candidate
@@ -239,6 +310,12 @@ class AutoSkillEvolver:
                 best, best_score, best_frac = candidate, score, frac
         if best is None or best_score < self.min_transfer:
             _log.debug("no transferable auto-skill kept (best gate=%.2f)", best_score)
+            return None
+        # Gate 3 — black-box holdout. It has to be here as well as on the single path, and for a
+        # sharper reason: the score above is the best of k candidates, so the winner's advantage is
+        # partly the winner's curse. Asking it about a task it has never seen is the one question
+        # that picking the best of k cannot flatter.
+        if not self._clears_holdout(best, task):
             return None
         self._mark_and_store(best, tainted=tainted)
         _log.debug("kept collective auto-skill %s (frac=%.2f gate=%.2f)", best.name, best_frac, best_score)

--- a/chimera/evolution/holdout.py
+++ b/chimera/evolution/holdout.py
@@ -1,0 +1,152 @@
+"""Black-box holdout for auto-evolution — does a minted skill work on a task it has never seen?
+
+Auto-evolution announces two gates before it stores a skill (:mod:`chimera.evolution.auto_evolve`).
+Read against what they do, neither asks the question this module exists for:
+
+- the **executable smoke test** runs the candidate on ``test_input`` and checks
+  ``lambda out: bool(out.strip())`` — that the model said *something*. Any live model passes it.
+- the **transferability gate** (:meth:`CollectiveSkillEvolver.transfer_counts`) loops over nine
+  models with **the same ``test_input``** and the same non-empty check. It varies the MODEL and
+  holds the TASK fixed, so ``min_transfer=0.5`` reads "at least five of nine models were reachable
+  and answered". That is availability, and it is worth measuring, but it is not transfer.
+
+And ``test_input`` is the task the skill was minted from, substituted into every placeholder. So
+today a skill is kept on the strength of running once, on its own task, on models that were up.
+
+This module adds the missing axis: score the candidate on tasks it was **not** minted from, with a
+check that can actually fail, and refuse to store one that does not hold up. The cases are injected
+rather than discovered, so the gate is unit-testable with fakes — the same shape
+:class:`~chimera.fusion.verifier_select.VerifierSelector` uses.
+
+Three rules are structural rather than advisory, because each one is a way this gate could look like
+it worked while measuring nothing:
+
+1. **The minting task is excluded, and the exclusion is counted.** A gate that scores a skill on its
+   own task is measuring memorisation. The count is reported so "nothing was excluded" and "the
+   exclusion happened" are different observations rather than the same silence.
+2. **Too few remaining cases produce ``measured=False``, never a pass.** ``chimera/eval/transfer.py``
+   already set this precedent for the promotion path: *"an honest 'promoted without a transfer
+   check', never a silent pass"*. A gate that waves through whatever it could not measure is worse
+   than no gate, because it reports a verdict.
+3. **The rejection rate is part of the verdict.** A verifier that accepts everything supports no
+   loop built on it — the lesson this project paid for when it measured a runtime verifier accepting
+   95% of what it saw and discovered the retry loop around it almost never fired.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("evolution.holdout")
+
+
+@dataclass(frozen=True)
+class HoldoutCase:
+    """One task the candidate may be scored on, plus the check that says the output was right.
+
+    ``task_id`` is what makes the holdout black-box: it is compared against the id of the task the
+    candidate was minted from, and a match is excluded. It must therefore identify the TASK and not
+    the run — two runs of the same task share an id, or the exclusion does not exclude.
+    """
+
+    task_id: str
+    inputs: dict[str, str]
+    check: Callable[[str], bool]
+
+
+@dataclass(frozen=True)
+class HoldoutVerdict:
+    """What the holdout found, including whether it was in a position to find anything.
+
+    ``measured`` False means the gate could not run — not that the skill failed and not that it
+    passed. A caller that collapses those three into a boolean has re-created the silence this
+    module exists to remove.
+    """
+
+    measured: bool
+    passed: int = 0
+    total: int = 0
+    excluded: int = 0
+    reason: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def rate(self) -> float:
+        """Share of holdout cases the skill got right, or 0.0 when nothing was measured."""
+        return self.passed / self.total if self.total else 0.0
+
+    def summary(self) -> str:
+        if not self.measured:
+            return f"holdout not measured ({self.reason})"
+        return (
+            f"holdout {self.passed}/{self.total} = {self.rate:.0%} "
+            f"(excluded {self.excluded} case(s) from the minting task)"
+        )
+
+
+class HoldoutGate:
+    """Scores a candidate skill on tasks it was not minted from."""
+
+    def __init__(
+        self,
+        cases: Sequence[HoldoutCase],
+        *,
+        min_pass: float = 0.5,
+        min_cases: int = 2,
+    ) -> None:
+        #: Two is the floor rather than one because a single case makes the gate a coin flip whose
+        #: only outcomes are 0% and 100%, and both would clear or fail any threshold by construction.
+        self.cases = list(cases)
+        self.min_pass = min_pass
+        self.min_cases = max(1, min_cases)
+
+    def evaluate(self, skill: object, *, minted_from: str) -> HoldoutVerdict:
+        """Run ``skill`` on every case that is not the minting task.
+
+        A case whose execution raises counts as a FAILURE rather than being skipped. Skipping it
+        would let an unreachable model produce a perfect score over the one case that answered —
+        the same reasoning ``transfer_counts`` gives for keeping failed calls in its denominator.
+        The error strings are carried on the verdict so "the skill is wrong" and "the provider was
+        down" can still be told apart afterwards, which the pass count alone cannot do.
+        """
+        candidates = [case for case in self.cases if case.task_id != minted_from]
+        excluded = len(self.cases) - len(candidates)
+        if len(candidates) < self.min_cases:
+            return HoldoutVerdict(
+                measured=False,
+                excluded=excluded,
+                reason=(
+                    f"{len(candidates)} case(s) left after excluding the minting task, "
+                    f"below min_cases={self.min_cases}"
+                ),
+            )
+
+        passed = 0
+        errors: list[str] = []
+        for case in candidates:
+            try:
+                result = skill.execute(**case.inputs)  # type: ignore[attr-defined]
+                if getattr(result, "ok", False) and case.check(getattr(result, "output", "")):
+                    passed += 1
+            except Exception as exc:  # noqa: BLE001 — an error is a failure, never a skip
+                errors.append(f"{case.task_id}: {type(exc).__name__}: {exc}")
+        verdict = HoldoutVerdict(
+            measured=True,
+            passed=passed,
+            total=len(candidates),
+            excluded=excluded,
+            errors=errors,
+        )
+        _log.debug("holdout for a candidate skill: %s", verdict.summary())
+        return verdict
+
+    def accepts(self, verdict: HoldoutVerdict) -> bool:
+        """Whether a verdict clears the bar. An unmeasured verdict does NOT clear it.
+
+        The caller decides what to do with an unmeasured one — store it and say so, or hold it back
+        — but it may not read as a pass here, because this method is what a gate is.
+        """
+        return verdict.measured and verdict.rate >= self.min_pass

--- a/tests/test_evolution_holdout.py
+++ b/tests/test_evolution_holdout.py
@@ -1,0 +1,250 @@
+"""The black-box holdout: does a minted skill work on a task it has never seen?
+
+Auto-evolution had two gates before this and neither asked that question. The **smoke test** runs the
+candidate on ``test_input`` — which is the minting task substituted into every placeholder — and
+checks ``bool(out.strip())``, so any live model passes it. The **transferability gate** loops over
+nine models with that same input and that same check, varying the MODEL while holding the TASK
+fixed; ``min_transfer=0.5`` therefore reads "at least five of nine models were reachable".
+
+Everything here is deterministic and free: the skill is a fake with a scripted answer table, so what
+is under test is the gate's arithmetic and its refusals, never a model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chimera.evolution.auto_evolve import AutoSkillEvolver, _task_id
+from chimera.evolution.holdout import HoldoutCase, HoldoutGate
+
+
+class _Result:
+    def __init__(self, ok: bool, output: str) -> None:
+        self.ok, self.output = ok, output
+
+
+class _Skill:
+    """A skill whose answer depends only on the input, so a case can be made to pass or fail."""
+
+    name = "fake_skill"
+
+    def __init__(self, answers: dict[str, str], *, raises: set[str] | None = None) -> None:
+        self.answers = answers
+        self.raises = raises or set()
+        self.seen: list[str] = []
+
+    def execute(self, **inputs: str) -> _Result:
+        key = inputs.get("q", "")
+        self.seen.append(key)
+        if key in self.raises:
+            raise RuntimeError("provider is down")
+        return _Result(True, self.answers.get(key, ""))
+
+
+def _case(task_id: str, question: str, expected: str) -> HoldoutCase:
+    return HoldoutCase(task_id=task_id, inputs={"q": question}, check=lambda out: out == expected)
+
+
+# --------------------------------------------------------------------------- the exclusion
+
+
+def test_the_minting_task_is_never_scored() -> None:
+    """A gate that scores a skill on its own task is measuring memorisation and calling it transfer.
+
+    The count of exclusions is on the verdict for a reason: "the minting task was not in the set"
+    and "the minting task was excluded" would otherwise be the same silence.
+    """
+    skill = _Skill({"own": "yes", "a": "A", "b": "B"})
+    gate = HoldoutGate([_case("T1", "own", "yes"), _case("T2", "a", "A"), _case("T3", "b", "B")])
+
+    verdict = gate.evaluate(skill, minted_from="T1")
+
+    assert "own" not in skill.seen, "the skill was scored on the task it was minted from"
+    assert verdict.excluded == 1
+    assert verdict.total == 2 and verdict.passed == 2
+
+
+def test_too_few_cases_left_is_unmeasured_and_not_a_pass() -> None:
+    """`chimera/eval/transfer.py` set this rule for the promotion path: an honest "promoted without
+    a transfer check", never a silent pass. A gate that waves through what it could not measure is
+    worse than no gate, because it reports a verdict."""
+    gate = HoldoutGate([_case("T1", "own", "yes"), _case("T2", "a", "A")], min_cases=2)
+
+    verdict = gate.evaluate(_Skill({"a": "A"}), minted_from="T1")
+
+    assert verdict.measured is False
+    assert gate.accepts(verdict) is False, "an unmeasured verdict cleared the gate"
+    assert "below min_cases" in verdict.reason
+
+
+def test_a_single_case_is_not_enough_by_default() -> None:
+    """One case makes the gate a coin flip whose only outcomes are 0% and 100%, and both would clear
+    or fail any threshold by construction."""
+    gate = HoldoutGate([_case("T2", "a", "A")])
+
+    assert gate.evaluate(_Skill({"a": "A"}), minted_from="T1").measured is False
+
+
+# --------------------------------------------------------------------------- the scoring
+
+
+def test_a_wrong_answer_fails_where_the_shipped_smoke_test_would_pass() -> None:
+    """The gap this module exists for. The existing gate checks `bool(out.strip())`, so a confident
+    wrong answer clears it; here the case's own check decides."""
+    skill = _Skill({"a": "WRONG BUT NON-EMPTY", "b": "ALSO WRONG"})
+    gate = HoldoutGate([_case("T2", "a", "A"), _case("T3", "b", "B")])
+
+    verdict = gate.evaluate(skill, minted_from="T1")
+
+    assert verdict.passed == 0 and verdict.total == 2
+    assert gate.accepts(verdict) is False
+    assert all(answer.strip() for answer in skill.answers.values()), (
+        "the fixture must produce NON-EMPTY wrong answers, or it is not testing the gap"
+    )
+
+
+def test_an_execution_error_counts_as_a_failure_and_is_not_skipped() -> None:
+    """Skipping it would let one reachable model produce a perfect score over the single case that
+    answered — the reasoning `transfer_counts` already gives for keeping failed calls in its
+    denominator. The error strings are kept so "wrong" and "the provider was down" stay separable."""
+    skill = _Skill({"a": "A", "b": "B"}, raises={"b"})
+    gate = HoldoutGate([_case("T2", "a", "A"), _case("T3", "b", "B")])
+
+    verdict = gate.evaluate(skill, minted_from="T1")
+
+    assert verdict.total == 2, "the failed case left the denominator"
+    assert verdict.passed == 1
+    assert len(verdict.errors) == 1 and "provider is down" in verdict.errors[0]
+
+
+def test_the_threshold_is_the_rate_over_the_cases_that_ran() -> None:
+    gate = HoldoutGate(
+        [_case("T2", "a", "A"), _case("T3", "b", "B"), _case("T4", "c", "C")], min_pass=0.6
+    )
+
+    verdict = gate.evaluate(_Skill({"a": "A", "b": "B", "c": "nope"}), minted_from="T1")
+
+    assert verdict.rate == pytest.approx(2 / 3)
+    assert gate.accepts(verdict) is True
+
+
+# --------------------------------------------------------------------------- the wiring
+
+
+class _Store(dict):
+    def add(self, skill: Any) -> None:
+        self[skill.name] = skill
+
+
+class _Evolver:
+    """Proposes one fixed candidate and passes every smoke test — like the shipped one does."""
+
+    def __init__(self, candidate: Any) -> None:
+        self.candidate = candidate
+
+    def propose(self, task: str, solution: str) -> Any:
+        return self.candidate
+
+    def test_skill(self, skill: Any, test_input: dict, check: Any) -> bool:
+        return True
+
+
+class _Candidate(_Skill):
+    def __init__(self, answers: dict[str, str]) -> None:
+        super().__init__(answers)
+        self.prompt_template = "{q}"
+        self.provenance = "clean"
+        self.status = "active"
+
+    def to_dict(self) -> dict:
+        return {"name": self.name}
+
+
+def _auto(candidate: Any, holdout: HoldoutGate | None, store: _Store) -> AutoSkillEvolver:
+    return AutoSkillEvolver(_Evolver(candidate), store, min_recurrences=1, holdout=holdout)
+
+
+def test_without_a_gate_nothing_changes() -> None:
+    """Opt-in means opt-in. A behaviour change that arrives without being asked for is the thing
+    this project refuses on principle, and it would silently alter what a running agent learns."""
+    store = _Store()
+
+    _auto(_Candidate({"a": "WRONG"}), None, store).maybe_evolve("t", "s", prior_successes=2)
+
+    assert "fake_skill" in store
+
+
+def test_a_candidate_that_fails_the_holdout_is_not_stored() -> None:
+    store = _Store()
+    gate = HoldoutGate([_case("T2", "a", "A"), _case("T3", "b", "B")])
+
+    kept = _auto(_Candidate({"a": "WRONG", "b": "ALSO WRONG"}), gate, store).maybe_evolve(
+        "t", "s", prior_successes=2
+    )
+
+    assert kept is None and "fake_skill" not in store
+
+
+def test_a_candidate_that_clears_the_holdout_is_stored() -> None:
+    store = _Store()
+    gate = HoldoutGate([_case("T2", "a", "A"), _case("T3", "b", "B")])
+
+    kept = _auto(_Candidate({"a": "A", "b": "B"}), gate, store).maybe_evolve(
+        "t", "s", prior_successes=2
+    )
+
+    assert kept is not None and "fake_skill" in store
+
+
+def test_an_unmeasured_holdout_stores_the_skill_rather_than_blocking_it() -> None:
+    """Unmeasured is not a failure. It must not reject — but the audit row below is what keeps
+    "checked and cleared" and "never checked" from becoming the same fact."""
+    store = _Store()
+    gate = HoldoutGate([_case("T2", "a", "A")], min_cases=2)
+
+    kept = _auto(_Candidate({"a": "A"}), gate, store).maybe_evolve("t", "s", prior_successes=2)
+
+    assert kept is not None and "fake_skill" in store
+
+
+def test_the_rejected_ones_reach_the_audit_log() -> None:
+    """The rejected half is the half worth keeping. A gate whose rejection rate is zero supports
+    nothing built on top of it, and the surviving skills cannot show that."""
+
+    class _Audit:
+        def __init__(self) -> None:
+            self.rows: list[tuple[str, dict]] = []
+
+        def record(self, kind: str, payload: dict) -> None:
+            self.rows.append((kind, payload))
+
+    audit = _Audit()
+    gate = HoldoutGate([_case("T2", "a", "A"), _case("T3", "b", "B")])
+    evolver = AutoSkillEvolver(
+        _Evolver(_Candidate({"a": "WRONG", "b": "WRONG"})),
+        _Store(),
+        min_recurrences=1,
+        holdout=gate,
+        audit=audit,  # type: ignore[arg-type]
+    )
+
+    evolver.maybe_evolve("t", "s", prior_successes=2)
+
+    rows = [payload for kind, payload in audit.rows if kind == "skill_holdout"]
+    assert rows and rows[0]["kept"] is False
+    assert rows[0]["passed"] == 0 and rows[0]["total"] == 2
+
+
+def test_the_task_identity_is_hashed_and_not_a_prefix_slug() -> None:
+    """A slug of the opening words collides across tasks that begin the same way, and a collision
+    here does not fail loudly — it silently drops a case that should have been scored, shrinking the
+    holdout toward "unmeasured" with nothing saying so."""
+    a = "fix the failing test in the parser module"
+    b = "fix the failing test in the renderer module"
+
+    assert _task_id(a) != _task_id(b)
+    assert _task_id(a) == _task_id("fix   the failing\ttest in the parser module"), (
+        "whitespace should not change a task's identity"
+    )


### PR DESCRIPTION
Item 6. Auto-evolution announced two gates before it stored a skill. Read against what they do, **neither asks whether the skill works on a task it has never seen.**

## What the two existing gates actually check

**The "executable smoke test"** runs the candidate and checks:

```python
test_input = {field: task for field in _placeholders(candidate.prompt_template)}
self.evolver.test_skill(candidate, test_input, lambda out: bool(out.strip()))
```

That the model said *something*. Any live model passes it. And `test_input` is the **minting task itself**, substituted into every placeholder.

**The "transferability gate"** (`CollectiveSkillEvolver.transfer_counts`) loops over nine models with *that same input* and *that same check*. It varies the **model** and holds the **task** fixed — so `min_transfer=0.5` reads *"at least five of nine models were reachable and answered"*. That is availability. Worth measuring, and not transfer.

So a skill was kept on the strength of running once, on its own task, on models that were up.

## What this adds

`HoldoutGate` scores the candidate on tasks it was **not** minted from, with a check that can fail, and refuses to store one that does not hold up. Cases are injected rather than discovered, so the gate is unit-tested with fakes — the shape `VerifierSelector` already uses.

Three rules are structural, because each is a way this gate could look like it worked while measuring nothing:

1. **The minting task is excluded, and the exclusion is counted.** Scoring a skill on its own task measures memorisation and calls it transfer. Without the count, *"the minting task was not in the set"* and *"it was excluded"* are the same silence.
2. **Too few remaining cases produce `measured=False`, never a pass.** `chimera/eval/transfer.py` set this precedent for the promotion path: *"an honest 'promoted without a transfer check', never a silent pass."* A gate that waves through what it could not measure is worse than no gate, because it reports a verdict.
3. **The verdict reaches the audit log kept or not.** The rejected half is the half worth keeping — a gate whose rejection rate is zero supports nothing built on top of it, and the surviving skills cannot show that.

Two more decisions worth the words:

- **An execution error counts as a failure, never a skip.** Skipping would let one reachable model produce a perfect score over the single case that answered — the reasoning `transfer_counts` already gives for keeping failed calls in its denominator. The error strings ride on the verdict so *wrong* and *the provider was down* stay separable.
- **The task identity is a hash of the normalised task, not a prefix slug.** A slug collides across tasks that open the same way (*"fix the failing test in ..."*), and the collision does not fail loudly — it silently drops a case that should have been scored, shrinking the holdout toward "unmeasured" with nothing saying so.

On the **collective** path the gate is there for a sharper reason: that score is the best of k candidates, so the winner's advantage is partly the winner's curse. A task it has never seen is the one question picking the best of k cannot flatter.

## Opt-in

Off changes nothing — without a gate the class behaves exactly as before. Turning it on changes what a running agent learns, which is not a change that may arrive unasked.

## Tests

12, deterministic and free. **Six guards sabotage-tested** — the exclusion, the unmeasured verdict, the error-is-a-failure rule, the wiring on the single path, the audit row for a rejection, and the hashed task id — **and all six bite.**

Full suite 4271 passed, 14 skipped (the one failure is `test_cli_schema_dump::test_the_committed_snapshot_is_current`, which reproduces on a pristine `origin/main` worktree). `ruff` and `mypy` clean (326 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)