### PR TITLE
fix(runs): keep the work a revert throws away

### DIFF
--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -44,6 +44,13 @@ class FileDiffReceipt(BaseModel):
 class AttemptReceipt(BaseModel):
     """One attempt's proof: whether it verified, whether it was reverted, and what it changed."""
 
+    discarded_at: str = ""
+    """Where the reverted work was written IN FULL, or "" when nothing was reverted.
+
+    `diffs` below is bounded at 4,000 chars per patch so this file stays readable, and that bound
+    makes it a souvenir rather than a recovery: measured on a real run, a 581-line `index.html` was
+    reverted and the clipped patch was the only copy left of it."""
+
     index: int = 0
     verified: bool = False
     reverted: bool = False
@@ -194,6 +201,7 @@ def build_receipt(
             prompt_tokens=int(getattr(a, "prompt_tokens", 0) or 0),
             completion_tokens=int(getattr(a, "completion_tokens", 0) or 0),
             model=str(getattr(a, "model", "") or ""),
+            discarded_at=str(getattr(a, "discarded_at", "") or ""),
         )
         for a in result.attempts
     ]

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -238,6 +238,14 @@ class Attempt:
     verify_output: str = ""
     diff_summary: str = ""
     diffs: list[FileDiff] = field(default_factory=list)  # real per-file unified diffs (pre-revert)
+    #: Onde o trabalho revertido foi guardado inteiro, ou "" quando nao houve reversao.
+    #:
+    #: `diffs` acima existe e nao serve para recuperar nada: o recibo corta cada patch em 4.000
+    #: caracteres. Medido numa corrida real — um `index.html` de 581 linhas virou um souvenir
+    #: truncado, e era a UNICA copia. A reversao estava certa (o verificador reprovou), mas a
+    #: tentativa que a produziu tinha custado 374 mil tokens e o nucleo dela passava todos os
+    #: testes; o que se perdeu nao foi trabalho ruim, foi trabalho quase pronto.
+    discarded_at: str = ""
     #: What actually decided this attempt: "verifier" (a command exited 0), "diff+manager" (files
     #: changed and an LLM approved the answer), "manager" (an LLM approved prose, nothing else
     #: checked), or "none". A receipt that says "success" without saying on whose authority invites
@@ -980,6 +988,10 @@ class AutonomousAgent:
             attempt.model = str(getattr(agent_result, "model", "") or "")
             self._emit(_ev_result(index, ok, detail=(fb or vout)[:200]))
             if not ok and snapshot is not None and self.guard is not None:
+                # Antes de apagar, guardar. `restore` e' a decisao certa — o verificador reprovou —
+                # mas ela e' irreversivel, e sem esta linha a unica copia do que a tentativa
+                # escreveu passa a ser o patch cortado em 4.000 caracteres dentro do recibo.
+                attempt.discarded_at = self._preserve_discarded(attempt, index)
                 self.guard.restore(snapshot)
                 attempt.reverted = True
 
@@ -1226,6 +1238,40 @@ class AutonomousAgent:
         result = AutonomousResult(answer=answer, success=True, attempts=attempts, plan=plan)
         self._persist_receipt(result, task)
         return result
