### PR TITLE
fix(cost): the money is the run's, and the screen counts it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,40 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **A dollar ceiling was a per-ATTEMPT ceiling, and the reviewer was under none.** `max_usd` reads
+  as "this run may spend $X". `Agent.run` built the budget from it and the autonomous loop calls
+  `run` once per attempt, so the real limit was `max_usd × max_attempts`. Measured by asking the
+  app for **$0.000002** with three attempts: it spent **$0.0129**, each attempt started again at
+  zero, and the sentence it printed — *"spend cap reached: $0.0037"* — was one attempt's counter,
+  3.5× smaller than its own receipt. Worse, reaching the cap did not stop anything: attempts 2 and
+  3 ran anyway, each paying a reviewer to criticise a worker whose entire answer was that it had
+  hit a spending limit. The budget now belongs to the run, every attempt draws on the same money,
+  and hitting the ceiling ends the run with the reason instead of buying two more rounds. The
+  reviewer is inside it too — it is a model call per attempt and it was outside every ceiling —
+  wrapped by copy, never rebuilt from its fields, because rebuilding keeps a reviewer's name and
+  discards any overridden `review`. A reviewer the ceiling refuses **abstains**: it never looked,
+  and reading its silence as a veto would let verify-or-revert delete work the money already
+  bought.
+
+- **The Cost screen showed 6% of what had been spent.** `record_spend` writes `usage.jsonl` and has
+  exactly two callers, a chat turn and an orchestration run. Runs are neither: they write receipts
+  to `runs.jsonl`, which that screen never read. Measured on a real install: the headline read
+  **$0.2574** where the logs together say **$4.0897**, and the "by day" list stopped at the
+  previous day while runs were happening. The screen now reads both — reading the receipts that
+  already exist rather than writing the number in a second place, because two writers of one figure
+  drift. The session panel keeps 20 rows and nearly every session is one turn, so its tie broke on
+  input order; runs are concatenated last, which would have pushed every one of them off the panel
+  whose whole subject is where the money went. Ties now break on spend.
+
+- **A run was invisible in the folder it ran in.** The project filter compared raw strings, and on
+  Windows one folder has several spellings: two runs started with forward slashes returned nothing
+  when the list asked for the same folder spelled with the OS separator. They were recorded
+  correctly the whole time, which is what makes it read as the app having lost them. Compared as
+  paths now — separator, trailing separator, `.`/`..`, and case where the platform says case is not
+  significant. Deliberately not `resolve()`: that reads the filesystem, and a list of receipts must
+  not depend on which projects still exist on disk. Asking for `""` still finds the runs that have
+  no project at all — it is a query, not an absent filter, and it is the only door to them.
+
 - **The coverage checklist graded prose too, and deleted the file that satisfied the requirement.**
   Found by driving the release that had just fixed the same blindness one gate over. A run with
   `--gen-tests` on a machine without pytest: the requirement was *"somar(a, b) devolve a + b"*, the

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -105,7 +105,13 @@ from chimera.api.schemas import (
 )
 from chimera.api.sessions import SessionManager, SessionStore
 from chimera.api.sse import SSE_RESPONSE
-from chimera.api.usage import UsageRecord, append_usage, load_usage, summarize_usage
+from chimera.api.usage import (
+    UsageRecord,
+    append_usage,
+    load_usage,
+    summarize_usage,
+    usage_from_runs,
+)
 from chimera.config import Settings, get_settings
 from chimera.core.agent import ToolActivity
 from chimera.core.events import AgentEvent, EventSink
