### PR TITLE
perf(app): cache the model catalogue, and bound the folder of reverted work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,30 @@ You could not choose which model answered you. The endpoint accepted one all alo
 
 ### Fixed — found by installing each release candidate and using it
 
+- **The model picker re-fetched its whole catalogue on every open.** Measured on a real install:
+  **2,136 ms** for a 94 KB network round trip, paid again every time the Settings screen opened, and
+  the only slow route in the app — the other 42 answered in under 220 ms. Cached for ten minutes,
+  which is far shorter than the rate at which a model catalogue changes and long enough that a
+  screen opened twice in a session is instant the second time.
+  Keyed on everything the answer depends on — the requested provider, the set of configured
+  providers, the API base and the default model — so a changed key or a changed default invalidates
+  it instead of being served the previous machine's list. Per app instance rather than a module
+  global: two installs pointed at different providers must not read each other's catalogue, and one
+  test must not inherit another's. Failures are cached too, exactly as the version check does: a
+  provider that is down already answers with its own reason, and re-asking it on every screen open
+  turns one slow answer into a burst of them.
+
+- **The folder of reverted work had no ceiling.** Every attempt a verify command rejects writes its
+  full diff to `discarded/`, which is what makes that work recoverable — and nothing ever removed
+  one. Measured: 3 files in one session, 7 eighteen hours later, ~2 KB each, growing forever. Small
+  today, and the shape nobody notices until it is a problem.
+  Bounded on BOTH axes — 500 files and 50 MB — because either alone can be defeated: a count alone
+  lets one enormous diff fill a disk, a size alone lets thousands of tiny ones fill an inode table.
+  Oldest first, deliberately: recovering work you were just doing is the whole point of the folder,
+  and a reverted attempt from last month is not something anyone comes back for. The path stays in
+  the old receipt after its file goes — a dangling pointer to work gone for months is a smaller
+  cost than a folder with no bound, and it is the only one of the two anyone can see.
+
 - **The `rejected` outcome was never wired to anything.** Added in the previous release together
   with its dispatch status, its engine branch and its tests — and the one line that FEEDS it was
   not changed. `run_job` still returned a bare answer string, which the dispatch reads as `ok`, so

--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime
@@ -764,6 +765,15 @@ def build_api_app(
             "reason": found.reason,
         }
 
