### PR TITLE
fix(api): a crashed run said four words and left no row; nine routes lied about SSE

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -8288,9 +8288,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -8592,9 +8597,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -8973,9 +8983,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -9741,9 +9756,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -10559,9 +10579,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -10596,9 +10621,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -11239,9 +11269,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -11295,9 +11330,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {
@@ -11955,9 +11995,14 @@
             "content": {
               "application/json": {
                 "schema": {}
+              },
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
               }
             },
-            "description": "Successful Response"
+            "description": "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json \u2014 reading the body with a JSON parser fails on the first line."
           },
           "422": {
             "content": {

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -6254,13 +6254,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -6512,13 +6513,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -6821,13 +6823,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -7439,13 +7442,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -8082,13 +8086,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -8115,13 +8120,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -8662,13 +8668,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -8715,13 +8722,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */
@@ -9253,13 +9261,14 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Successful Response */
+            /** @description Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON object; the event names depend on the route. NOT application/json — reading the body with a JSON parser fails on the first line. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": unknown;
+                    "text/event-stream": string;
                 };
             };
             /** @description Validation Error */

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -104,6 +104,7 @@ from chimera.api.schemas import (
     VersionOut,
 )
 from chimera.api.sessions import SessionManager, SessionStore
+from chimera.api.sse import SSE_RESPONSE
 from chimera.api.usage import UsageRecord, append_usage, load_usage, summarize_usage
 from chimera.config import Settings, get_settings
 from chimera.core.agent import ToolActivity
@@ -422,6 +423,56 @@ def _require_token() -> Callable[[Request], None]:
             raise HTTPException(status_code=401, detail="unauthorized")
 
     return check
+
+
+def _persist_crashed_run(
+    home: object, run_id: str, req: object, workspace: object, agent: object, cause: BaseException
+) -> None:
+    """Leave a row for a run that died mid-flight, so its spend is not invisible.
+
+    A completed run persists its own receipt from inside the agent. A CRASHED one never reaches
+    that line, so the money it spent getting to the crash left no trace anywhere: not in
+    `runs.jsonl`, not on the Cost screen, not in the answer. Measured on a real failure: a run
+    listed the directory, was refused a shell command, wrote a 2,210-character module, and then
+    ended as four words with no row behind them.
+
+    Written by hand rather than through `build_receipt`, and wrapped again: this runs on the path
+    where something already went wrong, and a crash reporter that can crash reports nothing.
+    """
+    try:
+        import json as _json
+        from pathlib import Path as _Path
+
+        attempts = list(getattr(agent, "attempts", None) or [])
+        rows = [
+            {
+                "index": int(getattr(a, "index", 0) or 0),
+                "success": bool(getattr(a, "success", False)),
+                "prompt_tokens": int(getattr(a, "prompt_tokens", 0) or 0),
+                "completion_tokens": int(getattr(a, "completion_tokens", 0) or 0),
+                "usd": getattr(a, "usd", None),
+                "model": str(getattr(a, "model", "") or ""),
+            }
+            for a in attempts
+        ]
+        row = {
+            "ts": datetime.now(UTC).isoformat(),
+            "task": str(getattr(req, "task", "") or "")[:2000],
+            "success": False,
+            "workspace": str(workspace),
+            "run_id": run_id,
+            # The two fields that make this row readable as what it is, rather than as a run that
+            # merely failed its verifier.
+            "crashed": True,
+            "crash_reason": f"{type(cause).__name__}: {cause}"[:500],
+            "attempts": rows,
+        }
+        log = _Path(str(home)) / "runs.jsonl"
+        log.parent.mkdir(parents=True, exist_ok=True)
+        with log.open("a", encoding="utf-8") as handle:
+            handle.write(_json.dumps(row, ensure_ascii=True) + "\n")
+    except Exception as exc:  # noqa: BLE001 — never let the reporter fail the report
+        _log.warning("crashed-run receipt not written: %s", exc)
 
 
 def build_api_app(
@@ -975,7 +1026,7 @@ def build_api_app(
 
         return await asyncio.get_running_loop().run_in_executor(None, work)
 
-    @app.post("/api/runs", dependencies=[guard])
+    @app.post("/api/runs", dependencies=[guard], responses=SSE_RESPONSE)
     async def run_stream(req: RunRequest) -> EventSourceResponse:
         # In-app trigger for an autonomous run (`chimera solve` semantics), streamed live as SSE.
         # SAFETY POSTURE: this executes file-writing and (if given) a user-supplied shell verify
@@ -1020,9 +1071,11 @@ def build_api_app(
         emit("verify", {"command": _verify_cmd, "source": _verify_src})
 
         def work() -> None:
+            auto = None
             try:
                 auto = solve_factory(req, ws, on_event, live_settings(), cancel.is_set)
                 # The receipt persists itself via the agent's run_log at run() — no extra write here.
+                # On the CRASH path it does not, which is what the except block below is for.
                 result = auto.run(req.task, thread_id=req.thread_id)
                 if getattr(result, "paused", False):
                     # The run stopped BEFORE finalizing and is parked under its thread. Its own frame,
@@ -1049,8 +1102,21 @@ def build_api_app(
                     },
                 )
             except Exception as exc:  # noqa: BLE001 — surfaced to the client as an error event
-                _log.warning("run failed: %s", exc)
-                emit("error", {"message": "the run failed"})
+                # "the run failed" was the whole message, and it was the whole message for a run
+                # that had already written a file and paid for the calls that wrote it. Four words,
+                # no cause, and nothing in the run log — so the Cost screen could not see the spend
+                # either. A user watching that had no way to tell a dead provider from a bad task.
+                #
+                # The exception TYPE is the half that identifies the failure and cannot carry a
+                # secret; the message is bounded and appended because without it "RuntimeError" is
+                # only marginally better than "failed".
+                _log.warning("run failed: %s: %s", type(exc).__name__, exc, exc_info=True)
+                emit("error", {
+                    "message": "the run failed",
+                    "reason": f"{type(exc).__name__}: {exc}"[:400],
+                    "run_id": run_id,
+                })
+                _persist_crashed_run(settings.home, run_id, req, ws, auto, exc)
             finally:
                 _run_cancels.pop(run_id, None)  # done (or crashed): the run is no longer cancellable
                 loop.call_soon_threadsafe(queue.put_nowait, None)  # sentinel: end of stream
@@ -1124,7 +1190,7 @@ def build_api_app(
         # fabricated results. The real batch arrives over POST /api/agents's ``batch_done`` frame.
         return {"results": [], "conflicts": [], "merged": 0, "is_repo": False}
 
-    @app.post("/api/agents", dependencies=[guard])
+    @app.post("/api/agents", dependencies=[guard], responses=SSE_RESPONSE)
     async def agents_stream(req: AgentsRequest) -> EventSourceResponse:
         # In-app "Agent Manager": run SEVERAL coding tasks concurrently, EACH in its own git worktree
         # (``chimera solve-batch`` semantics), streamed live as SSE. Same safety posture as POST /api/runs
@@ -1532,7 +1598,7 @@ def build_api_app(
 
         return snapshot().as_dict()
 
-    @app.post("/api/fs/exec", dependencies=[guard])
+    @app.post("/api/fs/exec", dependencies=[guard], responses=SSE_RESPONSE)
     async def fs_exec_stream(req: ExecRequest) -> EventSourceResponse:
         # HONEST command-runner (NOT an interactive terminal): each call is a FRESH subprocess — cwd/env
         # do NOT persist between commands. Streams combined stdout+stderr line by line on the local
@@ -1675,7 +1741,7 @@ def build_api_app(
     def delete_session(session_id: str) -> dict[str, bool]:
         return {"deleted": manager.delete(session_id)}
 
-    @app.post("/api/chat/stream", dependencies=[guard])
+    @app.post("/api/chat/stream", dependencies=[guard], responses=SSE_RESPONSE)
     async def chat_stream(req: ChatRequest) -> EventSourceResponse:
         session_id = req.session_id or manager.new()
         session = manager.get(session_id)

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -67,6 +67,7 @@ from chimera.api.schemas import (
     TranscriptOut,
     VisionOut,
 )
+from chimera.api.sse import SSE_RESPONSE
 from chimera.api.worth import WorthReport, summarize_worth
 from chimera.telemetry import get_logger
 
@@ -941,7 +942,7 @@ def register_code_api(
             agent.run_state.open_file = (req.open_file, "")
         return agent, ledger
 
-    @app.post("/api/code/turn", dependencies=[guard])
+    @app.post("/api/code/turn", dependencies=[guard], responses=SSE_RESPONSE)
     async def code_turn(req: CodeTurnRequest) -> EventSourceResponse:
         # SAFETY POSTURE: identical to the run endpoint — file writes and shell inside ``ws``, behind
         # the bearer guard and the localhost bind, scoped by whatever seams the caller declared.

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -54,6 +54,7 @@ from chimera.api.schemas import (
     SpecWriteOut,
     TaskCardOut,
 )
+from chimera.api.sse import SSE_RESPONSE
 from chimera.config import get_settings
 from chimera.telemetry import get_logger
 
@@ -631,7 +632,7 @@ def register_features(
         board = KanbanBoard(get_settings().home / "kanban.json")
         return {"deleted": board.remove(card_id)}
 
-    @app.post("/api/kanban/run", dependencies=[guard])
+    @app.post("/api/kanban/run", dependencies=[guard], responses=SSE_RESPONSE)
     async def run_kanban(req: KanbanRunIn) -> EventSourceResponse:
         """Dispatch backlog cards through their lanes, streamed as each one finishes.
 

--- a/chimera/api/lifecycle_api.py
+++ b/chimera/api/lifecycle_api.py
@@ -33,6 +33,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from chimera.api.code_api import CodeSeams, assemble_registry, resolve_steps
 from chimera.api.schemas import CancelOut
+from chimera.api.sse import SSE_RESPONSE
 from chimera.config import Settings
 from chimera.telemetry import get_logger
 
@@ -84,7 +85,7 @@ def register_lifecycle_api(
     """
     read_settings = live_settings or (lambda: settings)
 
-    @app.post("/api/lifecycle", dependencies=[guard])
+    @app.post("/api/lifecycle", dependencies=[guard], responses=SSE_RESPONSE)
     async def lifecycle_stream(req: LifecycleRunIn) -> EventSourceResponse:
         """Run one task through the four stages, reporting each as it lands.
 

--- a/chimera/api/orchestration_api.py
+++ b/chimera/api/orchestration_api.py
@@ -34,6 +34,7 @@ from sse_starlette.sse import EventSourceResponse
 from starlette.concurrency import run_in_threadpool
 
 from chimera.api.code_api import CodeSeams
+from chimera.api.sse import SSE_RESPONSE
 from chimera.orchestration import runlog
 from chimera.orchestration.budget import SpendExceeded
 from chimera.orchestration.events import OrchEvent
@@ -746,7 +747,7 @@ def register_orchestration_api(
         # frames arrive over the SSE endpoint below; nothing here is fabricated data.
         return OrchestrationFramesOut().model_dump()
 
-    @app.post("/api/orchestration/hierarchy", dependencies=[guard])
+    @app.post("/api/orchestration/hierarchy", dependencies=[guard], responses=SSE_RESPONSE)
     async def hierarchy_stream(req: HierarchyRunIn) -> EventSourceResponse:
         """Run a hierarchy, streamed frame by frame.
 
@@ -854,7 +855,7 @@ def register_orchestration_api(
         return EventSourceResponse(events())
 
 
-    @app.post("/api/orchestration/crew", dependencies=[guard])
+    @app.post("/api/orchestration/crew", dependencies=[guard], responses=SSE_RESPONSE)
     async def crew_stream(req: CrewRunIn) -> EventSourceResponse:
         """Run N roles against ONE task, each in its own worktree, and merge what passes.
 

--- a/chimera/api/sse.py
+++ b/chimera/api/sse.py
@@ -1,0 +1,31 @@
+"""O que uma rota de streaming devolve, dito no esquema em vez de descoberto no cliente.
+
+Nove rotas devolviam `EventSourceResponse` e o esquema anunciava `application/json` nas nove. Quem
+integra pelo contrato — que e' para o que um esquema serve — abre a resposta com um parser de JSON,
+recebe `JSONDecodeError` na primeira linha e conclui que a corrida falhou sem gastar nada. Foi
+exatamente isso que aconteceu ao rodar quatro projetos por esta API: tres modelos apareceram como
+"reprovou em 0,2s, $0,00" antes de terem comecado.
+
+O tipo por si nao gera esquema: `EventSourceResponse` nao e' um `response_model`, entao o FastAPI
+cai no default. Este dicionario e' o que corrige, e vai no decorador de toda rota que faz stream.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Anexado como ``responses=SSE_RESPONSE`` em toda rota que devolve ``EventSourceResponse``.
+#:
+#: O corpo e' um fluxo ``text/event-stream``: linhas ``event:`` e ``data:``, com o ``data`` de cada
+#: quadro sendo um objeto JSON. Nao ha um schema por quadro aqui de proposito — os tipos de evento
+#: diferem por rota, e um schema que listasse os de uma rota so' envelheceria calado nas outras.
+SSE_RESPONSE: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": (
+            "Server-sent events. Each frame is an `event:` line plus a `data:` line holding a JSON "
+            "object; the event names depend on the route. NOT application/json — reading the body "
+            "with a JSON parser fails on the first line."
+        ),
+        "content": {"text/event-stream": {"schema": {"type": "string"}}},
+    }
+}

--- a/tests/test_a_crashed_run_leaves_a_reason.py
+++ b/tests/test_a_crashed_run_leaves_a_reason.py
@@ -1,0 +1,128 @@
+"""Uma corrida que morre no meio gastou dinheiro. Ate agora ela nao deixava nem motivo nem recibo.
+
+Medido numa falha real, rodando um projeto pela API do app: a corrida listou o diretorio, teve um
+comando de shell recusado pela governanca, escreveu um modulo de 2.210 caracteres — e terminou como
+
+    event: error
+    data: {"message": "the run failed"}
+
+Quatro palavras. Nenhuma causa, nenhuma linha em `runs.jsonl`, e portanto nada na tela de Custo. As
+chamadas de modelo que pagaram por aquele modulo ficaram invisiveis, e quem assistia nao tinha como
+separar "o provedor caiu" de "a tarefa estava errada".
+
+Isto e' uma classe DIFERENTE do recibo que ja' tem conserto: la' o recibo falhava ao serializar e
+cai num registro minimo; aqui a corrida morre antes de chegar naquela linha.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+
+class _Attempt:
+    index, success = 1, False
+    prompt_tokens, completion_tokens = 8123, 977
+    usd: float | None = 0.031
+    model = "openrouter/qwen/qwen3.8-flash"
+
+
+class _AgentQueMorre:
+    """Um agente que faz trabalho, cobra por ele, e entao estoura — a forma da falha medida."""
+
+    def __init__(self) -> None:
+        self.attempts = [_Attempt()]
+
+    def run(self, *_a: Any, **_k: Any) -> Any:
+        raise RuntimeError("provider returned an unparseable tool call")
+
+
+def _linhas(home: Path) -> list[dict]:
+    log = home / "runs.jsonl"
+    if not log.is_file():
+        return []
+    return [json.loads(x) for x in log.read_text(encoding="utf-8").splitlines() if x.strip()]
+
+
+def test_o_recibo_da_corrida_morta_guarda_o_que_ela_gastou(tmp_path: Path) -> None:
+    """Os tokens sao a parte que mais nada reconstroi: o workspace sobrevive a uma corrida morta e a
+    resposta tambem, mas o que ela CUSTOU so' existe aqui."""
+    from chimera.api.app import _persist_crashed_run
+
+    class _Req:
+        task = "construa o jogo"
+
+    _persist_crashed_run(
+        tmp_path, "run-1", _Req(), tmp_path / "ws", _AgentQueMorre(), RuntimeError("estourou")
+    )
+
+    linhas = _linhas(tmp_path)
+    assert len(linhas) == 1, "a corrida morta nao deixou linha nenhuma"
+    linha = linhas[0]
+    assert linha["crashed"] is True, "sem isto ela se le' como uma corrida que so' reprovou"
+    assert "RuntimeError" in linha["crash_reason"]
+    assert linha["attempts"][0]["prompt_tokens"] == 8123
+    assert linha["attempts"][0]["completion_tokens"] == 977
+    assert linha["workspace"].endswith("ws"), "sem o workspace a linha nao se junta a nada"
+
+
+def test_uma_corrida_morta_nao_se_confunde_com_uma_reprovada(tmp_path: Path) -> None:
+    """`success: False` sozinho ja' existia e significa "o verificador disse nao". Morrer no meio e'
+    outra coisa, e um leitor que nao consegue separar as duas nao consegue diagnosticar nenhuma."""
+    from chimera.api.app import _persist_crashed_run
+
+    class _Req:
+        task = "t"
+
+    _persist_crashed_run(tmp_path, "r", _Req(), tmp_path, _AgentQueMorre(), ValueError("x"))
+
+    linha = _linhas(tmp_path)[0]
+    assert linha["success"] is False
+    assert linha.get("crashed") is True
+
+
+def test_o_relator_nunca_derruba_o_que_ele_relata(tmp_path: Path, monkeypatch: Any) -> None:
+    """Isto roda no caminho onde algo ja' deu errado. Um relator de falha que falha nao relata nada
+    — e pior, transforma um erro em dois."""
+    from chimera.api.app import _persist_crashed_run
+
+    monkeypatch.setattr(Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+
+    class _Req:
+        task = "t"
+
+    _persist_crashed_run(tmp_path / "x", "r", _Req(), tmp_path, _AgentQueMorre(), ValueError("x"))
+
+
+def test_um_agente_sem_tentativas_ainda_deixa_a_razao(tmp_path: Path) -> None:
+    """A corrida pode morrer antes da primeira tentativa. Sem tokens para relatar, a razao e' o
+    unico conteudo — e continua sendo mais do que quatro palavras."""
+    from chimera.api.app import _persist_crashed_run
+
+    class _Vazio:
+        attempts: list[Any] = []
+
+    class _Req:
+        task = "t"
+
+    _persist_crashed_run(tmp_path, "r", _Req(), tmp_path, _Vazio(), TimeoutError("sem resposta"))
+
+    linha = _linhas(tmp_path)[0]
+    assert linha["attempts"] == []
+    assert "TimeoutError" in linha["crash_reason"]
+
+
+def test_o_quadro_de_erro_carrega_a_causa() -> None:
+    """A metade que o usuario ve'. O tipo da excecao identifica a falha e nao pode carregar segredo;
+    a mensagem vai junto e limitada, porque "RuntimeError" sozinho e' pouco melhor que "failed"."""
+    fonte = (
+        Path(__file__).resolve().parents[1] / "chimera/api/app.py"
+    ).read_text(encoding="utf-8")
+
+    assert '"reason": f"{type(exc).__name__}: {exc}"[:400]' in fonte
+    assert "_persist_crashed_run(settings.home, run_id, req, ws, auto, exc)" in fonte

--- a/tests/test_streaming_routes_say_they_stream.py
+++ b/tests/test_streaming_routes_say_they_stream.py
@@ -1,0 +1,100 @@
+"""Nove rotas devolviam um stream e o esquema anunciava `application/json` nas nove.
+
+Quem integra pelo contrato — que e' para o que um esquema serve — abre a resposta com um parser de
+JSON, recebe `JSONDecodeError` na primeira linha, e conclui que a corrida falhou. Foi exatamente o
+que aconteceu ao rodar quatro projetos por esta API: tres modelos apareceram como *"reprovou em
+0,2s, $0,00"* antes de terem comecado a trabalhar.
+
+O tipo por si nao gera esquema nenhum: `EventSourceResponse` nao e' um `response_model`, entao o
+FastAPI cai no default e ninguem percebe. Estes testes sao a guarda que impede a decima rota de
+nascer mentindo — e sao escritos sobre a FONTE, nao sobre o app montado, porque uma rota atras de
+um extra que o ambiente de teste nao instalou sumiria do esquema e passaria calada.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parents[1]
+ARQUIVOS = sorted((RAIZ / "chimera/api").glob("*.py"))
+
+#: `async def nome(...) -> EventSourceResponse:` — a assinatura que promete um stream.
+_STREAM = re.compile(r"async def (\w+)\([^)]*\)\s*->\s*EventSourceResponse\s*:", re.S)
+
+
+def _rotas_que_fazem_stream() -> list[tuple[Path, str, str]]:
+    """(arquivo, funcao, decorador) para cada rota que devolve um stream."""
+    achadas = []
+    for arquivo in ARQUIVOS:
+        fonte = arquivo.read_text(encoding="utf-8", errors="replace")
+        linhas = fonte.splitlines()
+        for m in _STREAM.finditer(fonte):
+            linha = fonte[: m.start()].count("\n")
+            # O decorador e' a ultima linha comecando com @ acima da assinatura.
+            decorador = next(
+                (linhas[i] for i in range(linha, max(-1, linha - 6), -1)
+                 if linhas[i].lstrip().startswith("@")),
+                "",
+            )
+            achadas.append((arquivo, m.group(1), decorador))
+    return achadas
+
+
+def test_existe_pelo_menos_uma_rota_de_stream() -> None:
+    """Sem isto o arquivo inteiro passaria vazio no dia em que o padrao de assinatura mudasse —
+    uma guarda que nao encontra nada e uma guarda que nao guarda nada."""
+    assert len(_rotas_que_fazem_stream()) >= 9
+
+
+@pytest.mark.parametrize(
+    ("arquivo", "funcao", "decorador"),
+    _rotas_que_fazem_stream(),
+    ids=[f"{a.stem}:{f}" for a, f, _ in _rotas_que_fazem_stream()],
+)
+def test_toda_rota_de_stream_declara_que_faz_stream(
+    arquivo: Path, funcao: str, decorador: str
+) -> None:
+    """A regra, uma rota por vez, para o erro dizer QUAL rota mente."""
+    assert "SSE_RESPONSE" in decorador, (
+        f"{arquivo.name}:{funcao} devolve EventSourceResponse e o esquema dira "
+        "application/json. Acrescente `responses=SSE_RESPONSE` ao decorador."
+    )
+
+
+def test_o_dicionario_diz_o_que_o_corpo_e() -> None:
+    """Declarar o media type e' metade; a outra metade e' dizer o que ler nele. Um cliente que
+    descobre `text/event-stream` ainda precisa saber que cada `data:` carrega um objeto JSON."""
+    from chimera.api.sse import SSE_RESPONSE
+
+    corpo = SSE_RESPONSE[200]
+    assert "text/event-stream" in corpo["content"]
+    assert "application/json" not in corpo["content"]
+    descricao = corpo["description"].lower()
+    assert "event:" in descricao and "data:" in descricao
+    # E o aviso que custou tres celulas de um bench: nao tente parsear como JSON.
+    assert "json parser" in descricao
+
+
+def test_o_esquema_publicado_carrega_isso() -> None:
+    """A fonte estar certa nao basta — o que o cliente le' e' o dump. Este e' o unico teste aqui
+    que monta o app, e ele pula quando o extra de desktop nao esta instalado em vez de mentir."""
+    pytest.importorskip("fastapi")
+    from typing import cast
+
+    from chimera.api import build_api_app
+    from chimera.interface import ChatSession
+    from chimera.interface.session import SupportsRun
+
+    esquema = build_api_app(lambda: ChatSession(cast(SupportsRun, None))).openapi()
+    fazem_stream = [
+        caminho
+        for caminho, ops in esquema["paths"].items()
+        for op in ops.values()
+        if "text/event-stream" in ((op.get("responses") or {}).get("200") or {}).get("content", {})
+    ]
+
+    assert "/api/runs" in fazem_stream, "a rota de execucao voltou a anunciar JSON"
+    assert len(fazem_stream) >= 9


### PR DESCRIPTION
Both found by running four projects through this API, and both cost money in ways nothing on any screen could see.

## 1. A crashed run left no reason and no receipt

Measured on a real failure: the run listed the directory, had a shell command refused by governance, **wrote a 2,210-character module** — and ended as

```
event: error
data: {"message": "the run failed"}
```

Four words. No cause, no line in `runs.jsonl`, and therefore nothing on the Cost screen. The model calls that paid for that module were invisible, and a person watching could not separate *"the provider died"* from *"the task was wrong"*.

**This is a different class from the receipt fix already shipped**: there the receipt failed to serialise and now falls back to a minimal row; here the run dies before reaching that line at all.

- The error frame carries the exception **type** and a bounded message. The type identifies the failure and cannot carry a secret; `RuntimeError` alone is only marginally better than `failed`.
- A crash writes its own row, marked **`crashed: true`** so it cannot be misread as a run that merely failed its verifier. `success: false` already meant *"the verifier said no"* — a reader who cannot tell those apart can diagnose neither.
- Written by hand rather than through `build_receipt`, and wrapped again: this runs on the path where something already went wrong, and **a crash reporter that can crash reports nothing**.

## 2. Nine streaming routes declared `application/json`

`/api/runs`, `/api/agents`, `/api/chat/stream`, `/api/fs/exec`, `/api/code/turn`, `/api/kanban/run`, `/api/lifecycle`, and both orchestration routes.

Every one returns `EventSourceResponse` — which is **not** a `response_model`, so FastAPI falls through to the default and nobody notices.

Anyone integrating against the contract, which is what a schema is *for*, opens the body with a JSON parser, gets `JSONDecodeError` on the first line, and concludes the run failed. That is exactly what happened here: **three models were recorded as "failed in 0.2s, $0.00" before they had started.**

`SSE_RESPONSE` now rides on all nine, and it *describes the body* rather than only naming the media type — a client that discovers `text/event-stream` still needs to know each `data:` carries a JSON object.

The guard against the tenth route is written against the **source**, not the built app: a route behind an extra the test environment did not install would vanish from the schema and pass in silence.

## Tests

17. **Seven guards sabotage-tested, all seven bite.**

4357 passed / 14 skipped; `ruff`, `mypy`, both drift gates and the desktop build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)