+
+    def _preserve_discarded(self, attempt: Attempt, index: int) -> str:
+        """Escreve o diff INTEIRO da tentativa em disco e devolve o caminho, ou "" se nada houver.
+
+        Fora do `runs.jsonl` de proposito: aquele arquivo e' lido inteiro por varias telas e o corte
+        em 4.000 caracteres existe para ele nao inchar. Os dois requisitos — log limitado e trabalho
+        recuperavel — so' convivem se forem arquivos diferentes.
+
+        Melhor esforco em todos os sentidos: um erro aqui nao pode impedir a reversao, que e' a
+        parte que mantem o workspace consistente.
+        """
+        if not attempt.diffs or self.run_log is None:
+            return ""
+        try:
+            # O id vem da tentativa, que ja o leu do worker algumas linhas acima — o agente nao tem um.
+            destino = (
+                self.run_log.parent / "discarded" / f"{attempt.run_id or 'run'}-{index}.diff"
+            )
+            destino.parent.mkdir(parents=True, exist_ok=True)
+            corpo = [
+                f"# tentativa {index} revertida: o verificador reprovou",
+                f"# {len(attempt.diffs)} arquivo(s); isto e' o que estava escrito antes da reversao",
+                "",
+            ]
+            for d in attempt.diffs:
+                corpo.append(f"--- {getattr(d, 'path', '?')}")
+                corpo.append(str(getattr(d, "patch", "") or ""))
+                corpo.append("")
+            destino.write_text("\n".join(corpo), encoding="utf-8")
+            _log.info("trabalho revertido guardado em %s", destino)
+            return str(destino)
+        except Exception as exc:  # noqa: BLE001 — guardar nunca pode impedir reverter
+            _log.warning("nao consegui guardar o trabalho revertido: %s", exc)
+            return ""
 
     def _persist_receipt(self, result: AutonomousResult, task: str) -> None:
         """Append a run receipt recording how this finished run PROVED its work (read-only evidence).

--- a/tests/test_reverted_work_is_recoverable.py
+++ b/tests/test_reverted_work_is_recoverable.py
@@ -1,0 +1,121 @@
+"""Reverter estava certo. Jogar fora a unica copia do trabalho e' que nao estava.
+
+Medido numa corrida real de um projeto de verdade — uma area de trabalho no navegador, quatro
+modelos, portao executavel. Um dos bracos gastou **374 mil tokens e $0,70** em tres tentativas e as
+tres foram revertidas. O verificador reprovou nas tres, entao a reversao esta' correta e este
+arquivo nao a discute.
+
+O que ele discute e' o que sobrou. Na terceira tentativa o verificador imprimiu
+
+    PASS - nucleo ok
+    FAIL (1):
+      - janelas sem role=dialog
+
+O nucleo passava a suite inteira — pureza, ordenacao, z-order — e a pagina errava UM atributo. Tudo
+foi apagado, e a unica copia que restou foi o patch dentro do recibo, cortado em 4.000 caracteres
+sobre um `index.html` de 581 linhas. Um souvenir, nao uma recuperacao.
+
+Os dois requisitos — log limitado e trabalho recuperavel — so' convivem em arquivos diferentes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.core.autonomous import Attempt, AutonomousAgent
+
+
+class _Diff:
+    def __init__(self, path: str, patch: str) -> None:
+        self.path, self.patch, self.truncated = path, patch, False
+
+
+def _agente(tmp_path: Path) -> Any:
+    """So' os campos que `_preserve_discarded` toca — o resto do agente nao participa disto."""
+    a = AutonomousAgent.__new__(AutonomousAgent)
+    a.run_log = tmp_path / "runs.jsonl"
+    return a
+
+
+def _tentativa(*diffs: _Diff, run_id: str = "abc123") -> Attempt:
+    t = Attempt(index=3, answer="", approved=False, verified=False, reverted=False)
+    t.diffs = list(diffs)  # type: ignore[assignment]
+    t.run_id = run_id
+    return t
+
+
+def test_o_arquivo_grande_sobrevive_inteiro(tmp_path: Path) -> None:
+    """O caso medido: 581 linhas. O corte de 4.000 caracteres do recibo nao pode alcancar isto."""
+    grande = "\n".join(f"+  <div class='janela-{i}'>conteudo</div>" for i in range(581))
+    t = _tentativa(_Diff("index.html", grande))
+
+    caminho = _agente(tmp_path)._preserve_discarded(t, 3)
+
+    assert caminho, "nada foi guardado"
+    texto = Path(caminho).read_text(encoding="utf-8")
+    assert len(texto) > 4000, "guardou uma copia cortada, que e' o problema e nao a solucao"
+    assert "janela-580" in texto, "a ultima linha do arquivo nao sobreviveu"
+
+
+def test_guarda_todos_os_arquivos_da_tentativa(tmp_path: Path) -> None:
+    """A tentativa que valia a pena recuperar tinha DOIS arquivos, e o que passava a suite era o
+    segundo. Guardar so' o primeiro seria perder exatamente a parte boa."""
+    t = _tentativa(_Diff("index.html", "+<html>"), _Diff("nucleo.js", "+module.exports = {}"))
+
+    texto = Path(_agente(tmp_path)._preserve_discarded(t, 3)).read_text(encoding="utf-8")
+
+    assert "index.html" in texto and "nucleo.js" in texto
+    assert "module.exports" in texto
+
+
+def test_diz_por_que_aquilo_esta_ali(tmp_path: Path) -> None:
+    """Um arquivo de diff solto numa pasta, sem cabecalho, e' lixo que ninguem sabe apagar nem
+    usar. Ele tem de dizer que aquilo foi revertido e por que."""
+    texto = Path(
+        _agente(tmp_path)._preserve_discarded(_tentativa(_Diff("a.js", "+x")), 3)
+    ).read_text(encoding="utf-8")
+
+    assert "revertida" in texto
+    assert "verificador reprovou" in texto
+
+
+def test_sem_diff_nao_cria_arquivo_vazio(tmp_path: Path) -> None:
+    """Uma tentativa que nao escreveu nada nao tem trabalho a preservar, e uma pasta cheia de
+    arquivos vazios ensina a ignorar a pasta."""
+    t = Attempt(index=1, answer="", approved=False, verified=False, reverted=False)
+    t.run_id = "x"
+
+    assert _agente(tmp_path)._preserve_discarded(t, 1) == ""
+    assert not (tmp_path / "discarded").exists()
+
+
+def test_guardar_nunca_impede_reverter(tmp_path: Path, monkeypatch: Any) -> None:
+    """Esta e' a ordem que importa: preservar acontece ANTES de restaurar, e restaurar e' o que
+    mantem o workspace consistente. Um erro ao guardar tem de devolver "" e sair do caminho."""
+    monkeypatch.setattr(Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+
+    assert _agente(tmp_path)._preserve_discarded(_tentativa(_Diff("a", "+x")), 1) == ""
+
+
+def test_a_preservacao_vem_antes_da_restauracao() -> None:
+    """Afirmado sobre a fonte porque a ordem e' o invariante: depois de `restore` o disco ja' nao
+    tem o que copiar, e um teste de comportamento passaria com as duas linhas trocadas."""
+    fonte = (
+        Path(__file__).resolve().parents[1] / "chimera/core/autonomous.py"
+    ).read_text(encoding="utf-8")
+    preservar = fonte.index("attempt.discarded_at = self._preserve_discarded(attempt, index)")
+    restaurar = fonte.index("self.guard.restore(snapshot)", preservar - 400)
+
+    assert preservar < restaurar, "guardar passou a acontecer depois de apagar"
+
+
+def test_o_recibo_leva_o_caminho() -> None:
+    """Guardar sem dizer onde e' guardar num lugar que ninguem encontra."""
+    from chimera.api.runs import AttemptReceipt
+
+    assert "discarded_at" in AttemptReceipt.model_fields
+    fonte = (
+        Path(__file__).resolve().parents[1] / "chimera/api/runs.py"
+    ).read_text(encoding="utf-8")
+    assert 'discarded_at=str(getattr(a, "discarded_at", "") or "")' in fonte


### PR DESCRIPTION
## A correction first, because I reported this wrong

I said the reviewer reverts good work for process reasons. **It does not.** Reading the receipts: the executable verifier **ran on all three attempts and failed all three**, and every attempt carries `evidence: verifier`. The revert was correct and this change does not touch it.

What is wrong is what survives it.

## What was actually lost

Measured on a real run — a browser desktop project, four models, executable gate. One arm spent **374,000 tokens and $0.70** across three attempts. On the third the verifier printed:

```
PASS - nucleo ok
FAIL (1):
  - janelas sem role=dialog
```

**The core module passed its entire suite** — purity, ordering, z-order — and the page missed one attribute. All of it was deleted, and the only copy left was the patch inside the receipt, clipped at 4,000 characters over a **581-line** `index.html`. A souvenir, not a recovery.

## The fix

The bound is right for `runs.jsonl`: several screens read that file whole. The two requirements — **a bounded log** and **recoverable work** — only coexist in different files.

A reverted attempt now writes its **full** diff to `<home>/discarded/<run_id>-<n>.diff`, and the receipt carries the path.

Four details decide whether this helps:

- **It happens before `restore`.** After the rollback the disk no longer holds what to copy — and a behavioural test would pass with the two lines swapped, so the order is asserted against the source.
- **It never blocks the revert.** Preserving is best-effort in every direction; the rollback is what keeps the workspace consistent.
- **Every file of the attempt, not the first.** The attempt worth recovering had two, and the one that passed its suite was the second.
- **The file says why it is there.** A loose diff in a folder with no header is litter nobody knows whether to use or delete.

An attempt that wrote nothing produces no file: a folder of empty files teaches people to ignore the folder.

## Tests

7. **Seven guards sabotage-tested, all seven bite.**

4352 passed / 14 skipped; `ruff`, `mypy` and the drift gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)