### PR TITLE
fix(evolution): stop paying to mint skills nothing in the loop can read

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -307,6 +307,19 @@ class Settings(BaseSettings):
     skill_cards_couple_read: bool = Field(
         default=False, validation_alias="CHIMERA_SKILL_CARDS_READ"
     )
+    #: Mint learned skills even when the agent cannot read them back. OFF, and that is the point.
+    #:
+    #: Reading is opt-in because it was MEASURED and did not clear its gate (`bench/skillcard`:
+    #: +16.7pp, CI includes zero, +300% tokens). Minting was never coupled to it, so the default
+    #: install paid for a proposal call, a validation and a smoke test — and on the panel path a
+    #: proposal per panel model plus a nine-model transfer probe — to produce cards nothing in the
+    #: loop would ever read. Four projects run end to end minted 14 of them and used 0.
+    #:
+    #: A person can still browse them on the Knowledge screen, which is why this exists at all
+    #: rather than the write being deleted: set it to keep collecting a library on purpose.
+    mint_unreadable_skills: bool = Field(
+        default=False, validation_alias="CHIMERA_MINT_UNREADABLE_SKILLS"
+    )
 
     # --- ACE playbook curation from errors (Level-2 P3): when curating the playbook after a run,
     # feed the curator the actual error evidence — the failing verifier output and the diff that

--- a/chimera/evolution/auto_evolve.py
+++ b/chimera/evolution/auto_evolve.py
@@ -17,6 +17,7 @@ non-destructive; the gates above keep it honest rather than guarding against har
 from __future__ import annotations
 
 import hashlib
+import re
 import string
 from typing import TYPE_CHECKING
 
@@ -50,6 +51,28 @@ def _placeholders(template: str) -> list[str]:
     return [field for _, field, _, _ in string.Formatter().parse(template) if field]
 
 
+def _assinatura(skill: object) -> set[str]:
+    """As palavras que dizem o que uma skill FAZ, sem o nome.
+
+    O nome e' a parte que menos ajuda: tres cartoes para "pagina HTML de arquivo unico a partir de
+    um brief" sairam com tres nomes diferentes (`build_standalone_html_from_brief`,
+    `brief_to_offline_single_file_page`, `offline_single_file_html_from_brief`) e o mesmo conteudo.
+    Comparar descricao + gatilho + acao pega isso; comparar nome nao pega nada.
+    """
+    partes = " ".join(
+        str(getattr(skill, campo, "") or "")
+        for campo in ("description", "trigger", "do", "prompt_template")
+    ).lower()
+    return {t for t in re.findall(r"[a-zà-ÿ]{4,}", partes)}
+
+
+def _semelhanca(a: set[str], b: set[str]) -> float:
+    """Jaccard. Sem modelo e sem embedding: o custo de deduplicar nao pode ser outra chamada paga."""
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
 class AutoSkillEvolver:
     """Proposes, gates and stores a learned skill when a task recurs."""
 
@@ -66,6 +89,7 @@ class AutoSkillEvolver:
         provisional: bool = False,
         audit: AuditLog | None = None,
         holdout: HoldoutGate | None = None,
+        dedupe_at: float = 0.72,
     ) -> None:
         self.evolver = evolver
         self.store = store
@@ -80,6 +104,11 @@ class AutoSkillEvolver:
         # single-model proposal. Falls back to single-model when unset.
         self.collective = collective
         self.min_transfer = min_transfer
+        #: Acima disto, um candidato e' considerado o mesmo cartao que um ja' guardado e nao entra.
+        #: Quatro projetos produziram tres cartoes quase identicos para a mesma tarefa porque nada
+        #: olhava a biblioteca antes de escrever nela. Guardar 3 ou 300 e' identico se nenhum e'
+        #: lido; guardar 3 iguais e' pior que guardar 1, porque o proximo recall tem de escolher.
+        self.dedupe_at = dedupe_at
         # Opt-in, and off changes nothing: without a gate this class behaves exactly as it did.
         # What it adds is the axis the other two gates do not have — the smoke test runs the
         # candidate on its OWN task and checks the output is non-empty, and `min_transfer` varies
@@ -112,6 +141,24 @@ class AutoSkillEvolver:
                 "below min_transfer=%.2f. Lower min_transfer, enlarge the panel, or use 'point'.",
                 n, n, ceiling, k, self.min_transfer,
             )
