### PR TITLE
feat(cron): make the scheduled dispatch testable; fix the prerelease update check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,41 @@ You could not choose which model answered you. The endpoint accepted one all alo
   and a reverted attempt from last month is not something anyone comes back for. The path stays in
   the old receipt after its file goes — a dangling pointer to work gone for months is a smaller
   cost than a folder with no bound, and it is the only one of the two anyone can see.
+- **An app on a release candidate was told about nothing at all.** Two causes, stacked, either one
+  enough on its own: `_parse_version("0.48.0rc46")` returned None because every dot-separated
+  segment had to be digits, so every comparison answered False — not a newer candidate, not even
+  the final `0.48.0`; and `/releases/latest` excludes prereleases by GitHub's own definition, so
+  the newest thing the check could ever report was the last stable. Measured on a real install
+  running rc46: `latest: "0.47.0", update_available: false`. With forty-six candidates in this
+  series that is the common case, not the edge.
+  A stable install is still never offered a candidate — someone on 0.47.0 did not opt into a
+  prerelease track — and the two questions have separate cache slots, because one slot would serve
+  a stable install the candidate list. The newest is chosen by parsed version rather than by the
+  list's order: GitHub sorts by creation date, and a patch cut after a candidate would otherwise be
+  announced as the newer of the two. The comparison is written here rather than taken from
+  `packaging`, which is not a declared dependency of this project: a version check that breaks a
+  clean install is worse than one that understands two shapes.
+
+- **The run log was read whole, four times over.** `read_text().splitlines()` on a 5.5 MB log of
+  1000 receipts peaks at **22 MB** — the raw bytes, the decoded string and the list of lines are
+  all alive at once — and three routes read that same file. Streamed line by line it peaks at
+  **0.1 MB**. The time was never the problem and the first framing of this said otherwise: 1000
+  receipts parse in 24 ms either way, and streaming is marginally *faster* at 20.5 ms. (A first
+  attempt to measure that reported streaming as twice as slow, because `tracemalloc` was left
+  running during the timing.)
+
+### Changed — the scheduled dispatch can be driven
+
+- **`run_job` moved out of the CLI command into `chimera/scheduler/job_runner.py`.** It was a
+  149-line closure inside a Typer command, so nothing could call it — which is the reason two
+  defects reached users through it: the verdict it returns and the workspace it names are both
+  produced there, and the tests that stood in for it handed a `JobOutcome` straight to the part
+  that RECORDS one. Every step of the path except the step that was broken.
+  It is a factory now, taking what it used to capture, and eleven tests drive it end to end with a
+  fake backend: the gate's verdict, the folder on the receipt, the daily cap's refusal, the usage
+  row that sums every attempt, and the reviewer that must not exist. The source-text assertions
+  that stood in for those are gone — one of them used to pass with the line **commented out**,
+  because the substring was still in the file.
 
 - **The `rejected` outcome was never wired to anything.** Added in the previous release together
   with its dispatch status, its engine branch and its tests — and the one line that FEEDS it was

--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -280,14 +280,20 @@ def load_runs(path: Path, *, workspace: str | None = None) -> list[RunReceipt]:
     if not path.exists():
         return []
     out: list[RunReceipt] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        try:
-            receipt = RunReceipt.model_validate_json(line)
-        except ValueError:  # pragma: no cover - defensive
-            _log.warning("skipping malformed run receipt line")
-            continue
-        if workspace is None or _in_project(receipt.workspace, workspace):
-            out.append(receipt)
+    # Line by line, not `read_text().splitlines()`. Measured on a 5.5 MB log of 1000 receipts: the
+    # whole-file read peaks at 22 MB — four times the file, because the raw bytes, the decoded
+    # string and the list of lines are all alive at once — against 0.1 MB streaming. Three routes
+    # read this file and a receipt embeds its diffs, so the log grows at ~5.6 KB a run and the
+    # multiplier travels with it. The parse time is NOT the problem: 1000 receipts parse in 24 ms.
+    with path.open(encoding="utf-8", errors="replace") as arquivo:
+        for line in arquivo:
+            if not line.strip():
+                continue
+            try:
+                receipt = RunReceipt.model_validate_json(line)
+            except ValueError:  # pragma: no cover - defensive
+                _log.warning("skipping malformed run receipt line")
+                continue
+            if workspace is None or _in_project(receipt.workspace, workspace):
+                out.append(receipt)
     return out

