### PR TITLE
fix(cron): connect the verdict, and finish the join that was half done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,25 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **The `rejected` outcome was never wired to anything.** Added in the previous release together
+  with its dispatch status, its engine branch and its tests — and the one line that FEEDS it was
+  not changed. `run_job` still returned a bare answer string, which the dispatch reads as `ok`, so
+  a scheduled job whose gate rejected every attempt and reverted every file kept showing a green
+  row with `consecutive_failures: 0`. Measured twice on a real install: once before the outcome
+  type existed, and once after it existed and changed nothing.
+  The tests that were meant to cover it injected a `JobOutcome` straight into the dispatch — every
+  part of the path except the only place that produces one. A guard outside the flow, wearing the
+  name of the thing it was not checking. The producer now returns the verdict, and only for a job
+  that declared a gate: without one there is nothing that could reject the work, and `success`
+  there reflects gates this path does not run.
+
+- **The double-billing join fixed half the double-billing.** A scheduled dispatch writes ONE usage
+  row holding the total across every attempt, keyed by the LAST attempt's id. Skipping only the
+  attempt whose id matched left the earlier ones to be added on top of a total that already
+  contained them: two attempts of $0.004247 and $0.006598 against a $0.010845 row were counted as
+  $0.015092. Found by arithmetic — two deliberate actions should have moved the total by $0.0116
+  and it moved by $0.0267. A run any of whose attempts is already counted is now skipped whole.
+
 - **A run that hit its dollar cap recorded no spending at all.** Introduced by the cap fix one
   release earlier and found by re-running the same experiment against it: the run stopped
   correctly, said *"spend cap reached: $0.0030"*, and left a receipt reading `usd: null,

--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -139,7 +139,7 @@ def usage_from_runs(path: Path, *, already: set[str] | None = None) -> list[Usag
         return []
     contadas = already or set()
     out: list[UsageRecord] = []
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():  # noqa: PLR1702
         if not line.strip():
             continue
         try:
@@ -150,13 +150,16 @@ def usage_from_runs(path: Path, *, already: set[str] | None = None) -> list[Usag
         if not isinstance(row, dict):
             continue
         run_ts = str(row.get("ts") or "")
-        for attempt in row.get("attempts") or []:
-            if not isinstance(attempt, dict):
-                continue
-            # Skipped, not zeroed: this attempt is already in the other log, and a zero row would
-            # still count a turn that has been counted.
-            if str(attempt.get("run_id") or "") in contadas:
-                continue
+        tentativas = [a for a in (row.get("attempts") or []) if isinstance(a, dict)]
+        # The WHOLE run, not the one attempt whose id matched. A scheduled dispatch writes ONE
+        # usage row holding the total across every attempt, keyed by the LAST attempt's id — so
+        # skipping only that attempt left the earlier ones to be added on top of a total that
+        # already contained them. Measured on a real job: two attempts of $0.004247 and $0.006598
+        # against a $0.010845 row, counted as $0.015092. The first version of this join fixed half
+        # the double-count and the arithmetic said so.
+        if any(str(a.get("run_id") or "") in contadas for a in tentativas):
+            continue
+        for attempt in tentativas:
             usd = attempt.get("usd")
             out.append(
                 UsageRecord(

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1902,13 +1902,14 @@ def _start_cron_daemon(
     from chimera.orchestration.budget import BudgetExceeded
     from chimera.scheduler import CronDaemon, CronJob, Scheduler, make_agent_dispatch
     from chimera.scheduler.delivery import make_deliver
+    from chimera.scheduler.models import JobOutcome
     from chimera.tools import default_registry
 
     scheduler = Scheduler(_cron_store())
     settings = get_settings()
     usage_path = settings.home / "usage.jsonl"
 
-    def run_job(job: CronJob) -> str:
+    def run_job(job: CronJob) -> JobOutcome:
         """One dispatch, inside whatever the money allows.
 
         Three things happen here that did not before. The DAILY cap is checked before the job is
@@ -2045,7 +2046,17 @@ def _start_cron_daemon(
                 f"[yellow]cron '{job.name}': governance touched {touched} action(s) — "
                 f"{detail}[/yellow]"
             )
-        return result.answer
+        # The VERDICT, not just the answer. Returning a bare string is read as `ok` by the
+        # dispatch, and that is how a job whose gate rejected every attempt and reverted every
+        # file showed a green row with zero failures — measured twice, once before the outcome
+        # type existed and once after, because the type was added and this line was not changed.
+        #
+        # Only when the job declared a gate. Without one there is nothing that could reject the
+        # work, `success` then reflects gates this path does not run, and reporting it would turn
+        # every ungated job into a failure. Absence of a verdict is not a failure.
+        if not gated:
+            return JobOutcome(result.answer)
+        return JobOutcome(result.answer, ok=bool(result.success))
 
     def run_task(task: str) -> str:
         """The job-less fallback. Governed too — it is reachable, and "reachable but forgotten" is

--- a/tests/test_a_scheduled_job_reports_what_happened.py
+++ b/tests/test_a_scheduled_job_reports_what_happened.py
@@ -165,6 +165,49 @@ def test_the_scheduled_loop_is_given_the_folder_it_runs_in() -> None:
     )
 
 
+def _corpo_do_run_job() -> str:
+    """The source of the closure that actually runs a scheduled job.
+
+    Bounded to the function rather than searched across the file: `return result.answer` appears
+    elsewhere for a different command, and a whole-file search would find that one and report the
+    wiring as present while the scheduled path returned a bare string.
+    """
+    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
+    inicio = fonte.index("def run_job(job: CronJob)")
+    return fonte[inicio : fonte.index("def run_task(", inicio)]
+
+
+def test_the_scheduled_job_actually_reports_its_verdict() -> None:
+    """The half that shipped missing, and the reason it shipped missing.
+
+    ``JobOutcome``, the ``rejected`` status and the engine branch that records it were all added
+    together — and the one line that FEEDS them was not. A bare string is read as ``ok``, so a job
+    whose gate rejected every attempt and reverted every file still showed a green row. Measured
+    twice on a real install: once before the outcome type existed, and once after.
+
+    The tests that were supposed to cover it injected a ``JobOutcome`` straight into the dispatch,
+    which is every part of the path except the only place that produces one — a guard outside the
+    flow, wearing the name of the thing it was not checking.
+    """
+    corpo = _corpo_do_run_job()
+    linhas = [linha.strip() for linha in corpo.splitlines()]
+
+    assert "return result.answer" not in linhas, (
+        "the scheduled path returns a bare answer, which the dispatch reads as ok — the verdict "
+        "never reaches the schedule"
+    )
+    assert "return JobOutcome(result.answer, ok=bool(result.success))" in linhas
+
+
+def test_an_ungated_job_reports_no_verdict_at_all() -> None:
+    """Without a gate there is nothing that could reject the work, and ``success`` then reflects
+    gates this path does not run — reporting it would turn every ungated job into a failure."""
+    corpo = _corpo_do_run_job()
+
+    assert "if not gated:" in corpo
+    assert "return JobOutcome(result.answer)" in [linha.strip() for linha in corpo.splitlines()]
+
+
 def test_the_folder_comes_from_the_job_not_the_process() -> None:
     """`job_root` is the job's own folder falling back to the process root. Passing `workspace`
     (the process one) instead would attribute every scheduled run to whatever folder the daemon

--- a/tests/test_the_cost_screen_counts_runs.py
+++ b/tests/test_the_cost_screen_counts_runs.py
@@ -160,6 +160,47 @@ def test_without_the_join_it_really_would_be_billed_twice(tmp_path: Path) -> Non
     assert round(sem_juncao["totals"]["usd"], 6) == 0.0217
 
 
+def test_a_scheduled_run_with_SEVERAL_attempts_is_counted_once(tmp_path: Path) -> None:
+    """The half the first join missed, in the exact shape it was measured.
+
+    A scheduled dispatch writes ONE usage row holding the total across every attempt, keyed by the
+    LAST attempt's id. Skipping only the matching attempt left the earlier ones to be added on top
+    of a total that already contained them: two attempts of $0.004247 and $0.006598 against a
+    $0.010845 row came out as $0.015092.
+    """
+    append_usage(tmp_path / "usage.jsonl", UsageRecord(
+        ts="2026-08-31T02:02:30+00:00", session_id="cron:8e9681d2:e0e62070", model="m",
+        usd=0.010845,
+    ))
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(
+        run_id="0c2854db", usd=0.004247,
+        extra_attempts=[{"index": 2, "run_id": "e0e62070", "model": "m",
+                         "prompt_tokens": 10, "completion_tokens": 1, "usd": 0.006598}],
+    ))
+
+    summary = summarize_usage(turnos + usage_from_runs(runs, already=_already_counted(turnos)))
+
+    assert summary["totals"]["turns"] == 1, "an earlier attempt was added on top of its own total"
+    assert round(summary["totals"]["usd"], 6) == 0.010845
+
+
+def test_a_run_none_of_whose_attempts_are_counted_survives_whole(tmp_path: Path) -> None:
+    """The control for the rule above: skipping the WHOLE run is right only when the run is
+    already counted. A run the usage log has never seen must keep every attempt."""
+    turnos = load_usage(tmp_path / "usage.jsonl")
+    runs = _write_runs(tmp_path, _run_row(
+        run_id="aaa", usd=0.01,
+        extra_attempts=[{"index": 2, "run_id": "bbb", "model": "m",
+                         "prompt_tokens": 10, "completion_tokens": 1, "usd": 0.02}],
+    ))
+
+    summary = summarize_usage(turnos + usage_from_runs(runs, already=_already_counted(turnos)))
+
+    assert summary["totals"]["turns"] == 2
+    assert round(summary["totals"]["usd"], 6) == 0.03
+
+
 def test_a_bare_chat_session_is_never_read_as_a_run_id(tmp_path: Path) -> None:
     """The dangerous direction. A chat turn writes a bare 32-hex session id and no receipt; reading
     one as a run id would silently DROP a real charge, and under-counting money must never happen


### PR DESCRIPTION
Both fixes shipped in rc45 and **neither worked**. Found by driving rc45 as a user: a scheduled job with a gate written to fail, and arithmetic on the Cost screen.

## `rejected` was never wired to anything

The dispatch status, the `JobOutcome` type, the engine branch that records it and the tests all landed together in rc45. The one line that **feeds** them did not.

`run_job` still ended with `return result.answer` — a bare string, which the dispatch reads as `ok`. So a scheduled job whose gate rejected every attempt and reverted every file kept showing:

```
last_status: "ok"      consecutive_failures: 0      folder: empty
```

Measured twice on a real install: once before the outcome type existed, and once after it existed and changed nothing.

**Why the tests did not catch it.** They injected a `JobOutcome` straight into `make_agent_dispatch` — every part of the path except the only place that produces one. A guard outside the flow, wearing the name of the thing it was not checking. The file's own docstring talks about wiring while its tests bypass the wiring.

The new test reads the body of `run_job` **bounded to the function**, because `return result.answer` appears in another command in the same file, and a whole-file search finds that one and reports the wiring as present.

The verdict travels only for a job that declared a gate: without one there is nothing that could reject the work, and `success` there reflects gates this path does not run — reporting it would turn every ungated job into a failure.

## The double-billing join fixed half the double-billing

A scheduled dispatch writes **one** usage row holding the total across every attempt, keyed by the **last** attempt's id. Skipping only the attempt whose id matched left the earlier ones to be added on top of a total that already contained them.

| | |
|---|---:|
| attempt 1 | $0.004247 |
| attempt 2 | $0.006598 |
| the usage row (their total) | **$0.010845** |
| what the screen counted | **$0.015092** |

Found by arithmetic, not by suspicion: two deliberate actions should have moved the total by $0.0116, and it moved by $0.0267. A run any of whose attempts is already counted is now skipped whole, with a control test asserting that a run the usage log has never seen keeps every attempt.

Real total on the measured install: **$4.1526**, against the **$4.1611** rc45 reports.

## What did work in rc45

Worth recording, because two of the four fixes did land:

- A run that hits its dollar cap now records what it spent — `attempts: 1`, `usd: 0.003984`, with tokens and model. rc44 wrote `usd: null, attempts: []`.
- A scheduled receipt now carries its workspace — `workspace='…\rc45-cron'`, not empty.

**4462 tests, ruff and mypy clean on 329 files.** Four sabotages, four failures, including one that reproduces the shipped defect exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