+
+    def _duplicata(self, candidato: LearnedSkill) -> str | None:
+        """O nome do cartao ja' guardado que diz a mesma coisa, ou None.
+
+        So' compara com cartoes do MESMO `kind`: um anti-padrao que descreve o mesmo assunto de um
+        padrao nao e' duplicata dele — um diz "faca assim" e o outro "nao faca assim", e colapsar os
+        dois apagaria metade do par.
+        """
+        alvo = _assinatura(candidato)
+        if len(alvo) < 4:
+            return None  # assinatura curta demais para afirmar semelhanca de nada
+        for nome in self.store.names():
+            outro = self.store.get(nome)
+            if outro is None or getattr(outro, "kind", "") != getattr(candidato, "kind", ""):
+                continue
+            if _semelhanca(alvo, _assinatura(outro)) >= self.dedupe_at:
+                return str(nome)
+        return None
 
     def _mark_and_store(self, skill: LearnedSkill, *, tainted: bool) -> LearnedSkill:
         """Store a skill with anti-poisoning provenance (Zombie Agents defense).
@@ -157,6 +204,14 @@ class AutoSkillEvolver:
             return False
         self._record_holdout(candidate, verdict, kept=True)
         return True
+
+    def _record_dedupe(self, novo: str, igual: str) -> None:
+        """Uma deduplicacao silenciosa e' a mesma classe de silencio que este projeto passa o dia
+        consertando: sem esta linha, "nao aprendeu nada" e "aprendeu e foi descartado por ja' saber"
+        sao o mesmo nada no log."""
+        if self.audit is None:
+            return
+        self.audit.record("skill_dedupe", {"discarded": novo, "same_as": igual})
 
     def _record_holdout(
         self, candidate: LearnedSkill, verdict: HoldoutVerdict, *, kept: bool
@@ -249,6 +304,10 @@ class AutoSkillEvolver:
         if candidate.name in self.store:
             _log.debug("auto-skill %s already exists; skipping", candidate.name)
             return None
+        if (igual := self._duplicata(candidate)) is not None:
+            _log.info("auto-skill %s descartada: diz o mesmo que %s", candidate.name, igual)
+            self._record_dedupe(candidate.name, igual)
+            return None
 
         # Gate 1 — governance: reject an unsafe proposal before it ever runs.
         if self.validator is not None and not self.validator.validate(candidate.to_dict()).accepted:
@@ -308,6 +367,10 @@ class AutoSkillEvolver:
             )
             if score > best_score:
                 best, best_score, best_frac = candidate, score, frac
+        if best is not None and (igual := self._duplicata(best)) is not None:
+            _log.info("auto-skill coletiva %s descartada: diz o mesmo que %s", best.name, igual)
+            self._record_dedupe(best.name, igual)
+            return None
         if best is None or best_score < self.min_transfer:
             _log.debug("no transferable auto-skill kept (best gate=%.2f)", best_score)
             return None

--- a/chimera/evolution/context.py
+++ b/chimera/evolution/context.py
@@ -28,12 +28,16 @@ from chimera.evolution.experience import ExperienceBuffer
 from chimera.evolution.playbook import Playbook
 from chimera.evolution.skill_store import SkillStore
 from chimera.governance.validator import SkillValidator
+from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:
     from chimera.config import Settings
     from chimera.ecosystem.trajectory import TrajectoryCollector
     from chimera.governance.audit import AuditLog
     from chimera.providers.gateway import SupportsComplete
+
+
+_log = get_logger("evolution.context")
 
 
 @dataclass
@@ -122,7 +126,21 @@ def build_evolution_context(
     else:
         use_cards = settings.skill_cards
     auto_evolver: AutoSkillEvolver | None = None
-    if evolve_skills:
+    # Reading and writing were decided next to each other, in this function, and never compared.
+    # Minting costs a proposal call, a validation and a smoke test on every recurring task — and on
+    # the panel path a proposal per panel model plus a nine-model transfer probe. With reading off,
+    # every one of those buys a card the loop cannot retrieve.
+    #
+    # Reading stays off because it was measured, not because it was forgotten (`bench/skillcard`:
+    # +16.7pp, CI includes zero, +300% tokens — the registered gate failed). So the half to change
+    # is the writing, and the escape hatch is explicit for the person who wants a library anyway.
+    mint = use_cards or settings.mint_unreadable_skills
+    if evolve_skills and not mint:
+        _log.debug(
+            "skill minting skipped: the agent cannot read cards back "
+            "(CHIMERA_SKILL_CARDS=0). Set CHIMERA_MINT_UNREADABLE_SKILLS=1 to collect anyway."
+        )
+    if evolve_skills and mint:
         auto_evolver = AutoSkillEvolver(
             SkillEvolver(gateway, model),
             SkillStore(home / "skills.json"),

--- a/tests/test_advice_you_can_follow.py
+++ b/tests/test_advice_you_can_follow.py
@@ -55,6 +55,9 @@ def test_the_evolver_is_built_with_it(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("chimera.evolution.context.AutoSkillEvolver", _Spy)
     monkeypatch.setenv("CHIMERA_SKILL_MIN_TRANSFER", "0.25")
+    # A cunhagem passou a seguir a leitura, e este teste e' sobre o valor CHEGAR ao construtor —
+    # nao sobre quando ele e' chamado. Ligar os cartoes aqui mantem o teste sobre o que ele testa.
+    monkeypatch.setenv("CHIMERA_SKILL_CARDS", "1")
 
     from chimera.evolution.context import build_evolution_context
 

--- a/tests/test_evolution_context.py
+++ b/tests/test_evolution_context.py
@@ -42,10 +42,35 @@ def test_factory_builds_default_seams(tmp_path: Path) -> None:
     assert isinstance(ctx.experience, ExperienceBuffer)
     assert ctx.trajectories is None
     assert ctx.cards is None
-    # evolve_skills defaults True -> an evolver is built
-    assert isinstance(ctx.auto_evolver, AutoSkillEvolver)
+    # E com os cartoes ilegiveis, NAO se cunha. `evolve_skills` continua True por padrao; o que
+    # mudou e' que ele deixou de ser suficiente sozinho. Cunhar custa uma proposta, uma validacao e
+    # um teste de fumaca por tarefa recorrente — e no caminho do painel, uma proposta por modelo
+    # mais uma sondagem em nove — para produzir cartao que este mesmo contexto acabou de decidir
+    # que ninguem vai ler (`ctx.cards is None`, duas linhas acima).
+    assert ctx.auto_evolver is None
     assert ctx.memory is None
     assert ctx.playbook is None
+
+
+def test_ler_cartoes_e_o_que_liga_a_cunhagem(tmp_path: Path) -> None:
+    """A metade que faltava. Ligar a leitura religa a escrita, sem mais nenhum interruptor."""
+    ctx = build_evolution_context(
+        _settings(CHIMERA_SKILL_CARDS="1"), _FakeGateway(), "m", home=tmp_path
+    )
+
+    assert ctx.cards is not None
+    assert isinstance(ctx.auto_evolver, AutoSkillEvolver)
+
+
+def test_da_para_colecionar_de_proposito(tmp_path: Path) -> None:
+    """Uma pessoa ainda le' os cartoes na tela de Conhecimento, entao juntar uma biblioteca de
+    proposito continua possivel — o que deixou de existir e' pagar por ela sem pedir."""
+    ctx = build_evolution_context(
+        _settings(CHIMERA_MINT_UNREADABLE_SKILLS="1"), _FakeGateway(), "m", home=tmp_path
+    )
+
+    assert ctx.cards is None
+    assert isinstance(ctx.auto_evolver, AutoSkillEvolver)
 
 
 def test_evolve_skills_false_disables_evolver(tmp_path: Path) -> None:

