### PR TITLE
fix(ui): four things the screens knew and did not say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,38 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **The Security screen explained the machine's boundary in English, on a Portuguese interface.**
+  Everything around it was translated; the one sentence that says WHY no kernel sandbox applies came
+  from the server verbatim and was printed as it arrived. That sentence is the substance of the
+  panel, on the one screen a person opens to learn what protects them. The endpoint now reports a
+  cause **code** beside the sentence — the shape `PostureFacts.fell_back_reason` already used — and
+  the screen says it in the reader's language, in all ten. The English rides along as the fallback:
+  a cause a client has never heard of has to degrade to English, never to a blank line. Code and
+  sentence are produced by one function so they cannot drift into a screen confidently explaining
+  the wrong cause.
+
+- **A scheduled job with a gate looked exactly like one without.** The `verify` field could be set
+  on the form and then vanished: the card showed the schedule, the task and the folder, and nothing
+  about the command that decides whether the work is **kept**. Created one through the API with
+  `python -m pytest -q` and the word "pytest" appeared nowhere on the screen afterwards. The card
+  names the gate now, and stays silent when there is none — a row that always shows a gate line
+  trains people to stop reading it.
+
+- **Fourteen learned cards, all marked ACTIVE, all reading `0 uses`.** The available reading is that
+  the agent tried them and they were useless. Nothing consulted them: retrieval is off by default
+  because it was measured (+16.7pp, a confidence interval including zero, +300% tokens) and left
+  off. A count of zero means two different things depending on that flag, and the screen was showing
+  the count without the flag. `GET /api/skills` reports it now and the panel explains the zero —
+  and stays quiet when reading IS on, because then zero really is a verdict on the card.
+
+- **A memory "fact" was the whole request plus the whole answer.** Four of them on a real install,
+  630–950 characters each, filed as semantic facts and recalled into the context of every later run
+  in that folder. The answer side was already bounded to 160 characters; the task side was not, and
+  the task is the long half. A fact is now the task's **opening line**, bounded — a brief opens with
+  what it wants and continues with how, so 769 characters became 34. The dedup key still hashes the
+  full task: four real briefs opened with "Leia BRIEF.md e construa…", and keying on the shortened
+  head would fold them into one entry that overwrites itself.
+
 - **A dollar ceiling was a per-ATTEMPT ceiling, and the reviewer was under none.** `max_usd` reads
   as "this run may spend $X". `Agent.run` built the budget from it and the autonomous loop calls
   `run` once per attempt, so the real limit was `max_usd × max_attempts`. Measured by asking the

--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -7160,6 +7160,20 @@
             "default": "",
             "title": "Reason",
             "type": "string"
+          },
+          "reason_code": {
+            "default": "",
+            "enum": [
+              "",
+              "windows",
+              "bwrap_missing",
+              "userns_refused",
+              "seatbelt_missing",
+              "unsupported_os",
+              "no_container"
+            ],
+            "title": "Reason Code",
+            "type": "string"
           }
         },
         "required": [
@@ -7400,6 +7414,11 @@
       },
       "SkillsOut": {
         "properties": {
+          "cards_read": {
+            "default": false,
+            "title": "Cards Read",
+            "type": "boolean"
+          },
           "retirement_candidates": {
             "items": {
               "type": "string"

--- a/apps/desktop/src/components/Cron.tsx
+++ b/apps/desktop/src/components/Cron.tsx
@@ -278,6 +278,17 @@ export function Cron({ embedded = false }: { embedded?: boolean } = {}) {
                     </div>
                   </details>
                 ) : null}
+                {/* A job with a gate and a job without one looked identical, and the gate is what
+                    decides whether the work is KEPT: without it the run accepts its own answer,
+                    with it a failing command reverts the workspace. Somebody reading this list to
+                    ask "is this job checked?" had no way to tell, and the field is set on a form
+                    they may not have filled in themselves. Shown as the command, because "verified"
+                    alone would not say what was run. */}
+                {j.verify && (
+                  <div className="mt-0.5 truncate text-xs text-muted-foreground" title={j.verify}>
+                    {t("cron.gatedBy", { command: j.verify })}
+                  </div>
+                )}
                 {/* The HOST, never the URL. A webhook URL is a credential — anyone who reads it off
                     a shared screen can post into that channel — and the host is what answers the
                     question the row is asking: where does this end up? */}

--- a/apps/desktop/src/components/Cron.verify.test.tsx
+++ b/apps/desktop/src/components/Cron.verify.test.tsx
@@ -101,3 +101,42 @@ describe("Cron — the gate", () => {
     expect(field).toHaveAttribute("placeholder", expect.stringMatching(/no gate/i));
   });
 });
+
+describe("Cron — a job that has a gate says so", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCron.mockResolvedValue({} as never);
+  });
+
+  function job(over: Record<string, unknown> = {}) {
+    return {
+      id: "j1", name: "nightly tests", trigger: "cron", schedule: "0 4 * * *",
+      action: "run the tests", enabled: true, next_run: 1, last_run: null,
+      last_status: null, last_error: null, consecutive_failures: 0,
+      created_by: "human", workspace: "/w", deliver_to: null,
+      verify: "", max_attempts: 1, ...over,
+    } as never;
+  }
+
+  it("shows the command that judges the job", async () => {
+    // Found by creating one through the API and reading the list: the gate round-tripped and the
+    // card said nothing about it, so a checked job and an unchecked one were the same row — and
+    // the gate is what decides whether the work is kept at all.
+    mockGetCron.mockResolvedValue([job({ verify: "python -m pytest -q", max_attempts: 2 })]);
+
+    renderWithProviders(<Cron />);
+
+    expect(await screen.findByText(/python -m pytest -q/)).toBeTruthy();
+  });
+
+  it("says nothing at all when there is no gate", async () => {
+    // The absence has to be legible too. A row that always shows a gate line — empty, or reading
+    // "none" — trains people to stop reading it, and then the one that matters is invisible.
+    mockGetCron.mockResolvedValue([job({ verify: "" })]);
+
+    renderWithProviders(<Cron />);
+
+    await screen.findByText(/nightly tests/);
+    expect(screen.queryByText(/gated by/i)).toBeNull();
+  });
+});

--- a/apps/desktop/src/components/Governance.sandbox.test.tsx
+++ b/apps/desktop/src/components/Governance.sandbox.test.tsx
@@ -118,3 +118,64 @@ describe("Governance — the execution boundary", () => {
     expect(screen.queryByText(/would run on this machine/i)).not.toBeInTheDocument();
   });
 });
+
+describe("Governance — the reason is said in the reader's language", () => {
+  it("translates the CAUSE instead of relaying the server's English", async () => {
+    // Measured in the shipped app: the panel printed "Windows has no OS sandbox in Chimera…" in
+    // English on a Portuguese UI, one line below its own translated prose. The sentence came
+    // straight from the API, and only the code can be translated.
+    mockSandbox.mockResolvedValue(state({
+      reason_code: "windows",
+      reason: "Windows has no OS sandbox in Chimera: the mechanism there is a restricted token.",
+    }));
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/Set CHIMERA_SANDBOX=docker for a real boundary/)).toBeTruthy();
+    expect(screen.queryByText(/restricted token\.$/)).toBeNull();
+  });
+
+  it("falls back to the server's sentence for a cause it has no translation for", async () => {
+    // A new cause must degrade to English, never to a blank line or to a raw i18n key. This is the
+    // half that lets the backend add a reason without shipping the frontend on the same day.
+    mockSandbox.mockResolvedValue(state({
+      reason_code: "a_cause_this_build_never_heard_of",
+      reason: "Something specific the server knows and this build does not.",
+    }));
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/Something specific the server knows/)).toBeTruthy();
+    expect(screen.queryByText(/governance\.sandbox\.why/)).toBeNull();
+  });
+
+  it("says nothing about a cause when the sandbox IS isolated", async () => {
+    mockSandbox.mockResolvedValue(state({
+      isolated: true, backend: "bubblewrap", reason: "", reason_code: "", platform: "Linux",
+    }));
+
+    renderWithProviders(<Governance />);
+
+    await screen.findByText(/kernel sandbox/);
+    expect(screen.queryByText(/run on this machine\./)).toBeNull();
+  });
+});
+
+describe("Governance — the defect exactly as it was seen", () => {
+  it("says the reason in Portuguese on a Portuguese interface", async () => {
+    // The report, reproduced: `lang="pt"`, the surrounding prose translated, and this one line in
+    // English because it came from the server. Rendering only in English cannot show that — the
+    // sentence would look correct in every assertion while being wrong for the person reading it.
+    localStorage.setItem("chimera.lang", "pt");
+    mockSandbox.mockResolvedValue(state({
+      reason_code: "windows",
+      reason: "Windows has no OS sandbox in Chimera: the mechanism there is a restricted token.",
+    }));
+
+    renderWithProviders(<Governance />);
+
+    expect(await screen.findByText(/fronteira de verdade/)).toBeTruthy();
+    expect(screen.queryByText(/Windows has no OS sandbox/)).toBeNull();
+    localStorage.removeItem("chimera.lang");
+  });
+});

