### PR TITLE
fix(money): the cap hid its own spending, and the schedule hid its own failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,41 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **A run that hit its dollar cap recorded no spending at all.** Introduced by the cap fix one
+  release earlier and found by re-running the same experiment against it: the run stopped
+  correctly, said *"spend cap reached: $0.0030"*, and left a receipt reading `usd: null,
+  attempts: []`. The attempt that reached the ceiling is the one that CALLED a model — that is how
+  it reached it — and returning before the loop's bookkeeping dropped the only record of the money.
+  The Cost screen, which reads those attempts, then showed a paid run as free. A cap that hides its
+  own spending is worse than no cap: the number it exists to protect is the number it erased. The
+  stopped attempt is now recorded with its tokens, its price and the model that answered.
+
+- **The Cost screen billed every scheduled run twice.** Also introduced one release earlier. A
+  scheduled job writes a usage row keyed `cron:<job>:<run_id>` *and* a run receipt carrying the same
+  `run_id`; the merge added both. Measured on a real install: four nightly runs, **$0.0449** counted
+  twice, and a headline of $4.1792 where the truth is $4.1344. The argument that shipped it was that
+  the id namespaces cannot collide — true, and the wrong property: the collision is not between two
+  ids, it is the same WORK written to two files under different names. Only the run id joins them,
+  so only the run id can separate them. Read from compound ids alone, because a bare session id is a
+  chat turn that writes no receipt, and reading one as a run id would silently drop a real charge.
+
+- **Every scheduled run was invisible in the folder it ran in.** The scheduled loop was given its
+  run log and not its workspace — the guard and the tools were rooted in the job's folder, the loop
+  was not — so each receipt was written with an empty workspace. A receipt with no workspace is
+  deliberately excluded from every filtered list, which made each one unfindable from the only
+  screen that would look. The previous fix here went half the distance: the receipt existed and
+  could not be found.
+
+- **A scheduled job whose gate rejected everything reported `ok`.** Found by letting a real job fire
+  with a verify command written to fail: two attempts, both judged by the verifier, every file
+  reverted — and a green row with `consecutive_failures: 0`. The dispatch returned only the answer
+  string, so the run's success never reached the schedule. Every existing outcome (`error`,
+  `timeout`, `budget`) arrives by exception, and this one does not: nothing breaks, which is exactly
+  why it needed its own name. `rejected` is now a dispatch status, it counts as a failure, and the
+  silence alarm — which reads that counter — can finally see it. A dispatch with no verdict still
+  means `ok`: a job that declared no gate has nothing that could reject it, and absence of a verdict
+  is not a failure.
+
 - **The Security screen explained the machine's boundary in English, on a Portuguese interface.**
   Everything around it was translated; the one sentence that says WHY no kernel sandbox applies came
   from the server verbatim and was printed as it arrived. That sentence is the substance of the

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -107,6 +107,7 @@ from chimera.api.sessions import SessionManager, SessionStore
 from chimera.api.sse import SSE_RESPONSE
 from chimera.api.usage import (
     UsageRecord,
+    _already_counted,
     append_usage,
     load_usage,
     summarize_usage,
@@ -829,9 +830,16 @@ def build_api_app(
     def usage_endpoint() -> dict[str, Any]:
         # BOTH logs. `usage.jsonl` holds chat turns and orchestration; runs write their receipts to
         # `runs.jsonl` and were simply missing from this screen — see `usage_from_runs`.
+        # BOTH logs, joined on the run id. `usage.jsonl` holds chat turns and orchestration;
+        # runs write their receipts to `runs.jsonl` and were missing from this screen entirely.
+        # A SCHEDULED run writes to both, so the merge has to subtract what is already counted —
+        # see `_already_counted`, and the measured $0.049 it was billing twice.
+        turnos = load_usage(settings.home / "usage.jsonl")
         return summarize_usage(
-            load_usage(settings.home / "usage.jsonl")
-            + usage_from_runs(settings.home / "runs.jsonl")
+            turnos
+            + usage_from_runs(
+                settings.home / "runs.jsonl", already=_already_counted(turnos)
+            )
         )
 
     @app.get("/api/runs", dependencies=[guard], response_model=list[RunReceiptOut])

--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -95,7 +95,31 @@ def record_spend(
 RUN_SESSION_PREFIX = "run:"
 
 
-def usage_from_runs(path: Path) -> list[UsageRecord]:
+def _already_counted(records: list[UsageRecord]) -> set[str]:
+    """Run ids that ``usage.jsonl`` ALREADY accounts for, so the merge cannot bill them twice.
+
+    The scheduled path writes both: a usage row keyed ``cron:<job>:<run_id>`` *and* a run receipt
+    carrying the same ``run_id``. Measured on a real install — four nightly runs, ~$0.049, counted
+    once in each file and therefore twice on the Cost screen.
+
+    The first version of this merge argued that the id NAMESPACES cannot collide, which is true and
+    was the wrong property: the collision is not between two ids, it is the same WORK written to
+    two files under different names. Only the run id joins them, so only the run id can separate
+    them.
+
+    Read from compound ids alone (``a:b:<run_id>``). A bare session id is a chat turn, which writes
+    no receipt — treating one as a run id could silently drop a real charge, and under-counting
+    money is the direction that must never happen by accident.
+    """
+    seen: set[str] = set()
+    for r in records:
+        partes = str(r.session_id or "").split(":")
+        if len(partes) >= 2 and partes[-1]:
+            seen.add(partes[-1])
+    return seen
+
+
+def usage_from_runs(path: Path, *, already: set[str] | None = None) -> list[UsageRecord]:
     """One record per ATTEMPT of every autonomous run, so the Cost screen counts them too.
 
     ``record_spend`` has exactly two callers — a chat turn and an orchestration run — and the
@@ -113,6 +137,7 @@ def usage_from_runs(path: Path) -> list[UsageRecord]:
     path = Path(path)
     if not path.exists():
         return []
+    contadas = already or set()
     out: list[UsageRecord] = []
     for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
         if not line.strip():
@@ -127,6 +152,10 @@ def usage_from_runs(path: Path) -> list[UsageRecord]:
         run_ts = str(row.get("ts") or "")
         for attempt in row.get("attempts") or []:
             if not isinstance(attempt, dict):
+                continue
+            # Skipped, not zeroed: this attempt is already in the other log, and a zero row would
+            # still count a turn that has been counted.
+            if str(attempt.get("run_id") or "") in contadas:
                 continue
             usd = attempt.get("usd")
             out.append(

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -2001,6 +2001,13 @@ def _start_cron_daemon(
             # The receipt. `runs.jsonl` is what the Runs screen reads, and a job that has fired
             # nightly for a month left nothing there to read.
             run_log=settings.home / "runs.jsonl",
+            # And the folder it happened in, or the receipt is unreadable from the only screen
+            # that would look for it. The guard and the tools were rooted here already; the LOOP
+            # was not, so every scheduled receipt was written with an empty workspace — and a
+            # receipt with no workspace is deliberately excluded from every filtered list, which
+            # made each one invisible in the project it ran in. The fix above went half the
+            # distance: the receipt existed and could not be found.
+            workspace=job_root,
         )
         result = loop.run(job.action)
         # Summed across attempts rather than read off one: with `max_attempts > 1` a dispatch can

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -804,7 +804,9 @@ class AutonomousAgent:
             # already passed, and each one paid for a reviewer to criticise a worker that was only
             # saying it had hit the limit.
             if getattr(agent_result, "stopped_reason", "") in ("spend", "budget"):
-                return self._finalize_capped(task, attempts, plan, thread_id, agent_result.answer)
+                return self._finalize_capped(
+                    task, attempts, plan, thread_id, agent_result, index
+                )
             answer = agent_result.answer
             # Surface a degrading trajectory where a person will see it, not only in the trace. It
             # is advisory: the attempt is judged on its result as always, and the run continues.
@@ -1268,7 +1270,8 @@ class AutonomousAgent:
         attempts: list[Attempt],
         plan: Plan | None,
         thread_id: str | None,
-        answer: str,
+        agent_result: AgentResult,
+        index: int,
     ) -> AutonomousResult:
         """The money ran out: return what was bought, and stop buying.
 
@@ -1281,9 +1284,32 @@ class AutonomousAgent:
         spent — "the run failed" for a run that simply reached its cap is the four-word ending this
         release spent its time removing.
         """
+        # The stopped attempt is RECORDED, not dropped. It called a model — that is how the cap was
+        # reached — and returning here before the normal bookkeeping left a receipt reading
+        # `usd: null, attempts: []` for a run that had just spent money. Measured on a real run:
+        # the answer said "spend cap reached: $0.0030" while the receipt reported nothing, so the
+        # Cost screen showed a paid run as free. A cap that hides its own spending is worse than
+        # no cap: the number it exists to protect is the number it erases.
+        from chimera.orchestration.metering import add_usd
+
+        over_usd, over_prompt, over_completion = (
+            self.meter.take() if self.meter is not None else (0.0, 0, 0)
+        )
+        parcial = Attempt(index, agent_result.answer, False, False, False, False)
+        parcial.usd = add_usd(getattr(agent_result, "usd", None), over_usd)
+        parcial.overhead_usd = over_usd
+        parcial.prompt_tokens = int(getattr(agent_result, "prompt_tokens", 0) or 0) + over_prompt
+        parcial.completion_tokens = (
+            int(getattr(agent_result, "completion_tokens", 0) or 0) + over_completion
+        )
+        parcial.model = str(getattr(agent_result, "model", "") or "")
+        parcial.run_id = str(getattr(agent_result, "run_id", "") or "")
+        parcial.evidence = "none"
+        attempts = [*attempts, parcial]
+
         self._emit(_ev_status("stopped on budget"))
         self._clear_checkpoint(thread_id)
-        last = answer or (attempts[-1].answer if attempts else "")
+        last = agent_result.answer or (attempts[-1].answer if attempts else "")
         self._emit(_ev_final(False, last))
         result = AutonomousResult(
             answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="spend"

--- a/chimera/scheduler/daemon.py
+++ b/chimera/scheduler/daemon.py
@@ -14,12 +14,15 @@ import time
 from collections.abc import Callable
 
 from chimera.scheduler.engine import Scheduler
-from chimera.scheduler.models import CronJob
+from chimera.scheduler.models import CronJob, DispatchStatus, JobOutcome
 from chimera.telemetry import get_logger
 
 _log = get_logger("scheduler.daemon")
 
-Dispatch = Callable[[CronJob], None]
+Dispatch = Callable[[CronJob], "DispatchStatus | None"]
+"""A dispatch may report how the job ended. ``None`` means "nothing to report", which the
+engine reads as ``ok`` — every dispatch written before this returns None and keeps its
+meaning, so the new outcome costs nothing to the callers that have no verdict to give."""
 
 
 def make_agent_dispatch(
@@ -27,7 +30,7 @@ def make_agent_dispatch(
     on_result: Callable[[CronJob, str], None] | None = None,
     *,
     delivery_retries: int = 2,
-    run_job: Callable[[CronJob], str] | None = None,
+    run_job: Callable[[CronJob], JobOutcome | str] | None = None,
 ) -> Dispatch:
     """Build a dispatch that runs a job's ``action`` through ``run_task`` (task -> answer).
 
@@ -43,17 +46,27 @@ def make_agent_dispatch(
     so it's easy to test and to wire.
     """
 
-    def dispatch(job: CronJob) -> None:
-        answer = run_job(job) if run_job is not None else run_task(job.action)
-        _log.info("cron '%s' ran -> %s", job.name, (answer or "").replace("\n", " ")[:200])
+    def dispatch(job: CronJob) -> DispatchStatus | None:
+        bruto = run_job(job) if run_job is not None else run_task(job.action)
+        # A bare string is a caller with no verdict — a job that declared no gate has nothing
+        # that could reject it — and is read as `ok`, which is what every caller meant before.
+        outcome = bruto if isinstance(bruto, JobOutcome) else JobOutcome(str(bruto or ''))
+        answer = outcome.answer
+        status: DispatchStatus | None = None if outcome.ok else "rejected"
+        _log.info(
+            "cron '%s' ran%s -> %s",
+            job.name,
+            " (its gate rejected the work)" if status else "",
+            (answer or "").replace('\\n', " ")[:200],
+        )
         if on_result is None:
-            return
+            return status
         last_exc: Exception | None = None
         for attempt in range(1, delivery_retries + 2):
             try:
                 on_result(job, answer)
                 _log.info("cron '%s' result delivered (attempt %d)", job.name, attempt)
-                return
+                return status
             except Exception as exc:  # noqa: BLE001 — retry, then give up loudly
                 last_exc = exc
                 _log.warning("cron '%s' delivery attempt %d failed: %s", job.name, attempt, exc)
@@ -63,6 +76,7 @@ def make_agent_dispatch(
             delivery_retries + 1,
             last_exc,
         )
+        return status
 
     return dispatch
 

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -23,8 +23,8 @@ _log = get_logger("scheduler.engine")
 
 
 def _dispatch_bounded(
-    job: CronJob, dispatch: Callable[[CronJob], None], timeout: float | None
-) -> None:
+    job: CronJob, dispatch: Callable[[CronJob], DispatchStatus | None], timeout: float | None
+) -> DispatchStatus | None:
     """Run ``dispatch(job)``, raising :class:`TimeoutError` if it overruns ``timeout``.
 
     ``None`` runs it inline (the previous, unbounded behaviour) so nothing pays for a thread when
@@ -36,7 +36,7 @@ def _dispatch_bounded(
     at interpreter exit no matter what ``shutdown(wait=False)`` says, so a stuck job let the tick
     finish and then held the process open until it unstuck. See :mod:`chimera.concurrency`.
     """
-    call_with_deadline(lambda: dispatch(job), timeout)
+    return call_with_deadline(lambda: dispatch(job), timeout)
 
 
 def _next_after(cron_expr: str, after_epoch: float) -> float:
@@ -188,7 +188,7 @@ class Scheduler:
             if job.enabled and job.trigger == "webhook" and job.schedule == hook
         ]
 
-    def fire_webhook(self, hook: str, now: float, dispatch: Callable[[CronJob], None]) -> list[CronJob]:
+    def fire_webhook(self, hook: str, now: float, dispatch: Callable[[CronJob], DispatchStatus | None]) -> list[CronJob]:
         """Dispatch every job registered for ``hook`` (an inbound webhook). Returns those run."""
         ran: list[CronJob] = []
         for job in self.jobs_for_webhook(hook):
@@ -287,7 +287,7 @@ class Scheduler:
     def run_due(
         self,
         now: float,
-        dispatch: Callable[[CronJob], None],
+        dispatch: Callable[[CronJob], DispatchStatus | None],
         *,
         job_timeout: float | None = None,
     ) -> list[CronJob]:
@@ -307,8 +307,18 @@ class Scheduler:
             # has failed on every tick for a month look healthy: `last_run` is a minute ago, because
             # the attempt happened, and nothing anywhere said the attempt lost.
             try:
-                _dispatch_bounded(job, dispatch, job_timeout)
-                self._record(job, "ok", None)
+                veredito = _dispatch_bounded(job, dispatch, job_timeout)
+                # `rejected` is not an error and reaches here without an exception: the job ran,
+                # the work it produced failed the job's own verify command, and the workspace was
+                # reverted. Recorded as its own outcome because "ok" for that is the state that
+                # made a nightly job look healthy while producing nothing for a month.
+                if veredito == "rejected":
+                    self._record(
+                        job, "rejected",
+                        "the job ran and its verify command rejected the work, which was reverted",
+                    )
+                else:
+                    self._record(job, veredito or "ok", None)
             except TimeoutError:
                 _log.warning(
                     "cron job %s (%s) exceeded %ss and was abandoned; the schedule continues",
@@ -341,7 +351,7 @@ class Scheduler:
         else:
             job.consecutive_failures += 1
 
-    def fire_event(self, event: str, now: float, dispatch: Callable[[CronJob], None]) -> list[CronJob]:
+    def fire_event(self, event: str, now: float, dispatch: Callable[[CronJob], DispatchStatus | None]) -> list[CronJob]:
         """Dispatch every job registered for ``event``. Returns those run."""
         ran: list[CronJob] = []
         for job in self.jobs_for_event(event):

--- a/chimera/scheduler/models.py
+++ b/chimera/scheduler/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -9,7 +10,29 @@ from pydantic import BaseModel, Field
 Trigger = Literal["cron", "event", "webhook"]
 CreatedBy = Literal["human", "agent"]
 
-DispatchStatus = Literal["ok", "error", "timeout", "budget"]
+DispatchStatus = Literal["ok", "error", "timeout", "budget", "rejected"]
+"""How a dispatch ended.
+
+``rejected`` is the one that is not an error: the job RAN, produced work, and its own verify
+command threw that work away. Nothing broke, so none of the exception paths fire — which is
+exactly why it needed its own name. Measured on a real install: a nightly job whose gate rejected
+every attempt and reverted every file reported ``ok`` with ``consecutive_failures: 0``, so the
+Automation screen showed a green row over a job that had produced nothing, and the silence alarm
+never saw it either. A gate that works and cannot be seen to have fired is not a signal."""
+
+
+@dataclass(frozen=True)
+class JobOutcome:
+    """What a dispatch has to say about the job it just ran.
+
+    ``ok=False`` means the work was REJECTED by the job's own gate, not that anything failed. A
+    caller with no verdict to give — one running a job that declared no gate — returns a bare
+    string instead and is read as ``ok``: absence of a verdict is not a failure, the same rule the
+    reviewer and the verifier already follow when they abstain.
+    """
+
+    answer: str
+    ok: bool = True
 """What happened on the last dispatch — which is not the same question as whether one happened.
 
 ``last_run`` records the ATTEMPT: the scheduler sets it outside the try/except on purpose, so a job

--- a/tests/test_a_scheduled_job_reports_what_happened.py
+++ b/tests/test_a_scheduled_job_reports_what_happened.py
@@ -1,0 +1,174 @@
+"""A scheduled job has to say where it ran and whether its work survived.
+
+Both found by letting a real job fire in the shipped app, with a gate written to reject everything:
+
+* the receipt was written with an **empty workspace**, so the run was invisible in the project it
+  ran in — a receipt with no workspace is deliberately excluded from every filtered list, which is
+  the rule that makes an unattributable receipt unfindable rather than misattributed;
+* the job reported **``last_status: "ok"``** with ``consecutive_failures: 0`` after its gate had
+  rejected both attempts and reverted every file, because the dispatch returned only the answer
+  string and the run's ``success`` was dropped on the floor.
+
+The second is the worse one: the gate WORKS — it ran, it judged, it reverted — and a gate whose
+firing cannot be seen is not a signal. The silence alarm reads `consecutive_failures`, so it never
+saw it either.
+
+Free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from chimera.scheduler import CronJob, Scheduler, make_agent_dispatch
+from chimera.scheduler.models import JobOutcome
+
+
+def _scheduler(tmp_path: Path, **kw: Any) -> Scheduler:
+    """A scheduler holding one job that is due at t=60.
+
+    Scheduled through `schedule_cron` rather than constructed and stored by hand: that is what
+    computes `next_run`, and a job whose `next_run` is None is never due — so a hand-built one
+    would leave `last_status` as None and every assertion here would report the state before the
+    tick, failing for a reason that has nothing to do with the outcome.
+    """
+    from chimera.scheduler import CronStore
+
+    sched = Scheduler(CronStore(tmp_path / "jobs.json"))
+    sched.schedule_cron("nightly", "* * * * *", "fix the tests", now=0, workspace="/w", **kw)
+    return sched
+
+
+def _depois(sched: Scheduler, dispatch: Any) -> CronJob:
+    """Run the tick and return the job AS THE SCHEDULER LEFT IT.
+
+    Read back rather than kept: the scheduler works on instances it loads from the store, so a
+    local `CronJob` is a different object and would still hold the state from before the tick.
+    """
+    ran = sched.run_due(60.0, dispatch)
+    assert ran, "the job was not due, so nothing here is measuring a dispatch"
+    return sched.store.list()[0]
+
+
+# --- the verdict reaches the schedule ----------------------------------------------------------
+
+
+def test_a_job_whose_gate_rejected_the_work_is_not_ok(tmp_path: Path) -> None:
+    """The measured case: two attempts, both reverted, and a green row on the Automation screen."""
+    sched = _scheduler(tmp_path)
+    dispatch = make_agent_dispatch(
+        lambda task: "unused", run_job=lambda j: JobOutcome("gave up", ok=False)
+    )
+
+    job = _depois(sched, dispatch)
+
+    assert job.last_status == "rejected"
+    assert job.consecutive_failures == 1, "the silence alarm reads this and would never fire"
+    assert job.last_error and "rejected" in job.last_error
+
+
+def test_a_job_that_kept_its_work_is_still_ok(tmp_path: Path) -> None:
+    sched = _scheduler(tmp_path)
+    dispatch = make_agent_dispatch(lambda task: "unused", run_job=lambda j: JobOutcome("done"))
+
+    job = _depois(sched, dispatch)
+
+    assert job.last_status == "ok"
+    assert job.consecutive_failures == 0
+
+
+def test_a_dispatch_with_no_verdict_still_means_ok(tmp_path: Path) -> None:
+    """Every dispatch written before this returns a bare string, and must keep its meaning: a job
+    that declared no gate has nothing that could reject it, and absence of a verdict is not a
+    failure — the same rule the reviewer and the verifier follow when they abstain."""
+    sched = _scheduler(tmp_path)
+
+    job = _depois(sched, make_agent_dispatch(lambda task: "ran"))
+
+    assert job.last_status == "ok"
+
+
+def test_a_rejection_still_delivers_the_answer(tmp_path: Path) -> None:
+    """The work was thrown away; the report of it was not. Someone reading a webhook has to learn
+    the job produced nothing, which is exactly the message they need most."""
+    entregue: dict[str, str] = {}
+    sched = _scheduler(tmp_path)
+    dispatch = make_agent_dispatch(
+        lambda task: "unused",
+        on_result=lambda j, ans: entregue.__setitem__(j.name, ans),
+        run_job=lambda j: JobOutcome("the gate rejected every attempt", ok=False),
+    )
+
+    job = _depois(sched, dispatch)
+
+    assert entregue["nightly"] == "the gate rejected every attempt"
+    assert job.last_status == "rejected", "delivery succeeded, so the WORK was reported as fine"
+
+
+def test_a_failed_delivery_does_not_erase_the_rejection(tmp_path: Path) -> None:
+    """Two independent facts. A webhook that is down must not turn a rejected job into a fine one,
+    nor the reverse."""
+    sched = _scheduler(tmp_path)
+
+    def sempre_falha(j: CronJob, ans: str) -> None:
+        raise RuntimeError("webhook down")
+
+    dispatch = make_agent_dispatch(
+        lambda task: "unused", on_result=sempre_falha, delivery_retries=0,
+        run_job=lambda j: JobOutcome("gave up", ok=False),
+    )
+    job = _depois(sched, dispatch)
+
+    assert job.last_status == "rejected"
+
+
+def test_an_exception_is_still_an_error_not_a_rejection(tmp_path: Path) -> None:
+    """The two are different claims: `error` means something broke, `rejected` means the job worked
+    and its own gate threw the result away. Collapsing them loses the distinction that makes the
+    new one worth having."""
+    sched = _scheduler(tmp_path)
+
+    def explode(j: CronJob) -> JobOutcome:
+        raise RuntimeError("boom")
+
+    job = _depois(sched, make_agent_dispatch(lambda t: "x", run_job=explode))
+
+    assert job.last_status == "error"
+
+
+# --- the receipt says where it ran --------------------------------------------------------------
+
+
+def test_the_scheduled_loop_is_given_the_folder_it_runs_in() -> None:
+    """A wiring assertion, because the defect was wiring: the guard and the tools were rooted in the
+    job's folder and the LOOP was not, so `_persist_receipt` wrote an empty workspace.
+
+    Asserted on the source because the closure lives inside a CLI command and cannot be reached
+    from a test — and asserting nothing was how it shipped.
+    """
+    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
+    bloco = re.search(
+        r"run_log=settings\.home / \"runs\.jsonl\",(.{0,900}?)\)\n", fonte, re.S
+    )
+
+    assert bloco, "the scheduled loop no longer names its run log — this test is looking at nothing"
+    # An ARGUMENT, not the substring. Commenting the line out leaves `workspace=job_root` in the
+    # file, and a substring check passes over it — measured: that sabotage walked straight through
+    # the first version of this assertion.
+    linhas = [linha.strip() for linha in bloco.group(1).splitlines()]
+
+    assert "workspace=job_root," in linhas, (
+        "the scheduled receipt is written without a workspace, so it is unfindable from the "
+        "project it ran in"
+    )
+
+
+def test_the_folder_comes_from_the_job_not_the_process() -> None:
+    """`job_root` is the job's own folder falling back to the process root. Passing `workspace`
+    (the process one) instead would attribute every scheduled run to whatever folder the daemon
+    happened to start in — misattribution, which is worse than the empty string it replaces."""
+    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
+
+    assert "job_root = Path(job.workspace).expanduser() if job.workspace else workspace" in fonte

--- a/tests/test_the_cost_screen_counts_runs.py
+++ b/tests/test_the_cost_screen_counts_runs.py
@@ -21,6 +21,7 @@ from typing import Any
 from chimera.api.usage import (
     RUN_SESSION_PREFIX,
     UsageRecord,
+    _already_counted,
     append_usage,
     load_usage,
     summarize_usage,
@@ -106,8 +107,13 @@ def test_overhead_is_a_share_of_the_price_not_an_addition(tmp_path: Path) -> Non
 
 
 def test_a_run_and_a_chat_turn_stay_separate_sessions(tmp_path: Path) -> None:
-    """The merge counts each side once because the id namespaces cannot overlap: chat writes a bare
-    session id, orchestration writes ``orchestration:``, runs write ``run:``."""
+    """Two different sessions stay two rows in the panel.
+
+    This used to be cited as the reason the merge could not double-count, and that argument was
+    wrong: id namespaces not colliding says nothing about the same WORK being written to both
+    files under different names, which is exactly what a scheduled run does. The property this
+    checks is the grouping — see the dedupe tests below for the one that actually protects money.
+    """
     append_usage(tmp_path / "usage.jsonl", UsageRecord(ts="2026-08-30T00:00:00+00:00",
                                                        session_id="r1", model="m", usd=1.0))
 
@@ -117,6 +123,85 @@ def test_a_run_and_a_chat_turn_stay_separate_sessions(tmp_path: Path) -> None:
     sessions = {s["session_id"] for s in summary["by_session"]}
     assert sessions == {"r1", RUN_SESSION_PREFIX + "r1"}
     assert summary["totals"]["turns"] == 2
+
+
+# --- the same work must not be billed twice ------------------------------------------------------
+
+
+def test_a_scheduled_run_written_to_both_logs_is_counted_once(tmp_path: Path) -> None:
+    """The measured defect: a scheduled run writes a usage row keyed ``cron:<job>:<run_id>`` AND a
+    receipt carrying the same ``run_id``. Four of them on a real install — $0.0449 billed twice.
+    """
+    append_usage(tmp_path / "usage.jsonl", UsageRecord(
+        ts="2026-08-30T14:39:43+00:00", session_id="cron:c8b9a2e3:32002e09", model="m", usd=0.01085,
+        prompt_tokens=19000, completion_tokens=412,
+    ))
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(run_id="32002e09", usd=0.01085))
+
+    summary = summarize_usage(turnos + usage_from_runs(runs, already=_already_counted(turnos)))
+
+    assert summary["totals"]["turns"] == 1, "the same run was counted from both logs"
+    assert round(summary["totals"]["usd"], 6) == 0.01085
+
+
+def test_without_the_join_it_really_would_be_billed_twice(tmp_path: Path) -> None:
+    """The control. Without it, the assertion above could pass because the fixture never overlapped
+    — and this test file's first version passed for exactly that kind of reason."""
+    append_usage(tmp_path / "usage.jsonl", UsageRecord(
+        ts="2026-08-30T14:39:43+00:00", session_id="cron:c8b9a2e3:32002e09", model="m", usd=0.01085,
+    ))
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(run_id="32002e09", usd=0.01085))
+
+    sem_juncao = summarize_usage(turnos + usage_from_runs(runs))
+
+    assert sem_juncao["totals"]["turns"] == 2
+    assert round(sem_juncao["totals"]["usd"], 6) == 0.0217
+
+
+def test_a_bare_chat_session_is_never_read_as_a_run_id(tmp_path: Path) -> None:
+    """The dangerous direction. A chat turn writes a bare 32-hex session id and no receipt; reading
+    one as a run id would silently DROP a real charge, and under-counting money must never happen
+    by accident."""
+    append_usage(tmp_path / "usage.jsonl", UsageRecord(
+        ts="2026-08-30T00:00:00+00:00", session_id="32002e09", model="m", usd=1.0,
+    ))
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(run_id="32002e09", usd=0.5))
+
+    summary = summarize_usage(turnos + usage_from_runs(runs, already=_already_counted(turnos)))
+
+    assert summary["totals"]["turns"] == 2, "a real charge was dropped"
+    assert round(summary["totals"]["usd"], 6) == 1.5
+
+
+def test_an_ordinary_run_is_still_counted(tmp_path: Path) -> None:
+    """The other half: a run that is NOT in the usage log has to survive the join."""
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(run_id="nunca-visto", usd=0.02))
+
+    summary = summarize_usage(turnos + usage_from_runs(runs, already=_already_counted(turnos)))
+
+    assert round(summary["totals"]["usd"], 6) == 0.02
+
+
+def test_the_route_joins_them_too(tmp_path: Path) -> None:
+    """Through HTTP, because a join the endpoint does not perform is a join nobody performs."""
+    from tests.test_api import _client  # noqa: PLC0415
+
+    client = _client(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    append_usage(home / "usage.jsonl", UsageRecord(
+        ts="2026-08-30T14:39:43+00:00", session_id="cron:j1:abc123", model="m", usd=0.01,
+    ))
+    _write_runs(home, _run_row(run_id="abc123", usd=0.01))
+
+    body = client.get("/api/usage").json()
+
+    assert body["totals"]["turns"] == 1
+    assert round(body["totals"]["usd"], 6) == 0.01
 
 
 # --- it survives a bad file --------------------------------------------------------------------

--- a/tests/test_the_dollar_cap_is_the_runs.py
+++ b/tests/test_the_dollar_cap_is_the_runs.py
@@ -61,6 +61,23 @@ class _StoppedOnSpendWorker:
         )
 
 
+class _SpendingStoppedWorker:
+    """Stopped on spend, and carrying the usage of the call that got it there."""
+
+    def __init__(self) -> None:
+        self.config = _Config(5.0)
+
+    def run(self, task: str, **kwargs: Any) -> AgentResult:
+        r = AgentResult(
+            answer="spend cap reached: $0.0052 of $0.0000", steps=1, stopped_reason="spend"
+        )
+        r.usd = 0.005197
+        r.prompt_tokens = 8870
+        r.completion_tokens = 193
+        r.model = "openrouter/deepseek/deepseek-chat-v3.1"
+        return r
+
+
 class _OldWorker:
     """Predates the parameter: its ``run`` takes no ``spend``, and must still be callable."""
 
@@ -190,6 +207,36 @@ def test_a_worker_stopped_on_money_is_not_reviewed_and_not_retried() -> None:
     assert manager.calls == 0, "a reviewer was paid to judge a worker that never worked"
     assert result.success is False
     assert result.stopped_reason == "spend"
+
+
+def test_the_run_that_hit_the_cap_records_what_it_spent() -> None:
+    """A cap that hides its own spending is worse than no cap.
+
+    Measured on the shipped fix: the run stopped correctly and its receipt read
+    ``usd: null, attempts: []`` while the answer said *"spend cap reached: $0.0030"*. The attempt
+    that reached the ceiling had called a model — that is HOW it reached it — and returning before
+    the loop's bookkeeping dropped the only record of the money. The Cost screen, which reads those
+    attempts, then showed a paid run as free.
+    """
+    worker = _StoppedOnSpendWorker()
+
+    result = _auto(worker, _CountingManager(), 3).run("do the task")
+
+    assert len(result.attempts) == 1, "the attempt that spent the money left no record"
+    assert result.attempts[0].index == 1
+
+
+def test_the_recorded_attempt_carries_the_tokens_it_used() -> None:
+    """Not just a row: the row has to hold the numbers, or the receipt is a placeholder."""
+    worker = _SpendingStoppedWorker()
+
+    result = _auto(worker, _CountingManager(), 2).run("do the task")
+
+    attempt = result.attempts[0]
+    assert attempt.prompt_tokens == 8870
+    assert attempt.completion_tokens == 193
+    assert attempt.usd == 0.005197
+    assert attempt.model == "openrouter/deepseek/deepseek-chat-v3.1"
 
 
 def test_the_ending_says_which_ceiling_and_what_it_had_spent() -> None:


### PR DESCRIPTION
Four defects found by driving rc44 as a user. **Two are mine, shipped yesterday**, and both were found by re-running the very experiments that produced the fixes.

## A run that hit its dollar cap recorded no spending

The cap fix works — the run stops, says `stopped_reason: "spend"`, and does not burn the remaining attempts. Then it writes:

```
usd: null      attempts: []      answer: "spend cap reached: $0.0030 of $0.0000"
```

The attempt that reaches the ceiling is the one that **called a model** — that is how it reached it — and returning before the loop's bookkeeping dropped the only record of the money. The Cost screen reads those attempts, so a paid run showed as free.

A cap that hides its own spending is worse than no cap: the number it exists to protect is the number it erases. Before the fix the run burned three attempts and at least the money was visible.

## The Cost screen billed every scheduled run twice

A scheduled job writes a usage row keyed `cron:<job>:<run_id>` **and** a run receipt carrying the same `run_id`. The merge I shipped added both.

| | `usage.jsonl` | `runs.jsonl` |
|---|---|---|
| 30/08 14:39 | $0.01085 · `cron:c8b9a2e3:32002e09…` | $0.01085 · `run_id 32002e091e76` |
| 30/08 11:00 | $0.012254 · `cron:f9e7baf2:09e6f678…` | $0.012254 · `run_id 09e6f678c546` |

Four runs, **$0.0449 doubled** — a headline of $4.1792 where the truth is $4.1344.

The argument that shipped it was that the id namespaces cannot collide. True, and **the wrong property**: the collision is not between two ids, it is the same *work* written to two files under different names. Only the run id joins them, so only the run id can separate them. Read from compound ids alone — a bare session id is a chat turn that writes no receipt, and reading one as a run id would silently drop a real charge. Under-counting money must never happen by accident.

## Every scheduled run was invisible in the folder it ran in

The scheduled loop was given its run log and not its workspace. The guard and the tools were rooted in the job's folder; the loop was not, so each receipt was written with an empty workspace — and an unattributable receipt is excluded from every filtered list by design. The previous fix went half the distance: the receipt existed and could not be found.

## A scheduled job whose gate rejected everything reported `ok`

Found by letting a real job fire with a verify command written to fail. Two attempts, both judged by the verifier, every file reverted, the folder left empty — and a green row with `consecutive_failures: 0`.

The dispatch returned only the answer string, so the run's `success` never reached the schedule. Every other outcome (`error`, `timeout`, `budget`) arrives by **exception**, and this one does not: nothing breaks, which is exactly why it needed its own name. `rejected` is now a dispatch status, it counts as a failure, and the silence alarm — which reads that counter — can finally see it.

A dispatch with no verdict still means `ok`. A job that declared no gate has nothing that could reject it, and absence of a verdict is not a failure — the same rule the reviewer and the verifier already follow when they abstain.

## The process caught two of my own guards passing for the wrong reason

- A wiring assertion survived the line being **commented out** — the substring `workspace=job_root` stayed in the file. It now requires an actual argument line, and is sabotaged three ways: commented, deleted, and swapped for the process root.
- A scheduler fixture built its job by hand, so `next_run` was never set and the job was never due. Every assertion reported the state from *before* the tick. The helper now refuses to report on a dispatch that did not happen.

The dedupe test also carries its own control: without the join, the same fixture bills $0.0217 instead of $0.01085.

**4458 tests, ruff and mypy clean on 329 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