@@ -821,7 +827,12 @@ def build_api_app(
 
     @app.get("/api/usage", dependencies=[guard], response_model=UsageSummaryOut)
     def usage_endpoint() -> dict[str, Any]:
-        return summarize_usage(load_usage(settings.home / "usage.jsonl"))
+        # BOTH logs. `usage.jsonl` holds chat turns and orchestration; runs write their receipts to
+        # `runs.jsonl` and were simply missing from this screen — see `usage_from_runs`.
+        return summarize_usage(
+            load_usage(settings.home / "usage.jsonl")
+            + usage_from_runs(settings.home / "runs.jsonl")
+        )
 
     @app.get("/api/runs", dependencies=[guard], response_model=list[RunReceiptOut])
     def runs_endpoint(workspace: str | None = None) -> list[Any]:

--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -13,6 +13,7 @@ guard supplies the types for static checking only.
 
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -231,6 +232,38 @@ def append_run(path: Path, receipt: RunReceipt) -> None:
         handle.write(line)
 
 
+def same_folder(a: str, b: str) -> bool:
+    """Whether two spellings name the same folder, without touching the disk.
+
+    ``==`` on the raw strings was the filter, and on Windows one folder has several spellings.
+    Measured in the app: two runs started with forward slashes returned nothing when the list asked
+    for the same folder spelled with the OS separator. The runs were recorded correctly and simply
+    never appeared under their own project — which reads as the app having lost them.
+
+    ``normpath`` settles the separator, a trailing one, and any ``.``/``..``; ``normcase`` settles
+    the case, and only where the platform says case is not significant — on POSIX it is the
+    identity, so two folders differing in case stay two folders.
+
+    Deliberately NOT ``resolve()``: that reads the filesystem, follows symlinks and would make a
+    list of receipts depend on which of them still exist on disk.
+    """
+    return os.path.normcase(os.path.normpath(a)) == os.path.normcase(os.path.normpath(b))
+
+
+def _in_project(receipt_workspace: str, workspace: str) -> bool:
+    """Whether a receipt belongs to the project being asked for.
+
+    ``""`` is a query in its own right, not "no filter": it asks for the receipts that have NO
+    workspace, which is the only way to reach them once any filter is applied. Comparing it as a
+    path would break that — ``normpath("")`` is ``"."``, so an unattributed receipt would answer to
+    a query for the current directory and, worse, ``""`` would stop finding the receipts it exists
+    to find.
+    """
+    if not workspace:
+        return not receipt_workspace
+    return bool(receipt_workspace) and same_folder(receipt_workspace, workspace)
+
+
 def load_runs(path: Path, *, workspace: str | None = None) -> list[RunReceipt]:
     """Load persisted run receipts; malformed lines are skipped.
 
@@ -240,7 +273,8 @@ def load_runs(path: Path, *, workspace: str | None = None) -> list[RunReceipt]:
     A receipt with no workspace is NOT included in a filtered result. It predates the field or came
     from an agent built without one, and there is no honest way to place it: showing it under
     whichever project happens to be open is fabricated evidence in the one view whose job is to say
-    what a configuration was worth, and it would be fabricated differently for each reader.
+    what a configuration was worth, and it would be fabricated differently for each reader. It is
+    still reachable by asking for ``""`` — see :func:`_in_project`.
     """
     path = Path(path)
     if not path.exists():
@@ -254,6 +288,6 @@ def load_runs(path: Path, *, workspace: str | None = None) -> list[RunReceipt]:
         except ValueError:  # pragma: no cover - defensive
             _log.warning("skipping malformed run receipt line")
             continue
-        if workspace is None or receipt.workspace == workspace:
+        if workspace is None or _in_project(receipt.workspace, workspace):
             out.append(receipt)
     return out

--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -8,6 +8,7 @@ separately, so an unknown price can never be laundered into a fake $0.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -86,6 +87,61 @@ def record_spend(
         )
     except Exception as exc:  # noqa: BLE001 -- see the docstring
         _log.debug("usage logging skipped: %s", exc)
+
+
+#: Marks a record reconstructed from a run receipt. Chat writes a bare session id and the
+#: orchestrator writes ``orchestration:``, so the three namespaces cannot collide — which is what
+#: keeps the merge below from counting the same money twice without needing to check.
+RUN_SESSION_PREFIX = "run:"
+
+
+def usage_from_runs(path: Path) -> list[UsageRecord]:
+    """One record per ATTEMPT of every autonomous run, so the Cost screen counts them too.
+
+    ``record_spend`` has exactly two callers — a chat turn and an orchestration run — and the
+    autonomous run path is not one of them. Runs write their receipts to ``runs.jsonl`` instead,
+    which the Cost screen never read: measured in the desktop app, a day with $0.0270 of runs
+    showed a total that stopped at the previous day. The screen answered "how much have I spent"
+    with a number that was confidently too low, and too low by exactly the most expensive kind of
+    work the app does.
+
+    Read here rather than ALSO written there: two writers of one number drift, and the receipt is
+    already the record. ``usd`` is the attempt's own total — ``overhead_usd`` is a share of it, not
+    an addition — and stays None when the price is unknown, which `summarize_usage` counts as an
+    unpriced turn rather than laundering into $0.
+    """
+    path = Path(path)
+    if not path.exists():
+        return []
+    out: list[UsageRecord] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            _log.warning("skipping malformed run record line")
+            continue
+        if not isinstance(row, dict):
+            continue
+        run_ts = str(row.get("ts") or "")
+        for attempt in row.get("attempts") or []:
+            if not isinstance(attempt, dict):
+                continue
+            usd = attempt.get("usd")
+            out.append(
+                UsageRecord(
+                    ts=run_ts,
+                    # The attempt carries the run id; the run row itself does not.
+                    session_id=RUN_SESSION_PREFIX + str(attempt.get("run_id") or run_ts),
+                    model=str(attempt.get("model") or ""),
+                    prompt_tokens=int(attempt.get("prompt_tokens") or 0),
+                    completion_tokens=int(attempt.get("completion_tokens") or 0),
+                    usd=float(usd) if isinstance(usd, int | float) else None,
+                    tools=len(attempt.get("tool_names") or []),
+                )
+            )
+    return out
 
 
 def load_usage(path: Path) -> list[UsageRecord]:
@@ -176,7 +232,13 @@ def summarize_usage(records: list[UsageRecord]) -> dict[str, Any]:
         "totals": totals,
         "by_day": sorted(by_day.values(), key=lambda d: d["day"]),
         "by_model": sorted(by_model.values(), key=lambda m: m["turns"], reverse=True),
-        "by_session": sorted(by_session.values(), key=lambda s: s["turns"], reverse=True)[:20],
+        # Ties broken by SPEND, not by input order. Nearly every session is one turn, so the
+        # old key left the order to whichever log was concatenated first — and runs are
+        # appended last, which would have kept the most expensive work out of the panel
+        # that exists to show where the money went.
+        "by_session": sorted(
+            by_session.values(), key=lambda s: (s["turns"], s["usd"]), reverse=True
+        )[:20],
         "cache_hit_pct": cache_hit_pct,
         "route_mix": route_mix,
     }

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -399,6 +399,7 @@ class Agent:
         history: list[MessageLike] | None = None,
         images: list[str] | None = None,
         should_stop: Callable[[], bool] | None = None,
+        spend: SpendBudget | None = None,
     ) -> AgentResult:
         """Run the tool loop. ``on_token`` streams model text deltas as they arrive (when the backend
         supports it); ``on_tool`` fires once per tool call with its outcome. ``on_edit`` fires with
@@ -475,7 +476,13 @@ class Agent:
         # Per RUN, not per Agent: the same Agent object serves several runs (a conversation, a
         # scheduler dispatching jobs), and a cap that carried across them would refuse the second
         # task because the first one used its allowance.
-        spend = SpendBudget(self.config.max_usd) if self.config.max_usd else None
+        #
+        # Unless the CALLER owns one. `AutonomousAgent` calls this once per ATTEMPT, so a budget
+        # built here gave a three-attempt run three separate ceilings: measured, a run asking for
+        # $0.000002 spent $0.0129 and the loop never noticed. A caller that spans several `run`
+        # calls passes its own, and every attempt then draws on the same money.
+        if spend is None and self.config.max_usd:
+            spend = SpendBudget(self.config.max_usd)
         steplog = StepLog()
         nudged = False
         loop_detector = ToolLoopDetector() if self.config.detect_tool_loops else None

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -17,6 +17,7 @@ Every dependency is injectable, so the whole loop is testable without a network.
 
 from __future__ import annotations
 
+import copy
 import inspect
 import re
 from collections.abc import Callable
@@ -57,6 +58,7 @@ from chimera.evolution.experience import ExperienceBuffer, Outcome, format_lesso
 from chimera.evolution.playbook import Playbook
 from chimera.evolution.stagnation import StagnationDetector
 from chimera.evolution.trace_probe import anti_pattern_hint
+from chimera.orchestration.budget import SpendBudget, SpendCappedBackend, SpendExceeded
 from chimera.telemetry import get_logger
 
 _log = get_logger("core.autonomous")
@@ -466,7 +468,9 @@ class AutonomousAgent:
             )
         )
 
-    def _run_worker(self, worker: Worker, prompt: str) -> AgentResult:
+    def _run_worker(
+        self, worker: Worker, prompt: str, *, spend: SpendBudget | None = None
+    ) -> AgentResult:
         """Run the worker, passing the live callbacks it actually supports and a sink exists for.
 
         Backward-compatible in both directions: with no event sink the call is the bare
@@ -487,6 +491,12 @@ class AutonomousAgent:
         kwargs: dict[str, Any] = {}
         if self.should_stop is not None and "should_stop" in accepted:
             kwargs["should_stop"] = self.should_stop
+        # NOT an event either, and passed for the same reason `should_stop` is: without it every
+        # attempt builds its own ceiling from the same `max_usd` and the run's real limit becomes
+        # `max_usd * max_attempts`. A worker that predates the parameter is called without it and
+        # keeps the old per-attempt behaviour rather than failing.
+        if spend is not None and "spend" in accepted:
+            kwargs["spend"] = spend
         if self.on_event is not None:
             if "on_edit" in accepted:
                 kwargs["on_edit"] = self._emit_edit