+    #: Answers to `/api/models`, by what the answer depends on. Per app instance rather than a
+    #: module global: a test builds its own app and must not inherit another test's catalogue.
+    _models_cache: dict[tuple[Any, ...], tuple[float, dict[str, Any]]] = {}
+    #: Ten minutes. The Settings screen fetches this on every open and the call is a 94 KB network
+    #: round trip — measured at 2.1 seconds, every time, on the only slow route in the app. Model
+    #: catalogues change on the order of weeks, so ten minutes is far shorter than the thing it is
+    #: caching and long enough that a screen opened twice in a session is instant the second time.
+    _MODELS_TTL = 600.0
+
     @app.get("/api/models", dependencies=[guard], response_model=ModelsOut)
     async def models_endpoint(provider: str | None = None) -> dict[str, Any]:
         """The models a request may name, so choosing one stops being a memory test.
@@ -783,6 +793,20 @@ def build_api_app(
         from chimera.providers.listing import available_models
 
         settings_now = live_settings()
+        # Everything the answer depends on, so a changed key or a changed default invalidates it
+        # rather than being served the previous machine's list. The keys are what decide WHICH
+        # catalogues are listed, and `default_model` rides in the payload — a cache keyed on the
+        # provider alone would keep showing the old default after someone changed it.
+        chave = (
+            provider or "",
+            tuple(sorted(settings_now.configured_providers())),
+            getattr(settings_now, "api_base", None),
+            settings_now.default_model,
+        )
+        agora = time.monotonic()
+        guardado = _models_cache.get(chave)
+        if guardado is not None and agora - guardado[0] < _MODELS_TTL:
+            return guardado[1]
 
         def resolve() -> dict[str, Any]:
             listing = available_models(settings_now, provider=provider)
@@ -793,7 +817,12 @@ def build_api_app(
                 "reason": listing.reason,
             }
 
-        return await asyncio.get_running_loop().run_in_executor(None, resolve)
+        resposta = await asyncio.get_running_loop().run_in_executor(None, resolve)
+        # Failures are cached too, exactly as the version check does: a provider that is down
+        # already answers with its own `reason`, and re-asking it on every screen open turns one
+        # slow answer into a burst of them.
+        _models_cache[chave] = (agora, resposta)
+        return resposta
 
     # --- Messaging: reach the user on Discord/Telegram, controlled from the UI --------------------
     @app.get("/api/messaging", dependencies=[guard], response_model=dict[str, MessagingPlatformOut])

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -316,6 +316,49 @@ class AutonomousResult:
 _JUDGE_DIFF_CHARS = 4000
 
 
+#: How much reverted work is kept, and it is a bound on BOTH axes because either alone can be
+#: defeated. A count alone lets one enormous diff fill a disk; a size alone lets thousands of tiny
+#: ones fill an inode table. Measured on a real install: 7 files in 18 hours at ~2 KB each, one per
+#: reverted attempt, growing forever — small today and unbounded, which is the shape nobody notices
+#: until it is a problem.
+_DISCARDED_MAX_FILES = 500
+_DISCARDED_MAX_BYTES = 50 * 1024 * 1024
+
+
+def _podar_descartados(pasta: Path) -> int:
+    """Keep the newest reverted diffs, drop the oldest, and return how many were dropped.
+
+    Oldest first, deliberately: recovering work you were just doing is the whole point of the
+    folder, and a reverted attempt from last month is not something anyone comes back for. The path
+    stays in the old receipt after its file goes — a dangling pointer to work gone for months is a
+    smaller cost than a folder with no ceiling, and it is the only one of the two anyone can see.
+
+    Best-effort like the write it follows: failing to prune must never be why a revert fails.
+    """
+    try:
+        arquivos = sorted(
+            (f for f in pasta.glob("*.diff") if f.is_file()), key=lambda f: f.stat().st_mtime
+        )
+        total = sum(f.stat().st_size for f in arquivos)
+    except OSError as exc:  # pragma: no cover - defensive
+        _log.debug("nao consegui listar os descartados para poda: %s", exc)
+        return 0
+    removidos = 0
+    for f in arquivos:
+        if len(arquivos) - removidos <= _DISCARDED_MAX_FILES and total <= _DISCARDED_MAX_BYTES:
+            break
+        try:
+            tamanho = f.stat().st_size
+            f.unlink()
+            total -= tamanho
+            removidos += 1
+        except OSError as exc:  # pragma: no cover - defensive
+            _log.debug("nao consegui remover %s: %s", f, exc)
+    if removidos:
+        _log.info("descartados: %d arquivo(s) antigo(s) removido(s)", removidos)
+    return removidos
+
+
 class AutonomousAgent:
     """Runs a task autonomously with planning, supervision and verify-or-revert."""
 
@@ -1397,6 +1440,7 @@ class AutonomousAgent:
                 corpo.append("")
             destino.write_text("\n".join(corpo), encoding="utf-8")
             _log.info("trabalho revertido guardado em %s", destino)
+            _podar_descartados(destino.parent)
             return str(destino)
         except Exception as exc:  # noqa: BLE001 — guardar nunca pode impedir reverter
             _log.warning("nao consegui guardar o trabalho revertido: %s", exc)

--- a/tests/test_the_slow_route_and_the_growing_folder.py
+++ b/tests/test_the_slow_route_and_the_growing_folder.py
@@ -1,0 +1,249 @@
+"""Two costs measured on a real install, neither of them a wrong answer.
+
+* ``/api/models`` was the only slow route in the app — **2,136 ms** for a 94 KB network round trip,
+  paid again on every open of the Settings screen, uncached.
+* ``discarded/`` grew by one file per reverted attempt with no ceiling of any kind: 3 files in one
+  session, 7 eighteen hours later, forever. Small today, and the shape nobody notices until it is
+  a problem.
+
+Free: no model call, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.core.autonomous import (
+    _DISCARDED_MAX_BYTES,
+    _DISCARDED_MAX_FILES,
+    _podar_descartados,
+)
+
+# --- the folder that had no ceiling ---------------------------------------------------------------
+
+
+def _diffs(pasta: Path, quantos: int, *, tamanho: int = 100) -> list[Path]:
+    """``quantos`` diffs, oldest first — the mtimes are set explicitly rather than left to the
+    filesystem, because a test that writes them in a loop can produce identical timestamps and
+    then "oldest first" would be whatever order the directory happens to return."""
+    pasta.mkdir(parents=True, exist_ok=True)
+    feitos = []
+    for i in range(quantos):
+        f = pasta / f"run{i:04d}-1.diff"
+        f.write_text("x" * tamanho, encoding="utf-8")
+        import os
+
+        os.utime(f, (1_000_000 + i, 1_000_000 + i))
+        feitos.append(f)
+    return feitos
+
+
+def test_a_folder_under_the_cap_is_left_alone(tmp_path: Path) -> None:
+    """Pruning must be invisible to anyone who has not hit the bound."""
+    _diffs(tmp_path, 5)
+
+    assert _podar_descartados(tmp_path) == 0
+    assert len(list(tmp_path.glob("*.diff"))) == 5
+
+
+def test_the_oldest_go_first(tmp_path: Path) -> None:
+    """Recovering work you were just doing is the whole point; a revert from last month is not
+    something anyone comes back for."""
+    _diffs(tmp_path, _DISCARDED_MAX_FILES + 3)
+
+    _podar_descartados(tmp_path)
+
+    restantes = {f.name for f in tmp_path.glob("*.diff")}
+    assert len(restantes) == _DISCARDED_MAX_FILES
+    assert "run0000-1.diff" not in restantes, "the oldest survived"
+    assert f"run{_DISCARDED_MAX_FILES + 2:04d}-1.diff" in restantes, "the newest was deleted"
+
+
+def test_size_binds_even_when_the_count_does_not(tmp_path: Path) -> None:
+    """Both axes, because either alone can be defeated: a handful of enormous diffs fills a disk
+    while the file count sits comfortably under its bound."""
+    grande = _DISCARDED_MAX_BYTES // 2
+    _diffs(tmp_path, 3, tamanho=grande)
+
+    _podar_descartados(tmp_path)
+
+    total = sum(f.stat().st_size for f in tmp_path.glob("*.diff"))
+    assert len(list(tmp_path.glob("*.diff"))) < 3, "the count was under its cap so nothing pruned"
+    assert total <= _DISCARDED_MAX_BYTES
+
+
+def test_count_binds_even_when_the_size_does_not(tmp_path: Path) -> None:
+    """The mirror: thousands of tiny files are nowhere near the byte cap and still fill a folder."""
+    _diffs(tmp_path, _DISCARDED_MAX_FILES + 10, tamanho=10)
+
+    _podar_descartados(tmp_path)
+
+    assert len(list(tmp_path.glob("*.diff"))) == _DISCARDED_MAX_FILES
+
+
+def test_it_only_touches_diffs(tmp_path: Path) -> None:
+    """The folder is ours, and a pruner that deletes by position rather than by pattern is one
+    stray file away from removing something it was never told about."""
+    import os
+
+    _diffs(tmp_path, _DISCARDED_MAX_FILES + 5)
+    estranho = tmp_path / "LEIA-ME.txt"
+    estranho.write_text("nao me apague", encoding="utf-8")
+    # OLDER than every diff, deliberately. Written last it would be the newest and would survive a
+    # pruner that deleted by position rather than by pattern — measured: that sabotage walked
+    # straight through the first version of this test.
+    os.utime(estranho, (1, 1))
+
+    _podar_descartados(tmp_path)
+
+    assert estranho.exists(), "the pruner deleted a file it was never told about"
+
+
+def test_a_missing_folder_is_not_an_error(tmp_path: Path) -> None:
+    """Best-effort throughout: failing to prune must never be the reason a revert fails."""
+    assert _podar_descartados(tmp_path / "nunca-existiu") == 0
+
+
+def test_the_writer_prunes_after_writing() -> None:
+    """A pruner nothing calls is a folder with no ceiling. The call sits after the write, so a
+    failure to prune cannot cost the file that was just saved."""
+    import inspect
+
+    from chimera.core.autonomous import AutonomousAgent
+
+    fonte = inspect.getsource(AutonomousAgent._preserve_discarded)
+
+    assert "_podar_descartados(destino.parent)" in fonte
+    assert fonte.index("destino.write_text") < fonte.index("_podar_descartados")
+
+
+# --- the only slow route in the app ---------------------------------------------------------------
+
+
+def _client(tmp_path: Path) -> Any:
+    from tests.test_api import _client as build
+
+    return build(tmp_path)
+
+
+def test_the_model_list_is_fetched_once_and_reused(tmp_path: Path, monkeypatch: Any) -> None:
+    """Measured: 2,136 ms per call, on every open of the Settings screen."""
+    chamadas = {"n": 0}
+    import chimera.providers.listing as listing_mod
+
+    class _Listing:
+        models: list[Any] = []
+        sources: list[str] = ["catalog"]
+        reason = ""
+
+    def _fake(settings: Any, *, provider: str | None = None, **kw: Any) -> Any:
+        chamadas["n"] += 1
+        return _Listing()
+
+    monkeypatch.setattr(listing_mod, "available_models", _fake)
+    client = _client(tmp_path)
+
+    client.get("/api/models")
+    client.get("/api/models")
+    client.get("/api/models")
+
+    assert chamadas["n"] == 1, f"the catalogue was fetched {chamadas['n']} times for three opens"
+
+
+def test_a_different_provider_is_a_different_answer(tmp_path: Path, monkeypatch: Any) -> None:
+    """``?provider=`` is the onboarding wizard asking *what does this key buy*. Serving it the
+    previous provider's list is the one thing that question cannot survive — four different values
+    returning byte-identical bodies is a defect this endpoint has already had once."""
+    vistos: list[str | None] = []
+    import chimera.providers.listing as listing_mod
+
+    class _Listing:
+        models: list[Any] = []
+        sources: list[str] = []
+        reason = ""
+
+    def _fake(settings: Any, *, provider: str | None = None, **kw: Any) -> Any:
+        vistos.append(provider)
+        return _Listing()
+
+    monkeypatch.setattr(listing_mod, "available_models", _fake)
+    client = _client(tmp_path)
+
+    client.get("/api/models")
+    client.get("/api/models?provider=anthropic")
+    client.get("/api/models?provider=openai")
+
+    assert vistos == [None, "anthropic", "openai"]
+
+
+def test_an_expired_entry_is_fetched_again(tmp_path: Path, monkeypatch: Any) -> None:
+    """A cache with no expiry is a snapshot. The clock is moved rather than waited on."""
+    chamadas = {"n": 0}
+    import chimera.api.app as app_mod
+    import chimera.providers.listing as listing_mod
+
+    class _Listing:
+        models: list[Any] = []
+        sources: list[str] = []
+        reason = ""
+
+    def _fake(settings: Any, *, provider: str | None = None, **kw: Any) -> Any:
+        chamadas["n"] += 1
+        return _Listing()
+
+    monkeypatch.setattr(listing_mod, "available_models", _fake)
+    relogio = {"t": 1000.0}
+    monkeypatch.setattr(app_mod.time, "monotonic", lambda: relogio["t"])
+    client = _client(tmp_path)
+
+    client.get("/api/models")
+    relogio["t"] += 10_000  # far past any sane TTL
+    client.get("/api/models")
+
+    assert chamadas["n"] == 2
+
+
+def test_two_apps_do_not_share_a_catalogue(tmp_path: Path, monkeypatch: Any) -> None:
+    """Per app instance, not a module global: one test's fixture must not become another's answer,
+    and two installs pointed at different providers must not read each other's list."""
+    chamadas = {"n": 0}
+    import chimera.providers.listing as listing_mod
+
+    class _Listing:
+        models: list[Any] = []
+        sources: list[str] = []
+        reason = ""
+
+    def _fake(settings: Any, *, provider: str | None = None, **kw: Any) -> Any:
+        chamadas["n"] += 1
+        return _Listing()
+
+    monkeypatch.setattr(listing_mod, "available_models", _fake)
+
+    _client(tmp_path / "a").get("/api/models")
+    _client(tmp_path / "b").get("/api/models")
+
+    assert chamadas["n"] == 2
+
+
+@pytest.mark.parametrize("campo", ["default", "models", "sources", "reason"])
+def test_the_cached_answer_is_the_whole_answer(tmp_path: Path, monkeypatch: Any, campo: str) -> None:
+    """A cache that drops a field turns a fast route into a wrong one."""
+    import chimera.providers.listing as listing_mod
+
+    class _Listing:
+        models: list[Any] = []
+        sources: list[str] = ["catalog"]
+        reason = ""
+
+    monkeypatch.setattr(listing_mod, "available_models", lambda *a, **k: _Listing())
+    client = _client(tmp_path)
+
+    primeira = client.get("/api/models").json()
+    segunda = client.get("/api/models").json()
+
+    assert campo in segunda
+    assert segunda[campo] == primeira[campo]


