### PR TITLE
feat(security): the Security screen says whether commands are isolated

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -7136,6 +7136,40 @@
         "title": "SandboxCfgOut",
         "type": "object"
       },
+      "SandboxStateOut": {
+        "description": "Whether a command the model chooses can reach this machine, and if it can, why.\n\nOn the Security screen because that is the one screen a person opens to ask what protects them,\nand until now it answered about prompt injection and the audit log and said nothing about the\nboundary around execution. The posture line above the composer does say it \u2014 but only after\nchoosing a project and turning commands on, which is exactly the moment it is too late to be\nreading about it for the first time.",
+        "properties": {
+          "backend": {
+            "title": "Backend",
+            "type": "string"
+          },
+          "configured": {
+            "title": "Configured",
+            "type": "string"
+          },
+          "isolated": {
+            "title": "Isolated",
+            "type": "boolean"
+          },
+          "platform": {
+            "default": "",
+            "title": "Platform",
+            "type": "string"
+          },
+          "reason": {
+            "default": "",
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "configured",
+          "backend",
+          "isolated"
+        ],
+        "title": "SandboxStateOut",
+        "type": "object"
+      },
       "SearchHitOut": {
         "description": "One matching line.",
         "properties": {
@@ -10265,6 +10299,24 @@
           }
         },
         "summary": "Governance Injection Endpoint"
+      }
+    },
+    "/api/governance/sandbox": {
+      "get": {
+        "operationId": "governance_sandbox_endpoint_api_governance_sandbox_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxStateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Governance Sandbox Endpoint"
       }
     },
     "/api/health": {

--- a/apps/desktop/src/components/Governance.chain.test.tsx
+++ b/apps/desktop/src/components/Governance.chain.test.tsx
@@ -7,6 +7,9 @@ import { renderWithProviders } from "@/test/utils";
 vi.mock("@/lib/api", () => ({
   getGovernanceAudit: vi.fn(),
   getGovernanceInjection: vi.fn(),
+  // The screen gained an execution-boundary panel; a mock missing it makes the whole screen throw,
+  // which is this file's tests failing about something they are not testing.
+  getSandboxState: vi.fn(),
 }));
 
 /**

--- a/apps/desktop/src/components/Governance.declares.test.tsx
+++ b/apps/desktop/src/components/Governance.declares.test.tsx
@@ -7,6 +7,9 @@ import { renderWithProviders } from "@/test/utils";
 vi.mock("@/lib/api", () => ({
   getGovernanceAudit: vi.fn(),
   getGovernanceInjection: vi.fn(),
+  // The screen gained an execution-boundary panel; a mock missing it makes the whole screen throw,
+  // which is this file's tests failing about something they are not testing.
+  getSandboxState: vi.fn(),
 }));
 
 /**

--- a/apps/desktop/src/components/Governance.sandbox.test.tsx
+++ b/apps/desktop/src/components/Governance.sandbox.test.tsx
@@ -1,0 +1,120 @@
+/** The Security screen now answers the question it was named after.
+ *
+ * It reported prompt-injection defence and the audit log, and said nothing about the boundary around
+ * EXECUTION — the thing those two exist to defend. A person opening this screen to ask "what stops a
+ * command from reaching my files?" got an answer about a different question entirely.
+ *
+ * The posture line above the composer does say it, and that was the whole surface: reachable only
+ * after choosing a project and turning commands on, which is the moment it is already too late to be
+ * reading it for the first time.
+ */
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Governance } from "@/components/Governance";
+import { getGovernanceAudit, getGovernanceInjection, getSandboxState } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", () => ({
+  getGovernanceInjection: vi.fn(),
+  getGovernanceAudit: vi.fn(),
+  getSandboxState: vi.fn(),
+}));
+
+const mockSandbox = vi.mocked(getSandboxState);
+
+function state(over: Record<string, unknown> = {}) {
+  return {
+    configured: "auto",
+    backend: "host",
+    isolated: false,
+    reason: "",
+    platform: "Windows",
+    ...over,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The full shape, not a plausible subset: the screen reads `leaks_defended.length`, and a fixture
+  // missing it throws before anything renders — so every assertion in this file would have failed
+  // about a field none of them are testing.
+  vi.mocked(getGovernanceInjection).mockResolvedValue({
+    total_attacks: 6,
+    defended_asr: 0.17,
+    undefended_asr: 1,
+    defended_block_rate: 0.83,
+    undefended_block_rate: 0,
+    by_category: [{ category: "exfil", defended_asr: 0.5, undefended_asr: 1, count: 2 }],
+    attacks: [{
+      id: "http_exfil", category: "exfil", harmful_tool: "http_get",
+      blocked_defended: false, blocked_undefended: false,
+    }],
+    leaks_defended: ["http_exfil"],
+    defense: "taint_narrowing",
+    armed: true,
+    trust_kernel: false,
+  } as never);
+  vi.mocked(getGovernanceAudit).mockResolvedValue({
+    events: [], count: 0, populated: false, chain: null,
+  } as never);
+});
+
+describe("Governance — the execution boundary", () => {
+  it("says commands would run on this machine, and why", async () => {
+    mockSandbox.mockResolvedValue(
+      state({ reason: "Windows has no OS sandbox in Chimera." }),
+    );
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/would run on this machine/i)).toBeInTheDocument();
+    expect(screen.getByText(/Windows has no OS sandbox/i)).toBeInTheDocument();
+  });
+
+  it("says what still applies, so 'no jail' does not read as 'no protection'", async () => {
+    // The governance kernel, the write region and the confirmation prompt are not nothing. A panel
+    // that only reports the absence teaches the reader that the screen has nothing to offer.
+    mockSandbox.mockResolvedValue(state());
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/still apply/i)).toBeInTheDocument();
+  });
+
+  it("reports what was ASKED FOR beside what is ACTUALLY used", async () => {
+    // The two differ exactly when it matters. Showing only the setting would report an intention,
+    // and "I thought it was sandboxed" is what an intention reported as a fact produces.
+    mockSandbox.mockResolvedValue(state({ configured: "auto", backend: "host" }));
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/asked for: auto/i)).toBeInTheDocument();
+    expect(screen.getByText(/actually: host/i)).toBeInTheDocument();
+  });
+
+  it("says so plainly when a kernel boundary really does apply", async () => {
+    mockSandbox.mockResolvedValue(
+      state({ isolated: true, backend: "bubblewrap", platform: "Linux", reason: "" }),
+    );
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/inside a kernel sandbox/i)).toBeInTheDocument();
+    expect(screen.queryByText(/still apply/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/would run on this machine/i)).not.toBeInTheDocument();
+  });
+
+  it("a failed probe is an error to retry, never a silent 'you are isolated'", async () => {
+    // The dangerous default. An unreachable endpoint must not render as the reassuring state.
+    mockSandbox.mockRejectedValue(new Error("boom"));
+
+    renderWithProviders(<Governance />);
+
+    // Wait for the panel to settle on SOMETHING, then assert the reassuring sentence is not it.
+    await screen.findByText(/Commands on this machine/i);
+    expect(screen.queryByText(/inside a kernel sandbox/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/would run on this machine/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/Governance.tsx
+++ b/apps/desktop/src/components/Governance.tsx
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { ShieldCheck } from "lucide-react";
-import { getGovernanceAudit, getGovernanceInjection } from "@/lib/api";
+import { Lock, ShieldCheck, ShieldOff } from "lucide-react";
+import { getGovernanceAudit, getGovernanceInjection, getSandboxState } from "@/lib/api";
 import { Badge, EmptyState, Panel, Screen, Spinner } from "@/components/ui/panel";
 import { ErrorState } from "@/components/ui/async";
 import { useT, type TFunc } from "@/lib/i18n";
-import type { GovernanceAudit, InjectionReport } from "@/lib/types";
+import type { GovernanceAudit, InjectionReport, SandboxState } from "@/lib/types";
 
 type CategoryRow = InjectionReport["by_category"][number];
 type AttackRow = InjectionReport["attacks"][number];
@@ -214,13 +214,81 @@ function AuditPanel({ data, t }: { data: GovernanceAudit; t: TFunc }) {
   );
 }
 
+/** Whether a command the model chooses can reach this machine.
+ *
+ *  This screen is the one a person opens to ask what protects them, and it answered about prompt
+ *  injection and the audit log while saying nothing about the boundary around EXECUTION — the thing
+ *  those two are defending. The posture line above the composer does say it, but only after picking
+ *  a project and turning commands on, which is the moment it is already too late to be learning it.
+ *
+ *  The unisolated state is deliberately not styled as an error. On Windows there is no OS sandbox at
+ *  all and that is a documented, permanent fact rather than something the user did wrong; painting
+ *  it red every time the screen opens would train people to ignore the one colour that should mean
+ *  something. It is `warn`, it names the reason, and it says what still applies.
+ */
+function SandboxPanel({ data, t }: { data: SandboxState; t: TFunc }) {
+  return (
+    <Panel title={t("governance.sandbox.title")}>
+      <div className="flex items-start gap-3 px-4 py-4">
+        {data.isolated ? (
+          <Lock className="mt-0.5 h-4 w-4 shrink-0 text-ok" />
+        ) : (
+          <ShieldOff className="mt-0.5 h-4 w-4 shrink-0 text-warn-foreground" />
+        )}
+        <div className="flex flex-col gap-1.5">
+          <span className="text-sm text-foreground">
+            {data.isolated ? t("governance.sandbox.isolated") : t("governance.sandbox.host")}
+          </span>
+          {data.reason && (
+            <span className="text-xs text-muted-foreground">{data.reason}</span>
+          )}
+          {/* What still applies when the kernel boundary does not. Without this the panel reads as
+              "you have nothing", and the kernel, the write region and the confirmation prompt are
+              not nothing — they are simply not a jail. */}
+          {!data.isolated && (
+            <span className="text-xs text-muted-foreground">
+              {t("governance.sandbox.stillApplies")}
+            </span>
+          )}
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <Badge>{t("governance.sandbox.configured", { value: data.configured })}</Badge>
+            <Badge>{t("governance.sandbox.backend", { value: data.backend })}</Badge>
+            {data.platform && <Badge>{data.platform}</Badge>}
+          </div>
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
+
 export function Governance({ embedded = false }: { embedded?: boolean } = {}) {
   const t = useT();
   const injection = useQuery({ queryKey: ["governance-injection"], queryFn: getGovernanceInjection });
+  // Probed on every open rather than cached: a Docker daemon that died since the last look has to
+  // change the answer, not be served from a cache — the same rule the posture endpoint follows.
+  const sandbox = useQuery({
+    queryKey: ["governance-sandbox"], queryFn: getSandboxState, staleTime: 0, gcTime: 0,
+  });
   const audit = useQuery({ queryKey: ["governance-audit"], queryFn: getGovernanceAudit });
 
   return (
     <Screen title={t("governance.title")} icon={<ShieldCheck className="h-5 w-5" />} embedded={embedded}>
+      {/* First on the screen on purpose: it is the widest of the three. The injection score is
+          about one class of attack and the audit log is about what already happened; this is about
+          whether anything at all stands between a chosen command and the filesystem. */}
+      {sandbox.isError ? (
+        <Panel title={t("governance.sandbox.title")}>
+          <ErrorState error={sandbox.error} onRetry={() => sandbox.refetch()} />
+        </Panel>
+      ) : sandbox.isLoading || !sandbox.data ? (
+        <Panel title={t("governance.sandbox.title")}>
+          <Spinner />
+        </Panel>
+      ) : (
+        <SandboxPanel data={sandbox.data} t={t} />
+      )}
+
       {injection.isError ? (
         <Panel title={t("governance.injection.title")}>
           <ErrorState error={injection.error} onRetry={() => injection.refetch()} />

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -1043,6 +1043,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/governance/sandbox": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Governance Sandbox Endpoint */
+        get: operations["governance_sandbox_endpoint_api_governance_sandbox_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/health": {
         parameters: {
             query?: never;
@@ -5676,6 +5693,34 @@ export interface components {
             mode: string;
         };
         /**
+         * SandboxStateOut
+         * @description Whether a command the model chooses can reach this machine, and if it can, why.
+         *
+         *     On the Security screen because that is the one screen a person opens to ask what protects them,
+         *     and until now it answered about prompt injection and the audit log and said nothing about the
+         *     boundary around execution. The posture line above the composer does say it — but only after
+         *     choosing a project and turning commands on, which is exactly the moment it is too late to be
+         *     reading about it for the first time.
+         */
+        SandboxStateOut: {
+            /** Backend */
+            backend: string;
+            /** Configured */
+            configured: string;
+            /** Isolated */
+            isolated: boolean;
+            /**
+             * Platform
+             * @default
+             */
+            platform: string;
+            /**
+             * Reason
+             * @default
+             */
+            reason: string;
+        };
+        /**
          * SearchHitOut
          * @description One matching line.
          */
@@ -7806,6 +7851,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InjectionReportOut"];
+                };
+            };
+        };
+    };
+    governance_sandbox_endpoint_api_governance_sandbox_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SandboxStateOut"];
                 };
             };
         };

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   SearchResult,
   Benchmarks,
   GovernanceAudit,
+  SandboxState,
   InjectionReport,
   CatalogEntry,
   LibraryCard,
@@ -212,6 +213,9 @@ export const designAgent = (description: string) =>
 export const getGovernanceInjection = () =>
   json<InjectionReport>("/api/governance/injection");
 export const getGovernanceAudit = () => json<GovernanceAudit>("/api/governance/audit");
+/** Whether a command the model chooses can reach this machine. Probed live rather than read off the
+ *  config: asking for a sandbox and getting one are different facts. */
+export const getSandboxState = () => json<SandboxState>("/api/governance/sandbox");
 export const getTools = () => json<Tools>("/api/tools");
 
 // --- Filesystem (read-only tree + file viewer for the Code screen) ---

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1001,6 +1001,18 @@ const en: Dict = {
     "Still get through even defended (honest gap)",
   "governance.injection.note":
     "Measures defense-in-depth of an already-injected agent (synthetic corpus, no model) — not the model's susceptibility to being injected.",
+    "governance.sandbox.title":
+    "Commands on this machine",
+  "governance.sandbox.isolated":
+    "Commands run inside a kernel sandbox: no network, and writes confined to the working folder.",
+  "governance.sandbox.host":
+    "Commands would run on this machine — no kernel sandbox applies here.",
+  "governance.sandbox.stillApplies":
+    "The governance kernel, the write region and the confirmation prompt still apply — they are not a jail.",
+  "governance.sandbox.configured":
+    "asked for: {value}",
+  "governance.sandbox.backend":
+    "actually: {value}",
   "governance.audit.title": "Audit log",
   "governance.audit.intact":
     "chain intact",
@@ -2254,6 +2266,18 @@ const pt: Dict = {
   "governance.injection.leaksNote": "Passam mesmo com defesa (lacuna honesta)",
   "governance.injection.note":
     "Mede defesa-em-profundidade de um agente já injetado (corpus sintético, sem modelo) — não a suscetibilidade do modelo a ser injetado.",
+    "governance.sandbox.title":
+    "Comandos nesta máquina",
+  "governance.sandbox.isolated":
+    "Os comandos rodam dentro de um sandbox do kernel: sem rede, e escritas presas à pasta de trabalho.",
+  "governance.sandbox.host":
+    "Os comandos rodariam nesta máquina — nenhum sandbox de kernel se aplica aqui.",
+  "governance.sandbox.stillApplies":
+    "O kernel de governança, a região de escrita e o pedido de confirmação continuam valendo — eles não são uma jaula.",
+  "governance.sandbox.configured":
+    "pedido: {value}",
+  "governance.sandbox.backend":
+    "de fato: {value}",
   "governance.audit.title": "Registro de auditoria",
   "governance.audit.intact":
     "cadeia íntegra",
@@ -3519,6 +3543,18 @@ const es: Dict = {
     "Pasan incluso con defensa (brecha honesta)",
   "governance.injection.note":
     "Mide la defensa en profundidad de un agente ya inyectado (corpus sintético, sin modelo) — no la susceptibilidad del modelo a ser inyectado.",
+    "governance.sandbox.title":
+    "Comandos en esta máquina",
+  "governance.sandbox.isolated":
+    "Los comandos se ejecutan en un sandbox del kernel: sin red y con escrituras limitadas a la carpeta de trabajo.",
+  "governance.sandbox.host":
+    "Los comandos se ejecutarían en esta máquina: aquí no se aplica ningún sandbox del kernel.",
+  "governance.sandbox.stillApplies":
+    "El kernel de gobernanza, la región de escritura y la confirmación siguen vigentes: no son una jaula.",
+  "governance.sandbox.configured":
+    "solicitado: {value}",
+  "governance.sandbox.backend":
+    "en realidad: {value}",
   "governance.audit.title": "Registro de auditoría",
   "governance.audit.intact":
     "cadena íntegra",
@@ -4796,6 +4832,18 @@ const fr: Dict = {
     "Passent même avec défense (faille honnête)",
   "governance.injection.note":
     "Mesure la défense en profondeur d'un agent déjà injecté (corpus synthétique, sans modèle) — pas la susceptibilité du modèle à être injecté.",
+    "governance.sandbox.title":
+    "Commandes sur cette machine",
+  "governance.sandbox.isolated":
+    "Les commandes s'exécutent dans un bac à sable du noyau : sans réseau, écritures limitées au dossier de travail.",
+  "governance.sandbox.host":
+    "Les commandes s'exécuteraient sur cette machine — aucun bac à sable du noyau ne s'applique ici.",
+  "governance.sandbox.stillApplies":
+    "Le noyau de gouvernance, la région d'écriture et la confirmation s'appliquent toujours — ce n'est pas une prison.",
+  "governance.sandbox.configured":
+    "demandé : {value}",
+  "governance.sandbox.backend":
+    "en réalité : {value}",
   "governance.audit.title": "Journal d'audit",
   "governance.audit.intact":
     "chaîne intacte",
@@ -6072,6 +6120,18 @@ const de: Dict = {
     "Kommen selbst mit Abwehr durch (ehrliche Lücke)",
   "governance.injection.note":
     "Misst die tiefengestaffelte Abwehr eines bereits injizierten Agenten (synthetischer Korpus, kein Modell) — nicht die Anfälligkeit des Modells, injiziert zu werden.",
+    "governance.sandbox.title":
+    "Befehle auf diesem Rechner",
+  "governance.sandbox.isolated":
+    "Befehle laufen in einer Kernel-Sandbox: kein Netzwerk, Schreibzugriffe auf den Arbeitsordner begrenzt.",
+  "governance.sandbox.host":
+    "Befehle würden auf diesem Rechner laufen — hier greift keine Kernel-Sandbox.",
+  "governance.sandbox.stillApplies":
+    "Governance-Kernel, Schreibbereich und Bestätigung gelten weiterhin — ein Gefängnis sind sie nicht.",
+  "governance.sandbox.configured":
+    "angefordert: {value}",
+  "governance.sandbox.backend":
+    "tatsächlich: {value}",
   "governance.audit.title": "Audit-Protokoll",
   "governance.audit.intact":
     "Kette intakt",
@@ -7275,6 +7335,18 @@ const zh: Dict = {
   "governance.injection.leaksNote": "即使有防御仍能通过（诚实披露的缺口）",
   "governance.injection.note":
     "衡量已被注入的智能体的纵深防御（合成语料，无模型）——并非模型被注入的易感性。",
+    "governance.sandbox.title":
+    "本机上的命令",
+  "governance.sandbox.isolated":
+    "命令在内核沙箱中运行：没有网络，写入仅限工作目录。",
+  "governance.sandbox.host":
+    "命令将在这台机器上运行——此处不适用内核沙箱。",
+  "governance.sandbox.stillApplies":
+    "治理内核、写入范围和确认提示仍然生效——但它们不是牢笼。",
+  "governance.sandbox.configured":
+    "请求：{value}",
+  "governance.sandbox.backend":
+    "实际：{value}",
   "governance.audit.title": "审计日志",
   "governance.audit.intact":
     "链条完整",
@@ -8530,6 +8602,18 @@ const ja: Dict = {
   "governance.injection.leaksNote": "防御ありでも通過する（正直なギャップ）",
   "governance.injection.note":
     "すでに注入されたエージェントの多層防御を測定します（合成コーパス、モデルなし）— モデルが注入されやすさそのものではありません。",
+    "governance.sandbox.title":
+    "このマシンでのコマンド",
+  "governance.sandbox.isolated":
+    "コマンドはカーネルのサンドボックス内で実行されます。ネットワークなし、書き込みは作業フォルダーに限定。",
+  "governance.sandbox.host":
+    "コマンドはこの端末上で実行されます。ここではカーネルのサンドボックスは適用されません。",
+  "governance.sandbox.stillApplies":
+    "ガバナンスカーネル、書き込み範囲、確認プロンプトは引き続き有効です。ただし牢屋ではありません。",
+  "governance.sandbox.configured":
+    "要求: {value}",
+  "governance.sandbox.backend":
+    "実際: {value}",
   "governance.audit.title": "監査ログ",
   "governance.audit.intact":
     "連鎖は無傷",
@@ -9800,6 +9884,18 @@ const it: Dict = {
     "Passano ancora anche con la difesa attiva (lacuna dichiarata onestamente)",
   "governance.injection.note":
     "Misura la difesa in profondità di un agente già iniettato (corpus sintetico, nessun modello) — non la suscettibilità del modello a essere iniettato.",
+    "governance.sandbox.title":
+    "Comandi su questa macchina",
+  "governance.sandbox.isolated":
+    "I comandi vengono eseguiti in una sandbox del kernel: niente rete, scritture limitate alla cartella di lavoro.",
+  "governance.sandbox.host":
+    "I comandi verrebbero eseguiti su questa macchina: qui non si applica alcuna sandbox del kernel.",
+  "governance.sandbox.stillApplies":
+    "Il kernel di governance, la regione di scrittura e la conferma restano attivi: non sono una prigione.",
+  "governance.sandbox.configured":
+    "richiesto: {value}",
+  "governance.sandbox.backend":
+    "in realtà: {value}",
   "governance.audit.title": "Registro di audit",
   "governance.audit.intact":
     "catena integra",
@@ -11063,6 +11159,18 @@ const pl: Dict = {
     "Nadal przechodzą nawet przy włączonej obronie (uczciwie wskazana luka)",
   "governance.injection.note":
     "Mierzy obronę w głąb agenta już zainfekowanego (korpus syntetyczny, bez modelu) — a nie podatność modelu na zainfekowanie.",
+    "governance.sandbox.title":
+    "Polecenia na tej maszynie",
+  "governance.sandbox.isolated":
+    "Polecenia działają w piaskownicy jądra: bez sieci, zapisy ograniczone do folderu roboczego.",
+  "governance.sandbox.host":
+    "Polecenia działałyby na tej maszynie — nie obowiązuje tu żadna piaskownica jądra.",
+  "governance.sandbox.stillApplies":
+    "Jądro nadzoru, obszar zapisu i pytanie o zgodę nadal obowiązują — nie są więzieniem.",
+  "governance.sandbox.configured":
+    "żądano: {value}",
+  "governance.sandbox.backend":
+    "faktycznie: {value}",
   "governance.audit.title": "Dziennik audytu",
   "governance.audit.intact":
     "łańcuch nienaruszony",
@@ -12332,6 +12440,18 @@ const ru: Dict = {
     "Всё равно проходят даже при защите (честный пробел)",
   "governance.injection.note":
     "Измеряет глубину защиты уже внедрённого агента (синтетический корпус, без модели) — а не подверженность самой модели внедрению.",
+    "governance.sandbox.title":
+    "Команды на этой машине",
+  "governance.sandbox.isolated":
+    "Команды выполняются в песочнице ядра: без сети, запись ограничена рабочей папкой.",
+  "governance.sandbox.host":
+    "Команды выполнялись бы на этой машине — песочница ядра здесь не применяется.",
+  "governance.sandbox.stillApplies":
+    "Ядро управления, область записи и запрос подтверждения продолжают действовать — но это не тюрьма.",
+  "governance.sandbox.configured":
+    "запрошено: {value}",
+  "governance.sandbox.backend":
+    "фактически: {value}",
   "governance.audit.title": "Журнал аудита",
   "governance.audit.intact":
     "цепочка цела",

--- a/apps/desktop/src/lib/types.ts
+++ b/apps/desktop/src/lib/types.ts
@@ -96,6 +96,7 @@ export type GitRevertResult = Schemas["GitRevertOut"];
 export type GitInitResult = Schemas["GitInitOut"];
 export type InjectionReport = Schemas["InjectionReportOut"];
 export type GovernanceAudit = Schemas["GovernanceAuditOut"];
+export type SandboxState = Schemas["SandboxStateOut"];
 export type ToolInfo = Schemas["ToolInfoOut"];
 export type Tools = Schemas["ToolsOut"];
 export type Maturity = Schemas["MaturityOut"];

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -94,6 +94,7 @@ from chimera.api.schemas import (
     RequirementsRequest,
     ResourcesOut,
     RunReceiptOut,
+    SandboxStateOut,
     SearchOut,
     SessionDetailOut,
     SessionMetaOut,
@@ -856,6 +857,52 @@ def build_api_app(
         # unread smoke alarm detects fire.
         return {
             "events": events, "count": len(events), "populated": bool(events), "chain": chain
+        }
+
+    @app.get("/api/governance/sandbox", dependencies=[guard], response_model=SandboxStateOut)
+    def governance_sandbox_endpoint() -> dict[str, Any]:
+        # Probed live rather than read off the config, and probed with the SAME command line the
+        # sandbox actually uses: a kernel that refuses unprivileged user namespaces has bwrap
+        # installed and failing, and a config that says `auto` on Windows resolves to no boundary
+        # at all. Reporting the setting here would report an intention, and the question the screen
+        # asks is what is TRUE.
+        import platform as _platform
+
+        from chimera.sandbox import get_sandbox
+        from chimera.sandbox.confirm import sandbox_is_isolated
+        from chimera.sandbox.os_sandbox import (
+            bubblewrap_available,
+            seatbelt_available,
+            unavailable_reason,
+        )
+
+        live = live_settings()
+        configured = (live.sandbox or "auto").lower()
+        try:
+            isolated = sandbox_is_isolated(get_sandbox(live))
+        except Exception:  # noqa: BLE001 — an unbuildable sandbox is a host sandbox, the safe read
+            isolated = False
+        if isolated:
+            backend = (
+                "docker" if configured == "docker"
+                else "seatbelt" if seatbelt_available()
+                else "bubblewrap" if bubblewrap_available()
+                else "isolated"
+            )
+        else:
+            backend = "host"
+        return {
+            "configured": configured,
+            "backend": backend,
+            "isolated": isolated,
+            # `unavailable_reason` speaks about the OS sandbox. A Docker install that fell back has
+            # a different cause, so it gets its own sentence rather than borrowing a wrong one.
+            "reason": "" if isolated else (
+                "A container was configured and none answered." if configured == "docker"
+                else "" if configured == "local"
+                else unavailable_reason()
+            ),
+            "platform": _platform.system(),
         }
 
     @app.get("/api/maturity", dependencies=[guard], response_model=MaturityOut)

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -880,6 +880,30 @@ class MessagingPlatformOut(BaseModel):
     error: str | None = None
 
 
+class SandboxStateOut(BaseModel):
+    """Whether a command the model chooses can reach this machine, and if it can, why.
+
+    On the Security screen because that is the one screen a person opens to ask what protects them,
+    and until now it answered about prompt injection and the audit log and said nothing about the
+    boundary around execution. The posture line above the composer does say it — but only after
+    choosing a project and turning commands on, which is exactly the moment it is too late to be
+    reading about it for the first time.
+    """
+
+    configured: str
+    """What the install asked for: ``auto`` (the default), ``docker``, ``local``, ``none``."""
+    backend: str
+    """What would actually run a command here: ``seatbelt``, ``bubblewrap``, ``docker``, ``host``."""
+    isolated: bool
+    """True only when a kernel boundary really applies. Never inferred from `configured` — asking
+    for a sandbox and getting one are different facts, and conflating them is how "I thought it was
+    sandboxed" happens."""
+    reason: str = ""
+    """Why not, in a sentence a person can act on. Empty when it IS isolated."""
+    platform: str = ""
+    """The OS, because the answer is different on each and the reason names it."""
+
+
 class CronCreateIn(BaseModel):
     """Create a scheduled job from the UI (the CLI's `chimera cron add`, over HTTP)."""
 


### PR DESCRIPTION
Asked for directly. The screen reported prompt-injection defence and the audit log and said **nothing about the boundary around execution** — the thing those two exist to defend. Someone opening the screen named "Security" to ask what stops a chosen command from reaching their files got an answer to a different question.

The posture line above the composer does say it, and that was the *only* surface: reachable after picking a project and turning commands on, which is the moment it is already too late to be reading it for the first time.

## What it reports

`GET /api/governance/sandbox`, probed live:

| field | |
|---|---|
| `configured` | what the install **asked for** — `auto` / `docker` / `local` |
| `backend` | what would **actually** run a command — `seatbelt` / `bubblewrap` / `docker` / `host` |
| `isolated` | whether a kernel boundary really applies |
| `reason` | why not, in a sentence a person can act on |

**`configured` and `backend` are separate on purpose.** They differ exactly when it matters, and reporting only the setting would report an *intention* — which is what "I thought it was sandboxed" is made of. Probed rather than read for the same reason the posture endpoint is: a daemon that died since the last look has to change the answer, not be served from a cache.

## Two deliberate choices about tone

**The unisolated state is `warn`, not `bad`.** On Windows there is no OS sandbox at all, and that is documented and permanent rather than something the user did wrong. Painting it red on every open trains people to ignore the one colour that should mean something.

**The panel says what still applies** — the governance kernel, the write region, the confirmation prompt. A panel that only reports the absence teaches the reader that the screen has nothing to offer, and those three are not nothing. They are simply not a jail.

The Docker fall-back gets its own sentence rather than borrowing the OS sandbox's: *"a container was configured and none answered"* and *"no kernel mechanism exists here"* have different fixes, and only one of them is a daemon.

## Tests

Six strings across all ten locales. Five tests, and **four guards sabotage-tested** — the reason line, what-still-applies, asked-for-vs-actual, and isolated rendering differently from host. All four bite.

One thing worth recording about the fixture: the first version mocked a plausible **subset** of the injection report, the screen read `leaks_defended.length` on it, and the whole component threw before rendering anything — so five assertions failed about a field none of them were testing. A partial fixture fails in a way that looks like the feature is broken.

4328 Python / 969 frontend tests pass; `ruff`, `mypy` and both drift gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)