--- a/chimera/api/usage.py
+++ b/chimera/api/usage.py
@@ -139,40 +139,43 @@ def usage_from_runs(path: Path, *, already: set[str] | None = None) -> list[Usag
         return []
     contadas = already or set()
     out: list[UsageRecord] = []
-    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():  # noqa: PLR1702
-        if not line.strip():
-            continue
-        try:
-            row = json.loads(line)
-        except ValueError:
-            _log.warning("skipping malformed run record line")
-            continue
-        if not isinstance(row, dict):
-            continue
-        run_ts = str(row.get("ts") or "")
-        tentativas = [a for a in (row.get("attempts") or []) if isinstance(a, dict)]
-        # The WHOLE run, not the one attempt whose id matched. A scheduled dispatch writes ONE
-        # usage row holding the total across every attempt, keyed by the LAST attempt's id — so
-        # skipping only that attempt left the earlier ones to be added on top of a total that
-        # already contained them. Measured on a real job: two attempts of $0.004247 and $0.006598
-        # against a $0.010845 row, counted as $0.015092. The first version of this join fixed half
-        # the double-count and the arithmetic said so.
-        if any(str(a.get("run_id") or "") in contadas for a in tentativas):
-            continue
-        for attempt in tentativas:
-            usd = attempt.get("usd")
-            out.append(
-                UsageRecord(
-                    ts=run_ts,
-                    # The attempt carries the run id; the run row itself does not.
-                    session_id=RUN_SESSION_PREFIX + str(attempt.get("run_id") or run_ts),
-                    model=str(attempt.get("model") or ""),
-                    prompt_tokens=int(attempt.get("prompt_tokens") or 0),
-                    completion_tokens=int(attempt.get("completion_tokens") or 0),
-                    usd=float(usd) if isinstance(usd, int | float) else None,
-                    tools=len(attempt.get("tool_names") or []),
+    # Streamed for the reason spelled out in `chimera.api.runs.load_runs`: the whole-file read
+    # peaks at four times the file, and this is the same file.
+    with path.open(encoding="utf-8", errors="replace") as arquivo:
+        for line in arquivo:
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                _log.warning("skipping malformed run record line")
+                continue
+            if not isinstance(row, dict):
+                continue
+            run_ts = str(row.get("ts") or "")
+            tentativas = [a for a in (row.get("attempts") or []) if isinstance(a, dict)]
+            # The WHOLE run, not the one attempt whose id matched. A scheduled dispatch writes ONE
+            # usage row holding the total across every attempt, keyed by the LAST attempt's id — so
+            # skipping only that attempt left the earlier ones to be added on top of a total that
+            # already contained them. Measured on a real job: two attempts of $0.004247 and $0.006598
+            # against a $0.010845 row, counted as $0.015092. The first version of this join fixed half
+            # the double-count and the arithmetic said so.
+            if any(str(a.get("run_id") or "") in contadas for a in tentativas):
+                continue
+            for attempt in tentativas:
+                usd = attempt.get("usd")
+                out.append(
+                    UsageRecord(
+                        ts=run_ts,
+                        # The attempt carries the run id; the run row itself does not.
+                        session_id=RUN_SESSION_PREFIX + str(attempt.get("run_id") or run_ts),
+                        model=str(attempt.get("model") or ""),
+                        prompt_tokens=int(attempt.get("prompt_tokens") or 0),
+                        completion_tokens=int(attempt.get("completion_tokens") or 0),
+                        usd=float(usd) if isinstance(usd, int | float) else None,
+                        tools=len(attempt.get("tool_names") or []),
+                    )
                 )
-            )
     return out
 
 
@@ -182,13 +185,15 @@ def load_usage(path: Path) -> list[UsageRecord]:
     if not path.exists():
         return []
     out: list[UsageRecord] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        try:
-            out.append(UsageRecord.model_validate_json(line))
-        except ValueError:  # pragma: no cover - defensive
-            _log.warning("skipping malformed usage record line")
+    # Streamed for the same reason as the run log above.
+    with path.open(encoding="utf-8", errors="replace") as arquivo:
+        for line in arquivo:
+            if not line.strip():
+                continue
+            try:
+                out.append(UsageRecord.model_validate_json(line))
+            except ValueError:  # pragma: no cover - defensive
+                _log.warning("skipping malformed usage record line")
     return out
 
 

--- a/chimera/api/version_api.py
+++ b/chimera/api/version_api.py
@@ -11,6 +11,7 @@ PRIVACY: this is a plain GET of GitHub's PUBLIC releases API — no user data is
 from __future__ import annotations
 
 import json
+import re
 import time
 import urllib.request
 from typing import Any
@@ -21,32 +22,60 @@ _log = get_logger("api.version")
 
 # The releases API (newest release) + the human releases page fallback for the "notes" link.
 _RELEASES_LATEST_URL = "https://api.github.com/repos/brcampidelli/chimera-agent/releases/latest"
+#: The LIST, which is the only endpoint that returns prereleases — `/releases/latest` excludes
+#: them by GitHub's definition, which is the other half of why an app on a candidate was told
+#: about nothing: even with a parser that understood the version, the newest thing this could
+#: ever report was the last stable.
+_RELEASES_LIST_URL = (
+    "https://api.github.com/repos/brcampidelli/chimera-agent/releases?per_page=30"
+)
 _RELEASES_PAGE_URL = "https://github.com/brcampidelli/chimera-agent/releases"
 _USER_AGENT = "chimera-agent"  # GitHub's API rejects requests without a User-Agent
 _TIMEOUT = 4.0  # a short timeout — a slow/blocked network must not stall the version check
 _TTL = 3600.0  # cache the GitHub result for an hour so repeated GETs don't hammer the API
 
-# Module-level cache: (fetched_at_monotonic, (latest, notes_url)). ``None`` until the first fetch.
+# Module-level cache, keyed on whether prereleases were asked for — the two questions have
+# different answers and sharing one slot would serve a stable install a candidate.
 # Both successes and failures are cached, so a transient error won't trigger a burst of retries.
-_cache: tuple[float, tuple[str | None, str | None]] | None = None
+_cache: dict[bool, tuple[float, tuple[str | None, str | None]]] = {}
+
+
+#: ``0.48.0`` or ``0.48.0rc46`` — the only two shapes `scripts/cut_release.py` will produce. It
+#: refuses post and dev releases by name, so nothing else has to be understood here.
+_VERSION = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
 
 
 def _parse_version(text: str) -> tuple[int, ...] | None:
-    """Parse ``MAJOR.MINOR.PATCH`` into an int tuple for comparison; ``None`` when it doesn't parse.
+    """Parse a version into a sortable tuple; ``None`` when it doesn't parse.
 
-    Strict: every dot-separated segment must be a non-negative integer (a source-tree marker like
-    ``0.0.0+source`` or any pre-release suffix fails to parse and is treated as "can't compare" — which
-    yields ``update_available=False``, never a false positive).
+    Pre-releases are understood now, and until they were, an app on a release candidate was told
+    about nothing at all: ``0.48.0rc46`` failed to parse, so every comparison returned False — not
+    a newer candidate, not even the final ``0.48.0``. With forty-six candidates in this series that
+    is the common case rather than the edge.
+
+    The fourth element is what orders them: ``1`` for a final release and ``0`` for a candidate, so
+    ``0.48.0rc46 < 0.48.0`` while ``0.48.0rc45 < 0.48.0rc46``. Anything else — a source-tree marker
+    like ``0.0.0+source``, a post release, anything unrecognised — still returns None and still
+    yields ``update_available=False``. Never a false positive is the rule that has not changed.
+
+    Written here rather than taken from `packaging`, which is not a declared dependency of this
+    project and is present only transitively: a version check that breaks a clean install is worse
+    than one that understands two shapes.
     """
-    parts = text.split(".")
-    if not parts:
+    m = _VERSION.match(text.strip())
+    if m is None:
         return None
-    out: list[int] = []
-    for part in parts:
-        if not part.isdigit():
-            return None
-        out.append(int(part))
-    return tuple(out)
+    maior, menor, patch, rc = m.groups()
+    if rc is None:
+        return (int(maior), int(menor), int(patch), 1, 0)
+    return (int(maior), int(menor), int(patch), 0, int(rc))
+
+
+def _is_prerelease(text: str) -> bool:
+    """Whether this version is a release candidate. Unparseable is NOT a prerelease: a source
+    checkout must not be offered candidates it never opted into."""
+    parsed = _parse_version(text)
+    return parsed is not None and parsed[3] == 0
 
 
 def _is_newer(latest: str, current: str) -> bool:
@@ -62,42 +91,75 @@ def _is_newer(latest: str, current: str) -> bool:
     return latest_v > current_v
 
 
-def _fetch_latest() -> tuple[str | None, str | None]:
-    """Fetch the newest release ``(tag_without_leading_v, html_url)`` from GitHub.
-
-    Fail-silent: ANY error (network, timeout, rate-limit, non-JSON, missing keys) returns
-    ``(None, None)`` — it never raises. The caller turns that into "no update available".
-    """
-    req = urllib.request.Request(  # noqa: S310 — a fixed https GitHub API URL, not user input
-        _RELEASES_LATEST_URL,
-        headers={"User-Agent": _USER_AGENT, "Accept": "application/vnd.github+json"},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:  # noqa: S310 — fixed https URL
-            payload: Any = json.loads(resp.read().decode("utf-8"))
-    except Exception as exc:  # noqa: BLE001 — fail-silent: no update signal, never a raise
-        _log.debug("version check failed: %s", exc)
+def _tag_and_url(entrada: Any) -> tuple[str | None, str | None]:
+    """One release object -> ``(tag_without_leading_v, html_url)``, or ``(None, None)``."""
+    if not isinstance(entrada, dict):
         return None, None
-    if not isinstance(payload, dict):
-        return None, None
-    tag = payload.get("tag_name")
+    tag = entrada.get("tag_name")
     if not isinstance(tag, str) or not tag.strip():
         return None, None
     tag = tag.strip()
     latest = tag[1:] if tag[:1] in ("v", "V") else tag  # strip a single leading "v" (e.g. v0.31.0)
-    html_url = payload.get("html_url")
-    notes_url = html_url if isinstance(html_url, str) and html_url else None
-    return latest or None, notes_url
+    html_url = entrada.get("html_url")
+    return latest or None, (html_url if isinstance(html_url, str) and html_url else None)
 
 
-def _cached_latest() -> tuple[str | None, str | None]:
+def _get_json(url: str) -> Any:
+    """A fixed GitHub API GET, or ``None`` on ANY failure.
+
+    Fail-silent by design: network, timeout, rate-limit, non-JSON — all of it becomes "no update
+    signal" rather than an exception, because a version check must never be the reason the app
+    stops working.
+    """
+    req = urllib.request.Request(  # noqa: S310 — a fixed https GitHub API URL, not user input
+        url, headers={"User-Agent": _USER_AGENT, "Accept": "application/vnd.github+json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:  # noqa: S310 — fixed https URL
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001 — fail-silent: no update signal, never a raise
+        _log.debug("version check failed: %s", exc)
+        return None
+
+
+def _fetch_latest(*, include_prereleases: bool = False) -> tuple[str | None, str | None]:
+    """The newest release ``(tag_without_leading_v, html_url)`` on the asked-for track.
+
+    Without prereleases this is `/releases/latest`, one cheap request, and GitHub itself does the
+    excluding. With them it has to be the LIST, because that endpoint is the only one that returns
+    a candidate at all.
+
+    The newest is chosen by PARSED VERSION rather than by the list's own order: GitHub sorts by
+    creation date, and a patch cut after a candidate would otherwise be announced as the newer of
+    the two. Drafts and unparseable tags are skipped rather than guessed at.
+    """
+    if not include_prereleases:
+        return _tag_and_url(_get_json(_RELEASES_LATEST_URL))
+
+    payload = _get_json(_RELEASES_LIST_URL)
+    if not isinstance(payload, list):
+        return None, None
+    melhor: tuple[tuple[int, ...], str, str | None] | None = None
+    for entrada in payload:
+        if isinstance(entrada, dict) and entrada.get("draft"):
+            continue
+        tag, url = _tag_and_url(entrada)
+        parsed = _parse_version(tag or "")
+        if tag is None or parsed is None:
+            continue
+        if melhor is None or parsed > melhor[0]:
+            melhor = (parsed, tag, url)
+    return (melhor[1], melhor[2]) if melhor else (None, None)
+
+
+def _cached_latest(*, include_prereleases: bool = False) -> tuple[str | None, str | None]:
     """Return the (possibly cached) latest-release ``(latest, notes_url)``, refetching past the TTL."""
-    global _cache
     now = time.monotonic()
-    if _cache is not None and now - _cache[0] < _TTL:
-        return _cache[1]
-    result = _fetch_latest()
-    _cache = (now, result)
+    guardado = _cache.get(include_prereleases)
+    if guardado is not None and now - guardado[0] < _TTL:
+        return guardado[1]
+    result = _fetch_latest(include_prereleases=include_prereleases)
+    _cache[include_prereleases] = (now, result)
     return result
 
 
@@ -111,7 +173,10 @@ def check_version() -> dict[str, Any]:
     import chimera
 
     current = chimera.__version__
-    latest, html_url = _cached_latest()
+    # A candidate is offered candidates; a stable release is not. Someone running 0.47.0 never
+    # opted into a prerelease, and answering their update check with one would push them onto a
+    # track they did not choose — the same reason `/releases/latest` excludes them by default.
+    latest, html_url = _cached_latest(include_prereleases=_is_prerelease(current))
     available = bool(latest) and _is_newer(latest or "", current)
     return {
         "version": current,

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -1893,170 +1893,29 @@ def _start_cron_daemon(
     backend: SupportsComplete, model: str | None, max_steps: int, workspace: Path, tick: int
 ) -> Any:
     """Start the cron daemon in a background thread; return its stop event."""
-    from datetime import UTC, datetime
 
-    from chimera.api.usage import UsageRecord, append_usage, spent_today
     from chimera.core import Agent, AgentConfig
-    from chimera.core.instructions import load as load_identity
-    from chimera.core.instructions import render as render_identity
-    from chimera.orchestration.budget import BudgetExceeded
-    from chimera.scheduler import CronDaemon, CronJob, Scheduler, make_agent_dispatch
+    from chimera.scheduler import CronDaemon, Scheduler, make_agent_dispatch
     from chimera.scheduler.delivery import make_deliver
-    from chimera.scheduler.models import JobOutcome
+    from chimera.scheduler.job_runner import make_run_job
     from chimera.tools import default_registry
 
     scheduler = Scheduler(_cron_store())
     settings = get_settings()
     usage_path = settings.home / "usage.jsonl"
 
-    def run_job(job: CronJob) -> JobOutcome:
-        """One dispatch, inside whatever the money allows.
-
-        Three things happen here that did not before. The DAILY cap is checked before the job is
-        allowed to spend anything; the job's own cap is handed to the loop; and what the job spent
-        is written to the usage log — which is what makes the daily figure include cron at all. It
-        did not: the log was written only by the chat turn, so a daily cap read from it would have
-        been blind to exactly the spend it exists to bound.
-        """
-        cap = settings.daily_usd_cap
-        if cap and not job.critical:
-            today = datetime.now(UTC).strftime("%Y-%m-%d")
-            spent, unpriced = spent_today(usage_path, today=today)
-            if unpriced:
-                raise BudgetExceeded(
-                    f"today's spend cannot be known (an unpriced model ran); {job.name} refused. "
-                    "Price the model, or mark this job critical if it must run regardless"
-                )
-            if spent >= cap:
-                raise BudgetExceeded(f"daily cap reached: ${spent:.4f} of ${cap:.4f}")
-
-        # The folder THIS job was written against, falling back to the process root. A schedule
-        # fires for months: "wherever the app was pointing when it went off" is not a root anybody
-        # chose, and on a packaged build the process root is the install directory.
-        job_root = Path(job.workspace).expanduser() if job.workspace else workspace
-
-        # Governance on the path that runs unattended. In `observe` this refuses nothing and
-        # records what enforcement would have cost; the count is reported below, per job, which is
-        # the whole point of having a middle state.
-        job_registry, job_approvals = governed_profile(
-            default_registry(job_root),
-            settings=settings,
-            home=settings.home,
-            surface=f"cron:{job.name}",
-        )
-        agent = Agent(
-            backend,
-            job_registry,
-            AgentConfig(
-                model=model,
-                max_steps=max_steps,
-                max_usd=job.max_usd,
-                # The same workspace the job's tools are rooted in. A scheduled job is the surface
-                # LEAST able to be told the conventions any other way — nobody is at a terminal to
-                # restate them — and it was the one reading none.
-                project_root=job_root,
-                # And the owner's own instructions, which every other surface that answers a
-                # person already loads. A cron job reports to a person too — into Discord, into a
-                # log, into the app — and this was the second surface answering in English to an
-                # owner who had configured Portuguese, because the same rendered block carries the
-                # "always answer in {language}" line.
-                instructions=render_identity(load_identity(settings.home)),
-                # The path that runs the most was the one with no step-level record at all. Without
-                # it there is no success-versus-context curve, no replay of a job that went wrong,
-                # and no reliability bench for the 24/7 loop — every one of those reads this file.
-                trace_path=settings.home / "scheduler" / "cron_traces.jsonl",
-            ),
-        )
-        # THE HARNESS, on the surface that runs most often and had none of it.
-        #
-        # `chimera solve`, the Code screen and the run endpoint all wrap the worker in the
-        # autonomous loop — snapshot, verify, revert, retry, receipt. Cron called `agent.run`
-        # directly, so the path that fires unattended every day, for months, was the only one with
-        # no gate, no rollback, no retry and no entry in `runs.jsonl`. Nothing was watching the
-        # thing that runs when nobody is watching.
-        #
-        # The guard and the verifier are armed ONLY when the job declares a `verify`, and that is
-        # the whole design rather than a caution. `unverified_and_unchanged` fails an attempt that
-        # changed no file, and most scheduled jobs are reports that change no files — arming it for
-        # everyone would fail every report job with "this task requires editing code", which is a
-        # defect this project has already measured on its own release. With no guard the diff gate
-        # cannot fire (`diff_productive` stays None), so a report job behaves exactly as it did and
-        # gains only the receipt.
-        from chimera.core import AutonomousAgent, AutonomousConfig, WorkspaceGuard
-        from chimera.core.verify import CommandVerifier
-
-        gated = bool(job.verify.strip())
-        loop = AutonomousAgent(
-            agent,
-            planner=None,
-            manager=None,
-            verifier=CommandVerifier(job.verify, job_root) if gated else None,
-            guard=WorkspaceGuard(job_root) if gated else None,
-            config=AutonomousConfig(
-                max_attempts=max(1, job.max_attempts),
-                use_planner=False,
-                # Unchanged: cron has never had a reviewer, and adding one would spend a model call
-                # per dispatch to grade prose nobody asked to be graded.
-                use_manager=False,
-            ),
-            # The receipt. `runs.jsonl` is what the Runs screen reads, and a job that has fired
-            # nightly for a month left nothing there to read.
-            run_log=settings.home / "runs.jsonl",
-            # And the folder it happened in, or the receipt is unreadable from the only screen
-            # that would look for it. The guard and the tools were rooted here already; the LOOP
-            # was not, so every scheduled receipt was written with an empty workspace — and a
-            # receipt with no workspace is deliberately excluded from every filtered list, which
-            # made each one invisible in the project it ran in. The fix above went half the
-            # distance: the receipt existed and could not be found.
-            workspace=job_root,
-        )
-        result = loop.run(job.action)
-        # Summed across attempts rather than read off one: with `max_attempts > 1` a dispatch can
-        # pay for several, and reporting the last one would understate the cost of exactly the
-        # configuration that costs most. `usd` follows the all-or-nothing rule used everywhere else
-        # — one unpriced attempt makes the total unknown, never smaller.
-        attempts = result.attempts or []
-        usd_values = [a.usd for a in attempts]
-        append_usage(
-            usage_path,
-            UsageRecord(
-                ts=datetime.now(UTC).isoformat(),
-                # `run_id` in the session field is what joins this row to the trace line and to the
-                # job: three records, one run, one key.
-                session_id=f"cron:{job.id}:{attempts[-1].run_id if attempts else ''}",
-                # The model that ANSWERED, falling back to the one asked for. `model` is optional on
-                # this path (None = the settings default), so the empty string is the last resort —
-                # a usage row with no model is still a usage row, and inventing a name would be
-                # worse than leaving the field blank.
-                model=(attempts[-1].model if attempts else None) or model or "",
-                prompt_tokens=sum(int(a.prompt_tokens or 0) for a in attempts),
-                completion_tokens=sum(int(a.completion_tokens or 0) for a in attempts),
-                usd=None if any(v is None for v in usd_values) else sum(v or 0.0 for v in usd_values),
-            ),
-        )
-        # Said out loud, on the job, every time. A governance decision that only exists inside an
-        # observation string is one nobody counts — and on this path "nobody counted" reads as a
-        # green tick over work that never happened.
-        if job_approvals.granted or job_approvals.refused:
-            touched = len(job_approvals.granted) + len(job_approvals.refused)
-            detail = job_approvals.summary() or (
-                f"{len(job_approvals.granted)} would be refused under enforce"
-            )
-            console.print(
-                f"[yellow]cron '{job.name}': governance touched {touched} action(s) — "
-                f"{detail}[/yellow]"
-            )
-        # The VERDICT, not just the answer. Returning a bare string is read as `ok` by the
-        # dispatch, and that is how a job whose gate rejected every attempt and reverted every
-        # file showed a green row with zero failures — measured twice, once before the outcome
-        # type existed and once after, because the type was added and this line was not changed.
-        #
-        # Only when the job declared a gate. Without one there is nothing that could reject the
-        # work, `success` then reflects gates this path does not run, and reporting it would turn
-        # every ungated job into a failure. Absence of a verdict is not a failure.
-        if not gated:
-            return JobOutcome(result.answer)
-        return JobOutcome(result.answer, ok=bool(result.success))
+    # Built by the factory rather than defined here. As a closure inside this command it was
+    # unreachable from any test, and that is why two defects shipped: the verdict it returns
+    # and the workspace it names are both produced HERE, and nothing could drive it to check.
+    run_job = make_run_job(
+        settings=settings,
+        backend=backend,
+        workspace=workspace,
+        model=model,
+        max_steps=max_steps,
+        usage_path=usage_path,
+        warn=lambda linha: console.print(f"[yellow]{linha}[/yellow]"),
+    )
 
     def run_task(task: str) -> str:
         """The job-less fallback. Governed too — it is reachable, and "reachable but forgotten" is

--- a/chimera/scheduler/job_runner.py
+++ b/chimera/scheduler/job_runner.py
@@ -1,0 +1,191 @@
+"""The one scheduled dispatch, as a function a test can drive.
+
+It lived as a closure inside a CLI command, which is the reason two defects reached users: nothing
+could call it, so nothing tested the only place that produces a verdict or names a workspace. The
+tests that existed handed a `JobOutcome` straight to the part that RECORDS one — every step of the
+path except the step that was broken.
+
+`make_run_job` takes what the closure used to capture. `warn` replaces the console for the same
+reason the delivery sink takes one: a module that runs unattended must not own a terminal, and rich
+markup is the caller's business.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from chimera.api.usage import UsageRecord, append_usage, spent_today
+from chimera.core.agent import Agent, AgentConfig
+from chimera.core.instructions import load as load_identity
+from chimera.core.instructions import render as render_identity
+from chimera.governance import governed_profile
+from chimera.orchestration.budget import BudgetExceeded
+from chimera.scheduler.models import CronJob, JobOutcome
+from chimera.tools.builtin import default_registry
+
+
+def make_run_job(
+    *,
+    settings: Any,
+    backend: Any,
+    workspace: Path,
+    model: str | None,
+    max_steps: int,
+    usage_path: Path,
+    warn: Callable[[str], None] = lambda _linha: None,
+) -> Callable[[CronJob], JobOutcome]:
+    """Build the dispatch for one serve loop. Everything it used to close over is a parameter now."""
+
+    def run_job(job: CronJob) -> JobOutcome:
+        """One dispatch, inside whatever the money allows.
+
+        Three things happen here that did not before. The DAILY cap is checked before the job is
+        allowed to spend anything; the job's own cap is handed to the loop; and what the job spent
+        is written to the usage log — which is what makes the daily figure include cron at all. It
+        did not: the log was written only by the chat turn, so a daily cap read from it would have
+        been blind to exactly the spend it exists to bound.
+        """
+        cap = settings.daily_usd_cap
+        if cap and not job.critical:
+            today = datetime.now(UTC).strftime("%Y-%m-%d")
+            spent, unpriced = spent_today(usage_path, today=today)
+            if unpriced:
+                raise BudgetExceeded(
+                    f"today's spend cannot be known (an unpriced model ran); {job.name} refused. "
+                    "Price the model, or mark this job critical if it must run regardless"
+                )
+            if spent >= cap:
+                raise BudgetExceeded(f"daily cap reached: ${spent:.4f} of ${cap:.4f}")
+
+        # The folder THIS job was written against, falling back to the process root. A schedule
+        # fires for months: "wherever the app was pointing when it went off" is not a root anybody
+        # chose, and on a packaged build the process root is the install directory.
+        job_root = Path(job.workspace).expanduser() if job.workspace else workspace
+
+        # Governance on the path that runs unattended. In `observe` this refuses nothing and
+        # records what enforcement would have cost; the count is reported below, per job, which is
+        # the whole point of having a middle state.
+        job_registry, job_approvals = governed_profile(
+            default_registry(job_root),
+            settings=settings,
+            home=settings.home,
+            surface=f"cron:{job.name}",
+        )
+        agent = Agent(
+            backend,
+            job_registry,
+            AgentConfig(
+                model=model,
+                max_steps=max_steps,
+                max_usd=job.max_usd,
+                # The same workspace the job's tools are rooted in. A scheduled job is the surface
+                # LEAST able to be told the conventions any other way — nobody is at a terminal to
+                # restate them — and it was the one reading none.
+                project_root=job_root,
+                # And the owner's own instructions, which every other surface that answers a
+                # person already loads. A cron job reports to a person too — into Discord, into a
+                # log, into the app — and this was the second surface answering in English to an
+                # owner who had configured Portuguese, because the same rendered block carries the
+                # "always answer in {language}" line.
+                instructions=render_identity(load_identity(settings.home)),
+                # The path that runs the most was the one with no step-level record at all. Without
+                # it there is no success-versus-context curve, no replay of a job that went wrong,
+                # and no reliability bench for the 24/7 loop — every one of those reads this file.
+                trace_path=settings.home / "scheduler" / "cron_traces.jsonl",
+            ),
+        )
+        # THE HARNESS, on the surface that runs most often and had none of it.
+        #
+        # `chimera solve`, the Code screen and the run endpoint all wrap the worker in the
+        # autonomous loop — snapshot, verify, revert, retry, receipt. Cron called `agent.run`
+        # directly, so the path that fires unattended every day, for months, was the only one with
+        # no gate, no rollback, no retry and no entry in `runs.jsonl`. Nothing was watching the
+        # thing that runs when nobody is watching.
+        #
+        # The guard and the verifier are armed ONLY when the job declares a `verify`, and that is
+        # the whole design rather than a caution. `unverified_and_unchanged` fails an attempt that
+        # changed no file, and most scheduled jobs are reports that change no files — arming it for
+        # everyone would fail every report job with "this task requires editing code", which is a
+        # defect this project has already measured on its own release. With no guard the diff gate
+        # cannot fire (`diff_productive` stays None), so a report job behaves exactly as it did and
+        # gains only the receipt.
+        from chimera.core import AutonomousAgent, AutonomousConfig, WorkspaceGuard
+        from chimera.core.verify import CommandVerifier
+
+        gated = bool(job.verify.strip())
+        loop = AutonomousAgent(
+            agent,
+            planner=None,
+            manager=None,
+            verifier=CommandVerifier(job.verify, job_root) if gated else None,
+            guard=WorkspaceGuard(job_root) if gated else None,
+            config=AutonomousConfig(
+                max_attempts=max(1, job.max_attempts),
+                use_planner=False,
+                # Unchanged: cron has never had a reviewer, and adding one would spend a model call
+                # per dispatch to grade prose nobody asked to be graded.
+                use_manager=False,
+            ),
+            # The receipt. `runs.jsonl` is what the Runs screen reads, and a job that has fired
+            # nightly for a month left nothing there to read.
+            run_log=settings.home / "runs.jsonl",
+            # And the folder it happened in, or the receipt is unreadable from the only screen
+            # that would look for it. The guard and the tools were rooted here already; the LOOP
+            # was not, so every scheduled receipt was written with an empty workspace — and a
+            # receipt with no workspace is deliberately excluded from every filtered list, which
+            # made each one invisible in the project it ran in. The fix above went half the
+            # distance: the receipt existed and could not be found.
+            workspace=job_root,
+        )
+        result = loop.run(job.action)
+        # Summed across attempts rather than read off one: with `max_attempts > 1` a dispatch can
+        # pay for several, and reporting the last one would understate the cost of exactly the
+        # configuration that costs most. `usd` follows the all-or-nothing rule used everywhere else
+        # — one unpriced attempt makes the total unknown, never smaller.
+        attempts = result.attempts or []
+        usd_values = [a.usd for a in attempts]
+        append_usage(
+            usage_path,
+            UsageRecord(
+                ts=datetime.now(UTC).isoformat(),
+                # `run_id` in the session field is what joins this row to the trace line and to the
+                # job: three records, one run, one key.
+                session_id=f"cron:{job.id}:{attempts[-1].run_id if attempts else ''}",
+                # The model that ANSWERED, falling back to the one asked for. `model` is optional on
+                # this path (None = the settings default), so the empty string is the last resort —
+                # a usage row with no model is still a usage row, and inventing a name would be
+                # worse than leaving the field blank.
+                model=(attempts[-1].model if attempts else None) or model or "",
+                prompt_tokens=sum(int(a.prompt_tokens or 0) for a in attempts),
+                completion_tokens=sum(int(a.completion_tokens or 0) for a in attempts),
+                usd=None if any(v is None for v in usd_values) else sum(v or 0.0 for v in usd_values),
+            ),
+        )
+        # Said out loud, on the job, every time. A governance decision that only exists inside an
+        # observation string is one nobody counts — and on this path "nobody counted" reads as a
+        # green tick over work that never happened.
+        if job_approvals.granted or job_approvals.refused:
+            touched = len(job_approvals.granted) + len(job_approvals.refused)
+            detail = job_approvals.summary() or (
+                f"{len(job_approvals.granted)} would be refused under enforce"
+            )
+            warn(
+                f"cron '{job.name}': governance touched {touched} action(s) — "
+                f"{detail}"
+            )
+        # The VERDICT, not just the answer. Returning a bare string is read as `ok` by the
+        # dispatch, and that is how a job whose gate rejected every attempt and reverted every
+        # file showed a green row with zero failures — measured twice, once before the outcome
+        # type existed and once after, because the type was added and this line was not changed.
+        #
+        # Only when the job declared a gate. Without one there is nothing that could reject the
+        # work, `success` then reflects gates this path does not run, and reporting it would turn
+        # every ungated job into a failure. Absence of a verdict is not a failure.
+        if not gated:
+            return JobOutcome(result.answer)
+        return JobOutcome(result.answer, ok=bool(result.success))
+
+    return run_job

--- a/tests/test_a_prerelease_hears_about_updates.py
+++ b/tests/test_a_prerelease_hears_about_updates.py
@@ -1,0 +1,225 @@
+"""An app on a release candidate was told about nothing at all.
+
+Two causes, stacked, and either alone was enough:
+
+* ``_parse_version("0.48.0rc46")`` returned ``None`` — every segment had to be digits — so every
+  comparison answered False. Not a newer candidate, not even the final ``0.48.0``.
+* ``/releases/latest`` excludes prereleases by GitHub's own definition, so the newest thing the
+  check could ever report was the last stable.
+
+With forty-six candidates in this series that is the common case, not the edge — measured on a real
+install running rc46: ``latest: "0.47.0", update_available: false``.
+
+The property that must NOT change: a stable install is never offered a candidate. Someone on 0.47.0
+did not opt into a prerelease track, and answering their update check with one would move them onto
+a track they never chose.
+
+Free: no network — every fetch is replaced.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chimera.api import version_api
+from chimera.api.version_api import _is_newer, _is_prerelease, _parse_version
+
+
+@pytest.fixture(autouse=True)
+def _sem_cache() -> Any:
+    """The module caches by track. A test that inherits another's entry is measuring that entry."""
+    version_api._cache.clear()
+    yield
+    version_api._cache.clear()
+
+
+# --- ordering -------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mais_novo", "mais_velho"),
+    [
+        ("0.48.0rc46", "0.48.0rc45"),
+        ("0.48.0rc46", "0.48.0rc9"),  # numeric, not lexicographic: "rc9" must not beat "rc46"
+        ("0.48.0", "0.48.0rc46"),  # the final release outranks every candidate for it
+        ("0.48.0rc1", "0.47.0"),
+        ("1.0.0", "0.99.99"),
+    ],
+)
+def test_the_newer_one_is_newer(mais_novo: str, mais_velho: str) -> None:
+    assert _is_newer(mais_novo, mais_velho) is True
+    assert _is_newer(mais_velho, mais_novo) is False
+
+
+def test_the_same_version_is_not_an_update() -> None:
+    assert _is_newer("0.48.0rc46", "0.48.0rc46") is False
+
+
+@pytest.mark.parametrize("texto", ["0.0.0+source", "0.48.0.post1", "0.48.0dev3", "abc", "", "0.48"])
+def test_anything_unrecognised_never_claims_an_update(texto: str) -> None:
+    """Never a false positive is the rule this check has always had, and the parser getting more
+    capable must not cost it. A source checkout in particular reports ``0.0.0+source``."""
+    assert _parse_version(texto) is None
+    assert _is_newer(texto, "0.48.0") is False
+    assert _is_newer("0.48.0", texto) is False
+
+
+def test_a_source_checkout_is_not_treated_as_a_prerelease() -> None:
+    """It parses as nothing, and "nothing" must not be read as "opted into candidates"."""
+    assert _is_prerelease("0.0.0+source") is False
+    assert _is_prerelease("0.48.0") is False
+    assert _is_prerelease("0.48.0rc46") is True
+
+
+# --- which track is asked for ----------------------------------------------------------------------
+
+
+def _fake_github(monkeypatch: Any, *, latest: Any, listagem: Any) -> list[str]:
+    """Replace the network and record which URL was asked for."""
+    pedidos: list[str] = []
+
+    def _get(url: str) -> Any:
+        pedidos.append(url)
+        return listagem if "per_page" in url else latest
+
+    monkeypatch.setattr(version_api, "_get_json", _get)
+    return pedidos
+
+
+def _release(tag: str, **kw: Any) -> dict[str, Any]:
+    return {"tag_name": tag, "html_url": f"https://example/{tag}", **kw}
+
+
+def test_a_stable_install_is_never_offered_a_candidate(monkeypatch: Any) -> None:
+    """The safety property. `/releases/latest` excludes prereleases, and a stable install must keep
+    asking exactly that endpoint — otherwise the parser's new understanding would push someone onto
+    a track they never chose."""
+    pedidos = _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.0"),
+        listagem=[_release("v0.48.0rc46"), _release("v0.47.0")],
+    )
+    monkeypatch.setattr(version_api, "_current_version", lambda: "0.47.0", raising=False)
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.47.0")
+
+    resultado = version_api.check_version()
+
+    assert all("per_page" not in u for u in pedidos), "a stable install asked for prereleases"
+    assert resultado["latest"] == "0.47.0"
+    assert resultado["update_available"] is False
+
+
+def test_a_candidate_hears_about_a_newer_candidate(monkeypatch: Any) -> None:
+    """The measured case: rc46 installed, rc47 published, and the app said nothing."""
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.0"),
+        listagem=[_release("v0.48.0rc47"), _release("v0.48.0rc46"), _release("v0.47.0")],
+    )
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc46")
+
+    resultado = version_api.check_version()
+
+    assert resultado["latest"] == "0.48.0rc47"
+    assert resultado["update_available"] is True
+    assert resultado["notes_url"] == "https://example/v0.48.0rc47"
+
+
+def test_a_candidate_hears_about_the_final_release(monkeypatch: Any) -> None:
+    """The half that matters most: the whole point of a candidate is to be replaced by 0.48.0."""
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.48.0"),
+        listagem=[_release("v0.48.0"), _release("v0.48.0rc46")],
+    )
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc46")
+
+    resultado = version_api.check_version()
+
+    assert resultado["latest"] == "0.48.0"
+    assert resultado["update_available"] is True
+
+
+def test_the_newest_is_by_version_not_by_list_order(monkeypatch: Any) -> None:
+    """GitHub sorts the list by creation date. A patch cut AFTER a candidate would otherwise be
+    announced as the newer of the two, which is the wrong answer in the one direction that moves
+    someone backwards."""
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.1"),
+        listagem=[_release("v0.47.1"), _release("v0.48.0rc46")],  # newest-first by date
+    )
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc45")
+
+    assert version_api.check_version()["latest"] == "0.48.0rc46"
+
+
+def test_a_draft_is_not_a_release(monkeypatch: Any) -> None:
+    """A draft is not published. Announcing one sends people to a page they cannot download."""
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.0"),
+        listagem=[_release("v0.49.0rc1", draft=True), _release("v0.48.0rc46")],
+    )
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc45")
+
+    assert version_api.check_version()["latest"] == "0.48.0rc46"
+
+
+def test_an_unreadable_tag_is_skipped_not_guessed(monkeypatch: Any) -> None:
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.0"),
+        listagem=[_release("nightly-2026-08-31"), _release("v0.48.0rc46")],
+    )
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc45")
+
+    assert version_api.check_version()["latest"] == "0.48.0rc46"
+
+
+# --- it still fails silently ------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("resposta", [None, [], {}, "nao e json", [{"tag_name": ""}]])
+def test_a_failed_fetch_is_never_an_update(monkeypatch: Any, resposta: Any) -> None:
+    """The oldest rule here: offline, rate-limited or malformed all degrade to "no update", never
+    to a claim and never to an exception."""
+    _fake_github(monkeypatch, latest=resposta, listagem=resposta)
+    import chimera
+
+    monkeypatch.setattr(chimera, "__version__", "0.48.0rc46")
+
+    resultado = version_api.check_version()
+
+    assert resultado["latest"] is None
+    assert resultado["update_available"] is False
+    assert resultado["notes_url"] is None
+
+
+def test_the_two_tracks_do_not_share_a_cache(monkeypatch: Any) -> None:
+    """One slot for both questions would serve a stable install the candidate list."""
+    _fake_github(
+        monkeypatch,
+        latest=_release("v0.47.0"),
+        listagem=[_release("v0.48.0rc46")],
+    )
+
+    estavel = version_api._cached_latest(include_prereleases=False)
+    candidata = version_api._cached_latest(include_prereleases=True)
+
+    assert estavel[0] == "0.47.0"
+    assert candidata[0] == "0.48.0rc46"