### PR DESCRIPTION
Two costs measured by using rc46. Neither is a wrong answer — one is slow, the other grows without a ceiling.

## The model picker re-fetched its whole catalogue on every open

| route | latency |
|---|---:|
| `/api/models` | **2,136 ms** |
| the other 42 GET routes | under 220 ms |

94 KB over the network, paid again every time the Settings screen opened, and identical on the second and third call — nothing was cached.

Cached for **ten minutes**: far shorter than the rate at which a model catalogue changes, long enough that a screen opened twice in a session is instant the second time.

**Keyed on everything the answer depends on** — the requested provider, the set of configured providers, the API base, and the default model. A changed key or a changed default invalidates it instead of serving the previous machine's list. `default_model` is in the payload, so a cache keyed on the provider alone would keep showing the old default after someone changed it.

**Per app instance, not a module global.** Two installs pointed at different providers must not read each other's catalogue, and one test must not inherit another's fixture.

**Failures are cached too**, exactly as the version check already does: a provider that is down answers with its own `reason`, and re-asking it on every screen open turns one slow answer into a burst of them.

The `?provider=` path has its own test, because it is the onboarding wizard asking *what does this key buy* — and this endpoint has already shipped a defect where four different values returned byte-identical bodies.

## The folder of reverted work had no ceiling