--- a/apps/desktop/src/components/Governance.tsx
+++ b/apps/desktop/src/components/Governance.tsx
@@ -227,6 +227,12 @@ function AuditPanel({ data, t }: { data: GovernanceAudit; t: TFunc }) {
  *  something. It is `warn`, it names the reason, and it says what still applies.
  */
 function SandboxPanel({ data, t }: { data: SandboxState; t: TFunc }) {
+  // `t` returns the key itself when it has no entry, so an unknown code would print
+  // "governance.sandbox.why.something" at the reader. Compare against the key to detect that and
+  // fall through to the server's English instead.
+  const reasonKey = data.reason_code ? `governance.sandbox.why.${data.reason_code}` : "";
+  const translated = reasonKey ? t(reasonKey) : "";
+  const reasonText = translated === reasonKey ? "" : translated;
   return (
     <Panel title={t("governance.sandbox.title")}>
       <div className="flex items-start gap-3 px-4 py-4">
@@ -239,8 +245,15 @@ function SandboxPanel({ data, t }: { data: SandboxState; t: TFunc }) {
           <span className="text-sm text-foreground">
             {data.isolated ? t("governance.sandbox.isolated") : t("governance.sandbox.host")}
           </span>
-          {data.reason && (
-            <span className="text-xs text-muted-foreground">{data.reason}</span>
+          {/* The CODE decides the sentence, not the server's prose. This app ships in ten
+              languages and this line arrived in English beside translated text — on the one
+              screen a person opens to learn what protects them, which is the worst place to
+              be unreadable. `data.reason` stays the fallback: a cause this build has no
+              translation for must still say something, and English beats blank. */}
+          {(reasonText || data.reason) && (
+            <span className="text-xs text-muted-foreground">
+              {reasonText || data.reason}
+            </span>
           )}
           {/* What still applies when the kernel boundary does not. Without this the panel reads as
               "you have nothing", and the kernel, the write region and the confirmation prompt are

--- a/apps/desktop/src/components/Knowledge.test.tsx
+++ b/apps/desktop/src/components/Knowledge.test.tsx
@@ -43,7 +43,7 @@ afterEach(() => {
 function stubEmpty() {
   getMemory.mockResolvedValue([]);
   getMemoryLayers.mockResolvedValue({ layers: [], total: 0 });
-  getSkills.mockResolvedValue({ stats: [], retirement_candidates: [] });
+  getSkills.mockResolvedValue({ stats: [], retirement_candidates: [], cards_read: true });
   getMemoryProfile.mockResolvedValue({ profile: "", persona: [] });
 }
 

--- a/apps/desktop/src/components/Skills.library.test.tsx
+++ b/apps/desktop/src/components/Skills.library.test.tsx
@@ -46,7 +46,7 @@ function card(over: Record<string, unknown> = {}) {
 describe("Skills — the curated library", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getSkills).mockResolvedValue({ stats: [], retirement_candidates: [] } as never);
+    vi.mocked(getSkills).mockResolvedValue({ stats: [], retirement_candidates: [], cards_read: true } as never);
     vi.mocked(getSkillLibrary).mockResolvedValue([
       card(),
       card({ name: "chimera-thin-vertical-slice", description: "One slice end to end.", stage: "build" }),

--- a/apps/desktop/src/components/Skills.notread.test.tsx
+++ b/apps/desktop/src/components/Skills.notread.test.tsx
@@ -1,0 +1,79 @@
+/** A count of zero means two different things, and the screen was showing the count without the flag.
+ *
+ * Measured on a real install: fourteen learned cards, every one marked ACTIVE, every one reading
+ * `0 uses · 0 wins`. The available reading is that the agent tried them and they were useless. What
+ * actually happened is that nothing consulted them — retrieval is off by default because it was
+ * measured (+16.7pp, a confidence interval including zero, +300% tokens) and left off.
+ *
+ * The person who draws the wrong conclusion goes looking for a bug in the cards.
+ */
+
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Skills } from "@/components/Skills";
+import { getSkills } from "@/lib/api";
+import { renderWithProviders } from "@/test/utils";
+
+// The FULL surface the screen touches, not a plausible subset: a mock missing one export throws
+// during render, and every assertion in the file then fails about a function none of them test.
+vi.mock("@/lib/api", () => ({
+  getSkills: vi.fn(),
+  approveSkill: vi.fn(),
+  retireSkill: vi.fn(),
+  getSkillLibrary: vi.fn(async () => []),
+  getSkillLibraryCard: vi.fn(),
+  importSkillLibraryCard: vi.fn(),
+  getSkillCatalog: vi.fn(async () => []),
+  getSkillBundles: vi.fn(async () => []),
+  installSkillBundle: vi.fn(),
+  setSkillBundleStatus: vi.fn(),
+  uninstallSkillBundle: vi.fn(),
+}));
+
+const mockSkills = vi.mocked(getSkills);
+
+function body(cards_read: boolean) {
+  return {
+    stats: [{
+      name: "build_standalone_html_from_brief", kind: "learned", status: "active",
+      provenance: "clean", uses: 0, successes: 0, rate: null,
+    }],
+    retirement_candidates: [],
+    cards_read,
+  } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Skills — why every count is zero", () => {
+  it("says nothing reads these when retrieval is off", async () => {
+    mockSkills.mockResolvedValue(body(false));
+
+    renderWithProviders(<Skills />);
+
+    expect(await screen.findByText(/nothing consults them/i)).toBeTruthy();
+  });
+
+  it("stays quiet when retrieval IS on, because then zero is a verdict", async () => {
+    // The note must not become furniture. With reading on, `0 uses` really does mean the card was
+    // available and never picked — and a permanent disclaimer would explain that away.
+    mockSkills.mockResolvedValue(body(true));
+
+    renderWithProviders(<Skills />);
+
+    await screen.findByText(/build_standalone_html_from_brief/);
+    expect(screen.queryByText(/nothing consults them/i)).toBeNull();
+  });
+
+  it("still lists the cards themselves", async () => {
+    // The note is an explanation, not a replacement: it sits above the list and the list stays.
+    mockSkills.mockResolvedValue(body(false));
+
+    renderWithProviders(<Skills />);
+
+    expect(await screen.findByText(/build_standalone_html_from_brief/)).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/components/Skills.reactivate.test.tsx
+++ b/apps/desktop/src/components/Skills.reactivate.test.tsx
@@ -52,7 +52,7 @@ describe("a retired skill can be put back to work", () => {
   it("offers a way back, and it is not the approve-a-stranger wording", async () => {
     vi.mocked(getSkills).mockResolvedValue({
       stats: [stat({ status: "retired" })],
-      retirement_candidates: [],
+      retirement_candidates: [], cards_read: true,
     });
     renderWithProviders(<Skills />);
 
@@ -72,7 +72,7 @@ describe("a retired skill can be put back to work", () => {
     // put "Reactivate" beside every active skill on the screen.
     vi.mocked(getSkills).mockResolvedValue({
       stats: [stat({ status: "active" })],
-      retirement_candidates: [],
+      retirement_candidates: [], cards_read: true,
     });
     renderWithProviders(<Skills />);
 
@@ -87,7 +87,7 @@ describe("a retired skill can be put back to work", () => {
     // tainted, and one the user retired themselves. The words must not swap.
     vi.mocked(getSkills).mockResolvedValue({
       stats: [stat({ status: "pending" })],
-      retirement_candidates: [],
+      retirement_candidates: [], cards_read: true,
     });
     renderWithProviders(<Skills />);
 

--- a/apps/desktop/src/components/Skills.tsx
+++ b/apps/desktop/src/components/Skills.tsx
@@ -174,7 +174,18 @@ export function Skills({ embedded = false }: { embedded?: boolean } = {}) {
         ) : rows.length === 0 ? (
           <EmptyState text={t("skills.empty")} />
         ) : (
-          rows.map((s) => (
+          <>
+            {/* Why every count below is zero. Without this the list reads as "the agent tried
+                these and they did not help", when in fact nothing consulted them: retrieval is
+                off by default because it was measured and did not earn its tokens. A card marked
+                ACTIVE beside `0 uses` invites exactly the wrong conclusion, and the person who
+                draws it goes looking for a bug in the cards. */}
+            {skills.data?.cards_read === false && (
+              <div className="px-4 pb-1 pt-3 text-xs text-muted-foreground">
+                {t("skills.notRead")}
+              </div>
+            )}
+            {rows.map((s) => (
             <div key={s.name} className="flex items-center gap-3 px-4 py-3">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
@@ -222,7 +233,8 @@ export function Skills({ embedded = false }: { embedded?: boolean } = {}) {
                 )}
               </div>
             </div>
-          ))
+            ))}
+          </>
         )}
       </Panel>
 

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -5719,6 +5719,12 @@ export interface components {
              * @default
              */
             reason: string;
+            /**
+             * Reason Code
+             * @default
+             * @enum {string}
+             */
+            reason_code: "" | "windows" | "bwrap_missing" | "userns_refused" | "seatbelt_missing" | "unsupported_os" | "no_container";
         };
         /**
          * SearchHitOut
@@ -5821,6 +5827,11 @@ export interface components {
         };
         /** SkillsOut */
         SkillsOut: {
+            /**
+             * Cards Read
+             * @default false
+             */
+            cards_read: boolean;
             /** Retirement Candidates */
             retirement_candidates: string[];
             /** Stats */

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -41,7 +41,7 @@ import type {
   PoolWrite,
   ProjectState,
   RunReceipt,
-  SkillStat,
+  SkillsResponse,
   TaskCard,
   Tools,
   UsageSummary,
@@ -429,8 +429,7 @@ export const deleteMemory = (id: string) =>
   json<{ deleted: boolean }>(`/api/memory/${id}`, { method: "DELETE" });
 
 // --- Skills ---
-export const getSkills = () =>
-  json<{ stats: SkillStat[]; retirement_candidates: string[] }>("/api/skills");
+export const getSkills = () => json<SkillsResponse>("/api/skills");
 export const approveSkill = (name: string) =>
   json<{ approved: boolean }>(`/api/skills/${name}/approve`, { method: "POST" });
 export const retireSkill = (name: string) =>

--- a/apps/desktop/src/lib/i18n.reachable.test.ts
+++ b/apps/desktop/src/lib/i18n.reachable.test.ts
@@ -39,6 +39,11 @@ const DYNAMIC = [
   "crew.approach.",
   "crew.status.",
   "fusion.role.",
+  // `` t(`governance.sandbox.why.${data.reason_code}`) `` — the Security screen says WHY no
+  // kernel boundary applies, in the reader's language rather than relaying the server's
+  // English. The codes come from `chimera.sandbox.os_sandbox.UnavailableCode` plus the API
+  // layer's own `no_container`.
+  "governance.sandbox.why.",
   "lifecycle.stage.",
   "runs.reqs.kind.",
   "lifecycle.status.",

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -390,6 +390,8 @@ const en: Dict = {
   "skills.status.provisional": "provisional",
   "skills.status.pending": "pending",
   "skills.status.retired": "retired",
+  "skills.notRead":
+    "Reading these during a run is off, so nothing consults them — a count of zero here is not a verdict on the card.",
   "skills.learned": "Learned skills",
   "skills.retire": "Retire",
   "skills.reactivate": "Reactivate",
@@ -409,6 +411,7 @@ const en: Dict = {
   "cron.add.deliver": "Discord or Slack webhook URL (optional)",
   "cron.add.verify":
     "test command that proves the work (optional) — empty means no gate",
+  "cron.gatedBy": "gated by {command}",
   "cron.deliversTo": "delivers to {host}",
   "cron.lastAnswer": "Answered {when}",
   "cron.deliveryFailed": "delivery failed",
@@ -1009,6 +1012,18 @@ const en: Dict = {
     "Commands would run on this machine — no kernel sandbox applies here.",
   "governance.sandbox.stillApplies":
     "The governance kernel, the write region and the confirmation prompt still apply — they are not a jail.",
+  "governance.sandbox.why.windows":
+    "Windows has no OS sandbox in Chimera: the mechanism there is a restricted token plus network filters, which is native work this does not attempt. Set CHIMERA_SANDBOX=docker for a real boundary.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap is not installed (apt install bubblewrap), so commands run on this machine.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap is installed, but this kernel refuses to unshare a user namespace — common inside containers and on hardened kernels — so commands run on this machine.",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec is missing, so commands run on this machine.",
+  "governance.sandbox.why.unsupported_os":
+    "No OS sandbox is implemented for this system, so commands run on this machine.",
+  "governance.sandbox.why.no_container":
+    "A container was configured and none answered.",
   "governance.sandbox.configured":
     "asked for: {value}",
   "governance.sandbox.backend":
@@ -1647,6 +1662,8 @@ const pt: Dict = {
   "skills.status.provisional": "provisória",
   "skills.status.pending": "pendente",
   "skills.status.retired": "aposentada",
+  "skills.notRead":
+    "A leitura destes cartões durante uma execução está desligada, então nada os consulta — um zero aqui não é um veredito sobre o cartão.",
   "skills.learned": "Habilidades aprendidas",
   "skills.retire": "Aposentar",
   "skills.reactivate": "Reativar",
@@ -1667,6 +1684,7 @@ const pt: Dict = {
   "cron.add.deliver": "URL de webhook do Discord ou Slack (opcional)",
   "cron.add.verify":
     "comando de teste que prova o trabalho (opcional) — vazio = sem portão",
+  "cron.gatedBy": "com portão: {command}",
   "cron.deliversTo": "entrega em {host}",
   "cron.lastAnswer": "Respondeu {when}",
   "cron.deliveryFailed": "entrega falhou",
@@ -2274,6 +2292,18 @@ const pt: Dict = {
     "Os comandos rodariam nesta máquina — nenhum sandbox de kernel se aplica aqui.",
   "governance.sandbox.stillApplies":
     "O kernel de governança, a região de escrita e o pedido de confirmação continuam valendo — eles não são uma jaula.",
+  "governance.sandbox.why.windows":
+    "O Windows não tem sandbox de sistema no Chimera: o mecanismo lá é um token restrito mais filtros de rede, trabalho nativo que este projeto não tenta. Use CHIMERA_SANDBOX=docker para ter uma fronteira de verdade.",
+  "governance.sandbox.why.bwrap_missing":
+    "O bubblewrap não está instalado (apt install bubblewrap), então os comandos rodam nesta máquina.",
+  "governance.sandbox.why.userns_refused":
+    "O bubblewrap está instalado, mas este kernel recusa separar um namespace de usuário — comum dentro de contêineres e em kernels endurecidos — então os comandos rodam nesta máquina.",
+  "governance.sandbox.why.seatbelt_missing":
+    "O sandbox-exec não foi encontrado, então os comandos rodam nesta máquina.",
+  "governance.sandbox.why.unsupported_os":
+    "Não há sandbox de sistema implementado para este sistema, então os comandos rodam nesta máquina.",
+  "governance.sandbox.why.no_container":
+    "Um contêiner foi configurado e nenhum respondeu.",
   "governance.sandbox.configured":
     "pedido: {value}",
   "governance.sandbox.backend":
@@ -2603,6 +2633,7 @@ const es: Dict = {
   "cron.add.deliver": "URL de webhook de Discord o Slack (opcional)",
   "cron.add.verify":
     "comando de prueba que demuestra el trabajo (opcional) — vacío = sin puerta",
+  "cron.gatedBy": "con puerta: {command}",
   "cron.deliversTo": "entrega en {host}",
   "cron.lastAnswer": "Respondió {when}",
   "cron.deliveryFailed": "la entrega falló",
@@ -2938,6 +2969,8 @@ const es: Dict = {
   "skills.status.provisional": "provisional",
   "skills.status.pending": "pendiente",
   "skills.status.retired": "retirada",
+  "skills.notRead":
+    "La lectura de estas tarjetas durante una ejecución está desactivada, así que nada las consulta: un cero aquí no es un veredicto sobre la tarjeta.",
   "skills.learned": "Habilidades aprendidas",
   "skills.retire": "Retirar",
   "skills.reactivate": "Reactivar",
@@ -3551,6 +3584,18 @@ const es: Dict = {
     "Los comandos se ejecutarían en esta máquina: aquí no se aplica ningún sandbox del kernel.",
   "governance.sandbox.stillApplies":
     "El kernel de gobernanza, la región de escritura y la confirmación siguen vigentes: no son una jaula.",
+  "governance.sandbox.why.windows":
+    "Windows no tiene sandbox del sistema en Chimera: el mecanismo allí es un token restringido más filtros de red, trabajo nativo que este proyecto no intenta. Usa CHIMERA_SANDBOX=docker para tener una frontera real.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap no está instalado (apt install bubblewrap), así que los comandos se ejecutan en esta máquina.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap está instalado, pero este kernel se niega a separar un espacio de nombres de usuario —habitual dentro de contenedores y en kernels endurecidos—, así que los comandos se ejecutan en esta máquina.",
+  "governance.sandbox.why.seatbelt_missing":
+    "Falta sandbox-exec, así que los comandos se ejecutan en esta máquina.",
+  "governance.sandbox.why.unsupported_os":
+    "No hay sandbox del sistema implementado para este sistema, así que los comandos se ejecutan en esta máquina.",
+  "governance.sandbox.why.no_container":
+    "Se configuró un contenedor y ninguno respondió.",
   "governance.sandbox.configured":
     "solicitado: {value}",
   "governance.sandbox.backend":
@@ -3882,6 +3927,7 @@ const fr: Dict = {
   "cron.add.deliver": "URL de webhook Discord ou Slack (facultatif)",
   "cron.add.verify":
     "commande de test qui prouve le travail (facultatif) — vide = sans garde",
+  "cron.gatedBy": "vérifié par {command}",
   "cron.deliversTo": "livre sur {host}",
   "cron.lastAnswer": "Répondu {when}",
   "cron.deliveryFailed": "l'envoi a échoué",
@@ -4220,6 +4266,8 @@ const fr: Dict = {
   "skills.status.provisional": "provisoire",
   "skills.status.pending": "en attente",
   "skills.status.retired": "retirée",
+  "skills.notRead":
+    "La lecture de ces fiches pendant une exécution est désactivée, donc rien ne les consulte — un zéro ici n'est pas un verdict sur la fiche.",
   "skills.learned": "Compétences apprises",
   "skills.retire": "Retirer",
   "skills.reactivate": "Réactiver",
@@ -4840,6 +4888,18 @@ const fr: Dict = {
     "Les commandes s'exécuteraient sur cette machine — aucun bac à sable du noyau ne s'applique ici.",
   "governance.sandbox.stillApplies":
     "Le noyau de gouvernance, la région d'écriture et la confirmation s'appliquent toujours — ce n'est pas une prison.",
+  "governance.sandbox.why.windows":
+    "Windows n'a pas de bac à sable système dans Chimera : le mécanisme y repose sur un jeton restreint et des filtres réseau, un travail natif que ce projet ne tente pas. Utilisez CHIMERA_SANDBOX=docker pour une vraie frontière.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap n'est pas installé (apt install bubblewrap), donc les commandes s'exécutent sur cette machine.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap est installé, mais ce noyau refuse de détacher un espace de noms utilisateur — fréquent dans les conteneurs et sur les noyaux durcis — donc les commandes s'exécutent sur cette machine.",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec est absent, donc les commandes s'exécutent sur cette machine.",
+  "governance.sandbox.why.unsupported_os":
+    "Aucun bac à sable système n'est implémenté pour ce système, donc les commandes s'exécutent sur cette machine.",
+  "governance.sandbox.why.no_container":
+    "Un conteneur a été configuré et aucun n'a répondu.",
   "governance.sandbox.configured":
     "demandé : {value}",
   "governance.sandbox.backend":
@@ -5172,6 +5232,7 @@ const de: Dict = {
   "cron.add.deliver": "Discord- oder Slack-Webhook-URL (optional)",
   "cron.add.verify":
     "Testbefehl, der die Arbeit belegt (optional) — leer = kein Gate",
+  "cron.gatedBy": "geprüft durch {command}",
   "cron.deliversTo": "liefert an {host}",
   "cron.lastAnswer": "Geantwortet {when}",
   "cron.deliveryFailed": "Zustellung fehlgeschlagen",
@@ -5510,6 +5571,8 @@ const de: Dict = {
   "skills.status.provisional": "vorläufig",
   "skills.status.pending": "ausstehend",
   "skills.status.retired": "stillgelegt",
+  "skills.notRead":
+    "Das Lesen dieser Karten während eines Laufs ist ausgeschaltet, also zieht sie niemand heran — eine Null hier ist kein Urteil über die Karte.",
   "skills.learned": "Erlernte Fähigkeiten",
   "skills.retire": "Zurückziehen",
   "skills.reactivate": "Reaktivieren",
@@ -6128,6 +6191,18 @@ const de: Dict = {
     "Befehle würden auf diesem Rechner laufen — hier greift keine Kernel-Sandbox.",
   "governance.sandbox.stillApplies":
     "Governance-Kernel, Schreibbereich und Bestätigung gelten weiterhin — ein Gefängnis sind sie nicht.",
+  "governance.sandbox.why.windows":
+    "Windows hat in Chimera keine Betriebssystem-Sandbox: Der Mechanismus dort besteht aus einem eingeschränkten Token plus Netzwerkfiltern — native Arbeit, die dieses Projekt nicht unternimmt. Nutze CHIMERA_SANDBOX=docker für eine echte Grenze.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap ist nicht installiert (apt install bubblewrap), daher laufen Befehle auf diesem Rechner.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap ist installiert, aber dieser Kernel verweigert einen eigenen User-Namespace — üblich in Containern und auf gehärteten Kerneln — daher laufen Befehle auf diesem Rechner.",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec fehlt, daher laufen Befehle auf diesem Rechner.",
+  "governance.sandbox.why.unsupported_os":
+    "Für dieses System ist keine Betriebssystem-Sandbox implementiert, daher laufen Befehle auf diesem Rechner.",
+  "governance.sandbox.why.no_container":
+    "Ein Container war konfiguriert und keiner hat geantwortet.",
   "governance.sandbox.configured":
     "angefordert: {value}",
   "governance.sandbox.backend":
@@ -6456,6 +6531,7 @@ const zh: Dict = {
   "cron.add.deliver": "Discord 或 Slack 的 webhook 链接（可选）",
   "cron.add.verify":
     "证明工作完成的测试命令（可选）—— 留空则无门禁",
+  "cron.gatedBy": "由 {command} 把关",
   "cron.deliversTo": "发送到 {host}",
   "cron.lastAnswer": "{when} 的回答",
   "cron.deliveryFailed": "发送失败",
@@ -6769,6 +6845,8 @@ const zh: Dict = {
   "skills.status.provisional": "暂定",
   "skills.status.pending": "待定",
   "skills.status.retired": "已停用",
+  "skills.notRead":
+    "运行期间读取这些卡片的功能已关闭，因此没有任何环节会参考它们——这里的零并不是对卡片的评价。",
   "skills.learned": "已学技能",
   "skills.retire": "停用",
   "skills.reactivate": "重新启用",
@@ -7343,6 +7421,18 @@ const zh: Dict = {
     "命令将在这台机器上运行——此处不适用内核沙箱。",
   "governance.sandbox.stillApplies":
     "治理内核、写入范围和确认提示仍然生效——但它们不是牢笼。",
+  "governance.sandbox.why.windows":
+    "Chimera 在 Windows 上没有操作系统级沙箱：那里的机制是受限令牌加网络过滤器，属于本项目未涉足的原生开发。设置 CHIMERA_SANDBOX=docker 可获得真正的边界。",
+  "governance.sandbox.why.bwrap_missing":
+    "未安装 bubblewrap（apt install bubblewrap），因此命令在本机上运行。",
+  "governance.sandbox.why.userns_refused":
+    "已安装 bubblewrap，但此内核拒绝分离用户命名空间——在容器中和加固内核上很常见——因此命令在本机上运行。",
+  "governance.sandbox.why.seatbelt_missing":
+    "缺少 sandbox-exec，因此命令在本机上运行。",
+  "governance.sandbox.why.unsupported_os":
+    "本系统没有实现操作系统级沙箱，因此命令在本机上运行。",
+  "governance.sandbox.why.no_container":
+    "已配置容器，但没有任何容器响应。",
   "governance.sandbox.configured":
     "请求：{value}",
   "governance.sandbox.backend":
@@ -7670,6 +7760,7 @@ const ja: Dict = {
   "cron.add.deliver": "Discord または Slack の webhook URL（任意）",
   "cron.add.verify":
     "作業を検証するテストコマンド（任意）— 空ならゲートなし",
+  "cron.gatedBy": "{command} で検証",
   "cron.deliversTo": "{host} に届けます",
   "cron.lastAnswer": "{when} の回答",
   "cron.deliveryFailed": "配信に失敗",
@@ -8002,6 +8093,8 @@ const ja: Dict = {
   "skills.status.provisional": "暫定",
   "skills.status.pending": "保留中",
   "skills.status.retired": "廃止",
+  "skills.notRead":
+    "実行中にこれらのカードを読み込む機能はオフになっているため、どこからも参照されません。ここのゼロはカードへの評価ではありません。",
   "skills.learned": "習得したスキル",
   "skills.retire": "引退",
   "skills.reactivate": "再有効化",
@@ -8610,6 +8703,18 @@ const ja: Dict = {
     "コマンドはこの端末上で実行されます。ここではカーネルのサンドボックスは適用されません。",
   "governance.sandbox.stillApplies":
     "ガバナンスカーネル、書き込み範囲、確認プロンプトは引き続き有効です。ただし牢屋ではありません。",
+  "governance.sandbox.why.windows":
+    "Chimera には Windows 用の OS サンドボックスがありません。Windows での仕組みは制限付きトークンとネットワークフィルターで、本プロジェクトが手を出していないネイティブ実装です。本当の境界が必要なら CHIMERA_SANDBOX=docker を指定してください。",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap がインストールされていないため（apt install bubblewrap）、コマンドはこのマシン上で実行されます。",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap はインストールされていますが、このカーネルがユーザー名前空間の分離を拒否しています（コンテナ内や強化カーネルでよくあります）。そのためコマンドはこのマシン上で実行されます。",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec が見つからないため、コマンドはこのマシン上で実行されます。",
+  "governance.sandbox.why.unsupported_os":
+    "このシステム向けの OS サンドボックスは実装されていないため、コマンドはこのマシン上で実行されます。",
+  "governance.sandbox.why.no_container":
+    "コンテナが設定されていましたが、どれも応答しませんでした。",
   "governance.sandbox.configured":
     "要求: {value}",
   "governance.sandbox.backend":
@@ -9256,6 +9361,8 @@ const it: Dict = {
   "skills.status.provisional": "provvisoria",
   "skills.status.pending": "in attesa",
   "skills.status.retired": "ritirata",
+  "skills.notRead":
+    "La lettura di queste schede durante un'esecuzione è disattivata, quindi nulla le consulta: uno zero qui non è un verdetto sulla scheda.",
   "skills.learned": "Skill apprese",
   "skills.retire": "Ritira",
   "skills.reactivate": "Riattiva",
@@ -9276,6 +9383,7 @@ const it: Dict = {
   "cron.add.deliver": "URL webhook di Discord o Slack (facoltativo)",
   "cron.add.verify":
     "comando di test che dimostra il lavoro (opzionale) — vuoto = nessun gate",
+  "cron.gatedBy": "verificato da {command}",
   "cron.deliversTo": "consegna su {host}",
   "cron.lastAnswer": "Ha risposto {when}",
   "cron.deliveryFailed": "consegna fallita",
@@ -9892,6 +10000,18 @@ const it: Dict = {
     "I comandi verrebbero eseguiti su questa macchina: qui non si applica alcuna sandbox del kernel.",
   "governance.sandbox.stillApplies":
     "Il kernel di governance, la regione di scrittura e la conferma restano attivi: non sono una prigione.",
+  "governance.sandbox.why.windows":
+    "Windows non ha una sandbox di sistema in Chimera: il meccanismo lì è un token limitato più filtri di rete, lavoro nativo che questo progetto non tenta. Usa CHIMERA_SANDBOX=docker per avere un confine vero.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap non è installato (apt install bubblewrap), quindi i comandi girano su questa macchina.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap è installato, ma questo kernel rifiuta di separare un namespace utente — comune nei container e sui kernel irrigiditi — quindi i comandi girano su questa macchina.",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec non è presente, quindi i comandi girano su questa macchina.",
+  "governance.sandbox.why.unsupported_os":
+    "Nessuna sandbox di sistema è implementata per questo sistema, quindi i comandi girano su questa macchina.",
+  "governance.sandbox.why.no_container":
+    "Un container era configurato e nessuno ha risposto.",
   "governance.sandbox.configured":
     "richiesto: {value}",
   "governance.sandbox.backend":
@@ -10537,6 +10657,8 @@ const pl: Dict = {
   "skills.status.provisional": "tymczasowa",
   "skills.status.pending": "oczekująca",
   "skills.status.retired": "wycofana",
+  "skills.notRead":
+    "Czytanie tych kart podczas uruchomienia jest wyłączone, więc nic z nich nie korzysta — zero nie jest tu oceną karty.",
   "skills.learned": "Wyuczone umiejętności",
   "skills.retire": "Wycofaj",
   "skills.reactivate": "Przywróć",
@@ -10557,6 +10679,7 @@ const pl: Dict = {
   "cron.add.deliver": "Adres webhooka Discord lub Slack (opcjonalnie)",
   "cron.add.verify":
     "polecenie testowe potwierdzające pracę (opcjonalnie) — puste = bez bramki",
+  "cron.gatedBy": "bramkowane przez {command}",
   "cron.deliversTo": "wysyła na {host}",
   "cron.lastAnswer": "Odpowiedź {when}",
   "cron.deliveryFailed": "wysyłka nie powiodła się",
@@ -11167,6 +11290,18 @@ const pl: Dict = {
     "Polecenia działałyby na tej maszynie — nie obowiązuje tu żadna piaskownica jądra.",
   "governance.sandbox.stillApplies":
     "Jądro nadzoru, obszar zapisu i pytanie o zgodę nadal obowiązują — nie są więzieniem.",
+  "governance.sandbox.why.windows":
+    "Windows nie ma w Chimerze piaskownicy systemowej: mechanizm tam to token o ograniczonych uprawnieniach plus filtry sieciowe — natywna praca, której ten projekt nie podejmuje. Ustaw CHIMERA_SANDBOX=docker, aby mieć prawdziwą granicę.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap nie jest zainstalowany (apt install bubblewrap), więc polecenia działają na tej maszynie.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap jest zainstalowany, ale to jądro odmawia wydzielenia przestrzeni nazw użytkownika — częste w kontenerach i na utwardzonych jądrach — więc polecenia działają na tej maszynie.",
+  "governance.sandbox.why.seatbelt_missing":
+    "Brakuje sandbox-exec, więc polecenia działają na tej maszynie.",
+  "governance.sandbox.why.unsupported_os":
+    "Dla tego systemu nie zaimplementowano piaskownicy systemowej, więc polecenia działają na tej maszynie.",
+  "governance.sandbox.why.no_container":
+    "Kontener został skonfigurowany i żaden nie odpowiedział.",
   "governance.sandbox.configured":
     "żądano: {value}",
   "governance.sandbox.backend":
@@ -11813,6 +11948,8 @@ const ru: Dict = {
   "skills.status.provisional": "предварительный",
   "skills.status.pending": "ожидает",
   "skills.status.retired": "выведен",
+  "skills.notRead":
+    "Чтение этих карточек во время запуска выключено, поэтому к ним никто не обращается — ноль здесь не приговор карточке.",
   "skills.learned": "Усвоенные навыки",
   "skills.retire": "Вывести из обращения",
   "skills.reactivate": "Вернуть в работу",
@@ -11833,6 +11970,7 @@ const ru: Dict = {
   "cron.add.deliver": "URL вебхука Discord или Slack (необязательно)",
   "cron.add.verify":
     "команда теста, подтверждающая работу (необязательно) — пусто = без ворот",
+  "cron.gatedBy": "проверяется командой {command}",
   "cron.deliversTo": "отправляет в {host}",
   "cron.lastAnswer": "Ответ от {when}",
   "cron.deliveryFailed": "доставка не удалась",
@@ -12448,6 +12586,18 @@ const ru: Dict = {
     "Команды выполнялись бы на этой машине — песочница ядра здесь не применяется.",
   "governance.sandbox.stillApplies":
     "Ядро управления, область записи и запрос подтверждения продолжают действовать — но это не тюрьма.",
+  "governance.sandbox.why.windows":
+    "В Windows у Chimera нет песочницы уровня ОС: механизм там — ограниченный токен плюс сетевые фильтры, нативная работа, за которую этот проект не берётся. Задайте CHIMERA_SANDBOX=docker, чтобы получить настоящую границу.",
+  "governance.sandbox.why.bwrap_missing":
+    "bubblewrap не установлен (apt install bubblewrap), поэтому команды выполняются на этой машине.",
+  "governance.sandbox.why.userns_refused":
+    "bubblewrap установлен, но это ядро отказывается выделить пользовательское пространство имён — обычное дело в контейнерах и на укреплённых ядрах — поэтому команды выполняются на этой машине.",
+  "governance.sandbox.why.seatbelt_missing":
+    "sandbox-exec отсутствует, поэтому команды выполняются на этой машине.",
+  "governance.sandbox.why.unsupported_os":
+    "Для этой системы песочница уровня ОС не реализована, поэтому команды выполняются на этой машине.",
+  "governance.sandbox.why.no_container":
+    "Контейнер был настроен, и ни один не ответил.",
   "governance.sandbox.configured":
     "запрошено: {value}",
   "governance.sandbox.backend":

--- a/apps/desktop/src/lib/types.ts
+++ b/apps/desktop/src/lib/types.ts
@@ -16,6 +16,13 @@ export type MemoryItem = Schemas["MemoryItemOut"];
 export type MemoryLayers = Schemas["MemoryLayersOut"];
 export type MemoryProfile = Schemas["MemoryProfileOut"];
 export type SkillStat = Schemas["SkillStatOut"];
+/** The whole `GET /api/skills` body, from the generated schema rather than spelled out at
+ *  the call site. A hand-written shape there silently stops at whatever the backend had the
+ *  day it was typed — this repo has already shipped one field that reached the schema, the
+ *  generated types and the drift gate, and never the screen, because a local type shadowed
+ *  it. Only `npm run build` catches that: vitest does not typecheck, and the drift gate
+ *  compares generated types to the schema, where there was never any drift. */
+export type SkillsResponse = Schemas["SkillsOut"];
 /** One curated skill card that ships in the box, as opposed to a `SkillStat`, which is one the
  *  agent distilled from the user's own runs. `body` is empty in the list and filled on detail. */
 export type LibraryCard = Schemas["LibraryCardOut"];

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -935,7 +935,7 @@ def build_api_app(
         from chimera.sandbox.os_sandbox import (
             bubblewrap_available,
             seatbelt_available,
-            unavailable_reason,
+            unavailable_cause,
         )
 
         live = live_settings()
@@ -953,17 +953,29 @@ def build_api_app(
             )
         else:
             backend = "host"
+        if isolated:
+            reason_code, reason = "", ""
+        elif configured == "docker":
+            reason_code, reason = "no_container", "A container was configured and none answered."
+        elif configured == "local":
+            # Asked for the host and got the host: nothing failed, so there is nothing to explain.
+            reason_code, reason = "", ""
+        else:
+            reason_code, reason = unavailable_cause()
         return {
             "configured": configured,
             "backend": backend,
             "isolated": isolated,
-            # `unavailable_reason` speaks about the OS sandbox. A Docker install that fell back has
+            # `unavailable_cause` speaks about the OS sandbox. A Docker install that fell back has
             # a different cause, so it gets its own sentence rather than borrowing a wrong one.
-            "reason": "" if isolated else (
-                "A container was configured and none answered." if configured == "docker"
-                else "" if configured == "local"
-                else unavailable_reason()
-            ),
+            #
+            # The CODE is what the screen reads: this app is translated into ten languages, and a
+            # panel that relays an English sentence from the server explains the machine's boundary
+            # in a language its reader may not have. The sentence rides along as the fallback for a
+            # client that does not know the code yet — a new cause must degrade to English, never
+            # to silence.
+            "reason": reason,
+            "reason_code": reason_code,
             "platform": _platform.system(),
         }
 

--- a/chimera/api/features.py
+++ b/chimera/api/features.py
@@ -307,7 +307,13 @@ def register_features(
     @app.get("/api/skills", dependencies=[guard], response_model=SkillsOut)
     def list_skills() -> dict[str, Any]:
         store = _skill_store()
-        return {"stats": store.stats(), "retirement_candidates": store.retirement_candidates()}
+        return {
+            "stats": store.stats(),
+            "retirement_candidates": store.retirement_candidates(),
+            # Live, not the process default: this is a setting a person can change, and a screen
+            # explaining why a count is zero must explain the state the app is actually in.
+            "cards_read": bool(getattr(get_settings(), "skill_cards", False)),
+        }
 
     @app.post("/api/skills/{name}/approve", dependencies=[guard], response_model=ApprovedOut)
     def approve_skill(name: str) -> dict[str, bool]:

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -783,6 +783,14 @@ class SkillStatOut(BaseModel):
 class SkillsOut(BaseModel):
     stats: list[SkillStatOut]
     retirement_candidates: list[str]
+    cards_read: bool = False
+    """Whether a run actually retrieves these cards — ``CHIMERA_SKILL_CARDS``, off by default.
+
+    Without it the screen lists cards marked *active* with ``0 uses`` and no explanation, and the
+    only available reading is that the agent tried them and they were useless. The truth is that
+    nothing consulted them: reading was measured (+16.7pp, a confidence interval including zero,
+    +300% tokens) and left off. A count of zero means two very different things depending on this
+    flag, and the screen was showing the count without the flag."""
 
 
 class ApprovedOut(BaseModel):
@@ -880,6 +888,16 @@ class MessagingPlatformOut(BaseModel):
     error: str | None = None
 
 
+#: Why no kernel boundary applies. The OS causes come from `chimera.sandbox.os_sandbox`;
+#: ``no_container`` is this layer's own — a Docker install whose container never answered has a
+#: different cause from a machine with no OS sandbox, and borrowing the wrong sentence for it would
+#: send someone to install bubblewrap over a Docker daemon that is simply not running.
+SandboxReason = Literal[
+    "", "windows", "bwrap_missing", "userns_refused", "seatbelt_missing", "unsupported_os",
+    "no_container",
+]
+
+
 class SandboxStateOut(BaseModel):
     """Whether a command the model chooses can reach this machine, and if it can, why.
 
@@ -899,7 +917,16 @@ class SandboxStateOut(BaseModel):
     for a sandbox and getting one are different facts, and conflating them is how "I thought it was
     sandboxed" happens."""
     reason: str = ""
-    """Why not, in a sentence a person can act on. Empty when it IS isolated."""
+    """Why not, in a sentence a person can act on. Empty when it IS isolated.
+
+    ENGLISH, always, and the fallback rather than the display value — see ``reason_code``."""
+    reason_code: SandboxReason = ""
+    """Which cause, for a screen to say in its reader's language.
+
+    The app ships in ten languages and this panel was printing the server's English sentence beside
+    its own translated prose, on the one screen a person opens to learn what protects them. Same
+    shape and same reason as ``PostureFacts.fell_back_reason``. A client that meets a code it does
+    not know falls back to ``reason``: a new cause must degrade to English, never to silence."""
     platform: str = ""
     """The OS, because the answer is different on each and the reason names it."""
 

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -63,6 +63,10 @@ from chimera.telemetry import get_logger
 
 _log = get_logger("core.autonomous")
 
+#: Per side of a remembered fact — the task's opening line and the answer's. A fact is
+#: recalled into a later run's context, so its size is a recurring cost, not a one-off.
+_FACT_CHARS = 160
+
 # --diff-feedback wording and bound. Fixed in bench/retry_lift/PREREGISTRATION.md BEFORE the run that
 # measures it, because framing and truncation are the most temptingly tunable knobs in the whole
 # experiment — "it didn't work, let me reword the prompt" is how a null becomes a fabricated win.
@@ -1540,13 +1544,28 @@ class AutonomousAgent:
         """
         if self.memory is None:
             return
-        snippet = next((line.strip() for line in answer.splitlines() if line.strip()), "")[:160]
-        fact = f"Accomplished: {task}" + (f" — {snippet}" if snippet else "")
+        # The task's OPENING LINE, bounded — the same treatment the answer already got, and for
+        # the same reason. A memory fact is meant to be recalled; the whole request is a
+        # transcript. Measured on a real install: four facts of 630-950 characters, each one an
+        # entire project brief followed by an entire answer, sitting in the context budget of every
+        # later run in that folder. The same four under this rule are 31-36 characters of task.
+        #
+        # First line rather than a prefix of the whole: a brief opens with what it wants and
+        # continues with how, so the opening line is the part that identifies it — and a prefix
+        # cut at 160 lands mid-sentence in the middle of the instructions.
+        head = next((line.strip() for line in task.splitlines() if line.strip()), "")[:_FACT_CHARS]
+        snippet = next(
+            (line.strip() for line in answer.splitlines() if line.strip()), ""
+        )[:_FACT_CHARS]
+        fact = f"Accomplished: {head}" + (f" — {snippet}" if snippet else "")
         # Scoped to the folder the work happened in. "Accomplished: <task>" is about THIS
         # codebase, and a note from one project arriving as context in another is the noise this
         # exists to stop. A run with no workspace has no project and stays global.
         self.memory.remember(
             fact,
+            # Keyed on the FULL task, never on the shortened head: two briefs that open the same
+            # way — "Leia BRIEF.md e construa…" was four of them — are different work, and a key
+            # built from the head would fold them into one entry that overwrites itself.
             key=f"solve:{_slug(task)}",
             provenance="tainted" if tainted else "clean",
             project=str(self.workspace) if self.workspace else None,

--- a/chimera/sandbox/__init__.py
+++ b/chimera/sandbox/__init__.py
@@ -20,7 +20,12 @@ from typing import TYPE_CHECKING
 from chimera.sandbox.base import Sandbox, SandboxResult
 from chimera.sandbox.docker import DockerSandbox
 from chimera.sandbox.local import LocalSandbox
-from chimera.sandbox.os_sandbox import OsSandbox, os_sandbox_available, unavailable_reason
+from chimera.sandbox.os_sandbox import (
+    OsSandbox,
+    os_sandbox_available,
+    unavailable_cause,
+    unavailable_reason,
+)
 from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:
@@ -86,5 +91,6 @@ __all__ = [
     "OsSandbox",
     "get_sandbox",
     "os_sandbox_available",
+    "unavailable_cause",
     "unavailable_reason",
 ]

--- a/chimera/sandbox/os_sandbox.py
+++ b/chimera/sandbox/os_sandbox.py
@@ -34,6 +34,7 @@ import shutil
 import subprocess
 from functools import lru_cache
 from pathlib import Path
+from typing import Literal
 
 from chimera.sandbox.local import LocalSandbox
 from chimera.telemetry import get_logger
@@ -97,27 +98,48 @@ def os_sandbox_available() -> bool:
     return seatbelt_available() or bubblewrap_available()
 
 
-def unavailable_reason() -> str:
-    """Why not, in one sentence a person can act on. Empty when a sandbox IS available."""
+#: Machine-readable causes, so a screen can say this in the reader's language instead of relaying
+#: an English sentence from a server. Same shape and same reason as ``PostureFacts.fell_back_reason``:
+#: the app is translated into ten languages and the Security screen was printing this one in English
+#: beside its own translated prose, which reads as the panel not knowing what it is looking at.
+UnavailableCode = Literal[
+    "", "windows", "bwrap_missing", "userns_refused", "seatbelt_missing", "unsupported_os"
+]
+
+
+def unavailable_cause() -> tuple[UnavailableCode, str]:
+    """Why there is no OS sandbox, as ``(code, sentence)``. ``("", "")`` when one IS available.
+
+    One function returns both so they cannot drift: a code and a sentence maintained separately
+    eventually disagree, and the disagreement surfaces as a screen confidently explaining the wrong
+    cause. The sentence stays the fallback for a reader whose client does not know the code yet.
+    """
     if os_sandbox_available():
-        return ""
+        return "", ""
     system = platform.system()
     if system == "Windows":
-        return (
+        return "windows", (
             "Windows has no OS sandbox in Chimera: the mechanism there is a restricted token plus "
             "network filters, which is native work this does not attempt. Use CHIMERA_SANDBOX=docker "
             "for a real boundary."
         )
     if system == "Linux":
         if shutil.which("bwrap") is None:
-            return "bubblewrap is not installed (apt install bubblewrap), so commands run on the host."
-        return (
+            return "bwrap_missing", (
+                "bubblewrap is not installed (apt install bubblewrap), so commands run on the host."
+            )
+        return "userns_refused", (
             "bubblewrap is installed but this kernel refuses to unshare a user namespace "
             "(common in containers and on hardened kernels), so commands run on the host."
         )
     if system == "Darwin":
-        return f"{_SEATBELT} is missing, so commands run on the host."
-    return f"no OS sandbox is implemented for {system!r}, so commands run on the host."
+        return "seatbelt_missing", f"{_SEATBELT} is missing, so commands run on the host."
+    return "unsupported_os", f"no OS sandbox is implemented for {system!r}, so commands run on the host."
+
+
+def unavailable_reason() -> str:
+    """Why not, in one sentence a person can act on. Empty when a sandbox IS available."""
+    return unavailable_cause()[1]
 
 
 def _writable_roots(cwd: Path | None) -> list[Path]:

--- a/tests/test_a_remembered_fact_is_not_a_transcript.py
+++ b/tests/test_a_remembered_fact_is_not_a_transcript.py
@@ -1,0 +1,148 @@
+"""A long-term memory fact must be recallable, not a transcript of the request.
+
+Measured on a real install: four stored facts of 630-950 characters, each one an entire project
+brief followed by an entire answer, filed as a single *semantic fact*. They are scoped to their own
+folder, so the blast radius is small — but every later run in that folder pays context for them,
+and a fact's size is a recurring cost rather than a one-off.
+
+The answer side was already bounded. The task side was not, and the task is the long half.
+
+Free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.core.agent import AgentResult
+from chimera.core.autonomous import _FACT_CHARS, AutonomousAgent, AutonomousConfig
+
+BRIEFING = """Leia BRIEF.md e construa a pagina.
+
+Escreva o arquivo index.html na RAIZ desta pasta de trabalho — o mesmo lugar onde estao BRIEF.md
+e verificar.py. Nao crie subpastas, nao use caminhos de outros projetos, nao invente uma estrutura
+de diretorios. Um unico arquivo, com todo o CSS dentro de uma tag <style>: sem framework, sem CDN,
+sem fonte externa, porque a pagina precisa abrir offline. Cumpra o brief item por item."""
+
+
+class _Worker:
+    def run(self, task: str, **kwargs: Any) -> AgentResult:
+        return AgentResult(answer="Pronto.", steps=1, stopped_reason="final")
+
+
+class _Memory:
+    """Records what was filed, and under which key."""
+
+    def __init__(self) -> None:
+        self.facts: list[tuple[str, str]] = []
+
+    def remember(self, fact: str, *, key: str = "", **kwargs: Any) -> None:
+        self.facts.append((fact, key))
+
+    def search(self, *args: Any, **kwargs: Any) -> list[Any]:
+        return []
+
+
+def _remember(task: str, answer: str = "Pronto.") -> _Memory:
+    memory = _Memory()
+    auto = AutonomousAgent(
+        _Worker(), memory=memory, config=AutonomousConfig(use_planner=False, use_manager=False)
+    )
+    auto._remember_success(task, answer)
+    return memory
+
+
+# --- the size ------------------------------------------------------------------------------------
+
+
+def test_a_brief_is_remembered_by_what_it_asked_for() -> None:
+    """The measured case: 769 characters of brief became a 769-character "fact"."""
+    fact, _ = _remember(BRIEFING).facts[0]
+
+    assert "Leia BRIEF.md e construa a pagina." in fact
+    assert "sem framework, sem CDN" not in fact, "the whole brief is still in the fact"
+    assert len(fact) < 250, f"the fact is {len(fact)} characters"
+
+
+def test_a_long_single_line_task_is_cut_as_well() -> None:
+    """First-line-only is not a bound on its own: a task with no line breaks would pass through
+    whole, and the longest one measured on the real install was exactly that shape."""
+    fact, _ = _remember("x" * 900).facts[0]
+
+    assert len(fact) <= len("Accomplished: ") + _FACT_CHARS + len(" — ") + _FACT_CHARS
+
+
+def test_the_answer_side_stays_bounded_too() -> None:
+    """It always was. Pinned here so a change to one side does not quietly unbound the other."""
+    fact, _ = _remember("do the thing", answer="y" * 900).facts[0]
+
+    assert "y" * (_FACT_CHARS + 1) not in fact
+
+
+def test_a_short_task_is_left_alone() -> None:
+    """Most tasks are already short, and the fix must not turn those into something else."""
+    fact, _ = _remember("crie um arquivo OI.txt com a palavra oi").facts[0]
+
+    assert fact.startswith("Accomplished: crie um arquivo OI.txt com a palavra oi")
+
+
+# --- what must NOT change -------------------------------------------------------------------------
+
+
+def test_two_briefs_that_open_the_same_way_stay_two_facts() -> None:
+    """The key is what dedups, and four real briefs opened with "Leia BRIEF.md e construa…".
+
+    Keying on the shortened head would fold them into one entry that overwrites itself — the same
+    project's memory silently replacing another's, which is worse than the size it saves.
+    """
+    a = _remember("Leia BRIEF.md e construa a pagina.\n\nDetalhes A.").facts[0][1]
+    b = _remember("Leia BRIEF.md e construa a pagina.\n\nDetalhes B, bem diferentes.").facts[0][1]
+
+    assert a != b
+
+
+def test_the_same_task_still_updates_one_entry() -> None:
+    """The other half of the same property: re-solving one task must not accumulate entries."""
+    a = _remember(BRIEFING).facts[0][1]
+    b = _remember(BRIEFING).facts[0][1]
+
+    assert a == b
+
+
+def test_an_answer_that_is_only_whitespace_leaves_the_task_alone() -> None:
+    fact, _ = _remember("do the thing", answer="\n\n   \n").facts[0]
+
+    assert fact == "Accomplished: do the thing"
+
+
+# --- and the other half of the same screen --------------------------------------------------------
+
+
+def test_the_skills_endpoint_says_whether_anything_reads_the_cards(tmp_path: Any) -> None:
+    """A count of zero means two different things, and the screen was showing the count alone.
+
+    Measured: fourteen cards, all marked ACTIVE, all reading `0 uses`. The available reading is
+    that the agent tried them and they were useless; the truth is that retrieval is off by default,
+    so nothing consulted them. The flag has to travel with the count or the count misleads.
+    """
+    from tests.test_api import _client  # noqa: PLC0415
+
+    body = _client(tmp_path).get("/api/skills").json()
+
+    assert "cards_read" in body, "the screen cannot explain why every count is zero"
+    assert body["cards_read"] is False, "CHIMERA_SKILL_CARDS is off by default and this must say so"
+
+
+def test_the_flag_follows_the_setting_rather_than_being_hardcoded(tmp_path: Any) -> None:
+    """The half a constant would pass: a field pinned to one value is not a report of anything."""
+    import os  # noqa: PLC0415
+
+    from tests.test_api import _client  # noqa: PLC0415
+
+    os.environ["CHIMERA_SKILL_CARDS"] = "1"
+    try:
+        body = _client(tmp_path).get("/api/skills").json()
+    finally:
+        os.environ.pop("CHIMERA_SKILL_CARDS", None)
+
+    assert body["cards_read"] is True

--- a/tests/test_the_sandbox_reason_can_be_translated.py
+++ b/tests/test_the_sandbox_reason_can_be_translated.py
@@ -1,0 +1,180 @@
+"""The Security screen must be able to say WHY in its reader's language.
+
+The endpoint returned one English sentence and the panel printed it. Measured in the shipped app:
+*"Windows has no OS sandbox in Chimera…"* rendered on a Portuguese UI, one line below the panel's
+own translated prose, on the single screen a person opens to learn what protects them.
+
+The fix is the shape this repo already uses for ``PostureFacts.fell_back_reason``: a machine-readable
+code the client translates, with the English sentence riding along as the fallback so a cause the
+client has never heard of degrades to English rather than to a blank line.
+
+Free: no model call, no network, no sandbox actually built.
+"""
+
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.schemas import SandboxStateOut
+from chimera.sandbox.os_sandbox import unavailable_cause
+
+CAUSES = ("", "windows", "bwrap_missing", "userns_refused", "seatbelt_missing", "unsupported_os")
+
+
+def _sandbox(tmp_path: Path) -> dict[str, Any]:
+    from tests.test_api import _client  # noqa: PLC0415
+
+    return dict(_client(tmp_path).get("/api/governance/sandbox").json())
+
+
+# --- the endpoint ------------------------------------------------------------------------------
+
+
+def test_the_endpoint_reports_a_code_beside_the_sentence(tmp_path: Path) -> None:
+    body = _sandbox(tmp_path)
+
+    assert "reason_code" in body, "the screen has nothing to translate"
+    assert body["reason_code"] in (*CAUSES, "no_container")
+
+
+def test_a_machine_with_no_boundary_says_which_cause(tmp_path: Path) -> None:
+    """A code is only useful when it is populated exactly where the sentence was."""
+    body = _sandbox(tmp_path)
+
+    if body["isolated"]:
+        pytest.skip("this machine has a real sandbox, so there is no cause to report")
+    assert body["reason_code"], "no boundary applies and the panel is told nothing translatable"
+    assert body["reason"], "the English fallback went missing, so an unknown code renders blank"
+
+
+def test_the_code_agrees_with_the_sentence(tmp_path: Path) -> None:
+    """Two fields, one fact. They are produced together for this reason — maintained apart they
+    drift, and the drift surfaces as a screen confidently explaining the wrong cause."""
+    body = _sandbox(tmp_path)
+
+    if body["isolated"] or body["reason_code"] == "no_container":
+        pytest.skip("not an OS-sandbox cause")
+    code, sentence = unavailable_cause()
+    assert body["reason_code"] == code
+    assert body["reason"] == sentence
+
+
+# --- the pair cannot drift, on every platform and not just this one -----------------------------
+#
+# Forced, because the machine running the suite has ONE answer: in WSL bubblewrap works, so
+# `unavailable_cause()` returns ("", "") and every assertion about a cause passes without ever
+# reaching one. A first version of these tests did exactly that — two sabotages walked straight
+# through them — which is the same lesson as always: an instrument that cannot exhibit the effect
+# produces no evidence about it.
+
+PLATAFORMAS = [
+    ("Windows", None, "windows"),
+    ("Linux", None, "bwrap_missing"),
+    ("Linux", "/usr/bin/bwrap", "userns_refused"),
+    ("Darwin", None, "seatbelt_missing"),
+    ("Haiku", None, "unsupported_os"),
+]
+
+
+@pytest.fixture
+def sem_sandbox(monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    """Force "no OS sandbox here", then let each case say which platform it is."""
+    from chimera.sandbox import os_sandbox as mod
+
+    monkeypatch.setattr(mod, "os_sandbox_available", lambda: False)
+
+    def _forcar(system: str, bwrap: str | None) -> None:
+        monkeypatch.setattr(mod.platform, "system", lambda: system)
+        monkeypatch.setattr(mod.shutil, "which", lambda _name: bwrap)
+
+    return _forcar
+
+
+@pytest.mark.parametrize(("system", "bwrap", "esperado"), PLATAFORMAS)
+def test_every_platform_reports_its_own_cause(
+    sem_sandbox: Any, system: str, bwrap: str | None, esperado: str
+) -> None:
+    sem_sandbox(system, bwrap)
+
+    code, sentence = unavailable_cause()
+
+    assert code == esperado
+    assert sentence, "a cause with no sentence renders as an empty line for an unknown code"
+
+
+@pytest.mark.parametrize(("system", "bwrap", "esperado"), PLATAFORMAS)
+def test_the_code_is_one_the_schema_admits(
+    sem_sandbox: Any, system: str, bwrap: str | None, esperado: str
+) -> None:
+    """The ``Literal`` is what reaches TypeScript. A cause the schema does not list arrives at the
+    client as a code it can neither translate nor type."""
+    sem_sandbox(system, bwrap)
+    code, _ = unavailable_cause()
+    admitted = SandboxStateOut.model_fields["reason_code"].annotation
+
+    assert code in admitted.__args__  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(("system", "bwrap", "esperado"), PLATAFORMAS)
+def test_the_sentence_matches_the_cause_it_names(
+    sem_sandbox: Any, system: str, bwrap: str | None, esperado: str
+) -> None:
+    """Code and sentence are produced together so they cannot drift — but "cannot" is a claim, and
+    this is what checks it: each sentence has to mention the thing its code is about."""
+    sem_sandbox(system, bwrap)
+    marcas = {
+        "windows": "windows",
+        "bwrap_missing": "not installed",
+        "userns_refused": "namespace",
+        "seatbelt_missing": "sandbox-exec",
+        "unsupported_os": "no os sandbox",
+    }
+
+    _, sentence = unavailable_cause()
+
+    assert marcas[esperado] in sentence.lower()
+
+
+def test_an_available_sandbox_reports_no_cause_at_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Either both fields or neither. One alone is what renders an empty line where an explanation
+    should be."""
+    from chimera.sandbox import os_sandbox as mod
+
+    monkeypatch.setattr(mod, "os_sandbox_available", lambda: True)
+
+    assert unavailable_cause() == ("", "")
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="the cause is per platform")
+def test_windows_reports_the_windows_cause() -> None:
+    """The measured case, pinned: this is the machine the defect was found on."""
+    code, sentence = unavailable_cause()
+
+    assert code == "windows"
+    assert "docker" in sentence.lower(), "the one actionable instruction left the sentence"
+
+
+# --- every cause has somewhere to be translated -------------------------------------------------
+
+
+def test_every_cause_has_a_translation_key_in_every_language() -> None:
+    """The gap this fix exists to close, checked for all ten languages rather than for English.
+
+    A code with no entry falls back to English by design — correct as a safety net and wrong as a
+    steady state, and the difference is invisible unless something counts.
+    """
+    i18n = Path("apps/desktop/src/lib/i18n.tsx").read_text(encoding="utf-8")
+    idiomas = i18n.count('"governance.sandbox.stillApplies"')
+    assert idiomas == 10, f"expected ten language blocks, found {idiomas}"
+
+    for code in (*CAUSES, "no_container"):
+        if not code:
+            continue
+        chave = f'"governance.sandbox.why.{code}"'
+        assert i18n.count(chave) == idiomas, (
+            f"{code} is translated in {i18n.count(chave)} of {idiomas} languages"
+        )


### PR DESCRIPTION
The rest of what driving rc43 as a user turned up, after [#263](https://github.com/brcampidelli/chimera-agent/pull/263). None of these are wrong answers — they are facts the app already had and did not put where a person could read them.

## The Security screen explained the boundary in English, on a Portuguese interface

Everything around it was translated. The one sentence that says **why** no kernel sandbox applies came from the server and was printed verbatim — on the single screen a person opens to learn what protects them.

The endpoint now reports a cause **code** beside the sentence, the shape `PostureFacts.fell_back_reason` already used, and the panel says it in the reader's language in all ten. The English rides along as the fallback: a cause a client has never heard of must degrade to English, never to a blank line or a raw i18n key. Code and sentence are produced by one function so they cannot drift into a screen confidently explaining the wrong cause.

## A scheduled job with a gate looked identical to one without

`verify` could be set on the form and then vanished. Created one through the API with `python -m pytest -q`; afterwards the word "pytest" appeared nowhere on the screen. The gate is what decides whether the work is **kept**, and a job that has one now says so — and stays silent when there is none, because a row that always shows a gate line trains people to stop reading it.

## Fourteen cards marked ACTIVE, every one reading `0 uses`

The available reading is that the agent tried them and they were useless. Nothing consulted them: retrieval is off by default because it was measured (+16.7pp, an interval including zero, +300% tokens) and left off. A count of zero means two different things depending on that flag, and the screen was showing the count without the flag.

`GET /api/skills` reports it now and the panel explains the zero — and says nothing when reading **is** on, because then zero really is a verdict on the card.

## A memory "fact" was the whole brief plus the whole answer

Four of them on a real install, 630–950 characters each, recalled into the context of every later run in that folder. The answer side was already bounded to 160 characters; the task side was not, and the task is the long half.

A fact is now the task's **opening line**, bounded — a brief opens with what it wants and continues with how, so 769 characters became 34. The dedup key still hashes the full task: four real briefs opened with *"Leia BRIEF.md e construa…"*, and keying on the shortened head would fold them into one entry that overwrites itself.

## How this was checked

Sabotage batteries on all four — every guard reverted one at a time and required to fail. **Three escaped the first pass:**

- The sandbox causes were **unreachable on this machine**. The suite runs in WSL, where bubblewrap works, so `unavailable_cause()` returned `("", "")` and every assertion about a cause passed without ever reaching one. Two sabotages walked straight through. The platform is forced now, and all five causes are exercised.
- The skills flag had only a frontend test, which mocks the API — so hardcoding the endpoint's field changed nothing. It has a backend test now, sabotaged in both directions.
- One sabotage of mine targeted the render guard instead of the expression that picks the text, and reported a pass it had not earned.

The reported defect is reproduced directly: the panel is rendered with `chimera.lang = "pt"` and asserted to show the Portuguese sentence and **not** the server's English.

The i18n reachability gate wanted the new dynamic prefix registered — the documented price of a `` t(`prefix.${x}`) `` lookup, and the reason a dynamic key is exactly the kind that goes stale unnoticed.

**4443 Python tests, 977 frontend tests, `npm run build` clean.** The build matters here: it is the only check that sees a hand-written type, and `getSkills` had one that would have swallowed the new field silently — the same way `PostureFacts` did one release ago. It now uses the generated `SkillsOut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
