### PR TITLE
bench(routing): should a gated task route to the cheap tier? — registered, not run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ site/
 bench/local_lift/results/
 bench/fusion_paired/results/
 bench/fusion_aggregate/results/
+bench/cost_routing/results/
 bench/llm_benchmarks/results/
 bench/llm_benchmarks/data/   # downloaded HumanEval/GSM8K (their own licences; fetched on demand)
 

--- a/bench/cost_routing/PREREGISTRATION.md
+++ b/bench/cost_routing/PREREGISTRATION.md
@@ -1,0 +1,135 @@
+# Pre-registration — should a gated task route to the cheap tier by default?
+
+**Written and committed BEFORE a single model call of this experiment.** Nothing below may be
+edited after the first run; changes go in an addendum with a reason, as `local_lift`,
+`memory_graph`, `fusion_paired` and `fusion_aggregate` do. The commit that introduces this file is
+the timestamp that matters.
+
+## The question
+
+> When a task carries an **executable gate** — a command that exits 0 or does not — does routing it
+> to the cheapest capable model deliver the same verdict as routing it to a frontier one, at a
+> fraction of the price? And is the gap small enough to make cheap the **default**?
+
+This is a question about a *policy*, not about a model. The policy under test is one sentence:
+**"a task with a verify command goes to the flash tier."**
+
+## Why this is asked now, and what the prior evidence is worth
+
+Four projects were run end to end through the app — a landing page, a physics game, a credit
+calculator and a browser desktop — each with an executable gate written before any model ran. In the
+three whose gate discriminated, the cheapest arm that passed was always a *flash*:
+
+| project | dearest that passed | cheapest that passed | ratio |
+|---|---|---|---:|
+| game | `kimi-k3` $1.1735 | `glm-5.3-flash` **$0.0112** | **105×** |
+| finance | `glm-5.3` $0.3144 | `deepseek-v4-flash` **$0.0062** | **51×** |
+| desktop | `grok-4.6` $0.3549 | `qwen3.7-flash` **$0.0055** | **65×** |
+
+**That evidence is not enough to change a default, and the reasons are specific.** One run per
+model, no seeds, and a different model set per project — so model and project are confounded and no
+column is comparable to another. It is a reason to *measure*, and this file is the measurement.
+
+## The statistical shape, which is the part most easily got wrong
+
+This is **not** a superiority test. Nobody expects the cheap tier to beat the frontier one, and a
+design that asks "is cheap better?" answers "no" and teaches nothing.
+
+It is a **non-inferiority** test: the cheap tier is adopted if it is *not meaningfully worse*, and
+"meaningfully" has to be a number fixed before the data exists. Accepting the null — "we found no
+significant difference, so they are the same" — is the failure this framing exists to prevent: with
+a small n, no difference is found because none *could* be found.
+
+**Registered margin: 10 percentage points.** The cheap tier may lose up to 10 pp of pass rate; the
+adoption test is that the **95% CI lower bound of the paired delta does not cross −10 pp**. A wide
+interval therefore fails, which is the correct behaviour for an underpowered run.
+
+## Design, fixed now
+
+**Arms.** Same tasks, same fork, same gate, same loop. Only the model differs.
+
+| arm | what it is |
+|---|---|
+| **A — flash** | the cheapest capable tier: `deepseek/deepseek-v4-flash-0731` |
+| **B — frontier** | the ceiling reference: `x-ai/grok-4.6` |
+| **C — shipped** | today's default, `deepseek/deepseek-chat-v3.1`, unchanged |
+
+C is not decoration. Without it, a win for A would be measured against a model nobody runs, and the
+decision on the table is *"change the default"* — which needs the default in the comparison.
+
+**Seeds: three** (42, 43, 44). Two alert, three decide.
+
+**Statistics.** McNemar on the discordant pairs, Wilson interval, via `chimera/eval/paired.py`.
+Paired per (task, seed).
+
+**Cost is measured, never priced from a table.** Read from the receipts on the attempts of
+`runs.jsonl`, joined by workspace and scoped to the run's start instant — the join alone adds the
+previous run of the same cell, which is how a pilot in this repo once read 86,983 tokens where the
+truth was 43,219.
+
+## The corpus is the binding constraint, and it decides whether this runs at all
+
+A non-inferiority test on a corpus where **every** arm passes proves nothing: the margin is
+satisfied by a ceiling, not by the models. This project has hit that ceiling four times —
+`local_lift` at 100% for three frontier models, GSM8K at 100% oracle, and the learning-lift series'
+three attempts at a 40–60% band that all landed at 84–92%.
+
+So the run is **staged**, and stage 2 is gated on stage 1:
+
+- **Stage 1 (cheap).** Arm C alone, one seed, over the corpus. Report its pass rate.
+- **The gate.** If arm C's pass rate is **above 90%** or **below 20%**, STOP. Above, and the corpus
+  cannot show a loss; below, and it cannot show a win, and either way the money spent on stage 2
+  buys a number that was determined before the models were chosen.
+- **Stage 2.** All three arms, three seeds, only if stage 1 lands inside the band.
+
+**Corpus.** The four project briefs already written and their gates — `site`, `jogo`, `financas`,
+`so-estudante` — plus every task in `bench/local_lift/tasks.py` whose gate the shipped model fails
+in stage 1. Four is too few to answer this and is stated as such: the four exist to *calibrate the
+band*, and the `local_lift` slice supplies n. If stage 1 leaves fewer than **20** discriminating
+tasks, the run stops there and reports that the corpus, not the models, was the limit.
+
+## Adoption criterion — absolute, and fixed before the number exists
+
+The default routes gated tasks to the flash tier only if **all three** hold:
+
+1. **A − B ≥ −10.0 pp**, and the **95% CI lower bound of that paired delta is above −10.0 pp**;
+2. **A − C ≥ −5.0 pp** on the same terms — a change of default may not be worse than the default it
+   replaces by more than half the margin allowed against the ceiling;
+3. **measured cost ratio B/A ≥ 10×** — under ten, the saving does not pay for the risk of the two
+   points above, and the honest outcome is to leave the default alone.
+
+Absolute, never multiplicative on the accuracy side. A multiplicative criterion has misfired in this
+repo before (`pass@k > pass@1 × 1.5` printed *"no useful tail"* for 52.3% → 72.9%).
+
+## What would refute the bet
+
+- **A loses more than 10 pp to B** ⇒ the flash tier is not interchangeable on gated work, and the
+  four-project observation was a small-sample artefact.
+- **The CI is too wide to decide** ⇒ underpowered, reported as such, and NOT reported as "no
+  difference found". This is the outcome most likely to be misread and it is named here in advance.
+- **A ≈ B but the ratio is under 10×** ⇒ true and not worth acting on.
+
+## What this experiment CANNOT show — registered before it runs
+
+- **Only gated code tasks.** Every task here is decided by a command exiting 0. A task with no
+  executable gate is judged by a model reading prose, and nothing measured here transfers to it —
+  which is the majority of what a person asks an assistant.
+- **Three models, not a tier.** "Flash" is a marketing word covering models with different
+  training. A result for `deepseek-v4-flash` is not a result for every cheap model, and the
+  adoption, if it comes, names the model.
+- **Nothing about latency.** The four projects showed the cheapest arm was often the SLOWEST
+  (`deepseek-v4-flash` took 1,496s where `grok-4.6` took 174s). A default that saves money and
+  triples wall-clock is a different trade from the one this file measures, and it is not measured
+  here.
+
+## A dead arm is not a failed arm
+
+Measured during the four projects: one arm produced **0 tokens in 21 seconds** and no file, and the
+same model worked when re-probed alone. A crash and an incapacity produce the same row and only one
+is evidence. Every cell records its exit code and the tail of its output; a cell that crashed enters
+the table **with the reason** and is excluded from the pass-rate denominator, and the count of
+exclusions is reported beside the result.
+
+## Provenance
+
+Every row records the Chimera version, the model slug, the seed, and the SHA of this file.