Every attempt a verify command rejects writes its full diff to `discarded/` — that is what makes the work recoverable, and it is a feature this project shipped deliberately. Nothing ever removed one.

Measured: **3 files in one session, 7 eighteen hours later**, ~2 KB each, one per reverted attempt, forever. Small today, and the shape nobody notices until it is a problem.

Bounded on **both axes** — 500 files and 50 MB — because either alone can be defeated: a count alone lets one enormous diff fill a disk; a size alone lets thousands of tiny ones fill an inode table.

**Oldest first**, deliberately. Recovering work you were just doing is the whole point of the folder; a reverted attempt from last month is not something anyone comes back for. The path stays in the old receipt after its file goes — a dangling pointer to work gone for months is a smaller cost than a folder with no bound, and it is the only one of the two anyone can see.

## The battery caught one of mine passing for the wrong reason

`test_it_only_touches_diffs` wrote its stray `LEIA-ME.txt` **last**, making it the newest file — so a pruner that deleted by position rather than by pattern left it alone anyway, and the sabotage walked straight through. The stray file is now older than every diff, which is the only arrangement in which the assertion can discriminate.

Two fixtures also invented values for `sources` and `reason`, which the response model pins to `Literal` tokens — they failed validation before reaching the cache at all.

**Eight sabotages, eight failures. 4477 tests, ruff and mypy clean on 329 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