--- a/tests/test_a_scheduled_job_reports_what_happened.py
+++ b/tests/test_a_scheduled_job_reports_what_happened.py
@@ -18,7 +18,6 @@ Free: no model call, no network.
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 from typing import Any
 
@@ -138,80 +137,15 @@ def test_an_exception_is_still_an_error_not_a_rejection(tmp_path: Path) -> None:
     assert job.last_status == "error"
 
 
-# --- the receipt says where it ran --------------------------------------------------------------
-
-
-def test_the_scheduled_loop_is_given_the_folder_it_runs_in() -> None:
-    """A wiring assertion, because the defect was wiring: the guard and the tools were rooted in the
-    job's folder and the LOOP was not, so `_persist_receipt` wrote an empty workspace.
-
-    Asserted on the source because the closure lives inside a CLI command and cannot be reached
-    from a test — and asserting nothing was how it shipped.
-    """
-    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
-    bloco = re.search(
-        r"run_log=settings\.home / \"runs\.jsonl\",(.{0,900}?)\)\n", fonte, re.S
-    )
-
-    assert bloco, "the scheduled loop no longer names its run log — this test is looking at nothing"
-    # An ARGUMENT, not the substring. Commenting the line out leaves `workspace=job_root` in the
-    # file, and a substring check passes over it — measured: that sabotage walked straight through
-    # the first version of this assertion.
-    linhas = [linha.strip() for linha in bloco.group(1).splitlines()]
-
-    assert "workspace=job_root," in linhas, (
-        "the scheduled receipt is written without a workspace, so it is unfindable from the "
-        "project it ran in"
-    )
-
-
-def _corpo_do_run_job() -> str:
-    """The source of the closure that actually runs a scheduled job.
-
-    Bounded to the function rather than searched across the file: `return result.answer` appears
-    elsewhere for a different command, and a whole-file search would find that one and report the
-    wiring as present while the scheduled path returned a bare string.
-    """
-    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
-    inicio = fonte.index("def run_job(job: CronJob)")
-    return fonte[inicio : fonte.index("def run_task(", inicio)]
-
-
-def test_the_scheduled_job_actually_reports_its_verdict() -> None:
-    """The half that shipped missing, and the reason it shipped missing.
-
-    ``JobOutcome``, the ``rejected`` status and the engine branch that records it were all added
-    together — and the one line that FEEDS them was not. A bare string is read as ``ok``, so a job
-    whose gate rejected every attempt and reverted every file still showed a green row. Measured
-    twice on a real install: once before the outcome type existed, and once after.
-
-    The tests that were supposed to cover it injected a ``JobOutcome`` straight into the dispatch,
-    which is every part of the path except the only place that produces one — a guard outside the
-    flow, wearing the name of the thing it was not checking.
-    """
-    corpo = _corpo_do_run_job()
-    linhas = [linha.strip() for linha in corpo.splitlines()]
-
-    assert "return result.answer" not in linhas, (
-        "the scheduled path returns a bare answer, which the dispatch reads as ok — the verdict "
-        "never reaches the schedule"
-    )
-    assert "return JobOutcome(result.answer, ok=bool(result.success))" in linhas
-
-
-def test_an_ungated_job_reports_no_verdict_at_all() -> None:
-    """Without a gate there is nothing that could reject the work, and ``success`` then reflects
-    gates this path does not run — reporting it would turn every ungated job into a failure."""
-    corpo = _corpo_do_run_job()
-
-    assert "if not gated:" in corpo
-    assert "return JobOutcome(result.answer)" in [linha.strip() for linha in corpo.splitlines()]
-
-
-def test_the_folder_comes_from_the_job_not_the_process() -> None:
-    """`job_root` is the job's own folder falling back to the process root. Passing `workspace`
-    (the process one) instead would attribute every scheduled run to whatever folder the daemon
-    happened to start in — misattribution, which is worse than the empty string it replaces."""
-    fonte = Path("chimera/cli/main.py").read_text(encoding="utf-8")
-
-    assert "job_root = Path(job.workspace).expanduser() if job.workspace else workspace" in fonte
+# --- the receipt says where it ran, and the verdict is real ---------------------------------------
+#
+# These four properties used to be asserted HERE, against the source text of `chimera/cli/main.py`,
+# because `run_job` was a closure inside a CLI command and nothing could call it. That is the
+# fallback for a property with no reachable behaviour, and it is a poor one: one of those
+# assertions passed with the line COMMENTED OUT, because the substring was still in the file.
+#
+# `make_run_job` is importable now, so all four are checked by RUNNING it — the verdict it returns,
+# the folder it names, the money it logs and the daily cap it honours. See
+# `tests/test_the_scheduled_dispatch_can_be_driven.py`. Nothing was dropped; it moved from reading
+# the code to driving it, which is the only version of these checks that could have caught the two
+# defects that shipped.

