### PR TITLE
fix(rc41): a sentence that named the wrong cause, and a gate nothing could arm

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -2450,12 +2450,22 @@
             ],
             "title": "Deliver To"
           },
+          "max_attempts": {
+            "default": 1,
+            "title": "Max Attempts",
+            "type": "integer"
+          },
           "name": {
             "title": "Name",
             "type": "string"
           },
           "schedule": {
             "title": "Schedule",
+            "type": "string"
+          },
+          "verify": {
+            "default": "",
+            "title": "Verify",
             "type": "string"
           },
           "workspace": {
@@ -2584,6 +2594,11 @@
             ],
             "title": "Last Status"
           },
+          "max_attempts": {
+            "default": 1,
+            "title": "Max Attempts",
+            "type": "integer"
+          },
           "name": {
             "title": "Name",
             "type": "string"
@@ -2605,6 +2620,11 @@
           },
           "trigger": {
             "title": "Trigger",
+            "type": "string"
+          },
+          "verify": {
+            "default": "",
+            "title": "Verify",
             "type": "string"
           },
           "workspace": {
@@ -6167,6 +6187,16 @@
           "external_agent": {
             "default": "",
             "title": "External Agent",
+            "type": "string"
+          },
+          "fell_back_reason": {
+            "default": "",
+            "enum": [
+              "",
+              "no_container",
+              "no_os_sandbox"
+            ],
+            "title": "Fell Back Reason",
             "type": "string"
           },
           "fell_back_to_host": {

--- a/apps/desktop/src/components/Cron.test.tsx
+++ b/apps/desktop/src/components/Cron.test.tsx
@@ -45,6 +45,10 @@ describe("Cron — create a schedule from the UI", () => {
           // And where its answer goes. Null is "only the result file", which is what every
           // schedule did before this field was wired to anything: see Cron.deliver.test.tsx.
           deliver_to: null,
+          // The gate, empty because this test left the field alone — which is the default and
+          // keeps the previous behaviour. See Cron.verify.test.tsx for the other half.
+          verify: "",
+          max_attempts: 1,
         },
         expect.anything(), // react-query passes a context object as the 2nd arg
       ),

--- a/apps/desktop/src/components/Cron.tsx
+++ b/apps/desktop/src/components/Cron.tsx
@@ -64,11 +64,13 @@ function AddSchedule() {
   const [schedule, setSchedule] = useState("0 7 * * *");
   const [action, setAction] = useState("");
   const [deliverTo, setDeliverTo] = useState("");
+  const [verify, setVerify] = useState("");
   const create = useMutation({
     mutationFn: createCron,
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["cron"] });
       setName("");
+      setVerify("");
       setAction("");
       setDeliverTo("");
     },
@@ -125,6 +127,18 @@ function AddSchedule() {
           value={deliverTo}
           onChange={(e) => setDeliverTo(e.target.value)}
         />
+        {/* The gate, and it is optional for the reason the placeholder says. Most schedules are
+            reports that change no files, and a gate that fails a run for changing no file would
+            break every one of them. But a job that EDITS code had no way to opt in: the field
+            existed on the model, the dispatch armed the loop only when it was set, and nothing
+            anywhere could set it — not this screen, not `chimera cron add`. */}
+        <input
+          className="field w-full px-3 py-2 font-mono text-xs"
+          placeholder={t("cron.add.verify")}
+          aria-label={t("cron.add.verify")}
+          value={verify}
+          onChange={(e) => setVerify(e.target.value)}
+        />
         <div className="flex items-center justify-between gap-3 pt-0.5">
           <span className="text-xs text-muted-foreground">{t("cron.add.hint")}</span>
           <Button
@@ -139,6 +153,11 @@ function AddSchedule() {
                 action,
                 workspace: readWorkspace() || null,
                 deliver_to: deliverTo.trim() || null,
+                verify: verify.trim(),
+                // Two attempts only when there is a gate to decide between them: without one,
+                // nothing can tell a failed attempt from a finished one, so a retry would just
+                // do the work twice and keep the second answer.
+                max_attempts: verify.trim() ? 2 : 1,
               })
             }
             disabled={!canSubmit}

--- a/apps/desktop/src/components/Cron.verify.test.tsx
+++ b/apps/desktop/src/components/Cron.verify.test.tsx
@@ -1,0 +1,103 @@
+/** The gate a scheduled job can opt into — and could not, from anywhere, until this field existed.
+ *
+ * `CronJob` has carried `verify` and `max_attempts` since the scheduled run got its harness, and the
+ * dispatch arms the loop only when `verify` is non-empty. Nothing could write either one: not this
+ * screen, not `POST /api/cron`, not `chimera cron add`. So for every user `verify` was permanently
+ * `""`, the gate never armed, and the change kept its accounting half and none of the rest.
+ *
+ * Found by installing the release and trying to schedule a job that edits code.
+ */
+
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Cron } from "@/components/Cron";
+import { createCron, getCron } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", () => ({
+  getCronSilence: vi.fn(),
+  getCron: vi.fn(),
+  createCron: vi.fn(),
+  enableCron: vi.fn(),
+  disableCron: vi.fn(),
+  deleteCron: vi.fn(),
+}));
+
+const mockGetCron = vi.mocked(getCron);
+const mockCreateCron = vi.mocked(createCron);
+
+describe("Cron — the gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCron.mockResolvedValue([]);
+    mockCreateCron.mockResolvedValue({} as never);
+  });
+
+  it("sends the verify command the user typed, so the dispatch can arm its loop", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Cron />);
+
+    await user.type(await screen.findByPlaceholderText(/name/i), "nightly fix");
+    await user.type(screen.getByPlaceholderText(/what should Chimera do/i), "fix the failing test");
+    await user.type(screen.getByPlaceholderText(/test command/i), "pytest -q");
+    await user.click(screen.getByRole("button", { name: /Schedule/i }));
+
+    await vi.waitFor(() =>
+      expect(mockCreateCron).toHaveBeenCalledWith(
+        expect.objectContaining({ verify: "pytest -q" }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("only asks for a retry when there is a gate to judge it", async () => {
+    // Without a gate nothing can tell a failed attempt from a finished one, so a second attempt
+    // would just do the work twice and keep whichever answer came last.
+    const user = userEvent.setup();
+    renderWithProviders(<Cron />);
+
+    await user.type(await screen.findByPlaceholderText(/name/i), "morning brief");
+    await user.type(screen.getByPlaceholderText(/what should Chimera do/i), "summarise my email");
+    await user.click(screen.getByRole("button", { name: /Schedule/i }));
+
+    await vi.waitFor(() =>
+      expect(mockCreateCron).toHaveBeenCalledWith(
+        expect.objectContaining({ verify: "", max_attempts: 1 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("raises max_attempts once a gate exists", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Cron />);
+
+    await user.type(await screen.findByPlaceholderText(/name/i), "nightly fix");
+    await user.type(screen.getByPlaceholderText(/what should Chimera do/i), "fix the failing test");
+    await user.type(screen.getByPlaceholderText(/test command/i), "pytest -q");
+    await user.click(screen.getByRole("button", { name: /Schedule/i }));
+
+    await vi.waitFor(() =>
+      expect(mockCreateCron).toHaveBeenCalledWith(
+        expect.objectContaining({ max_attempts: 2 }),
+        expect.anything(),
+      ),
+    );
+  });
+
+  it("the field is optional, and says so where a lay user reads it", async () => {
+    // Most schedules are reports that change no files, and the diff gate fails an attempt that
+    // changed none — so arming this for everyone would break every report job. The label has to
+    // carry that, because a required-looking field is one people fill in with something wrong.
+    renderWithProviders(<Cron />);
+
+    // Two fields on this form say "(optional)", so the assertion has to name THIS one — matching
+    // loosely would pass on the delivery webhook and prove nothing about the gate.
+    const field = await screen.findByPlaceholderText(/test command/i);
+
+    expect(field).toHaveAttribute("placeholder", expect.stringMatching(/optional/i));
+    expect(field).toHaveAttribute("placeholder", expect.stringMatching(/no gate/i));
+  });
+});

--- a/apps/desktop/src/components/code/PostureNote.fellback.test.tsx
+++ b/apps/desktop/src/components/code/PostureNote.fellback.test.tsx
@@ -1,0 +1,79 @@
+/** Why the shell would run on this machine — and the sentence that says which reason it was.
+ *
+ * There was one sentence: *"A container was configured, but none is running — this is your
+ * machine."* It was written when a container was the only boundary there was, and it was true then.
+ *
+ * Once the default sandbox became `auto`, the same line started appearing on machines where nobody
+ * configured a container and no daemon would have helped — Windows, where the mechanism is a
+ * restricted token plus network filters and the app deliberately does not attempt it, and any Linux
+ * that refuses unprivileged user namespaces. The conclusion stayed right and the REASON became
+ * invented, which is worse than vague: it sends someone to start Docker to fix something Docker
+ * does not fix.
+ *
+ * Found by installing the release on Windows and turning commands on.
+ */
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PostureNote } from "@/components/code/PostureNote";
+import { getDoctor, getPostureFacts } from "@/lib/api";
+import { postureFacts as facts } from "@/test/code-api-mock";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", () => ({ getDoctor: vi.fn(), getPostureFacts: vi.fn() }));
+
+const mockFacts = vi.mocked(getPostureFacts);
+
+describe("PostureNote — why the shell is on this machine", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Left as a bare `vi.fn()` this resolves to `undefined`, react-query treats that as a failed
+    // query, and the component renders its error line instead of any sentence — so every assertion
+    // below would fail for a reason that has nothing to do with what is being tested.
+    vi.mocked(getDoctor).mockResolvedValue({ providers: [] } as never);
+  });
+
+  it("names the missing OS sandbox when there is no container in the story", async () => {
+    mockFacts.mockResolvedValue(
+      facts({ fell_back_to_host: true, fell_back_reason: "no_os_sandbox" }) as never,
+    );
+
+    renderWithProviders(<PostureNote workspace="/repo" reach="workspace_shell" approval="never" />);
+
+    expect(await screen.findByText(/no OS sandbox is available/i)).toBeInTheDocument();
+    expect(screen.queryByText(/container was configured/i)).not.toBeInTheDocument();
+  });
+
+  it("still names the container when a container really was configured", async () => {
+    // The original case did not go away and its advice works: start the daemon.
+    mockFacts.mockResolvedValue(
+      facts({ fell_back_to_host: true, fell_back_reason: "no_container" }) as never,
+    );
+
+    renderWithProviders(<PostureNote workspace="/repo" reach="workspace_shell" approval="never" />);
+
+    expect(await screen.findByText(/container was configured/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no OS sandbox is available/i)).not.toBeInTheDocument();
+  });
+
+  it("says nothing about a fall-back when there was none", async () => {
+    mockFacts.mockResolvedValue(facts({ shell: "isolated" }) );
+
+    renderWithProviders(<PostureNote workspace="/repo" reach="workspace_shell" approval="never" />);
+
+    await screen.findByText(/repo/i);
+    expect(screen.queryByText(/container was configured/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/no OS sandbox is available/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to the container sentence when the reason is missing", async () => {
+    // A server that predates `fell_back_reason` sends the flag without it. Reading that as "no
+    // sandbox exists here" would be a guess; the container sentence is what those servers meant.
+    mockFacts.mockResolvedValue(facts({ fell_back_to_host: true }) );
+
+    renderWithProviders(<PostureNote workspace="/repo" reach="workspace_shell" approval="never" />);
+
+    expect(await screen.findByText(/container was configured/i)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/code/PostureNote.tsx
+++ b/apps/desktop/src/components/code/PostureNote.tsx
@@ -120,9 +120,16 @@ export function PostureNote({
         // The one case where the honest answer contradicts what the user set up. Pre-emptive on
         // purpose: telling someone their sandbox was not running AFTER a shell command already ran
         // on their machine is a report, not a warning.
+        //
+        // Which sentence depends on WHY. "A container was configured, but none is running" was the
+        // only one there was, and once the default became `auto` it started appearing on machines
+        // where nobody configured a container and no daemon would help — right conclusion, invented
+        // reason, and it sent people to start Docker to fix something Docker does not fix.
         <p className="flex items-start gap-1.5 text-xs text-bad-foreground">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-          {t("code.posture.fellBack")}
+          {facts.data.fell_back_reason === "no_os_sandbox"
+            ? t("code.posture.fellBackNoSandbox")
+            : t("code.posture.fellBack")}
         </p>
       ) : null}
     </div>

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -3620,10 +3620,20 @@ export interface components {
             action: string;
             /** Deliver To */
             deliver_to?: string | null;
+            /**
+             * Max Attempts
+             * @default 1
+             */
+            max_attempts: number;
             /** Name */
             name: string;
             /** Schedule */
             schedule: string;
+            /**
+             * Verify
+             * @default
+             */
+            verify: string;
             /** Workspace */
             workspace?: string | null;
         };
@@ -3663,6 +3673,11 @@ export interface components {
             last_run: number | null;
             /** Last Status */
             last_status?: string | null;
+            /**
+             * Max Attempts
+             * @default 1
+             */
+            max_attempts: number;
             /** Name */
             name: string;
             /** Next Run */
@@ -3671,6 +3686,11 @@ export interface components {
             schedule: string;
             /** Trigger */
             trigger: string;
+            /**
+             * Verify
+             * @default
+             */
+            verify: string;
             /** Workspace */
             workspace?: string | null;
         };
@@ -5242,6 +5262,12 @@ export interface components {
              * @default
              */
             external_agent: string;
+            /**
+             * Fell Back Reason
+             * @default
+             * @enum {string}
+             */
+            fell_back_reason: "" | "no_container" | "no_os_sandbox";
             /**
              * Fell Back To Host
              * @default false

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -486,6 +486,11 @@ export const createCron = (
     action: string;
     workspace?: string | null;
     deliver_to?: string | null;
+    /** The gate. Empty means the job runs ungoverned, which is what every job did before this
+     *  field could be sent: `CronJob` has carried `verify` since the harness landed and neither
+     *  this route nor the CLI could write it, so the gate could never arm for anybody. */
+    verify?: string;
+    max_attempts?: number;
   },
 ) =>
   json<CronJob>("/api/cron", { method: "POST", body: JSON.stringify(body) });

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1299,9 +1299,19 @@ export interface PostureFacts {
   workspace: string;
   shell: "none" | "isolated" | "host" | "asks" | "refused";
   pauses: "always" | "tainted" | "never";
-  // True when the shell would run on this machine while the config asked for a container. The one
+  // True when the shell would run on this machine while the config asked for a boundary. The one
   // case where the honest answer contradicts the user's setup, so it is never folded into `shell`.
   fell_back_to_host: boolean;
+  /** WHY it fell back, because there are two reasons and they need different sentences.
+   *
+   *  `no_container` is the original: a container was configured and no daemon answered, so "start
+   *  Docker" is advice that works. `no_os_sandbox` is the `auto` default on a machine with no
+   *  kernel mechanism — Windows, or a Linux that refuses unprivileged user namespaces — where
+   *  naming a container is simply false and starting one is not what the user set up.
+   *
+   *  Optional because a server older than the field sends the flag without it; the screen reads a
+   *  missing reason as the container case, which is what those servers meant. */
+  fell_back_reason?: "" | "no_container" | "no_os_sandbox";
   // True when this surface has NO taint ledger: nothing marks the conversation after it reads
   // untrusted content, so the tools that would otherwise start refusing keep working. The default
   // for a chat, deliberately — and therefore something the sentence has to admit.

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -407,6 +407,8 @@ const en: Dict = {
   "cron.add.action": "what should Chimera do? (e.g. summarise my unread email)",
   "cron.add.when": "when — cron: minute hour day month weekday",
   "cron.add.deliver": "Discord or Slack webhook URL (optional)",
+  "cron.add.verify":
+    "test command that proves the work (optional) — empty means no gate",
   "cron.deliversTo": "delivers to {host}",
   "cron.lastAnswer": "Answered {when}",
   "cron.deliveryFailed": "delivery failed",
@@ -880,7 +882,9 @@ const en: Dict = {
   "code.posture.saysPause.never": "Never pauses for your sign-off.",
   "code.posture.fellBack":
     "A container was configured, but none is running — this is your machine.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "No OS sandbox is available here, so commands would run on this machine.",
+"code.posture.unguarded":
     "Nothing marks this conversation after it reads untrusted content, so it can still write files afterwards. Turn on the chat guard in Settings to change that.",
   "code.posture.unknown": "Could not determine what this posture means here.",
   "code.roles.title": "Models by role",
@@ -1649,6 +1653,8 @@ const pt: Dict = {
     "o que o Chimera deve fazer? (ex.: resumir meus e-mails não lidos)",
   "cron.add.when": "quando — cron: minuto hora dia mês dia-da-semana",
   "cron.add.deliver": "URL de webhook do Discord ou Slack (opcional)",
+  "cron.add.verify":
+    "comando de teste que prova o trabalho (opcional) — vazio = sem portão",
   "cron.deliversTo": "entrega em {host}",
   "cron.lastAnswer": "Respondeu {when}",
   "cron.deliveryFailed": "entrega falhou",
@@ -2128,7 +2134,9 @@ const pt: Dict = {
   "code.posture.saysPause.never": "Nunca para para pedir seu aval.",
   "code.posture.fellBack":
     "Um contêiner foi configurado, mas nenhum está rodando — esta é a sua máquina.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Não há sandbox de sistema disponível aqui, então os comandos rodariam nesta máquina.",
+"code.posture.unguarded":
     "Nada marca esta conversa depois que ela lê conteúdo não confiável, então ela ainda pode escrever arquivos em seguida. Ligue a proteção do chat em Ajustes para mudar isso.",
   "code.posture.unknown":
     "Não deu para determinar o que esta postura significa aqui.",
@@ -2569,6 +2577,8 @@ const es: Dict = {
     "¿qué debería hacer Chimera? (p. ej. resume mis correos sin leer)",
   "cron.add.when": "cuándo — cron: minuto hora día mes día-semana",
   "cron.add.deliver": "URL de webhook de Discord o Slack (opcional)",
+  "cron.add.verify":
+    "comando de prueba que demuestra el trabajo (opcional) — vacío = sin puerta",
   "cron.deliversTo": "entrega en {host}",
   "cron.lastAnswer": "Respondió {when}",
   "cron.deliveryFailed": "la entrega falló",
@@ -3388,7 +3398,9 @@ const es: Dict = {
   "code.posture.saysPause.never": "Nunca se detiene a pedir tu visto bueno.",
   "code.posture.fellBack":
     "Se configuró un contenedor, pero no hay ninguno en marcha — esta es tu máquina.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Aquí no hay sandbox del sistema disponible, así que los comandos se ejecutarían en esta máquina.",
+"code.posture.unguarded":
     "Nada marca esta conversación después de leer contenido no confiable, así que puede seguir escribiendo archivos. Activa la protección del chat en Ajustes para cambiarlo.",
   "code.posture.unknown":
     "No se pudo determinar qué significa esta postura aquí.",
@@ -3832,6 +3844,8 @@ const fr: Dict = {
     "que doit faire Chimera ? (par ex. résume mes e-mails non lus)",
   "cron.add.when": "quand — cron : minute heure jour mois jour-semaine",
   "cron.add.deliver": "URL de webhook Discord ou Slack (facultatif)",
+  "cron.add.verify":
+    "commande de test qui prouve le travail (facultatif) — vide = sans garde",
   "cron.deliversTo": "livre sur {host}",
   "cron.lastAnswer": "Répondu {when}",
   "cron.deliveryFailed": "l'envoi a échoué",
@@ -4660,7 +4674,9 @@ const fr: Dict = {
   "code.posture.saysPause.never": "Ne s'arrête jamais pour votre validation.",
   "code.posture.fellBack":
     "Un conteneur était configuré, mais aucun ne tourne — c'est votre machine.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Aucun bac à sable système n'est disponible ici, les commandes s'exécuteraient donc sur cette machine.",
+"code.posture.unguarded":
     "Rien ne marque cette conversation après qu'elle a lu du contenu non fiable : elle peut donc encore écrire des fichiers. Activez la protection du chat dans les Réglages pour changer cela.",
   "code.posture.unknown":
     "Impossible de déterminer ce que cette posture signifie ici.",
@@ -5106,6 +5122,8 @@ const de: Dict = {
     "Was soll Chimera tun? (z. B. fasse meine ungelesenen E-Mails zusammen)",
   "cron.add.when": "wann — cron: Minute Stunde Tag Monat Wochentag",
   "cron.add.deliver": "Discord- oder Slack-Webhook-URL (optional)",
+  "cron.add.verify":
+    "Testbefehl, der die Arbeit belegt (optional) — leer = kein Gate",
   "cron.deliversTo": "liefert an {host}",
   "cron.lastAnswer": "Geantwortet {when}",
   "cron.deliveryFailed": "Zustellung fehlgeschlagen",
@@ -5932,7 +5950,9 @@ const de: Dict = {
   "code.posture.saysPause.never": "Hält nie für Ihre Freigabe an.",
   "code.posture.fellBack":
     "Ein Container war konfiguriert, läuft aber nicht — das ist dein Rechner.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Hier ist keine Betriebssystem-Sandbox verfügbar, daher würden Befehle auf diesem Rechner laufen.",
+"code.posture.unguarded":
     "Nichts markiert diese Unterhaltung, nachdem sie nicht vertrauenswürdige Inhalte gelesen hat — sie kann danach weiterhin Dateien schreiben. Schalte den Chat-Schutz in den Einstellungen ein, um das zu ändern.",
   "code.posture.unknown":
     "Konnte nicht ermitteln, was diese Haltung hier bedeutet.",
@@ -6374,6 +6394,8 @@ const zh: Dict = {
   "cron.add.action": "要 Chimera 做什么？（例如：总结我的未读邮件）",
   "cron.add.when": "何时 —— cron：分 时 日 月 周",
   "cron.add.deliver": "Discord 或 Slack 的 webhook 链接（可选）",
+  "cron.add.verify":
+    "证明工作完成的测试命令（可选）—— 留空则无门禁",
   "cron.deliversTo": "发送到 {host}",
   "cron.lastAnswer": "{when} 的回答",
   "cron.deliveryFailed": "发送失败",
@@ -7138,7 +7160,9 @@ const zh: Dict = {
   "code.posture.saysPause.tainted": "如果读过不可信内容，会停下等待你签字。",
   "code.posture.saysPause.never": "从不为你的批准而暂停。",
   "code.posture.fellBack": "配置了容器，但没有一个在运行——这是你的机器。",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "此处没有可用的操作系统沙箱，因此命令将在这台机器上运行。",
+"code.posture.unguarded":
     "这个对话读了不可信内容之后没有任何标记，所以它之后仍然能写文件。到设置里打开聊天防护来改变这一点。",
   "code.posture.unknown": "无法判断这个姿态在这里意味着什么。",
   "code.roles.title": "按角色分配模型",
@@ -7572,6 +7596,8 @@ const ja: Dict = {
   "cron.add.action": "Chimera に何をさせますか？（例：未読メールを要約して）",
   "cron.add.when": "いつ — cron: 分 時 日 月 曜日",
   "cron.add.deliver": "Discord または Slack の webhook URL（任意）",
+  "cron.add.verify":
+    "作業を検証するテストコマンド（任意）— 空ならゲートなし",
   "cron.deliversTo": "{host} に届けます",
   "cron.lastAnswer": "{when} の回答",
   "cron.deliveryFailed": "配信に失敗",
@@ -8384,7 +8410,9 @@ const ja: Dict = {
   "code.posture.saysPause.never": "承認のために停止することはありません。",
   "code.posture.fellBack":
     "コンテナが設定されていますが、動いていません — これはあなたのマシンです。",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "このマシンでは OS のサンドボックスが使えないため、コマンドはこの端末上で実行されます。",
+"code.posture.unguarded":
     "この会話は信頼できない内容を読んだあとも何の印も付かないため、その後もファイルを書けます。設定でチャットの保護を有効にすると変わります。",
   "code.posture.unknown":
     "この姿勢がここで何を意味するか判定できませんでした。",
@@ -9162,6 +9190,8 @@ const it: Dict = {
     "cosa dovrebbe fare Chimera? (es. riassumi le mie email non lette)",
   "cron.add.when": "quando — cron: minuto ora giorno mese giorno-settimana",
   "cron.add.deliver": "URL webhook di Discord o Slack (facoltativo)",
+  "cron.add.verify":
+    "comando di test che dimostra il lavoro (opzionale) — vuoto = nessun gate",
   "cron.deliversTo": "consegna su {host}",
   "cron.lastAnswer": "Ha risposto {when}",
   "cron.deliveryFailed": "consegna fallita",
@@ -9648,7 +9678,9 @@ const it: Dict = {
   "code.posture.saysPause.never": "Non si ferma mai per la tua approvazione.",
   "code.posture.fellBack":
     "Era configurato un container, ma nessuno è in esecuzione — questa è la tua macchina.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Qui non è disponibile alcuna sandbox di sistema, quindi i comandi verrebbero eseguiti su questa macchina.",
+"code.posture.unguarded":
     "Niente contrassegna questa conversazione dopo che ha letto contenuti non attendibili, quindi può ancora scrivere file. Attiva la protezione della chat nelle Impostazioni per cambiarlo.",
   "code.posture.unknown":
     "Non è stato possibile determinare cosa significhi questa postura qui.",
@@ -10427,6 +10459,8 @@ const pl: Dict = {
     "co Chimera ma zrobić? (np. streść moje nieprzeczytane maile)",
   "cron.add.when": "kiedy — cron: minuta godzina dzień miesiąc dzień-tygodnia",
   "cron.add.deliver": "Adres webhooka Discord lub Slack (opcjonalnie)",
+  "cron.add.verify":
+    "polecenie testowe potwierdzające pracę (opcjonalnie) — puste = bez bramki",
   "cron.deliversTo": "wysyła na {host}",
   "cron.lastAnswer": "Odpowiedź {when}",
   "cron.deliveryFailed": "wysyłka nie powiodła się",
@@ -10908,7 +10942,9 @@ const pl: Dict = {
   "code.posture.saysPause.never": "Nigdy nie zatrzymuje się po twoją zgodę.",
   "code.posture.fellBack":
     "Skonfigurowano kontener, ale żaden nie działa — to twój komputer.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Nie ma tu dostępnej piaskownicy systemowej, więc polecenia działałyby na tej maszynie.",
+"code.posture.unguarded":
     "Nic nie oznacza tej rozmowy po tym, jak przeczyta niezaufaną treść, więc nadal może zapisywać pliki. Włącz ochronę czatu w Ustawieniach, żeby to zmienić.",
   "code.posture.unknown": "Nie udało się ustalić, co ta postawa tutaj oznacza.",
   "code.roles.title": "Modele wg roli",
@@ -11687,6 +11723,8 @@ const ru: Dict = {
     "что должна сделать Chimera? (например, кратко изложить непрочитанную почту)",
   "cron.add.when": "когда — cron: минута час день месяц день_недели",
   "cron.add.deliver": "URL вебхука Discord или Slack (необязательно)",
+  "cron.add.verify":
+    "команда теста, подтверждающая работу (необязательно) — пусто = без ворот",
   "cron.deliversTo": "отправляет в {host}",
   "cron.lastAnswer": "Ответ от {when}",
   "cron.deliveryFailed": "доставка не удалась",
@@ -12172,7 +12210,9 @@ const ru: Dict = {
   "code.posture.saysPause.never": "Никогда не останавливается ради вашего одобрения.",
   "code.posture.fellBack":
     "Контейнер был настроен, но ни один не запущен — это ваша машина.",
-  "code.posture.unguarded":
+    "code.posture.fellBackNoSandbox":
+    "Здесь нет доступной песочницы ОС, поэтому команды выполнялись бы на этой машине.",
+"code.posture.unguarded":
     "Ничто не помечает этот разговор после чтения недоверенного содержимого, поэтому он и дальше может записывать файлы. Включите защиту чата в настройках, чтобы это изменить.",
   "code.posture.unknown":
     "Не удалось определить, что здесь означает этот режим.",

--- a/apps/desktop/src/test/code-api-mock.ts
+++ b/apps/desktop/src/test/code-api-mock.ts
@@ -147,6 +147,10 @@ export function postureFacts(over: Partial<PostureFacts> = {}): PostureFacts {
     shell: "none",
     pauses: "tainted",
     fell_back_to_host: false,
+    // WHY it fell back, when it did. "" is the honest default for a fixture that did not fall back
+    // at all, and the component treats an absent reason as the container case — which is what a
+    // server that predates this field meant.
+    fell_back_reason: "",
     external_agent: "",
     // The coding turn is always assembled with the ledger, so the fixture's default is the guarded
     // case. A test that wants the unguarded chat has to ask for it — which is the right way round:

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -936,7 +936,7 @@
       "commands": [
         {
           "deprecated": false,
-          "help": "Add a cron, event- or webhook-triggered job.",
+          "help": "Add a cron, event- or webhook-triggered job.\n\n`--verify` is what turns a scheduled job into a run the harness governs. `CronJob` has carried\nthe field since the harness landed and nothing could write it \u2014 not this command, not the HTTP\nroute \u2014 so for every user the gate was permanently unarmed.",
           "hidden": false,
           "name": "add",
           "params": [
@@ -989,6 +989,28 @@
               ],
               "required": false,
               "type": "boolean"
+            },
+            {
+              "default": "''",
+              "help": "Gate: shell command run in the job's folder after the dispatch (exit 0 to keep the work, non-zero to revert it). Empty = no gate, which is the previous behaviour.",
+              "kind": "option",
+              "name": "verify",
+              "opts": [
+                "--verify"
+              ],
+              "required": false,
+              "type": "str"
+            },
+            {
+              "default": "1",
+              "help": "Attempts per dispatch. Worth raising only with --verify: without a gate nothing can tell a failed attempt from a finished one.",
+              "kind": "option",
+              "name": "max_attempts",
+              "opts": [
+                "--max-attempts"
+              ],
+              "required": false,
+              "type": "int"
             }
           ],
           "path": "cron add"

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -81,6 +81,10 @@ def _job_dict(job: Any) -> dict[str, Any]:
         "created_by": job.created_by,
         "workspace": job.workspace,
         "deliver_to": job.deliver_to,
+        # Echoed so a row can say whether this job is gated. Read off the job with a default rather
+        # than assumed present: the store holds jobs written before these fields existed.
+        "verify": getattr(job, "verify", "") or "",
+        "max_attempts": int(getattr(job, "max_attempts", 1) or 1),
     }
 
 
@@ -555,6 +559,8 @@ def register_features(
                 created_by="human",
                 workspace=body.workspace,
                 deliver_to=body.deliver_to,
+                verify=body.verify,
+                max_attempts=body.max_attempts,
             )
         except ValueError as exc:  # an invalid cron expression is a client error, not a 500
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/chimera/api/posture.py
+++ b/chimera/api/posture.py
@@ -141,6 +141,10 @@ Shell = Literal["none", "isolated", "host", "asks", "refused"]
 Pauses = Literal["always", "tainted", "never"]
 
 
+#: Why the shell would run on this machine. "" when it would not.
+FellBackReason = Literal["", "no_container", "no_os_sandbox"]
+
+
 class PostureFacts(BaseModel):
     """What is true right now, for the UI to render as one sentence.
 
@@ -158,6 +162,14 @@ class PostureFacts(BaseModel):
     #: is the one case where the honest answer contradicts what the user set up, and silently
     #: honouring the config here is exactly how "I thought it was sandboxed" happens.
     fell_back_to_host: bool = False
+    #: WHY the fall-back happened, because there are now two reasons and they need different
+    #: sentences. ``"no_container"`` is the original: a Docker sandbox was configured and no daemon
+    #: answered, so "start Docker" is advice that works. ``"no_os_sandbox"`` is the `auto` default on
+    #: a machine with no kernel mechanism — Windows, or a Linux that refuses unprivileged user
+    #: namespaces — where starting Docker is not what the user set up and telling them a container
+    #: was configured is simply false. The screen was saying the container sentence in both cases,
+    #: which reached the right conclusion by the wrong reason and sent people to fix the wrong thing.
+    fell_back_reason: FellBackReason = ""
     #: True when this surface has NO taint ledger — nothing marks the run after it reads untrusted
     #: content, so the tools that would otherwise start refusing keep working. Reported because the
     #: default is the permissive one (``CHIMERA_GUARD_CHAT`` is off), and a permissive default that
@@ -207,6 +219,7 @@ def describe(
 
     shell: Shell = "none"
     fell_back = False
+    fell_back_reason: FellBackReason = ""
     if not (EXEC_TOOLS & set(resolved.deny_tools)):
         isolated = False
         try:
@@ -219,7 +232,15 @@ def describe(
             # Anything but an explicit `local` asked for a boundary and did not get one. Under the
             # `auto` default this is how a Windows user — where no OS sandbox exists — is told that
             # their commands run on the host, on every posture read rather than once at startup.
-            fell_back = (settings.sandbox or "auto").lower() != "local"
+            configured = (settings.sandbox or "auto").lower()
+            fell_back = configured != "local"
+            # A container was named and did not answer, versus no kernel mechanism exists here at
+            # all. Both end on this machine; only one of them is fixed by starting a daemon.
+            fell_back_reason = (
+                "no_container" if configured in {"docker", "container", "podman"}
+                else "no_os_sandbox" if fell_back
+                else ""
+            )
             posture_env = (settings.host_exec or "ask").lower()
             # `ask` is honest about being unanswerable here: the server has no terminal, so the
             # confirm resolves to a refusal rather than to a prompt nobody will ever see.
@@ -235,6 +256,7 @@ def describe(
             else "never"
         ),
         fell_back_to_host=fell_back,
+        fell_back_reason=fell_back_reason,
         unguarded=not guarded,
         external_agent=external_agent,
     )

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -850,6 +850,11 @@ class CronJobOut(BaseModel):
     packaged build is the install directory, so the screen says so rather than leaving it blank."""
     deliver_to: str | None = None
     """A chat webhook URL the answer is posted to, or None to only write it to the result file."""
+    verify: str = ""
+    """The gate, echoed back so the screen can show whether this job has one. A job with an empty
+    `verify` runs ungoverned by design, and that is worth reading on the row rather than inferring
+    from its absence."""
+    max_attempts: int = 1
 
 
 class CronResultOut(BaseModel):
@@ -886,6 +891,17 @@ class CronCreateIn(BaseModel):
     that omits it gets the process root, which is the previous behaviour."""
     deliver_to: str | None = None
     """Optional chat webhook (Discord or Slack) the answer is posted to when the job fires."""
+    verify: str = ""
+    """Shell command that decides whether a dispatch KEPT its work; empty means no gate.
+
+    `CronJob` has carried this since the harness landed and no caller could write it — not this
+    route, not `chimera cron add` — so for every user `verify` was always empty, the gate could
+    never arm, and the scheduled run kept the accounting half of that change and none of the rest.
+    A field nothing can set is a field nobody has.
+    """
+    max_attempts: int = 1
+    """How many times one dispatch may try. Worth raising only alongside `verify`: without a gate
+    nothing can tell a failed attempt from a finished one."""
 
 
 # --- tasks (kanban + projects) --------------------------------------------------------------------

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -4768,20 +4768,44 @@ def cron_add(
     action: str = typer.Argument(..., help="What to do (task description / skill)."),
     event: bool = typer.Option(False, "--event", help="Treat SCHEDULE as an event name."),
     webhook: bool = typer.Option(False, "--webhook", help="Fire on POST /webhook/<SCHEDULE> (needs 'chimera serve')."),
+    verify: str = typer.Option(
+        "", "--verify",
+        help="Gate: shell command run in the job's folder after the dispatch (exit 0 to keep the "
+             "work, non-zero to revert it). Empty = no gate, which is the previous behaviour.",
+    ),
+    max_attempts: int = typer.Option(
+        1, "--max-attempts",
+        help="Attempts per dispatch. Worth raising only with --verify: without a gate nothing can "
+             "tell a failed attempt from a finished one.",
+    ),
 ) -> None:
-    """Add a cron, event- or webhook-triggered job."""
+    """Add a cron, event- or webhook-triggered job.
+
+    `--verify` is what turns a scheduled job into a run the harness governs. `CronJob` has carried
+    the field since the harness landed and nothing could write it — not this command, not the HTTP
+    route — so for every user the gate was permanently unarmed.
+    """
     import time
 
     from chimera.scheduler import Scheduler
 
     sched = Scheduler(_cron_store())
+    # Passed by name rather than unpacked from a dict: a `**kwargs` here type-erases both fields,
+    # and these are exactly the two that decide whether the run is governed.
     if webhook:
-        job = sched.schedule_webhook(name, schedule, action)
+        job = sched.schedule_webhook(
+            name, schedule, action, verify=verify, max_attempts=max_attempts
+        )
     elif event:
-        job = sched.schedule_event(name, schedule, action)
+        job = sched.schedule_event(
+            name, schedule, action, verify=verify, max_attempts=max_attempts
+        )
     else:
         try:
-            job = sched.schedule_cron(name, schedule, action, now=time.time())
+            job = sched.schedule_cron(
+                name, schedule, action, now=time.time(),
+                verify=verify, max_attempts=max_attempts,
+            )
         except ValueError as exc:
             console.print(f"[red]{exc}[/red]")
             raise typer.Exit(code=1) from exc

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -76,7 +76,19 @@ class Scheduler:
         created_by: CreatedBy = "human",
         workspace: str | None = None,
         deliver_to: str | None = None,
+        verify: str = "",
+        max_attempts: int = 1,
     ) -> CronJob:
+        """Register a job fired by a cron expression.
+
+        verify: Shell command that decides whether this job's dispatch KEPT its work; empty means
+            no gate, which is today's behaviour. Accepted here rather than only on the model
+            because a field nothing can set is a field nobody has: `CronJob` has carried `verify`
+            and `max_attempts` since the harness landed, and neither the HTTP route nor the CLI
+            could write them, so the gate could never arm for any user.
+        max_attempts: How many times one dispatch may try. Worth raising only alongside `verify` —
+            without a gate nothing can tell a failed attempt from a finished one.
+        """
         if not croniter.is_valid(cron_expr):
             raise ValueError(f"invalid cron expression: {cron_expr!r}")
         job = CronJob(
@@ -92,6 +104,8 @@ class Scheduler:
             next_run=_next_after(cron_expr, now),
             workspace=workspace,
             deliver_to=deliver_to,
+            verify=verify,
+            max_attempts=max(1, max_attempts),
         )
         self.store.add(job)
         return job
@@ -103,7 +117,19 @@ class Scheduler:
         action: str,
         *,
         created_by: CreatedBy = "human",
+        verify: str = "",
+        max_attempts: int = 1,
     ) -> CronJob:
+        """Register a job fired by a named event.
+
+        verify: Shell command that decides whether this job's dispatch KEPT its work; empty means
+            no gate, which is today's behaviour. Accepted here rather than only on the model
+            because a field nothing can set is a field nobody has: `CronJob` has carried `verify`
+            and `max_attempts` since the harness landed, and neither the HTTP route nor the CLI
+            could write them, so the gate could never arm for any user.
+        max_attempts: How many times one dispatch may try. Worth raising only alongside `verify` —
+            without a gate nothing can tell a failed attempt from a finished one.
+        """
         job = CronJob(
             id=uuid.uuid4().hex[:8],
             name=name,
@@ -112,6 +138,8 @@ class Scheduler:
             action=action,
             created_by=created_by,
             enabled=created_by != "agent",  # agent-created triggers start disabled (same invariant)
+            verify=verify,
+            max_attempts=max(1, max_attempts),
         )
         self.store.add(job)
         return job
@@ -123,8 +151,22 @@ class Scheduler:
         action: str,
         *,
         created_by: CreatedBy = "human",
+        verify: str = "",
+        max_attempts: int = 1,
     ) -> CronJob:
-        """Register a job fired by an inbound HTTP POST to ``/webhook/<hook>``."""
+        """Register a job fired by an inbound HTTP POST to ``/webhook/<hook>``.
+
+        A webhook job is the one most likely to edit code on somebody else's schedule, so it takes
+        the gate for the same reason a cron does.
+
+        verify: Shell command that decides whether this job's dispatch KEPT its work; empty means
+            no gate, which is today's behaviour. Accepted here rather than only on the model
+            because a field nothing can set is a field nobody has: `CronJob` has carried `verify`
+            and `max_attempts` since the harness landed, and neither the HTTP route nor the CLI
+            could write them, so the gate could never arm for any user.
+        max_attempts: How many times one dispatch may try. Worth raising only alongside `verify` —
+            without a gate nothing can tell a failed attempt from a finished one.
+        """
         job = CronJob(
             id=uuid.uuid4().hex[:8],
             name=name,
@@ -132,6 +174,8 @@ class Scheduler:
             schedule=hook,
             action=action,
             created_by=created_by,
+            verify=verify,
+            max_attempts=max(1, max_attempts),
         )
         self.store.add(job)
         return job

--- a/tests/test_the_scheduled_gate_is_reachable.py
+++ b/tests/test_the_scheduled_gate_is_reachable.py
@@ -1,0 +1,147 @@
+"""The gate a scheduled job can opt into, and the three layers that all had to carry it.
+
+`CronJob.verify` and `CronJob.max_attempts` shipped with the scheduled run's harness, and the
+dispatch arms the verify-or-revert loop only when `verify` is non-empty. Nothing could write either
+one — not `POST /api/cron`, not `chimera cron add`, not the Automation screen — so for every user
+`verify` was permanently `""`, the gate never armed, and that change kept its accounting half and
+none of the rest.
+
+Found by installing the release and trying to schedule a job that edits code. The frontend half is
+held by `apps/desktop/src/components/Cron.verify.test.tsx`; this file holds the two layers below it,
+because a field that reaches the route and stops there is the same defect one floor down.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from chimera.config import Settings
+from chimera.scheduler import Scheduler
+from chimera.scheduler.store import CronStore
+
+
+def _client(tmp_path: Path) -> TestClient:
+    from chimera.api import build_api_app
+    from chimera.interface import ChatSession
+    from tests.test_api import _FakeAgent  # the suite's existing stand-in
+
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"))
+    return TestClient(build_api_app(lambda: ChatSession(_FakeAgent()), settings=settings))
+
+
+def _store(tmp_path: Path) -> CronStore:
+    return CronStore(tmp_path / "jobs.json")
+
+
+# --------------------------------------------------------------------------- the scheduler
+
+
+def test_every_trigger_can_carry_the_gate(tmp_path: Path) -> None:
+    """Cron, event and webhook. A webhook job is the one most likely to edit code on somebody
+    else's schedule, so leaving it out would exempt the riskiest of the three."""
+    sched = Scheduler(_store(tmp_path))
+
+    cron = sched.schedule_cron("a", "0 7 * * *", "fix it", now=0.0, verify="pytest -q")
+    event = sched.schedule_event("b", "deploy", "fix it", verify="pytest -q")
+    hook = sched.schedule_webhook("c", "push", "fix it", verify="pytest -q")
+
+    assert [j.verify for j in (cron, event, hook)] == ["pytest -q"] * 3
+
+
+def test_a_job_without_a_gate_is_unchanged(tmp_path: Path) -> None:
+    """Opt-in, and the default has to stay exactly where it was: most scheduled jobs are reports
+    that change no files, and the diff gate fails an attempt that changed none."""
+    job = Scheduler(_store(tmp_path)).schedule_cron("a", "0 7 * * *", "summarise", now=0.0)
+
+    assert job.verify == "" and job.max_attempts == 1
+
+
+def test_max_attempts_can_never_be_zero(tmp_path: Path) -> None:
+    """Zero attempts is a job that cannot run. Clamped rather than rejected because it arrives from
+    a form field, and refusing a schedule over a number nobody meant is worse than fixing it."""
+    job = Scheduler(_store(tmp_path)).schedule_cron("a", "0 7 * * *", "x", now=0.0, max_attempts=0)
+
+    assert job.max_attempts == 1
+
+
+# --------------------------------------------------------------------------- the HTTP route
+
+
+def test_the_route_stores_the_gate_and_reads_it_back(tmp_path: Path) -> None:
+    """The layer that was missing. The screen sends it; without this the value was accepted into a
+    pydantic model and dropped on the floor before it reached the scheduler."""
+    client = _client(tmp_path)
+
+    created = client.post(
+        "/api/cron",
+        json={
+            "name": "nightly fix",
+            "schedule": "0 3 * * *",
+            "action": "fix the failing test",
+            "verify": "pytest -q",
+            "max_attempts": 2,
+        },
+    ).json()
+
+    assert created["verify"] == "pytest -q"
+    assert created["max_attempts"] == 2
+    listed = client.get("/api/cron").json()[0]
+    assert listed["verify"] == "pytest -q", "the gate did not survive the round trip"
+
+
+def test_a_client_that_sends_no_gate_keeps_the_old_behaviour(tmp_path: Path) -> None:
+    """An older client, or a report job. Neither may start failing because a field appeared."""
+    client = _client(tmp_path)
+
+    created = client.post(
+        "/api/cron", json={"name": "brief", "schedule": "0 7 * * *", "action": "summarise"}
+    ).json()
+
+    assert created["verify"] == "" and created["max_attempts"] == 1
+
+
+def test_a_job_written_before_these_fields_existed_still_reads(tmp_path: Path) -> None:
+    """The store holds jobs from earlier versions. Reading the row must not raise on their absence
+    — a screen that 500s on old data is a worse outcome than the gate not existing."""
+    from chimera.api.features import _job_dict
+
+    class _Old:
+        id, name, trigger, schedule, action = "j1", "old", "cron", "0 7 * * *", "x"
+        enabled, next_run, last_run = True, None, None
+        last_status = last_error = None
+        consecutive_failures, created_by = 0, "human"
+        workspace = deliver_to = None
+
+    row: dict[str, Any] = _job_dict(_Old())
+
+    assert row["verify"] == "" and row["max_attempts"] == 1
+
+
+# --------------------------------------------------------------------------- the CLI
+
+
+def test_the_cli_can_arm_the_gate(tmp_path: Path, monkeypatch: Any) -> None:
+    """`chimera cron add --verify`. The CLI is where a job that edits code is most likely to be
+    written, and it had no way to say what would prove the work."""
+    from typer.testing import CliRunner
+
+    from chimera.cli.main import app
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path / "home"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["cron", "add", "nightly", "0 3 * * *", "fix the test",
+         "--verify", "pytest -q", "--max-attempts", "3"],
+    )
+
+    assert result.exit_code == 0, result.output
+    store = CronStore(tmp_path / "home" / "scheduler" / "jobs.json")
+    jobs = store.list()
+    assert jobs, f"no job was stored: {result.output}"
+    assert jobs[0].verify == "pytest -q"
+    assert jobs[0].max_attempts == 3


### PR DESCRIPTION
Both found by **installing rc41 and using it**, and both are the same shape: the mechanism shipped and the wiring to the person stopped one layer short.

## 1. The fall-back sentence was from the world before this release

The backend *was* generalised when the sandbox default became `auto` — `fell_back = (settings.sandbox or "auto").lower() != "local"`, with a comment saying it is how a Windows user learns their commands run on the host. The frontend saw none of it: **the sandbox change touched zero files under `apps/desktop`.**

So on Windows, with commands on, the app said:

> *"A container was configured, but none is running — this is your machine."*

Nothing about a container was configured. The default is `auto`, and Windows has no mechanism at all — which the release notes say plainly. **Right conclusion, invented cause**, and it sends someone to start Docker to fix something Docker does not fix.

Rewording it would have been wrong too, because there are now **two** reasons and only one of them is fixed by starting a daemon. `PostureFacts` now carries `fell_back_reason` (`"no_container"` | `"no_os_sandbox"`) and the screen picks the sentence. A **missing** reason reads as the container case — which is what a server that predates the field meant.

## 2. `verify` and `max_attempts` on a scheduled job could not be set by anyone

`CronJob` has carried both since the scheduled run got its harness, and the dispatch arms the verify-or-revert loop **only when `verify` is non-empty**. The three ways a person creates a job:

| | fields |
|---|---|
| `POST /api/cron` | name, schedule, action, workspace, deliver_to |
| `chimera cron add` | name, schedule, action, `--event`, `--webhook` |
| Automation screen | name, time, action, folder, delivery webhook |

None could write either field, and there is no PATCH route. So for every user `verify` was permanently `""`, **the gate never armed**, and every scheduled job behaved exactly as before. The accounting half of that change — a `runs.jsonl` entry per firing — did land and is real. The headline half was unreachable.

Now on all three, plus the scheduler's **event and webhook** triggers: a webhook job is the one most likely to edit code on somebody else's schedule, so exempting it would have exempted the riskiest of the three. `max_attempts` is clamped at 1 rather than rejected, because it arrives from a form field and refusing a schedule over a number nobody meant is worse than fixing it.

The form raises `max_attempts` to 2 **only when a gate exists**. Without one nothing can tell a failed attempt from a finished one, so a retry would just do the work twice and keep whichever answer came last.

## Both stay opt-in

Neither default changes. Most scheduled jobs are reports that change no files, and the diff gate fails an attempt that changed none — arming it for everyone would break every report job.

## Tests, and why they exist

Two new files, plus two new i18n keys across all ten locales.

**The sabotage battery is the reason they exist.** Its first run caught the two frontend guards and **missed both backend ones** — I had wired the route and the CLI without guarding either, which is the same defect this PR is about, one level up. All four bite now:

```
CAUGHT  the gate never reaches the scheduler
CAUGHT  the CLI stops passing the gate
CAUGHT  the form stops sending the gate
CAUGHT  the sentence stops depending on the reason
```

4327 passed / 14 skipped; 964 frontend tests; `ruff` and `mypy` clean (328 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)