@@ -498,6 +508,41 @@ class AutonomousAgent:
             return worker.run(prompt, **kwargs)
         except TypeError:  # signature lied (e.g. **kwargs-only) — fall back to the plain call
             return worker.run(prompt)
+
+    def _run_budget(self) -> SpendBudget | None:
+        """One ceiling for this whole run, read off the worker that will spend the money.
+
+        Duck-typed on the worker for the same reason `_seed_run_state` is: `Worker` is a protocol,
+        and an implementation that carries no `config.max_usd` simply has no ceiling to share — it
+        then behaves exactly as before, building its own per-call budget if it has one.
+        """
+        cap = getattr(getattr(self.worker, "config", None), "max_usd", None)
+        return SpendBudget(cap) if cap else None
+
+    def _capped_manager(self, spend: SpendBudget | None) -> Manager | None:
+        """The reviewer, drawing on the run's money instead of on nothing.
+
+        The reviewer is a model call per attempt and it sat outside every ceiling: a run given a
+        cap still paid for reviews after reaching it. The ceiling goes around the BACKEND, once —
+        the shape `SpendCappedBackend` was written for, and the reason it refuses rather than
+        merely records.
+
+        A COPY, never a wrapper installed on `self.manager`: this one is per-run today, and a
+        mutation would make this run's spending follow a shared reviewer into the next one.
+
+        `copy.copy` rather than `Manager(...)`, and the difference is not style. Rebuilding the
+        class from its fields silently discards a subclass and every overridden `review` — the
+        reviewer would keep its name and lose its behaviour, which is the kind of substitution
+        nothing downstream can detect. A reviewer with no `backend` to wrap is returned untouched.
+        """
+        if spend is None or self.manager is None:
+            return self.manager
+        inner = getattr(self.manager, "backend", None)
+        if inner is None:
+            return self.manager
+        capped = copy.copy(self.manager)
+        capped.backend = SpendCappedBackend(inner, spend)
+        return capped
 
     def _seed_run_state(self, worker: Worker, task: str, plan: Plan | None) -> None:
         """Tell the worker what it was asked and which plan it is on, in the fields that mean those.
@@ -694,6 +739,17 @@ class AutonomousAgent:
         # rejected it and rolled the tree back. Between-attempt reverts still happen (each attempt stays
         # independent); only the final on-disk state is restored to this on a failed run.
         last_after = None
+        # ONE ceiling for the whole run, not one per attempt. `Agent.run` builds a `SpendBudget`
+        # from `AgentConfig.max_usd` and this loop calls `run` once per attempt, so a three-attempt
+        # run used to get three separate ceilings — measured: a run asking for $0.000002 spent
+        # $0.0129 and every attempt started again at zero. Same reasoning as `SpendCappedBackend`,
+        # which already says it for fan-outs: the money is the RUN's, so the budget is the run's.
+        spend = self._run_budget()
+        # The reviewer draws on the same money. It is a model call the user pays for, made once per
+        # attempt, and it was outside every ceiling — so a capped run still paid for reviews after
+        # the cap. Wrapped, never mutated: the Manager is per-run here, but a wrapper installed on
+        # a shared one would leak this run's spending into the next.
+        manager = self._capped_manager(spend)
         for index in range(start_index, self.config.max_attempts + 1):
             # Cooperative cancel (checked BEFORE the attempt starts): an in-flight model call can't be
             # interrupted, so a stop request halts the loop here — after the previous attempt finished,
@@ -724,7 +780,7 @@ class AutonomousAgent:
             # returns at its next step boundary.
             if self.should_stop is not None and self.should_stop():
                 return self._finalize_cancelled(task, attempts, plan, thread_id)
-            agent_result = self._run_worker(worker, prompt)
+            agent_result = self._run_worker(worker, prompt, spend=spend)
             # A worker that cut itself short produced a PARTIAL attempt, and verifying, reviewing and
             # scoring one is worse than useless: those are model calls the user has already asked us
             # not to make, spent to judge work that stopped halfway — and the failing verdict would
@@ -737,6 +793,14 @@ class AutonomousAgent:
             # `max_attempts=1`, return a run with no attempts at all.
             if getattr(agent_result, "stopped_reason", "") == "cancelled":
                 return self._finalize_cancelled(task, attempts, plan, thread_id)
+            # Same argument as the comment above, for the other reason a worker cuts itself short.
+            # A worker that stopped because the money ran out has produced a partial attempt, and
+            # verifying, reviewing and RETRYING it are exactly "model calls the user has already
+            # asked us not to make" — measured: three attempts ran under a cap the first call had
+            # already passed, and each one paid for a reviewer to criticise a worker that was only
+            # saying it had hit the limit.
+            if getattr(agent_result, "stopped_reason", "") in ("spend", "budget"):
+                return self._finalize_capped(task, attempts, plan, thread_id, agent_result.answer)
             answer = agent_result.answer
             # Surface a degrading trajectory where a person will see it, not only in the trace. It
             # is advisory: the attempt is judged on its result as always, and the run continues.
@@ -833,7 +897,9 @@ class AutonomousAgent:
             proxy_fb = ""
             proxy_abstained = False
             if self.probe_log is not None and self.manager is not None:
-                probe_proxy, proxy_fb, proxy_abstained = self._review(task, answer, attempt_judge_context)
+                probe_proxy, proxy_fb, proxy_abstained = self._review(
+                    task, answer, attempt_judge_context, manager=manager
+                )
             # Whether a manager actually judged THIS attempt, as opposed to being configured. Only
             # a real judgment may be named as one in the receipt below.
             review_abstained = True
@@ -846,9 +912,13 @@ class AutonomousAgent:
                 elif probe_proxy is not None:
                     approved, fb, review_abstained = probe_proxy, proxy_fb, proxy_abstained
                 else:
-                    approved, fb, review_abstained = self._review(task, answer, attempt_judge_context)
+                    approved, fb, review_abstained = self._review(
+                        task, answer, attempt_judge_context, manager=manager
+                    )
             else:
-                approved, fb, review_abstained = self._review(task, answer, attempt_judge_context)
+                approved, fb, review_abstained = self._review(
+                    task, answer, attempt_judge_context, manager=manager
+                )
                 # An abstaining reviewer is the only gate here and just declined to be one. Letting
                 # `ok` ride on it would decide the attempt on a non-answer; the contract, coverage
                 # and diff gates below still run and can still fail it.
@@ -1188,6 +1258,35 @@ class AutonomousAgent:
         self._persist_receipt(result, task)
         return result
 
+    def _finalize_capped(
+        self,
+        task: str,
+        attempts: list[Attempt],
+        plan: Plan | None,
+        thread_id: str | None,
+        answer: str,
+    ) -> AutonomousResult:
+        """The money ran out: return what was bought, and stop buying.
+
+        Shaped on `_finalize_cancelled`, not on the exhaustion path, and the difference is the
+        point: running out of money is not evidence the approach was wrong, so this distils no
+        anti-pattern card and credits no card failure. The run did what it was told to do with the
+        money it was given.
+
+        The worker's own message is the answer, because it names WHICH ceiling and what it had
+        spent — "the run failed" for a run that simply reached its cap is the four-word ending this
+        release spent its time removing.
+        """
+        self._emit(_ev_status("stopped on budget"))
+        self._clear_checkpoint(thread_id)
+        last = answer or (attempts[-1].answer if attempts else "")
+        self._emit(_ev_final(False, last))
+        result = AutonomousResult(
+            answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="spend"
+        )
+        self._persist_receipt(result, task)
+        return result
+
     def _finalize_success(
         self,
         task: str,
@@ -1453,15 +1552,29 @@ class AutonomousAgent:
             project=str(self.workspace) if self.workspace else None,
         )
 
-    def _review(self, task: str, answer: str, context: str) -> tuple[bool, str, bool]:
+    def _review(
+        self, task: str, answer: str, context: str, *, manager: Manager | None = None
+    ) -> tuple[bool, str, bool]:
         """Returns (approved, feedback, abstained). ``abstained`` = nobody actually judged — either
         no manager is configured, or the one configured replied with nothing readable. Same shape
         and same meaning as :meth:`_verify`'s third value, and for the same reason: the caller must
         fall back to its other gates instead of reading a non-answer as either answer."""
         if not self._manager_ran():
             return True, "", True
-        assert self.manager is not None
-        review = self.manager.review(task, answer, context=context)
+        # `manager` is the same reviewer wrapped in the run's ceiling; `self.manager` is the bare
+        # one. `_manager_ran` still asks the field, because whether a reviewer EXISTS is a fact
+        # about the agent and must not change with whether a budget was set.
+        reviewer = manager if manager is not None else self.manager
+        assert reviewer is not None
+        try:
+            review = reviewer.review(task, answer, context=context)
+        except SpendExceeded:
+            # The ceiling refused the reviewer's call. ABSTAINED, not rejected: a reviewer that was
+            # never allowed to look has not judged, and reading its silence as a veto would revert
+            # work the money had already bought. The run ends on the next pass at no cost — the
+            # worker draws on this same budget, so its first call is refused before it is made.
+            _log.info("review skipped: the run reached its dollar ceiling")
+            return True, "", True
         return review.approved, review.feedback, review.abstained
 
     def _manager_ran(self) -> bool:

--- a/tests/test_a_run_appears_in_its_own_folder.py
+++ b/tests/test_a_run_appears_in_its_own_folder.py
@@ -1,0 +1,131 @@
+"""A run must be listed under the folder it ran in, however that folder was spelled.
+
+The filter was ``receipt.workspace == workspace`` — raw string equality. On Windows one folder has
+several spellings, so a run started at ``C:/Users/.../rc43-teste`` returned nothing for
+``C:\\Users\\...\\rc43-teste``: measured in the app, two runs were recorded correctly and were
+invisible in the list for their own project, which reads as the app having lost them.
+
+Everything here is free: no model call, no network, and no filesystem lookup — `same_folder` is
+deliberately pure string work, so a receipt for a folder that has since been deleted still matches.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.runs import load_runs, same_folder
+
+WINDOWS_ONLY = pytest.mark.skipif(
+    os.name != "nt", reason="separator and case folding are Windows path semantics"
+)
+
+
+def _write(home: Path, *workspaces: str) -> Path:
+    path = home / "runs.jsonl"
+    rows: list[dict[str, Any]] = [
+        {"ts": f"2026-08-30T0{i}:00:00+00:00", "task": "t", "success": True,
+         "workspace": ws, "attempts": []}
+        for i, ws in enumerate(workspaces)
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+# --- the measured bug --------------------------------------------------------------------------
+
+
+@WINDOWS_ONLY
+def test_forward_slashes_find_a_run_recorded_with_backslashes(tmp_path: Path) -> None:
+    """The exact failure seen in the app: 0 runs one way, 2 the other, same folder."""
+    log = _write(tmp_path, r"C:\Users\brcam\Desktop\chimera-sim\rc43-teste")
+
+    found = load_runs(log, workspace="C:/Users/brcam/Desktop/chimera-sim/rc43-teste")
+
+    assert len(found) == 1
+
+
+@WINDOWS_ONLY
+def test_case_does_not_hide_a_run_on_windows(tmp_path: Path) -> None:
+    log = _write(tmp_path, r"C:\Users\brcam\Projects\Site")
+
+    assert len(load_runs(log, workspace=r"c:\users\brcam\projects\site")) == 1
+
+
+def test_a_trailing_separator_is_the_same_folder(tmp_path: Path) -> None:
+    log = _write(tmp_path, str(tmp_path / "proj"))
+
+    assert len(load_runs(log, workspace=str(tmp_path / "proj") + os.sep)) == 1
+
+
+def test_a_redundant_step_is_the_same_folder(tmp_path: Path) -> None:
+    log = _write(tmp_path, str(tmp_path / "proj"))
+
+    assert len(load_runs(log, workspace=str(tmp_path / "sub" / ".." / "proj"))) == 1
+
+
+# --- what must still NOT match -----------------------------------------------------------------
+
+
+def test_a_different_folder_is_still_a_different_folder(tmp_path: Path) -> None:
+    """The normalisation must not turn the filter into "everything"."""
+    log = _write(tmp_path, str(tmp_path / "a"), str(tmp_path / "b"))
+
+    assert len(load_runs(log, workspace=str(tmp_path / "a"))) == 1
+
+
+def test_a_sibling_whose_name_is_a_prefix_does_not_match(tmp_path: Path) -> None:
+    """``site`` must not collect ``site-old`` — a substring check would, and reads as correct."""
+    log = _write(tmp_path, str(tmp_path / "site-old"))
+
+    assert load_runs(log, workspace=str(tmp_path / "site")) == []
+
+
+def test_a_receipt_with_no_workspace_is_never_placed_in_one(tmp_path: Path) -> None:
+    """Documented rule, and now load-bearing: ``normpath("")`` is ``"."``, so an unattributed
+    receipt WOULD answer to a filter of ``.`` if it were normalised like any other path."""
+    log = _write(tmp_path, "")
+
+    assert load_runs(log, workspace=".") == []
+    assert load_runs(log, workspace=os.getcwd()) == []
+
+
+def test_asking_for_no_project_still_finds_the_unattributed_runs(tmp_path: Path) -> None:
+    """``""`` is a query, not "no filter" — the only way to reach a receipt written before the
+    workspace field existed. Normalising it as a path would have silently removed that door, which
+    is how the path comparison first broke this."""
+    log = _write(tmp_path, "", str(tmp_path / "proj"))
+
+    found = load_runs(log, workspace="")
+
+    assert len(found) == 1
+    assert found[0].workspace == ""
+
+
+def test_no_filter_still_returns_everything(tmp_path: Path) -> None:
+    log = _write(tmp_path, str(tmp_path / "a"), "", str(tmp_path / "b"))
+
+    assert len(load_runs(log)) == 3
+
+
+# --- the comparison itself ---------------------------------------------------------------------
+
+
+def test_it_does_not_read_the_filesystem(tmp_path: Path) -> None:
+    """A receipt for a folder that has since been deleted must still be findable — `resolve()`
+    would make the list depend on which projects still exist on disk."""
+    gone = str(tmp_path / "deleted-long-ago")
+
+    assert same_folder(gone, gone)
+    assert len(load_runs(_write(tmp_path, gone), workspace=gone)) == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX keeps case significant")
+def test_case_still_separates_two_folders_on_posix() -> None:
+    """``normcase`` is the identity on POSIX, and it must stay that way: there, ``/tmp/Site`` and
+    ``/tmp/site`` really are two folders and folding them would merge two projects' runs."""
+    assert not same_folder("/tmp/Site", "/tmp/site")

--- a/tests/test_the_cost_screen_counts_runs.py
+++ b/tests/test_the_cost_screen_counts_runs.py
@@ -1,0 +1,186 @@
+"""The Cost screen must count what the runs spent, because runs are the expensive part.
+
+``record_spend`` writes ``usage.jsonl`` and has exactly two callers — a chat turn and an
+orchestration run. The autonomous run path is not one of them: it writes its receipts to
+``runs.jsonl``, which the screen never read.
+
+Measured in the desktop app: a day with **$0.0270** of runs showed a total that stopped at the
+previous day, and the screen's headline figure was the chat spend alone. That is worse than an
+absent dashboard — an absent one is not consulted, and this one answered "how much have I spent"
+with a number that was confidently too low, in the one direction nobody checks.
+
+Everything here is free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from chimera.api.usage import (
+    RUN_SESSION_PREFIX,
+    UsageRecord,
+    append_usage,
+    load_usage,
+    summarize_usage,
+    usage_from_runs,
+)
+
+
+def _run_row(**kw: Any) -> dict[str, Any]:
+    attempt = {
+        "index": 1,
+        "run_id": kw.pop("run_id", "r1"),
+        "model": kw.pop("model", "openrouter/deepseek/deepseek-chat-v3.1"),
+        "prompt_tokens": kw.pop("prompt_tokens", 8870),
+        "completion_tokens": kw.pop("completion_tokens", 193),
+        "usd": kw.pop("usd", 0.005197),
+        "overhead_usd": kw.pop("overhead_usd", None),
+        "tool_names": kw.pop("tool_names", ["read_file"]),
+    }
+    return {
+        "ts": kw.pop("ts", "2026-08-30T04:21:23.067048+00:00"),
+        "task": "do the thing",
+        "success": False,
+        "workspace": "C:/w",
+        "attempts": [attempt, *kw.pop("extra_attempts", [])],
+    }
+
+
+def _write_runs(home: Path, *rows: dict[str, Any]) -> Path:
+    home.mkdir(parents=True, exist_ok=True)
+    path = home / "runs.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return path
+
+
+# --- the receipts become usage records ---------------------------------------------------------
+
+
+def test_a_run_attempt_is_counted(tmp_path: Path) -> None:
+    records = usage_from_runs(_write_runs(tmp_path, _run_row()))
+
+    assert len(records) == 1
+    assert records[0].usd == 0.005197
+    assert records[0].prompt_tokens == 8870
+    assert records[0].model == "openrouter/deepseek/deepseek-chat-v3.1"
+
+
+def test_every_attempt_counts_not_just_the_run(tmp_path: Path) -> None:
+    """Three attempts are three model calls and three bills. Counting the run once would report a
+    three-attempt run at the price of one — the exact shape of the under-count being fixed."""
+    row = _run_row(
+        extra_attempts=[
+            {"index": 2, "run_id": "r1", "model": "m", "prompt_tokens": 10,
+             "completion_tokens": 1, "usd": 0.002},
+            {"index": 3, "run_id": "r1", "model": "m", "prompt_tokens": 10,
+             "completion_tokens": 1, "usd": 0.003},
+        ]
+    )
+
+    total = summarize_usage(usage_from_runs(_write_runs(tmp_path, row)))
+
+    assert total["totals"]["turns"] == 3
+    assert round(total["totals"]["usd"], 6) == 0.010197
+
+
+def test_an_unpriced_attempt_is_unknown_never_zero(tmp_path: Path) -> None:
+    """The rule this module already holds for chat turns: an unknown price is counted apart, not
+    laundered into a $0 that makes the total look complete."""
+    summary = summarize_usage(usage_from_runs(_write_runs(tmp_path, _run_row(usd=None))))
+
+    assert summary["totals"]["unpriced_turns"] == 1
+    assert summary["totals"]["usd"] == 0.0
+
+
+def test_overhead_is_a_share_of_the_price_not_an_addition(tmp_path: Path) -> None:
+    """``Attempt.overhead_usd`` documents itself as "the share of ``usd`` that was NOT the worker".
+    Adding it on top would over-report by the planner and reviewer legs of every attempt."""
+    records = usage_from_runs(_write_runs(tmp_path, _run_row(usd=0.0058, overhead_usd=0.000608)))
+
+    assert records[0].usd == 0.0058
+
+
+# --- the two logs do not collide ---------------------------------------------------------------
+
+
+def test_a_run_and_a_chat_turn_stay_separate_sessions(tmp_path: Path) -> None:
+    """The merge counts each side once because the id namespaces cannot overlap: chat writes a bare
+    session id, orchestration writes ``orchestration:``, runs write ``run:``."""
+    append_usage(tmp_path / "usage.jsonl", UsageRecord(ts="2026-08-30T00:00:00+00:00",
+                                                       session_id="r1", model="m", usd=1.0))
+
+    merged = load_usage(tmp_path / "usage.jsonl") + usage_from_runs(_write_runs(tmp_path, _run_row()))
+    summary = summarize_usage(merged)
+
+    sessions = {s["session_id"] for s in summary["by_session"]}
+    assert sessions == {"r1", RUN_SESSION_PREFIX + "r1"}
+    assert summary["totals"]["turns"] == 2
+
+
+# --- it survives a bad file --------------------------------------------------------------------
+
+
+def test_a_missing_log_is_empty_not_an_error(tmp_path: Path) -> None:
+    assert usage_from_runs(tmp_path / "nothing.jsonl") == []
+
+
+def test_a_malformed_line_is_skipped_and_the_rest_still_counts(tmp_path: Path) -> None:
+    path = tmp_path / "runs.jsonl"
+    path.write_text("{not json\n" + json.dumps(_run_row()) + "\n", encoding="utf-8")
+
+    assert len(usage_from_runs(path)) == 1
+
+
+# --- the wiring, not just the function ---------------------------------------------------------
+
+
+def test_the_route_actually_merges_them(tmp_path: Path) -> None:
+    """A summariser that works while the endpoint never calls it is a guard outside the flow — the
+    failure mode this repo has hit before, so the assertion goes through the HTTP surface."""
+    from tests.test_api import _client  # noqa: PLC0415
+
+    client = _client(tmp_path)
+    home = tmp_path / "home"
+    _write_runs(home, _run_row(usd=0.0270))
+
+    body = client.get("/api/usage").json()
+
+    assert body["totals"]["turns"] == 1
+    assert round(body["totals"]["usd"], 6) == 0.027
+
+
+# --- the panel that shows where the money went -------------------------------------------------
+
+
+def test_the_session_panel_keeps_the_expensive_ones_not_the_first_ones(tmp_path: Path) -> None:
+    """The panel holds 20 rows and nearly every session is one turn, so the sort key decides which
+    20 by breaking a tie. Ordered by input, the tie went to whichever log was concatenated first —
+    and runs are concatenated last, so the merge would have pushed every run off the one panel
+    whose subject is where the money went.
+    """
+    cheap = [
+        UsageRecord(ts="2026-08-30T00:00:00+00:00", session_id=f"chat{i}", model="m", usd=0.0001)
+        for i in range(25)
+    ]
+    expensive = usage_from_runs(_write_runs(tmp_path, _run_row(run_id="pricey", usd=9.99)))
+
+    panel = summarize_usage(cheap + expensive)["by_session"]
+
+    assert len(panel) == 20
+    assert panel[0]["session_id"] == RUN_SESSION_PREFIX + "pricey"
+
+
+def test_more_turns_still_outrank_a_bigger_bill(tmp_path: Path) -> None:
+    """Spend is the TIE-break, not the sort. A three-attempt session is three turns and stays above
+    a one-turn session however expensive that one turn was — the panel is still by activity."""
+    one_big = [UsageRecord(ts="2026-08-30T00:00:00+00:00", session_id="whale", model="m", usd=50.0)]
+    three_small = [
+        UsageRecord(ts="2026-08-30T00:00:00+00:00", session_id="busy", model="m", usd=0.01)
+        for _ in range(3)
+    ]
+
+    panel = summarize_usage(one_big + three_small)["by_session"]
+
+    assert panel[0]["session_id"] == "busy"

--- a/tests/test_the_dollar_cap_is_the_runs.py
+++ b/tests/test_the_dollar_cap_is_the_runs.py
@@ -1,0 +1,364 @@
+"""A dollar ceiling belongs to the RUN, not to each attempt inside it.
+
+``AgentConfig.max_usd`` reads as "this run may spend $X". ``Agent.run`` built a ``SpendBudget`` from
+it, and ``AutonomousAgent`` calls ``run`` once per ATTEMPT — so the real limit was
+``max_usd * max_attempts``, and the reviewer, which is a model call per attempt and lives outside
+every ``Agent``, was under no ceiling at all.
+
+Measured in the app before the fix: a run asking for **$0.000002** with three attempts spent
+**$0.0129**. Attempts 2 and 3 each started again at zero, and each paid a reviewer to criticise a
+worker whose whole answer was that it had hit a spending limit.
+
+Everything here is free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.core.agent import Agent, AgentConfig, AgentResult
+from chimera.core.autonomous import AutonomousAgent, AutonomousConfig
+from chimera.core.supervisor import Review
+from chimera.orchestration.budget import SpendBudget, SpendCappedBackend, SpendExceeded
+from chimera.providers.gateway import ToolCall
+from chimera.tools.registry import Tool, ToolRegistry
+
+
+class _Config:
+    """Only the field the loop reads off a worker to size the ceiling."""
+
+    def __init__(self, max_usd: float | None) -> None:
+        self.max_usd = max_usd
+
+
+class _BudgetWorker:
+    """Records the budget it was handed on each attempt, and always fails so the loop retries.
+
+    Failing matters: a worker that succeeds ends the run on attempt 1, and then every assertion
+    about attempt 2 sharing a ceiling would pass without a second attempt ever happening.
+    """
+
+    def __init__(self, max_usd: float | None = 5.0) -> None:
+        self.config = _Config(max_usd)
+        self.seen: list[SpendBudget | None] = []
+
+    def run(self, task: str, *, spend: SpendBudget | None = None, **kwargs: Any) -> AgentResult:
+        self.seen.append(spend)
+        return AgentResult(answer="not done", steps=1, stopped_reason="final")
+
+
+class _StoppedOnSpendWorker:
+    """A worker that hit the ceiling mid-attempt — what ``Agent.run`` returns in that case."""
+
+    def __init__(self) -> None:
+        self.config = _Config(5.0)
+        self.calls = 0
+
+    def run(self, task: str, **kwargs: Any) -> AgentResult:
+        self.calls += 1
+        return AgentResult(
+            answer="spend cap reached: $0.0037 of $0.0000", steps=1, stopped_reason="spend"
+        )
+
+
+class _OldWorker:
+    """Predates the parameter: its ``run`` takes no ``spend``, and must still be callable."""
+
+    def __init__(self) -> None:
+        self.config = _Config(5.0)
+        self.calls = 0
+
+    def run(self, task: str) -> AgentResult:
+        self.calls += 1
+        return AgentResult(answer="done", steps=1, stopped_reason="final")
+
+
+class _ReviewResult:
+    """The shape a backend returns, priced high enough that one call moves a budget."""
+
+    content = "APPROVED"
+    model = "openrouter/deepseek/deepseek-chat"
+    prompt_tokens = 1_000_000
+    completion_tokens = 1_000_000
+    finish_reason = "stop"
+    route_meta = None
+    cache_read_tokens = 0
+    cache_write_tokens = 0
+
+    def __init__(self) -> None:
+        self.tool_calls: list[Any] = []
+
+
+class _CountingBackend:
+    """Stands in for the reviewer's gateway."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> _ReviewResult:
+        self.calls += 1
+        return _ReviewResult()
+
+
+class _CountingManager:
+    """A reviewer that always rejects, so the loop uses every attempt it is given."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.backend = _CountingBackend()
+        self.model: str | None = None
+        self.use_rubric = False
+        self.rubric_threshold = 0.6
+
+    def review(self, task: str, proposed: str, *, context: str = "") -> Review:
+        self.calls += 1
+        self.backend.complete([])
+        return Review(approved=False, feedback="again")
+
+
+def _config(**kw: Any) -> AutonomousConfig:
+    return AutonomousConfig(use_planner=False, use_manager=True, **kw)
+
+
+def _auto(worker: Any, manager: Any, attempts: int) -> AutonomousAgent:
+    return AutonomousAgent(worker, manager=manager, config=_config(max_attempts=attempts))
+
+
+# --- one ceiling, not one per attempt ----------------------------------------------------------
+
+
+def test_every_attempt_draws_on_the_same_budget() -> None:
+    """The whole defect in one assertion: three attempts, one budget object.
+
+    Identity, not equality — two ``SpendBudget(5.0)`` objects compare as different but each would
+    hold its own ``_spent``, which is precisely the bug.
+    """
+    worker = _BudgetWorker(max_usd=5.0)
+
+    _auto(worker, _CountingManager(), 3).run("do the task")
+
+    assert len(worker.seen) == 3, "the loop did not use all three attempts"
+    assert worker.seen[0] is not None, "the worker was handed no budget at all"
+    assert worker.seen[0] is worker.seen[1] is worker.seen[2], (
+        "each attempt got its own ceiling — a $5 run can spend $15"
+    )
+
+
+def test_spending_carries_from_one_attempt_to_the_next() -> None:
+    """What the shared object is FOR: money spent on attempt 1 is gone on attempt 2."""
+    worker = _BudgetWorker(max_usd=5.0)
+
+    _auto(worker, _CountingManager(), 2).run("do the task")
+
+    first, second = worker.seen[0], worker.seen[1]
+    assert first is not None and second is not None
+    first.record("openrouter/deepseek/deepseek-chat", 1_000_000, 1_000_000)
+    assert second.spent == first.spent > 0
+
+
+def test_a_worker_without_a_cap_is_handed_nothing() -> None:
+    """No ``max_usd`` is no ceiling, and must not become a zero-dollar one."""
+    worker = _BudgetWorker(max_usd=None)
+
+    _auto(worker, _CountingManager(), 2).run("do the task")
+
+    assert worker.seen == [None, None]
+
+
+def test_a_worker_that_predates_the_parameter_still_runs() -> None:
+    """Duck-typed, like ``should_stop`` beside it: an old ``Worker`` keeps its old behaviour."""
+    worker = _OldWorker()
+
+    result = _auto(worker, _CountingManager(), 1).run("do the task")
+
+    assert worker.calls == 1
+    assert result.attempts
+
+
+# --- reaching the ceiling ends the run ---------------------------------------------------------
+
+
+def test_a_worker_stopped_on_money_is_not_reviewed_and_not_retried() -> None:
+    """The measured waste: three attempts ran under a cap the first call had already passed, each
+    paying a reviewer to criticise a worker that was only reporting the limit."""
+    worker = _StoppedOnSpendWorker()
+    manager = _CountingManager()
+
+    result = _auto(worker, manager, 3).run("do the task")
+
+    assert worker.calls == 1, "the run kept retrying after the money ran out"
+    assert manager.calls == 0, "a reviewer was paid to judge a worker that never worked"
+    assert result.success is False
+    assert result.stopped_reason == "spend"
+
+
+def test_the_ending_says_which_ceiling_and_what_it_had_spent() -> None:
+    """Not "the run failed". The worker's own message names the cap and the spend."""
+    result = _auto(_StoppedOnSpendWorker(), _CountingManager(), 2).run("do the task")
+
+    assert "spend cap reached" in result.answer
+
+
+# --- the reviewer draws on the same money ------------------------------------------------------
+
+
+def test_the_reviewer_is_inside_the_ceiling() -> None:
+    """It is a model call per attempt, and it sat outside every budget in the app."""
+    manager = _CountingManager()
+    auto = _auto(_BudgetWorker(max_usd=5.0), manager, 1)
+
+    capped = auto._capped_manager(SpendBudget(5.0))
+
+    assert isinstance(capped.backend, SpendCappedBackend)
+    assert capped.backend.inner is manager.backend
+
+
+def test_capping_the_reviewer_keeps_its_class_and_its_review() -> None:
+    """Rebuilding a ``Manager`` from its fields would keep the name and lose the behaviour.
+
+    A subclass, or any duck-typed reviewer with its own ``review``, must survive being capped —
+    a substitution nothing downstream could detect, and one that would quietly turn a custom
+    verdict into the default APPROVED/REVISE parse of whatever the backend happened to say.
+    """
+    manager = _CountingManager()
+    auto = _auto(_BudgetWorker(max_usd=5.0), manager, 1)
+
+    capped = auto._capped_manager(SpendBudget(5.0))
+
+    assert type(capped) is type(manager)
+    assert capped.review("t", "a").approved is False, "the overridden verdict was lost"
+
+
+def test_a_reviewer_with_no_backend_to_wrap_is_left_alone() -> None:
+    class _NoBackend:
+        def review(self, task: str, proposed: str, *, context: str = "") -> Review:
+            return Review(approved=True)
+
+    auto = _auto(_BudgetWorker(max_usd=5.0), _NoBackend(), 1)
+
+    assert auto._capped_manager(SpendBudget(5.0)) is auto.manager
+
+
+def test_wrapping_the_reviewer_never_mutates_the_shared_one() -> None:
+    """A wrapper installed on ``self.manager`` would carry this run's spending into the next."""
+    manager = _CountingManager()
+    auto = _auto(_BudgetWorker(max_usd=5.0), manager, 1)
+
+    auto._capped_manager(SpendBudget(5.0))
+
+    assert not isinstance(manager.backend, SpendCappedBackend)
+
+
+def test_no_budget_means_the_reviewer_is_left_exactly_as_it_was() -> None:
+    auto = _auto(_BudgetWorker(max_usd=None), _CountingManager(), 1)
+
+    assert auto._capped_manager(None) is auto.manager
+
+
+# --- the real Agent, not a fake ----------------------------------------------------------------
+
+
+class _PingTool(Tool):
+    """Does nothing, so the loop keeps calling the model and only a cap can end it."""
+
+    name = "ping"
+    description = "does nothing"
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def run(self, **kwargs: Any) -> str:
+        return "pong"
+
+
+class _LoopingBackend:
+    """Calls ``ping`` forever, priced so that one call is worth roughly a cent."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> Any:
+        self.calls += 1
+        result = _ReviewResult()
+        result.tool_calls = [ToolCall(id=f"c{self.calls}", name="ping", arguments={})]
+        return result
+
+
+def _real_agent(backend: _LoopingBackend, max_usd: float) -> Agent:
+    """Loop detection OFF, deliberately: a worker that calls the same tool forever is exactly what
+    it exists to stop, and with it on both runs end at the same step for a reason that has nothing
+    to do with money — which is how the first version of these tests passed AND failed for the
+    wrong reason. ``max_steps`` is set high for the same reason: only the cap may end these runs."""
+    registry = ToolRegistry()
+    registry.register(_PingTool())
+    return Agent(
+        backend,
+        registry,
+        AgentConfig(max_usd=max_usd, max_steps=500, detect_tool_loops=False),
+    )
+
+
+def test_a_caller_owned_budget_is_the_one_the_agent_uses() -> None:
+    """The join between the two halves: without it the loop hands a budget down and ``Agent.run``
+    builds its own anyway, so nothing about a shared ceiling reaches the place that spends."""
+    backend = _LoopingBackend()
+    shared = SpendBudget(10.0)
+
+    _real_agent(backend, max_usd=10.0).run("go", spend=shared)
+
+    assert shared.spent > 0, "the agent spent on a budget of its own, not on the one it was given"
+
+
+def test_a_second_run_on_the_same_budget_has_less_to_spend() -> None:
+    """What a per-attempt ceiling could never do: the second run stops sooner than the first.
+
+    Sizing matters — the cap is set so the first run cannot exhaust it on one call, otherwise both
+    runs would make exactly one call and the assertion would hold for the wrong reason.
+    """
+    backend = _LoopingBackend()
+    shared = SpendBudget(10.0)
+    agent = _real_agent(backend, max_usd=10.0)
+
+    agent.run("go", spend=shared)
+    first = backend.calls
+    agent.run("go again", spend=shared)
+    second = backend.calls - first
+
+    assert first > 1, "the first run ended on one call — the cap is too small to measure carry-over"
+    assert second < first, "the second run started again at zero"
+
+
+def test_without_a_caller_budget_the_agent_still_builds_its_own() -> None:
+    """The standalone case the original comment defends: two runs, two allowances."""
+    backend = _LoopingBackend()
+    agent = _real_agent(backend, max_usd=10.0)
+
+    agent.run("go")
+    first = backend.calls
+    agent.run("go again")
+
+    assert backend.calls - first == first, "a standalone Agent lost its per-run allowance"
+
+
+class _RefusingManager(_CountingManager):
+    """A reviewer whose call the ceiling refuses — what the wrapped backend does once blocked."""
+
+    def review(self, task: str, proposed: str, *, context: str = "") -> Review:
+        self.calls += 1
+        raise SpendExceeded("spend cap reached: $5.0000 of $5.0000")
+
+
+def test_a_reviewer_refused_by_the_ceiling_abstains_it_does_not_veto() -> None:
+    """The direction matters, and only one of the two is safe.
+
+    A refused reviewer has not judged. Reading its silence as REVISE would revert work the money
+    had already bought — under verify-or-revert, deleting a correct patch because the budget ran
+    out while nobody was looking at it.
+    """
+    manager = _RefusingManager()
+    auto = _auto(_BudgetWorker(max_usd=5.0), manager, 1)
+
+    approved, feedback, abstained = auto._review("t", "a", "", manager=manager)
+
+    assert manager.calls == 1, "the reviewer was never reached — this proves nothing"
+    assert abstained is True, "a reviewer that was never allowed to look was recorded as a verdict"
+    assert approved is True, "silence became a veto, and verify-or-revert would delete the work"
+    assert feedback == ""

--- a/tests/test_the_judge_only_holds_you_to_the_agreement.py
+++ b/tests/test_the_judge_only_holds_you_to_the_agreement.py
@@ -40,7 +40,11 @@ def test_the_reviewer_is_given_the_judge_context() -> None:
     # `attempt_judge_context` is `judge_context` plus what THIS attempt changed on disk — the
     # agreement, plus evidence about the answer. The name changed when the diff was added; the
     # property did not, and the assertion that matters is the negative one below.
-    assert source.count("self._review(task, answer, attempt_judge_context)") == 3
+    # Matched on the ARGUMENT, not on one exact call shape: the call now also carries the run's
+    # capped reviewer and wraps across lines, and an anchor that pins the formatting fails on a
+    # change that leaves the property it guards untouched.
+    assert source.count("self._review(") == 3
+    assert source.count("task, answer, attempt_judge_context") == 3
     assert "self._review(task, answer, context)" not in source
     assert "self._review(task, answer, judge_context)" not in source
 

--- a/tests/test_the_reviewer_can_see_the_work.py
+++ b/tests/test_the_reviewer_can_see_the_work.py
@@ -138,5 +138,5 @@ def test_the_diff_is_measured_before_the_review_runs(tmp_path: Path) -> None:
 
     source = inspect.getsource(AutonomousAgent.run)
     assert source.index("diffs = unified_diffs(") < source.index(
-        "self._review(task, answer, attempt_judge_context)"
+        "task, answer, attempt_judge_context"
     ), "the diff is computed after the review again, so the evidence is always empty"


### PR DESCRIPTION
Three defects found by driving rc43 as a user. Each one makes the app either spend more than it was told to, or report less than it spent.

## The dollar cap was a per-attempt cap

`max_usd` reads as *"this run may spend $X"*. `Agent.run` builds a `SpendBudget` from it, and the autonomous loop calls `run` **once per attempt** — so the real limit was `max_usd × max_attempts`.

Measured by asking the app for **$0.000002** with three attempts:

| | |
|---|---:|
| requested ceiling | $0.000002 |
| actually spent | **$0.0129** |
| what the run's final sentence reported | $0.0037 |

The sentence is one attempt's counter, 3.5× smaller than the run's own receipt. And reaching the cap stopped nothing: attempts 2 and 3 ran anyway, each paying a reviewer to criticise a worker whose entire answer was that it had hit a spending limit.

- One budget per run; every attempt draws on it.
- Hitting it **ends** the run, with the reason, instead of buying two more rounds.
- The reviewer is inside the ceiling too — it is a model call per attempt and was outside every budget. Wrapped **by copy**, never rebuilt from its fields: rebuilding keeps a reviewer's name and silently discards any overridden `review`.
- A reviewer the ceiling refuses **abstains**. It never looked, and reading its silence as a veto would let verify-or-revert delete work the money had already bought.

## The Cost screen showed 6% of the spend

`record_spend` writes `usage.jsonl` and has exactly two callers — a chat turn and an orchestration run. Runs are neither; they write receipts to `runs.jsonl`, which that screen never read.

On a real install: the headline read **$0.2574** where the two logs together say **$4.0897**, and the by-day list stopped at the previous day while runs were happening.

It reads both now — by reading the receipts that already exist, not by writing the figure in a second place, because two writers of one number drift. The session panel keeps 20 rows and nearly every session is one turn, so its tie broke on input order; runs are concatenated last, which would have pushed every one of them off the panel whose whole subject is where the money went. Ties now break on spend.

## A run was invisible in the folder it ran in

The project filter compared raw strings. On Windows one folder has several spellings, so two runs started with forward slashes returned nothing when the list asked for the same folder with the OS separator — recorded correctly the whole time, which is what makes it read as the app having lost them.

Compared as paths now: separator, trailing separator, `.`/`..`, and case where the platform says case is not significant. Deliberately **not** `resolve()` — that reads the filesystem, and a list of receipts must not depend on which projects still exist on disk. Asking for `""` still finds the runs with no project at all; it is a query, not an absent filter, and it is the only door to them.

## How this was checked

Every guard was reverted one at a time and required to fail. Two escaped the first pass and are now covered — a reviewer refused by the ceiling, and rebuilding the reviewer from its fields rather than copying it.

The full suite caught two tests that anchor on the source text of `AutonomousAgent.run` and whose literal no longer matched. The anchors moved to the property they guard, and were themselves sabotaged to prove they still guard it. A third existing test showed that `workspace=""` is a deliberate query for the unattributed runs — the first version of the path comparison had closed that door.

**4415 tests, 16 skipped. ruff and mypy clean on 329 files. No OpenAPI drift.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