--- a/tests/test_the_logs_are_read_a_line_at_a_time.py
+++ b/tests/test_the_logs_are_read_a_line_at_a_time.py
@@ -1,0 +1,149 @@
+"""The run log is read line by line, and it has to stay that way.
+
+Measured on a 5.5 MB log of 1000 receipts, which is what ~1000 runs produces at the ~5.6 KB a
+receipt costs once its diffs are embedded:
+
+===========================  =========  ===========
+                              peak RAM   median time
+``read_text().splitlines()``    22.0 MB       24.0 ms
+line by line                     0.1 MB       20.5 ms
+===========================  =========  ===========
+
+Four times the file, because the raw bytes, the decoded string and the list of lines are all alive
+at once — and three routes read this same file. The time is not the point and never was: parsing
+1000 receipts costs 24 ms either way, and a first attempt to measure this reported the streamed
+version as *twice as slow* because `tracemalloc` was left running during the timing.
+
+The guard here is not a memory threshold, which drifts between platforms and Python versions. It is
+the property itself: these readers must work when reading the whole file at once is impossible.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.api.runs import load_runs
+from chimera.api.usage import load_usage, usage_from_runs
+
+
+@pytest.fixture
+def _sem_leitura_inteira(monkeypatch: Any) -> None:
+    """Make ``Path.read_text`` unusable.
+
+    A reader that still works cannot be holding the whole file, and unlike a byte threshold this
+    says so exactly rather than approximately.
+    """
+
+    def _proibido(self: Path, *a: Any, **k: Any) -> str:
+        raise AssertionError(f"{self.name} was read whole; these logs are streamed")
+
+    monkeypatch.setattr(Path, "read_text", _proibido)
+
+
+def _log_de_execucoes(pasta: Path, quantos: int) -> Path:
+    linhas = [
+        json.dumps({
+            "ts": f"2026-08-31T{i % 24:02d}:00:00+00:00",
+            "task": "t", "success": True, "workspace": "C:/proj",
+            "attempts": [{
+                "index": 1, "run_id": f"r{i}", "model": "m",
+                "prompt_tokens": 10, "completion_tokens": 1, "usd": 0.01,
+                # A receipt embeds its diffs, which is why one costs kilobytes rather than bytes.
+                "diffs": [{"path": "a.py", "patch": "x" * 2000, "truncated": False}],
+            }],
+        })
+        for i in range(quantos)
+    ]
+    caminho = pasta / "runs.jsonl"
+    caminho.write_text("\n".join(linhas) + "\n", encoding="utf-8")
+    return caminho
+
+
+def test_the_run_receipts_are_streamed(tmp_path: Path, _sem_leitura_inteira: None) -> None:
+    log = _log_de_execucoes(tmp_path, 50)
+
+    assert len(load_runs(log)) == 50
+
+
+def test_the_filtered_read_is_streamed_too(tmp_path: Path, _sem_leitura_inteira: None) -> None:
+    """The route the desktop actually calls always passes a project."""
+    log = _log_de_execucoes(tmp_path, 50)
+
+    assert len(load_runs(log, workspace="C:/proj")) == 50
+
+
+def test_the_cost_screen_streams_the_run_log(tmp_path: Path, _sem_leitura_inteira: None) -> None:
+    """The same file again, from the screen that totals what everything cost."""
+    log = _log_de_execucoes(tmp_path, 50)
+
+    registros = usage_from_runs(log)
+
+    assert len(registros) == 50
+    assert round(sum(r.usd or 0 for r in registros), 4) == 0.5
+
+
+def test_the_usage_log_is_streamed(tmp_path: Path, _sem_leitura_inteira: None) -> None:
+    """It is the smaller of the two today and grows with every chat turn."""
+    caminho = tmp_path / "usage.jsonl"
+    caminho.write_text(
+        "\n".join(
+            json.dumps({"ts": "2026-08-31T00:00:00+00:00", "session_id": f"s{i}", "usd": 0.01})
+            for i in range(50)
+        ) + "\n",
+        encoding="utf-8",
+    )
+
+    assert len(load_usage(caminho)) == 50
+
+
+# --- and none of it may change what they return ----------------------------------------------------
+
+
+def test_a_blank_line_is_skipped_quietly(tmp_path: Path, caplog: Any) -> None:
+    """Iterating a file hands back the newline that ``splitlines()`` removed, so a line that used to
+    arrive as an empty string now arrives as a lone newline.
+
+    The count alone cannot show this: a blank line reaching the parser raises and is skipped anyway,
+    so removing the check changes nothing a caller can see — measured, that sabotage walked straight
+    through the first version of this test. What it changes is the LOG: every blank line becomes a
+    "malformed record" warning, and a log that cries malformed at an empty line is one nobody reads
+    when a line really is malformed.
+    """
+    import logging
+
+    log = _log_de_execucoes(tmp_path, 3)
+    log.write_text(log.read_text(encoding="utf-8") + "\n\n   \n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        assert len(load_runs(log)) == 3
+        assert len(usage_from_runs(log)) == 3
+
+    ruidosas = [r for r in caplog.records if "malformed" in r.getMessage()]
+    assert not ruidosas, "a blank line was reported as a malformed record"
+
+
+def test_a_malformed_line_is_still_skipped(tmp_path: Path) -> None:
+    log = _log_de_execucoes(tmp_path, 3)
+    log.write_text("{nao e json\n" + log.read_text(encoding="utf-8"), encoding="utf-8")
+
+    assert len(load_runs(log)) == 3
+    assert len(usage_from_runs(log)) == 3
+
+
+def test_a_file_without_a_trailing_newline_keeps_its_last_row(tmp_path: Path) -> None:
+    """The row most likely to be lost by a reader that assumes every line ends in a newline — and
+    the one that matters most, because it is the most recent run."""
+    log = _log_de_execucoes(tmp_path, 3)
+    log.write_text(log.read_text(encoding="utf-8").rstrip("\n"), encoding="utf-8")
+
+    assert len(load_runs(log)) == 3
+
+
+def test_a_missing_file_is_still_empty(tmp_path: Path) -> None:
+    assert load_runs(tmp_path / "nada.jsonl") == []
+    assert usage_from_runs(tmp_path / "nada.jsonl") == []
+    assert load_usage(tmp_path / "nada.jsonl") == []

--- a/tests/test_the_scheduled_dispatch_can_be_driven.py
+++ b/tests/test_the_scheduled_dispatch_can_be_driven.py
@@ -1,0 +1,310 @@
+"""The scheduled dispatch, driven end to end — the test that did not exist when it mattered.
+
+Two defects reached users through this one function, and both for the same reason: it was a closure
+inside a CLI command, so nothing could call it. The tests that stood in for it handed a
+``JobOutcome`` straight to the part that RECORDS one — every step of the path except the step that
+was broken, twice over:
+
+* the verdict it returns (a bare string was read as ``ok``, so a job whose gate rejected every
+  attempt kept a green row and a zero failure count);
+* the workspace it names (left unset, so every scheduled receipt was filed under no project and was
+  excluded from every filtered list by design).
+
+Now that ``make_run_job`` is importable, both are checked by running it. No network: the backend is
+a fake and the verify command is a local ``python -c``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.config import Settings
+from chimera.scheduler.job_runner import make_run_job
+from chimera.scheduler.models import CronJob, JobOutcome
+
+
+class _Result:
+    """The shape the agent loop reads off a completion."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.model = "fake/model"
+        self.prompt_tokens = 10
+        self.completion_tokens = 5
+        self.cache_read_tokens = 0
+        self.cache_write_tokens = 0
+        self.tool_calls: list[Any] = []
+        self.finish_reason = "stop"
+        self.route_meta: dict[str, Any] | None = None
+
+
+class _Backend:
+    """Answers in prose and calls nothing, so the run ends on its own and the GATE decides."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> _Result:
+        self.calls += 1
+        return _Result("pronto")
+
+
+def _run(tmp_path: Path, *, verify: str, attempts: int = 1) -> tuple[JobOutcome, Path, _Backend]:
+    home = tmp_path / "home"
+    projeto = tmp_path / "projeto"
+    projeto.mkdir(parents=True, exist_ok=True)
+    settings = Settings(**{"CHIMERA_HOME": str(home)})
+    backend = _Backend()
+    run_job = make_run_job(
+        settings=settings,
+        backend=backend,
+        workspace=tmp_path / "nao-e-a-pasta-do-job",
+        model="fake/model",
+        max_steps=3,
+        usage_path=home / "usage.jsonl",
+    )
+    job = CronJob(
+        id="j1", name="nightly", trigger="cron", schedule="* * * * *",
+        action="escreva algo", workspace=str(projeto), verify=verify, max_attempts=attempts,
+    )
+    return run_job(job), home, backend
+
+
+def _recibo(home: Path) -> dict[str, Any]:
+    bruto = (home / "runs.jsonl").read_text(encoding="utf-8").splitlines()
+    linhas = [linha for linha in bruto if linha.strip()]
+    assert linhas, "the dispatch left no receipt at all"
+    return dict(json.loads(linhas[-1]))
+
+
+# --- the verdict --------------------------------------------------------------------------------
+
+
+def test_a_gate_that_rejects_makes_the_dispatch_say_so(tmp_path: Path) -> None:
+    """The defect, reproduced through the real producer: a bare answer string is read as ``ok`` by
+    the dispatch, and that is how a job that kept nothing showed a green row."""
+    outcome, _, backend = _run(tmp_path, verify=f'"{sys.executable}" -c "import sys; sys.exit(1)"')
+
+    assert backend.calls > 0, "the agent never ran, so nothing here is about a gate"
+    assert isinstance(outcome, JobOutcome)
+    assert outcome.ok is False, "the schedule was told the job was fine"
+
+
+def test_a_gate_that_passes_leaves_the_verdict_alone(tmp_path: Path) -> None:
+    outcome, _, _ = _run(tmp_path, verify=f'"{sys.executable}" -c "pass"')
+
+    assert outcome.ok is True
+
+
+def test_a_job_with_no_gate_reports_no_verdict(tmp_path: Path) -> None:
+    """Without a gate nothing could reject the work, and ``success`` there reflects gates this path
+    does not run — reporting it would turn every ungated job into a failure."""
+    outcome, _, _ = _run(tmp_path, verify="")
+
+    assert outcome.ok is True
+
+
+class _ExpensiveBackend(_Backend):
+    """Calls a tool first, so the loop takes a SECOND step — which is where the ceiling can bite.
+
+    A backend that answers on step one never gives the budget a chance to refuse anything: the cap
+    is checked BEFORE each call and only the first one had happened. Measured while writing this:
+    with a one-step backend an ungated run always ends successfully, so the assertion below could
+    not tell the branch it guards from its absence.
+    """
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> _Result:
+        self.calls += 1
+        r = _Result("pronto")
+        r.model = "openrouter/deepseek/deepseek-chat-v3.1"  # priced, so the spend accumulates
+        r.prompt_tokens, r.completion_tokens = 400_000, 400_000
+        if self.calls == 1:
+            from chimera.providers.gateway import ToolCall
+
+            r.tool_calls = [ToolCall(id="c1", name="list_dir", arguments={"path": "."})]
+        return r
+
+
+def test_an_ungated_job_that_failed_is_still_not_a_rejection(tmp_path: Path) -> None:
+    """The case that separates "no gate" from "the gate said no", and the reason the branch exists.
+
+    A job with no verify can still end unsuccessfully — this one stops on its own dollar ceiling.
+    Nothing could have REJECTED the work, so the schedule must not be told there was, or every
+    ungated job that runs out of money is filed as work a gate threw away.
+    """
+    home = tmp_path / "home"
+    backend = _ExpensiveBackend()
+    run_job = make_run_job(
+        settings=Settings(**{"CHIMERA_HOME": str(home)}), backend=backend, workspace=tmp_path,
+        model="openrouter/deepseek/deepseek-chat-v3.1", max_steps=6,
+        usage_path=home / "usage.jsonl",
+    )
+    job = CronJob(
+        id="j", name="n", trigger="cron", schedule="* * * * *", action="x",
+        workspace=str(tmp_path), verify="", max_usd=0.000001,
+    )
+
+    outcome = run_job(job)
+
+    assert backend.calls >= 1
+    assert "spend cap" in outcome.answer.lower(), (
+        "the run did not reach its ceiling, so this is not testing the ungated-failure case"
+    )
+    assert outcome.ok is True, "an ungated job was reported as though a gate had rejected it"
+
+
+def test_the_answer_survives_the_verdict(tmp_path: Path) -> None:
+    """The work was thrown away; the report of it was not. Someone reading a webhook needs to learn
+    the job produced nothing, which is exactly the message that matters most."""
+    outcome, _, _ = _run(tmp_path, verify=f'"{sys.executable}" -c "import sys; sys.exit(1)"')
+
+    assert outcome.answer, "the dispatch returned a verdict with nothing to deliver"
+
+
+# --- the workspace ------------------------------------------------------------------------------
+
+
+def test_the_receipt_is_filed_under_the_job_folder(tmp_path: Path) -> None:
+    """The other defect: the loop was given its run log and not its workspace, so every scheduled
+    receipt was unattributable — and an unattributable receipt is left out of every filtered list
+    by design, which made each one unfindable from the only screen that would look."""
+    _, home, _ = _run(tmp_path, verify=f'"{sys.executable}" -c "pass"')
+
+    recibo = _recibo(home)
+
+    assert recibo["workspace"], "the receipt names no project"
+    assert Path(recibo["workspace"]).name == "projeto"
+
+
+def test_the_folder_is_the_job_s_not_the_process_s(tmp_path: Path) -> None:
+    """`workspace` (the process root) and `job.workspace` are different things, and attributing
+    every scheduled run to wherever the daemon started is worse than the empty string it replaced."""
+    _, home, _ = _run(tmp_path, verify="")
+
+    assert Path(_recibo(home)["workspace"]).name != "nao-e-a-pasta-do-job"
+
+
+# --- the money ----------------------------------------------------------------------------------
+
+
+def test_the_dispatch_writes_what_it_spent(tmp_path: Path) -> None:
+    """The daily cap is read from this log, so a dispatch that does not write to it leaves the cap
+    blind to exactly the spend it exists to bound."""
+    _, home, _ = _run(tmp_path, verify="")
+
+    assert (home / "usage.jsonl").exists(), "the usage log was never written"
+    linha = json.loads((home / "usage.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    assert linha["session_id"].startswith("cron:")
+
+
+def test_a_daily_cap_already_reached_refuses_before_spending(tmp_path: Path) -> None:
+    """Refusal, not a cheaper run: the point of a daily ceiling is that the job does not start."""
+    from chimera.orchestration.budget import BudgetExceeded
+
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "usage.jsonl").write_text(
+        json.dumps({"ts": "2000-01-01T00:00:00+00:00", "session_id": "x", "usd": 999.0}) + "\n",
+        encoding="utf-8",
+    )
+    settings = Settings(**{"CHIMERA_HOME": str(home), "CHIMERA_DAILY_USD_CAP": "0.01"})
+    backend = _Backend()
+    run_job = make_run_job(
+        settings=settings, backend=backend, workspace=tmp_path, model="fake/model",
+        max_steps=3, usage_path=home / "usage.jsonl",
+    )
+    job = CronJob(id="j", name="n", trigger="cron", schedule="* * * * *", action="x")
+
+    # The cap reads TODAY, and the row above is from the year 2000 — so this must NOT refuse, which
+    # is the half that proves the refusal below is about the cap and not about any row existing.
+    run_job(job)
+    assert backend.calls > 0
+
+    (home / "usage.jsonl").write_text(
+        json.dumps({
+            "ts": __import__("datetime").datetime.now(__import__("datetime").UTC).isoformat(),
+            "session_id": "x", "usd": 999.0,
+        }) + "\n",
+        encoding="utf-8",
+    )
+    antes = backend.calls
+    with pytest.raises(BudgetExceeded):
+        run_job(job)
+    assert backend.calls == antes, "the job spent before being refused"
+
+
+class _TwoAttemptBackend(_Backend):
+    """Answers each time, so a two-attempt job really makes two rounds of calls."""
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> _Result:
+        self.calls += 1
+        r = _Result("pronto")
+        r.model = "openrouter/deepseek/deepseek-chat-v3.1"
+        r.prompt_tokens, r.completion_tokens = 1_000, 100
+        return r
+
+
+def test_the_usage_row_sums_every_attempt(tmp_path: Path) -> None:
+    """One row per dispatch, holding the whole dispatch.
+
+    With `max_attempts > 1` a job can pay several times, and reporting only the last would
+    understate exactly the configuration that costs most — the daily cap is read from this log, so
+    an understated row is a ceiling that lets the next job through when it should not.
+
+    Asserted by RUNNING a two-attempt job rather than by reading the summation out of the source,
+    which is what this was checked by until the dispatch became reachable.
+    """
+    home = tmp_path / "home"
+    projeto = tmp_path / "projeto"
+    projeto.mkdir(parents=True, exist_ok=True)
+    backend = _TwoAttemptBackend()
+    run_job = make_run_job(
+        settings=Settings(**{"CHIMERA_HOME": str(home)}), backend=backend, workspace=tmp_path,
+        model="openrouter/deepseek/deepseek-chat-v3.1", max_steps=3,
+        usage_path=home / "usage.jsonl",
+    )
+    job = CronJob(
+        id="j", name="n", trigger="cron", schedule="* * * * *", action="x",
+        workspace=str(projeto), verify=f'"{sys.executable}" -c "import sys; sys.exit(1)"',
+        max_attempts=2,
+    )
+
+    run_job(job)
+
+    linha = json.loads((home / "usage.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+    recibo = _recibo(home)
+    tentativas = recibo["attempts"]
+    assert len(tentativas) == 2, "the job did not make two attempts, so nothing here is a sum"
+    assert linha["prompt_tokens"] == sum(a["prompt_tokens"] for a in tentativas)
+    assert round(linha["usd"], 6) == round(sum(a["usd"] for a in tentativas), 6)
+
+
+def test_cron_still_has_no_reviewer(tmp_path: Path) -> None:
+    """A reviewer would be a model call per attempt spent grading prose nobody asked to be graded.
+
+    Counted rather than read off the source: a two-attempt run makes exactly the calls its worker
+    makes, and a reviewer would show up as extra ones.
+    """
+    home = tmp_path / "home"
+    backend = _TwoAttemptBackend()
+    run_job = make_run_job(
+        settings=Settings(**{"CHIMERA_HOME": str(home)}), backend=backend, workspace=tmp_path,
+        model="openrouter/deepseek/deepseek-chat-v3.1", max_steps=3,
+        usage_path=home / "usage.jsonl",
+    )
+    job = CronJob(
+        id="j", name="n", trigger="cron", schedule="* * * * *", action="x",
+        workspace=str(tmp_path), verify=f'"{sys.executable}" -c "import sys; sys.exit(1)"',
+        max_attempts=2,
+    )
+
+    run_job(job)
+
+    assert backend.calls == 2, (
+        f"{backend.calls} model calls for two attempts — something is grading the work"
+    )

--- a/tests/test_the_scheduled_run_is_governed_too.py
+++ b/tests/test_the_scheduled_run_is_governed_too.py
@@ -32,9 +32,17 @@ from chimera.providers import CompletionResult
 
 
 def _dispatch_source() -> str:
-    from chimera.cli import main
+    """The scheduled dispatch's source.
 
-    return inspect.getsource(main._start_cron_daemon)
+    It moved out of the CLI command into `chimera/scheduler/job_runner.py`, precisely so that these
+    properties could be checked by RUNNING it — see
+    `tests/test_the_scheduled_dispatch_can_be_driven.py`, which now covers the receipt, the gate and
+    the verdict by driving a real job. What is asserted here is what remains structural: which
+    classes the path is built from.
+    """
+    from chimera.scheduler import job_runner
+
+    return inspect.getsource(job_runner.make_run_job)
 
 
 # --------------------------------------------------------------------------- the job declares it

--- a/tests/test_version_api.py
+++ b/tests/test_version_api.py
@@ -19,17 +19,19 @@ import chimera.api.version_api as version_api
 @pytest.fixture(autouse=True)
 def _clear_cache() -> Any:
     """Reset the module-level GitHub cache before AND after each test (it persists across the process)."""
-    version_api._cache = None
+    version_api._cache.clear()
     yield
-    version_api._cache = None
+    version_api._cache.clear()
 
 
 # --- pure version comparison -----------------------------------------------------------------------
 
 
 def test_parse_version_parses_clean_tuples() -> None:
-    assert version_api._parse_version("0.30.0") == (0, 30, 0)
-    assert version_api._parse_version("1.2.3") == (1, 2, 3)
+    # Five elements now, not three: the fourth orders a final release above its candidates and the
+    # fifth is the candidate number. See `test_a_prerelease_hears_about_updates.py`.
+    assert version_api._parse_version("0.30.0") == (0, 30, 0, 1, 0)
+    assert version_api._parse_version("1.2.3") == (1, 2, 3, 1, 0)
 
 
 def test_parse_version_rejects_non_numeric() -> None:
@@ -58,7 +60,7 @@ def test_is_newer_false_when_either_side_unparseable() -> None:
 def test_update_available_true_when_github_is_newer(monkeypatch: Any) -> None:
     monkeypatch.setattr(chimera, "__version__", "0.30.0")
     monkeypatch.setattr(
-        version_api, "_fetch_latest", lambda: ("0.31.0", "https://example.test/releases/0.31.0")
+        version_api, "_fetch_latest", lambda **_: ("0.31.0", "https://example.test/releases/0.31.0")
     )
     out = version_api.check_version()
     assert out["version"] == "0.30.0"
@@ -69,7 +71,7 @@ def test_update_available_true_when_github_is_newer(monkeypatch: Any) -> None:
 
 def test_update_not_available_when_equal(monkeypatch: Any) -> None:
     monkeypatch.setattr(chimera, "__version__", "0.31.0")
-    monkeypatch.setattr(version_api, "_fetch_latest", lambda: ("0.31.0", "https://example.test/r"))
+    monkeypatch.setattr(version_api, "_fetch_latest", lambda **_: ("0.31.0", "https://example.test/r"))
     out = version_api.check_version()
     assert out["update_available"] is False
     assert out["notes_url"] is None  # nothing to link to when there's no update
@@ -77,7 +79,7 @@ def test_update_not_available_when_equal(monkeypatch: Any) -> None:
 
 def test_update_not_available_when_local_is_newer(monkeypatch: Any) -> None:
     monkeypatch.setattr(chimera, "__version__", "0.32.0")
-    monkeypatch.setattr(version_api, "_fetch_latest", lambda: ("0.31.0", "https://example.test/r"))
+    monkeypatch.setattr(version_api, "_fetch_latest", lambda **_: ("0.31.0", "https://example.test/r"))
     out = version_api.check_version()
     assert out["update_available"] is False
     assert out["latest"] == "0.31.0"  # honestly reported, just not an "update"
@@ -86,7 +88,7 @@ def test_update_not_available_when_local_is_newer(monkeypatch: Any) -> None:
 def test_fetch_failure_degrades_to_null_latest(monkeypatch: Any) -> None:
     # A fetch failure (mocked here as a return of (None, None)) → no update signal, a clean dict.
     monkeypatch.setattr(chimera, "__version__", "0.30.0")
-    monkeypatch.setattr(version_api, "_fetch_latest", lambda: (None, None))
+    monkeypatch.setattr(version_api, "_fetch_latest", lambda **_: (None, None))
     out = version_api.check_version()
     assert out == {
         "version": "0.30.0",
@@ -110,7 +112,7 @@ def test_check_version_caches_and_does_not_refetch(monkeypatch: Any) -> None:
     monkeypatch.setattr(chimera, "__version__", "0.30.0")
     calls = {"n": 0}
 
-    def _counted() -> tuple[str | None, str | None]:
+    def _counted(**_: object) -> tuple[str | None, str | None]:
         calls["n"] += 1
         return "0.31.0", "https://example.test/r"
 
@@ -222,7 +224,7 @@ def test_cached_latest_serves_from_cache_then_refetches_once_the_ttl_expires(
     monkeypatch.setattr(version_api.time, "monotonic", lambda: clock["t"])
     calls = {"n": 0}
 
-    def _fetch() -> tuple[str | None, str | None]:
+    def _fetch(**_: object) -> tuple[str | None, str | None]:
         calls["n"] += 1
         return f"0.{calls['n']}.0", "https://e.test/r"
 


### PR DESCRIPTION
Three items, all from measurements taken while driving rc46. Companion to [#270](https://github.com/brcampidelli/chimera-agent/pull/270) (the model-catalogue cache and the bound on `discarded/`).

## The scheduled dispatch can be driven

`run_job` was a **149-line closure inside a Typer command**, so nothing could call it. That is the reason two defects reached users through this one function: the verdict it returns and the workspace it names are both produced there, and the tests that stood in for it handed a `JobOutcome` straight to the part that **records** one — every step of the path except the step that was broken.

It is `chimera/scheduler/job_runner.py` now, built by a factory that takes what the closure used to capture. Eleven tests drive the real producer with a fake backend: the gate's verdict, the folder on the receipt, the daily cap's refusal (and, as its control, a stale row that must **not** refuse), the usage row that sums every attempt, and the reviewer that must not exist — counted in model calls rather than read off the source.

The source-text assertions that stood in for those are gone. One of them used to pass **with the line commented out**, because the substring was still in the file.

The extraction was done programmatically rather than retyped: transcribing 149 lines by hand is where errors enter.

## A prerelease hears about updates

Two causes, stacked, either enough on its own:

- `_parse_version("0.48.0rc46")` returned `None` — every dot-separated segment had to be digits — so every comparison answered False. Not a newer candidate, not even the final `0.48.0`.
- `/releases/latest` **excludes prereleases** by GitHub's own definition, so even a capable parser could only ever see the last stable.

Measured on a real install running rc46: `latest: "0.47.0", update_available: false`. With forty-six candidates in this series that is the common case, not the edge.

What did not change, and has its own test: **a stable install is never offered a candidate.** Someone on 0.47.0 did not opt into a prerelease track. The two questions have separate cache slots, because one slot would serve a stable install the candidate list. And the newest is chosen by **parsed version**, not by the list's order — GitHub sorts by creation date, so a patch cut after a candidate would otherwise be announced as the newer of the two.

The comparison is written here rather than taken from `packaging`, which this project does not declare as a dependency and which is present only transitively. A version check that breaks a clean install is worse than one that understands two shapes.

## The logs are streamed

| | peak RAM | median time |
|---|---:|---:|
| `read_text().splitlines()` | **22.0 MB** | 24.0 ms |
| line by line | **0.1 MB** | 20.5 ms |

On a 5.5 MB run log of 1000 receipts — four times the file, because the raw bytes, the decoded string and the list of lines are all alive at once. Three routes read that same file.

**The time was never the problem, and the first framing of this said otherwise.** Parsing 1000 receipts costs 24 ms either way. A first attempt to measure it reported streaming as *twice as slow*, because `tracemalloc` was left running during the timing.

The guard is not a memory threshold — those drift between platforms. The tests make `Path.read_text` **unusable** and require the readers to keep working, which is the property itself rather than a proxy for it.

## Three guards that passed for the wrong reason first

- An ungated run always succeeds in a one-step harness, so the branch separating *no gate* from *the gate said no* was indistinguishable from its absence. It needed a backend that calls a tool first, so the ceiling can bite on the **second** step.
- The blank-line check guards the **log**, not the count: a blank line reaching the parser raises and is skipped anyway. The test asserts no "malformed record" warning instead.
- The stray-file test wrote its stray file **last**, making it the newest — so a pruner deleting by position rather than by pattern left it alone regardless.

**4502 tests, ruff and mypy clean on 330 files.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