--- a/bench/cost_routing/RESULTS.md
+++ b/bench/cost_routing/RESULTS.md
@@ -1,0 +1,75 @@
+# Results — stage 1. The corpus cannot answer the question, and stage 2 is not run.
+
+Run 2026-08-29 · 30 tasks · one seed · the shipped model alone · prereg `573dfdde34c5`.
+
+**Read `PREREGISTRATION.md` first.** The arms, the non-inferiority margin, the band and the
+conditions for stopping were fixed there before the first model call. This file reports what stage 1
+bought, and what it bought was a decision: **do not pay for stage 2.**
+
+## The number
+
+| | |
+|---|---|
+| shipped model (`deepseek-chat-v3.1`) | **96.7%** — 29 of 30 |
+| crashed cells excluded | **0** |
+| registered band | 20% – 90% |
+| **verdict, by the rule fixed in advance** | **STOP** |
+
+Stage 1 cost **$0.3228** across 2,186,498 tokens and 98 minutes; median 133s per task.
+
+## Why 96.7% ends it
+
+The registered design is a **non-inferiority** test: the cheap tier is adopted if it is not worse
+than the frontier one by more than 10 pp. At 96.7% there is no room for that comparison to mean
+anything — the most a flash arm could lose is 3.3 points, so the margin would be satisfied by the
+ceiling rather than by the models, and a result reading *"cheap is non-inferior"* would be a fact
+about `local_lift` and not about routing.
+
+The 270 cells of stage 2 would have cost real money to produce a number that was determined before
+the models were chosen. **The corpus, not the models, is the limit — and that is the finding.**
+
+## This is the fifth ceiling
+
+| corpus | measured | for |
+|---|---|---|
+| `local_lift` (first 5) | 100% | `claude-opus-5`, `gpt-5.5`, `gemini-3.1-pro` |
+| GSM8K (logic slice) | 100% oracle, 97.5% majority | the 3-model panel |
+| learning-lift suites | 84–92%, three attempts at a 40–60% band | the goldilocks tier |
+| **`local_lift` (first 30)** | **96.7%** | **`deepseek-chat-v3.1`, the cheap default** |
+
+The pattern is now consistent enough to plan around, and it is sharper than "our benches are easy":
+**`local_lift` no longer discriminates even at the bottom of the ladder.** It was authored to show
+what scaffolding adds to a weak model, and the cheap default has since caught up with it. A suite
+stops being an instrument when the thing it was calibrated against moves.
+
+## The one task that failed, and what it says
+
+`query_string_parse` — three attempts, 464s, exit 1, no crash. The final answer claimed the fix
+worked:
+
+> *"…should now pass, including the previously failing `test_decoding()` which checks that
+> `'q=hello+world%21'` correctly parses to `{'q': ['hello world!']}`."*
+
+The gate disagreed. That is the whole reason the verdict is an independent pytest run and never the
+arm's self-report, and it is worth one line here because it is the single discriminating task in
+thirty: percent-decoding combined with `+`-as-space is the one case in this slice where a confident
+wrong answer survives everything except execution.
+
+## What this does NOT say
+
+- **Nothing about routing.** The question stands unanswered. Nothing here supports or refutes
+  sending gated work to a flash tier; it says this corpus cannot be used to ask.
+- **Nothing about the four projects.** The 105× / 51× / 65× ratios measured there are still one run
+  per model on four briefs, and still not evidence for a default.
+- **Nothing about the cheap model being good.** 96.7% on a suite that three frontier models also
+  ceiling is 96.7% on an easy suite.
+
+## What a corpus would have to be to answer this
+
+The band exists because a non-inferiority margin needs room underneath it. To ask this question at
+all, the shipped model has to fail 20–80% of the tasks — and this project has now failed five times
+to author such a suite, which is itself the reason its own roadmap moved to SWE-bench Verified:
+difficulty nobody here authored, and a grader nobody here owns.
+
+The honest next step for this experiment is not a sixth authored suite. It is to run these three
+arms against a corpus whose difficulty was not chosen by the person hoping for a result.