--- a/tests/test_flywheel_wiring.py
+++ b/tests/test_flywheel_wiring.py
@@ -38,7 +38,18 @@ def test_a_desktop_run_carries_the_learning_seams(tmp_path: Path) -> None:
     assert agent.memory is not None
     assert agent.experience is not None
     assert agent.playbook is not None
-    assert agent.auto_evolver is not None
+    # A cunhagem segue a leitura desde que as duas metades passaram a se olhar. O que este arquivo
+    # existe para segurar e' a PARIDADE — o terminal e o app tem de terminar no mesmo estado — e
+    # ela continua de pe: os dois deixam de cunhar quando o agente nao pode reler.
+    assert agent.auto_evolver is None
+
+
+def test_ligar_a_leitura_devolve_a_cunhagem_ao_app(tmp_path: Path, monkeypatch: Any) -> None:
+    """E a paridade vale nos dois sentidos: quem liga a leitura volta a cunhar PELO APP tambem,
+    sem precisar descobrir um segundo interruptor."""
+    monkeypatch.setenv("CHIMERA_SKILL_CARDS", "1")
+
+    assert _agent(tmp_path).auto_evolver is not None
 
 
 def test_trajectory_collection_stays_off(tmp_path: Path) -> None:

--- a/tests/test_skills_are_not_minted_unread.py
+++ b/tests/test_skills_are_not_minted_unread.py
@@ -1,0 +1,202 @@
+"""Duas metades do flywheel que eram decididas lado a lado e nunca comparadas.
+
+Quatro projetos rodados ponta a ponta pelo app — um site, um jogo, um app financeiro e uma area de
+trabalho — cunharam **14 skills e usaram 0**. As duas causas sao independentes e as duas custam
+dinheiro em toda corrida recorrente:
+
+1. **Cunhar o que o agente nao le.** Ler cartoes e' opt-in porque foi MEDIDO e nao passou o portao
+   registrado (`bench/skillcard`: +16,7 pp, IC inclui zero, +300% de tokens). Escrever nunca foi
+   acoplado a isso, entao a instalacao padrao paga uma chamada de proposta, uma validacao e um teste
+   de fumaca — e no caminho do painel, uma proposta por modelo do painel mais uma sondagem de
+   transferencia em nove modelos — para produzir cartoes que o laco nunca recupera.
+
+2. **Cunhar a quarta copia da mesma coisa.** Tres dos 14 diziam a mesma frase com nomes diferentes:
+   `build_standalone_html_from_brief`, `brief_to_offline_single_file_page` e
+   `offline_single_file_html_from_brief`. Nada olhava a biblioteca antes de escrever nela.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.evolution.auto_evolve import AutoSkillEvolver, _assinatura, _semelhanca
+
+
+class _Store(dict):
+    """O minimo que o evoluidor toca: adicionar, procurar por nome, listar, buscar."""
+
+    def add(self, skill: Any) -> None:
+        self[skill.name] = skill
+
+    def names(self) -> list[str]:
+        return list(self)
+
+    def get(self, nome: str) -> Any:  # type: ignore[override]
+        return dict.get(self, nome)
+
+
+class _Skill:
+    def __init__(self, name: str, description: str = "", trigger: str = "", do: str = "",
+                 kind: str = "pattern") -> None:
+        self.name, self.description, self.trigger, self.do, self.kind = (
+            name, description, trigger, do, kind
+        )
+        self.prompt_template = "{tarefa}"
+        self.provenance, self.status = "clean", "active"
+
+    def to_dict(self) -> dict:
+        return {"name": self.name}
+
+
+class _Evolver:
+    def __init__(self, candidato: Any) -> None:
+        self.candidato = candidato
+
+    def propose(self, task: str, solution: str) -> Any:
+        return self.candidato
+
+    def test_skill(self, skill: Any, test_input: dict, check: Any) -> bool:
+        return True
+
+
+def _auto(candidato: Any, store: _Store) -> AutoSkillEvolver:
+    return AutoSkillEvolver(_Evolver(candidato), store, min_recurrences=1)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------- a assinatura
+
+
+def test_o_nome_nao_entra_na_comparacao() -> None:
+    """O nome e' a parte que menos ajuda: os tres cartoes duplicados sairam com tres nomes
+    diferentes e o mesmo conteudo. Comparar nome nao teria pego nenhum dos tres."""
+    a = _Skill("build_standalone_html_from_brief", "gerar pagina HTML de arquivo unico offline")
+    b = _Skill("offline_single_file_html_from_brief", "gerar pagina HTML de arquivo unico offline")
+
+    assert _assinatura(a) == _assinatura(b)
+    assert a.name != b.name
+
+
+def test_assinatura_curta_nunca_afirma_semelhanca() -> None:
+    """Com quatro palavras ou menos nao da' para dizer que dois cartoes sao a mesma coisa, e um
+    falso positivo aqui APAGA aprendizado — e' o erro caro dos dois."""
+    store = _Store()
+    store.add(_Skill("existente", "faz"))
+    kept = _auto(_Skill("novo", "faz"), store).maybe_evolve("t", "s", prior_successes=2)
+
+    assert kept is not None, "descartou por semelhanca calculada sobre quase nada"
+
+
+# --------------------------------------------------------------------- a deduplicacao
+
+
+def test_o_terceiro_cartao_igual_nao_entra() -> None:
+    """O caso medido, com as frases que os projetos produziram de verdade."""
+    store = _Store()
+    store.add(_Skill(
+        "build_standalone_html_from_brief",
+        "construir uma pagina HTML de arquivo unico a partir de um brief, offline, sem framework",
+        trigger="brief pede pagina estatica",
+        do="escrever index.html com CSS embutido e rodar o verificador",
+    ))
+    candidato = _Skill(
+        "offline_single_file_html_from_brief",
+        "construir pagina HTML de arquivo unico offline a partir de brief, sem framework nenhum",
+        trigger="brief pede pagina estatica",
+        do="escrever index.html com o CSS embutido e rodar o verificador",
+    )
+
+    kept = _auto(candidato, store).maybe_evolve("t", "s", prior_successes=2)
+
+    assert kept is None, "a terceira copia da mesma skill entrou na biblioteca"
+    assert "offline_single_file_html_from_brief" not in store
+
+
+def test_um_cartao_sobre_outro_assunto_entra() -> None:
+    """A guarda tem de recusar copia e deixar passar novidade — senao ela nao deduplica, ela
+    congela a biblioteca no primeiro cartao."""
+    store = _Store()
+    store.add(_Skill("html", "construir pagina HTML de arquivo unico offline a partir de um brief",
+                     do="escrever index.html com CSS embutido"))
+    candidato = _Skill("fisica", "implementar funcoes puras de projetil, colisao e pontuacao",
+                       do="escrever fisica.js como modulo CommonJS sem DOM")
+
+    assert _auto(candidato, store).maybe_evolve("t", "s", prior_successes=2) is not None
+
+
+def test_um_anti_padrao_nunca_e_duplicata_de_um_padrao() -> None:
+    """Um diz "faca assim" e o outro "nao faca assim". Colapsar os dois apagaria metade do par, e
+    sobre o MESMO assunto e' exatamente quando eles se parecem mais."""
+    # As frases sao QUASE identicas de proposito: sobre o mesmo assunto, um padrao e um
+    # anti-padrao se parecem mais do que dois padroes quaisquer. Se elas nao passassem do limiar,
+    # este teste passaria por semelhanca baixa e a guarda de `kind` ficaria inerte sem ninguem ver.
+    texto = ("rodar o verificador ate imprimir PASS antes de entregar a tarefa "
+             "considerada pronta pelo agente")
+    padrao = _Skill("entregar_verificado", texto, trigger="tarefa pronta", do=texto, kind="pattern")
+    anti = _Skill("unverified_wip_delivery", texto, trigger="tarefa pronta", do=texto,
+                  kind="anti_pattern")
+    store = _Store()
+    store.add(padrao)
+
+    assert _semelhanca(_assinatura(anti), _assinatura(padrao)) >= 0.72, (
+        "as duas frases precisam ser semelhantes o bastante para que so' o `kind` as separe"
+    )
+    assert _auto(anti, store).maybe_evolve("t", "s", prior_successes=2) is not None
+
+
+def test_a_deduplicacao_vai_para_a_auditoria() -> None:
+    """Uma deduplicacao silenciosa e' a mesma classe de silencio que este projeto passa o dia
+    consertando: sem a linha, "nao aprendeu nada" e "ja' sabia" sao o mesmo nada no log."""
+
+    class _Audit:
+        def __init__(self) -> None:
+            self.rows: list[tuple[str, dict]] = []
+
+        def record(self, kind: str, payload: dict) -> None:
+            self.rows.append((kind, payload))
+
+    audit = _Audit()
+    store = _Store()
+    store.add(_Skill("primeiro", "construir pagina HTML de arquivo unico offline a partir de brief",
+                     do="escrever index.html com CSS embutido e rodar o verificador"))
+    evolver = AutoSkillEvolver(
+        _Evolver(_Skill("segundo", "construir pagina HTML de arquivo unico offline a partir do brief",
+                        do="escrever index.html com o CSS embutido e rodar o verificador")),
+        store, min_recurrences=1, audit=audit,  # type: ignore[arg-type]
+    )
+
+    evolver.maybe_evolve("t", "s", prior_successes=2)
+
+    linhas = [p for k, p in audit.rows if k == "skill_dedupe"]
+    assert linhas and linhas[0]["same_as"] == "primeiro"
+
+
+# --------------------------------------------------------------------- o acoplamento
+
+
+def test_nao_se_cunha_o_que_o_agente_nao_le() -> None:
+    """A decisao mora em `build_evolution_context`, onde leitura e escrita eram resolvidas em
+    linhas vizinhas sem nunca se olharem."""
+    from pathlib import Path
+
+    fonte = (Path(__file__).resolve().parents[1] / "chimera/evolution/context.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "mint = use_cards or settings.mint_unreadable_skills" in fonte
+    assert "if evolve_skills and mint:" in fonte
+    # E a saida tem de existir: uma pessoa ainda le' os cartoes na tela de Conhecimento, entao
+    # colecionar de proposito continua possivel.
+    assert "CHIMERA_MINT_UNREADABLE_SKILLS" in fonte
+
+
+def test_a_saida_existe_e_e_desligada_por_padrao() -> None:
+    from chimera.config import Settings
+
+    assert Settings().mint_unreadable_skills is False
+
+
+def test_jaccard_nao_cobra_uma_chamada_de_modelo() -> None:
+    """Deduplicar nao pode custar outra chamada paga — seria trocar um desperdicio por outro."""
+    assert _semelhanca({"a", "b", "c"}, {"a", "b", "c"}) == 1.0
+    assert _semelhanca({"a", "b"}, {"c", "d"}) == 0.0
+    assert _semelhanca(set(), {"a"}) == 0.0


### PR DESCRIPTION
Four projects run end to end through the app — a site, a physics game, a finance app and a desktop shell — minted **fourteen** learned skills and used **zero**. Two independent causes, both charged on every recurring task.

## 1. Minting was never coupled to reading

Reading cards is opt-in because it was **measured** and did not clear its own registered gate: `bench/skillcard`, **+16.7 pp accuracy but the CI includes zero, at +300% tokens**. That decision stands and this PR does not touch it.

Writing was never coupled to it. So a default install pays **a proposal call, a validation and a smoke test** per recurring task — and on the panel path **a proposal per panel model plus a nine-model transfer probe** — to produce cards the loop cannot retrieve. `build_evolution_context` decided both halves *four lines apart* and never compared them.

Minting now follows readability. The escape hatch is explicit and off: `CHIMERA_MINT_UNREADABLE_SKILLS=1` keeps collecting — because a person still browses these on the Knowledge screen, which is why the write is *coupled* rather than deleted.

## 2. Nothing looked at the library before writing to it

Three of the fourteen said the same sentence under three different names:

```
build_standalone_html_from_brief
brief_to_offline_single_file_page
offline_single_file_html_from_brief
```

One per project, because each run proposed in ignorance of the last two.

A candidate whose description + trigger + action overlaps a stored card by **≥ 0.72 Jaccard** is dropped, and the drop is **written to the audit log** — a silent dedupe is the same silence this project spends its days removing: *"learned nothing"* and *"already knew it"* would otherwise be the same absence.

Three details decide whether this helps or hurts:

- **The name is excluded from the comparison.** It is the part that helps least — the three duplicates had three different names and one content.
- **A signature under four words never claims similarity.** A false positive here *deletes* learning, which is the expensive direction of the two.
- **An anti-pattern is never a duplicate of a pattern.** One says *do this* and the other *never do this*, and on the same subject is exactly when they read most alike — collapsing them would erase half the pair.

Jaccard over tokens, **no model call**: paying for a second inference to avoid the first would trade one waste for another.

## A correction to an earlier reading of mine

`unverified_wip_delivery` is **not** a distillation gate confusing success with failure. It is `kind: anti_pattern` — a deliberate feature — and so is `read_verifier_source_instead_of_simulating_checks`, which is a good one. Twelve patterns, two anti-patterns.

## The three tests that had to change

They asserted the old default and now assert the coupling. They were written to fix a real defect — *the app learned nothing while the CLI did* — and that **parity** is what they exist for. It still holds: both surfaces stop minting together, and turning reading on returns minting to both.

## Tests

9 new. **Seven guards sabotage-tested**, and the battery earned its keep: the anti-pattern guard first passed **for the wrong reason** — the two fixtures were below the similarity threshold anyway, so `kind` was never what saved them. The test now asserts the similarity *first*, so the guard is the only thing between them. All seven bite.

4340 passed / 14 skipped; `ruff` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)