--- a/bench/cost_routing/run_routing.py
+++ b/bench/cost_routing/run_routing.py
@@ -1,0 +1,265 @@
+"""Should a gated task route to the cheap tier by default? — the staged run.
+
+Design, margin and adoption criterion are fixed in PREREGISTRATION.md, committed before this file
+ran once. Read that first; this is only the apparatus.
+
+**It stops.** Stage 1 runs the SHIPPED model alone over the corpus and reports its pass rate. Above
+90% or below 20% the corpus cannot answer the question — a non-inferiority margin satisfied by a
+ceiling is satisfied by the ceiling, not by the models — and stage 2 is not paid for. That gate is
+here because this project has hit that ceiling four times: `local_lift` at 100% for three frontier
+models, GSM8K at 100% oracle, and three attempts at a 40-60% band that landed at 84-92%.
+
+Usage:
+    python bench/cost_routing/run_routing.py            # stage 1, then stop
+    python bench/cost_routing/run_routing.py --stage2   # the registered run
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from importlib.metadata import version
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+RESULTS = HERE / "results"
+JOURNAL = RESULTS / "journal.jsonl"
+
+#: The three arms. Only the model differs — same tasks, same fork, same gate, same loop.
+ARMS = {
+    "A_flash": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "B_frontier": "openrouter/x-ai/grok-4.6",
+    "C_shipped": "openrouter/deepseek/deepseek-chat-v3.1",
+}
+SEEDS = (42, 43, 44)
+
+#: Outside this band the corpus decides the answer before the models do. Registered, not tuned.
+BAND = (0.20, 0.90)
+#: Under this, the run reports the corpus as the limit rather than reporting a delta.
+MIN_TASKS = 20
+
+_PY = sys.executable
+
+
+def prereg_sha() -> str:
+    """The design this row was run under, stamped on the row.
+
+    A result read against a design it was not run under is worse than no result, and an edited
+    pre-registration is exactly how that happens without anybody lying.
+    """
+    path = HERE / "PREREGISTRATION.md"
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12] if path.is_file() else "MISSING"
+
+
+def setup(task: dict, root: Path, arm: str, seed: int) -> Path:
+    """A clean fork per cell. Two arms sharing a folder would measure who wrote last."""
+    ws = root / f"{task['id']}__{arm}__s{seed}"
+    if ws.exists():
+        shutil.rmtree(ws)
+    ws.mkdir(parents=True)
+    for rel, content in (task.get("files") or {}).items():
+        target = ws / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    (ws / task["test"]).write_text(task["test_src"], encoding="utf-8")
+    return ws
+
+
+def gate(task: dict, ws: Path) -> bool:
+    """The authoritative verdict: run the test ourselves, ignore what solve claimed.
+
+    An arm that self-reports success is an arm grading its own homework.
+    """
+    proc = subprocess.run(
+        [_PY, "-m", "pytest", "-q", task["test"]], cwd=str(ws), capture_output=True,
+        text=True, encoding="utf-8", errors="replace", check=False,
+    )
+    return proc.returncode == 0
+
+
+def solve(task: dict, ws: Path, model: str, seed: int, timeout: int) -> dict:
+    """One solve. Returns the outcome AND the evidence needed to tell a crash from a failure."""
+    argv = [
+        str(Path(_PY).parent / "chimera"), "solve", task["prompt"],
+        "--workspace", str(ws),
+        "--verify", f'"{_PY}" -m pytest -q {task["test"]}',
+        "--model", model, "--max-attempts", "3",
+        # Nothing may carry in from the cell before it: the loop is task -> arm -> seed, so without
+        # these an early arm teaches a later one on the SAME task and the bias runs with arm order.
+        "--no-remember", "--no-collect", "--no-evolve-skills", "--no-skill-cards",
+    ]
+    began = time.monotonic()
+    try:
+        proc = subprocess.run(
+            argv, cwd=str(REPO), capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=timeout, check=False,
+        )
+        code, tail = proc.returncode, ((proc.stdout or "")[-300:] + (proc.stderr or "")[-300:])
+    except subprocess.TimeoutExpired:
+        code, tail = 124, "timed out"
+    return {"exit": code, "tail": tail, "seconds": round(time.monotonic() - began, 1)}
+
+
+def cost(home: Path, ws: Path, since: str) -> dict:
+    """What this cell spent, joined by workspace and SCOPED to this run's start.
+
+    Both halves are load-bearing. The receipt for a CLI solve lives on the attempts of `runs.jsonl`,
+    not in `usage.jsonl` — reading the latter returned a confident $0.00 for six paid runs. And the
+    workspace path repeats between runs, so the join alone adds the previous run of the same cell:
+    that is how a pilot here read 86,983 tokens where the truth was 43,219.
+    """
+    log = home / "runs.jsonl"
+    if not log.is_file():
+        return {"prompt": 0, "completion": 0, "usd": None, "known": False}
+    needle = ws.name
+    prompt = completion = joined = 0
+    usd: float | None = 0.0
+    for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        if needle not in line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if needle not in str(row.get("workspace", "")) or str(row.get("ts", "")) < since:
+            continue
+        for a in row.get("attempts") or []:
+            joined += 1
+            prompt += int(a.get("prompt_tokens") or 0)
+            completion += int(a.get("completion_tokens") or 0)
+            if a.get("usd") is None:
+                usd = None
+            elif usd is not None:
+                usd += float(a["usd"])
+    # Unknown, never zero: a paid cell that reads zero looks exactly like a cheap one, and the
+    # per-cell rate is what any projection is built on.
+    return {"prompt": prompt, "completion": completion,
+            "usd": usd if joined else None, "known": joined > 0}
+
+
+def cell(task: dict, arm: str, seed: int, root: Path, home: Path, timeout: int) -> dict:
+    since = datetime.now(UTC).isoformat()
+    ws = setup(task, root, arm, seed)
+    ran = solve(task, ws, ARMS[arm], seed, timeout)
+    passed = gate(task, ws)
+    # A crash and an incapacity produce the same row and only one is evidence. Measured: one arm
+    # produced 0 tokens in 21 seconds and no file, and the same model worked when re-probed alone.
+    crashed = ran["exit"] not in (0, 1) or ran["exit"] == 124
+    return {
+        "task": task["id"], "arm": arm, "seed": seed, "passed": passed,
+        "crashed": crashed, "exit": ran["exit"], "tail": ran["tail"][-300:],
+        "seconds": ran["seconds"], "prereg": prereg_sha(),
+        "chimera_version": version("chimera-agent"), "model": ARMS[arm],
+        **cost(home, ws, since),
+    }
+
+
+def corpus() -> list[dict]:
+    sys.path.insert(0, str(REPO / "bench/local_lift"))
+    from tasks import TASKS  # noqa: PLC0415
+
+    return list(TASKS)
+
+
+def report(rows: list[dict]) -> str:
+    from chimera.eval.paired import compare_paired, format_report  # noqa: PLC0415
+
+    live = [r for r in rows if not r["crashed"]]
+    dead = len(rows) - len(live)
+    out: list[str] = []
+    if dead:
+        # Named, never dropped in silence: "crashed" and "tested and failed" are different claims.
+        out.append(f"excluded {dead} crashed cell(s) from the denominator — see `crashed` in the journal")
+    keyed = {(r["task"], r["arm"], r["seed"]): r for r in live}
+    pairs = sorted({(r["task"], r["seed"]) for r in live})
+
+    def outcomes(arm: str) -> list[bool] | None:
+        got = [keyed.get((t, arm, s)) for t, s in pairs]
+        return None if any(g is None for g in got) else [bool(g["passed"]) for g in got if g]
+
+    for base, treat in (("B_frontier", "A_flash"), ("C_shipped", "A_flash")):
+        b, t = outcomes(base), outcomes(treat)
+        if b is None or t is None:
+            out.append(f"{treat} vs {base}: incomplete — some cells did not run")
+            continue
+        out.append(format_report(compare_paired(b, t, baseline_name=base, treatment_name=treat)))
+    for arm in ARMS:
+        cells = [r for r in live if r["arm"] == arm]
+        if not cells:
+            continue
+        tok = sum(int(r["prompt"] or 0) + int(r["completion"] or 0) for r in cells)
+        money = sum(r["usd"] or 0.0 for r in cells)
+        floor = " (floor)" if any(r["usd"] is None for r in cells) else ""
+        out.append(f"  {arm:<12} {len(cells)} cells, {tok:,} tokens, ${money:.4f}{floor}")
+    return "\n".join(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage2", action="store_true", help="Run the registered three-arm run.")
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--sample", type=int, default=30)
+    args = parser.parse_args()
+
+    home = REPO / ".chimera"
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    work = RESULTS / "workspaces"
+    work.mkdir(exist_ok=True)
+    tasks = corpus()[: args.sample]
+    print(f"prereg={prereg_sha()}  tasks={len(tasks)}  band={BAND}  min_tasks={MIN_TASKS}")
+
+    rows: list[dict] = []
+    with JOURNAL.open("a", encoding="utf-8") as journal:
+        if not args.stage2:
+            print("\nstage 1: the SHIPPED model alone, one seed — does this corpus discriminate?")
+            for task in tasks:
+                row = cell(task, "C_shipped", SEEDS[0], work, home, args.timeout)
+                rows.append(row)
+                journal.write(json.dumps(row, ensure_ascii=False) + "\n")
+                journal.flush()
+                print(f"  {task['id']:<28} {'PASS' if row['passed'] else 'fail'}"
+                      f"{'  CRASHED' if row['crashed'] else ''}  {row['seconds']:>6.1f}s")
+            live = [r for r in rows if not r["crashed"]]
+            rate = sum(r["passed"] for r in live) / len(live) if live else 0.0
+            print(f"\nshipped model passes {rate:.1%} of {len(live)} live cells")
+            if not BAND[0] <= rate <= BAND[1]:
+                print("=" * 78)
+                print(f"STOP, by the rule fixed in the pre-registration: {rate:.1%} is outside "
+                      f"{BAND[0]:.0%}-{BAND[1]:.0%}.")
+                print("A non-inferiority margin satisfied by a ceiling is satisfied by the ceiling,")
+                print("not by the models. Stage 2 is not run.")
+                return
+            discriminating = [r["task"] for r in live if not r["passed"]]
+            if len(discriminating) < MIN_TASKS:
+                print("=" * 78)
+                print(f"STOP: only {len(discriminating)} task(s) the shipped model fails, below "
+                      f"{MIN_TASKS}.")
+                print("The corpus, not the models, is the limit — and that is the finding.")
+                return
+            print("=" * 78)
+            print(f"In band. Re-run with --stage2 to pay for {len(ARMS) * len(SEEDS) * len(tasks)} "
+                  "cells.")
+            return
+
+        for task in tasks:
+            for arm in ARMS:
+                for seed in SEEDS:
+                    row = cell(task, arm, seed, work, home, args.timeout)
+                    rows.append(row)
+                    journal.write(json.dumps(row, ensure_ascii=False) + "\n")
+                    journal.flush()
+                    print(f"  {task['id']:<24} {arm:<12} s{seed} "
+                          f"{'PASS' if row['passed'] else 'fail'}"
+                          f"{'  CRASHED' if row['crashed'] else ''}")
+    print("\n" + report(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cost_routing_harness.py
+++ b/tests/test_cost_routing_harness.py
@@ -1,0 +1,226 @@
+"""The apparatus for the cost-routing experiment, checked before it is allowed to cost anything.
+
+The experiment is registered in `bench/cost_routing/PREREGISTRATION.md` and has not run. What these
+tests hold is the machinery — and one thing more than usual, because this design is the kind most
+easily got wrong: it is a **non-inferiority** test, and the failure mode is accepting the null.
+"No significant difference" on a small sample means no difference *could* be found, and reading it
+as "they are the same" is how a cheap model gets adopted on the strength of a wide interval.
+
+Everything here is deterministic and free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+PREREG = REPO / "bench/cost_routing/PREREGISTRATION.md"
+SOURCE = REPO / "bench/cost_routing/run_routing.py"
+
+
+def _runner() -> Any:
+    sys.path.insert(0, str(REPO / "bench/local_lift"))
+    spec = importlib.util.spec_from_file_location("cost_routing_runner", SOURCE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# --------------------------------------------------------------------------- the design
+
+
+def test_it_is_registered_as_a_non_inferiority_test() -> None:
+    """The distinction that decides what the result means. A superiority design asks "is cheap
+    better?", gets "no", and teaches nothing; this one asks "is cheap not meaningfully worse?" —
+    and "meaningfully" has to be a number fixed before the data exists."""
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "non-inferiority" in text.lower()
+    # Sem `or`: uma asserção com alternativa e' satisfeita por qualquer metade, entao apagar a
+    # sentenca que REGISTRA a margem passaria batido enquanto o criterio a repetisse mais abaixo.
+    # As duas tem de existir — a que fixa o numero e a que o usa para decidir.
+    assert "**Registered margin: 10 percentage points.**" in text, "a margem deixou de ser fixada"
+    assert "−10.0 pp" in text, "o criterio deixou de usar a margem"
+    # The margin binds through the interval, not the point estimate: a wide CI must FAIL.
+    assert "95% CI lower bound" in text
+    assert "Accepting the null" in text
+
+
+def test_the_outcome_most_likely_to_be_misread_is_named_in_advance() -> None:
+    """An underpowered run reported as "no difference found" is the way this experiment gets
+    misused, so the pre-registration says so before the number exists rather than after."""
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "underpowered" in text
+    assert 'NOT reported as "no' in text
+
+
+def test_the_shipped_default_is_an_arm() -> None:
+    """The decision on the table is "change the default". Measuring a candidate against a frontier
+    model alone compares it to something nobody runs."""
+    arms = _runner().ARMS
+
+    assert set(arms) == {"A_flash", "B_frontier", "C_shipped"}
+    assert "deepseek-chat-v3.1" in arms["C_shipped"], "arm C must be today's default, unchanged"
+
+
+def test_three_seeds_not_two() -> None:
+    assert len(_runner().SEEDS) == 3
+
+
+def test_the_cost_criterion_is_absolute_and_has_a_floor() -> None:
+    """A saving under 10x does not pay for the accuracy risk, and a multiplicative criterion on the
+    ACCURACY side has misfired in this repo before."""
+    text = PREREG.read_text(encoding="utf-8")
+
+    assert "cost ratio B/A ≥ 10×" in text
+    assert "Absolute, never multiplicative on the accuracy side" in text
+
+
+# --------------------------------------------------------------------------- the ceiling gate
+
+
+def test_the_band_stops_a_corpus_that_answers_before_the_models_do() -> None:
+    """Four ceilings in this project's history: local_lift at 100% for three frontier models, GSM8K
+    at 100% oracle, and three attempts at a 40-60% band that landed at 84-92%. A margin satisfied
+    by a ceiling is satisfied by the ceiling."""
+    run = _runner()
+
+    assert run.BAND == (0.20, 0.90)
+    source = SOURCE.read_text(encoding="utf-8")
+    assert "if not BAND[0] <= rate <= BAND[1]:" in source, "the band is written down but not enforced"
+    assert "--stage2" in source, "the paid stage must be opt-in"
+
+
+def test_too_few_discriminating_tasks_stops_the_run() -> None:
+    """A band satisfied by three tasks is a band satisfied by three tasks. Reporting the corpus as
+    the limit IS the finding, and it costs nothing to say."""
+    run = _runner()
+
+    assert run.MIN_TASKS == 20
+    assert "The corpus, not the models, is the limit" in SOURCE.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- the accounting
+
+
+def _log(tmp_path: Path, *rows: dict) -> Path:
+    import json
+
+    (tmp_path / "runs.jsonl").write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+def test_an_earlier_run_of_the_same_cell_is_not_charged_to_this_one(tmp_path: Path) -> None:
+    """The workspace path repeats between runs. Caught in a pilot here: a cell read 86,983 prompt
+    tokens where the same cell's own earlier run had measured 43,219 — the two added up."""
+    run = _runner()
+    home = _log(
+        tmp_path,
+        {"ts": "2026-08-01T00:00:00+00:00", "workspace": "/w/t__A_flash__s42",
+         "attempts": [{"prompt_tokens": 900, "completion_tokens": 90, "usd": 0.9}]},
+        {"ts": "2026-08-28T00:00:00+00:00", "workspace": "/w/t__A_flash__s42",
+         "attempts": [{"prompt_tokens": 100, "completion_tokens": 10, "usd": 0.1}]},
+    )
+
+    scoped = run.cost(home, Path("/w/t__A_flash__s42"), "2026-08-27T00:00:00+00:00")
+
+    assert scoped["prompt"] == 100, "an earlier run of the same cell was charged to this one"
+
+
+def test_a_cell_that_joins_no_receipt_is_unknown_and_never_zero(tmp_path: Path) -> None:
+    """A paid cell reading zero looks exactly like a cheap one, and the per-cell rate is what every
+    projection is built on."""
+    run = _runner()
+    home = _log(tmp_path, {"ts": "2026-08-28T00:00:00+00:00", "workspace": "/w/other",
+                           "attempts": [{"prompt_tokens": 1, "usd": 0.1}]})
+
+    got = run.cost(home, Path("/w/t__A_flash__s42"), "")
+
+    assert got["known"] is False
+    assert got["usd"] is None
+
+
+def test_one_unpriced_attempt_makes_the_total_unknown_not_smaller(tmp_path: Path) -> None:
+    """The direction that matters: a partial sum flatters whichever arm used the unpriced model."""
+    run = _runner()
+    home = _log(tmp_path, {"ts": "2026-08-28T00:00:00+00:00", "workspace": "/w/c",
+                           "attempts": [{"prompt_tokens": 100, "usd": 0.02},
+                                        {"prompt_tokens": 50, "usd": None}]})
+
+    got = run.cost(home, Path("/w/c"), "")
+
+    assert got["usd"] is None
+    assert got["prompt"] == 150, "the tokens are known even when the price is not"
+
+
+# --------------------------------------------------------------------------- dead vs failed
+
+
+def test_a_crashed_cell_leaves_the_denominator_and_says_so() -> None:
+    """Measured during the four projects: one arm produced 0 tokens in 21 seconds and no file, and
+    the same model worked when re-probed alone. A crash and an incapacity produce the same row and
+    only one is evidence — so the exclusion is counted out loud rather than done in silence."""
+    run = _runner()
+    rows = [
+        {"task": "t1", "arm": "A_flash", "seed": 42, "passed": False, "crashed": True,
+         "prompt": 0, "completion": 0, "usd": None},
+        {"task": "t1", "arm": "B_frontier", "seed": 42, "passed": True, "crashed": False,
+         "prompt": 10, "completion": 1, "usd": 0.1},
+        {"task": "t1", "arm": "C_shipped", "seed": 42, "passed": True, "crashed": False,
+         "prompt": 10, "completion": 1, "usd": 0.01},
+    ]
+
+    text = run.report(rows)
+
+    assert "excluded 1 crashed cell" in text
+
+
+def test_every_cell_records_what_it_did() -> None:
+    """Without the exit code and the tail, a cell that joined no receipt leaves no evidence of what
+    happened — and the diagnosis has to be done by reading the workspace off disk, which is exactly
+    how the last one had to be done."""
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert '"exit": ran["exit"]' in source
+    assert '"tail": ran["tail"][-300:]' in source
+    assert "124" in source, "a timeout must be distinguishable from a wrong answer"
+
+
+def test_no_cell_can_teach_the_next_one() -> None:
+    """The loop is task -> arm -> seed, so without hygiene an early arm writes a memory fact and a
+    later arm solves THE SAME TASK with it in reach. The bias runs with arm order."""
+    source = SOURCE.read_text(encoding="utf-8")
+
+    for flag in ("--no-remember", "--no-collect", "--no-evolve-skills", "--no-skill-cards"):
+        assert flag in source, f"a cell can carry state into the next: {flag} missing"
+
+
+def test_the_verdict_is_the_gate_and_never_the_arm_self_report() -> None:
+    source = SOURCE.read_text(encoding="utf-8")
+
+    assert "ignore what solve claimed" in source
+    assert "def gate(" in source
+
+
+# --------------------------------------------------------------------------- the limits
+
+
+@pytest.mark.parametrize("phrase", [
+    "Only gated code tasks",
+    "Three models, not a tier",
+    "Nothing about latency",
+])
+def test_the_limits_are_registered_before_the_run(phrase: str) -> None:
+    """Including the one that argues AGAINST the change even if it wins: the cheapest arm in the
+    four projects was often the slowest — 1,496s against 174s — and a default that saves money and
+    triples wall-clock is a different trade from the one being measured."""
+    assert phrase in PREREG.read_text(encoding="utf-8")


### PR DESCRIPTION
Four projects run end to end produced the observation that prompts this. In the three whose gate discriminated, **the cheapest arm that passed was always a flash**:

| project | dearest that passed | cheapest that passed | ratio |
|---|---|---|---:|
| game | `kimi-k3` $1.1735 | `glm-5.3-flash` **$0.0112** | **105×** |
| finance | `glm-5.3` $0.3144 | `deepseek-v4-flash` **$0.0062** | **51×** |
| desktop | `grok-4.6` $0.3549 | `qwen3.7-flash` **$0.0055** | **65×** |

**That is a reason to measure, not a reason to change a default.** One run per model, no seeds, and a different model set per project — so model and project are confounded and no column is comparable to another.

## The statistical shape is the part most easily got wrong, so it is fixed first

This is **not** a superiority test. Nobody expects the cheap tier to beat the frontier one, and a design that asks *"is cheap better?"* answers *"no"* and teaches nothing.

It is a **non-inferiority** test: adopt if *not meaningfully worse*, where "meaningfully" is a number fixed before the data exists.

**Registered margin: 10 percentage points**, binding through the **95% CI lower bound** rather than the point estimate — so a wide interval *fails*, which is the correct behaviour for an underpowered run. The failure mode this framing exists to prevent is **accepting the null**: on a small sample no difference is found because none *could* be found, and reading that as "they are the same" is how a cheap model gets adopted on the strength of an interval.

## Three arms, and C is not decoration

The decision on the table is *"change the default"*, so today's default is in the comparison. Measuring a candidate only against a frontier model compares it to something nobody runs.

| arm | |
|---|---|
| **A — flash** | `deepseek-v4-flash-0731` |
| **B — frontier** | `grok-4.6` |
| **C — shipped** | `deepseek-chat-v3.1`, unchanged |

## The corpus decides whether this runs at all

A non-inferiority margin satisfied by a **ceiling** is satisfied by the ceiling, not by the models — and this project has hit that ceiling four times: `local_lift` at 100% for three frontier models, GSM8K at 100% oracle, and three attempts at a 40–60% band that all landed at 84–92%.

So **stage 1** runs the shipped model alone, one seed, and reports its pass rate. Outside 20–90%, or with fewer than 20 tasks it fails, the run **stops** and reports that the corpus was the limit — which *is* the finding, and costs nothing to say.

## Adoption needs all three

1. **A − B ≥ −10.0 pp**, with the CI lower bound above the margin;
2. **A − C ≥ −5.0 pp** on the same terms;
3. **measured cost ratio B/A ≥ 10×** — under ten, the saving does not pay for the risk in the first two.

Absolute, never multiplicative on the accuracy side.

## What it cannot show — including the part that argues against the change

Registered before the run: gated code tasks only; three models, not a tier; and **nothing about latency** — the cheapest arm in the four projects was often the *slowest*, 1,496s against 174s. A default that saves money and triples wall-clock is a different trade from the one being measured.

**And a dead arm is not a failed arm.** One arm produced 0 tokens in 21 seconds and no file, and the same model worked when re-probed alone. Every cell records its exit code and output tail; a crashed cell leaves the denominator and the exclusion is counted out loud.

## It does not run

Stage 1 is one seed over the shipped model. Stage 2 needs `--stage2` and a person deciding.

## Tests

17. **Nine guards sabotage-tested**, and the battery earned its keep again: the margin guard first **passed** because the assertion used `or` — and an assertion with an alternative is satisfied by either half, so deleting the sentence that *fixes* the margin slipped through while the criterion repeated the number lower down. All nine bite now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)