### PR TITLE
perf(ollama): budget connecting apart from answering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,26 @@ You could not choose which model answered you. The endpoint accepted one all alo
   provider that is down already answers with its own reason, and re-asking it on every screen open
   turns one slow answer into a burst of them.
 
+- **Asking the local Ollama what it has pulled cost two seconds, on the machines with no Ollama.**
+  The Settings screen asks every time a model picker mounts — deliberately uncached, because a tag
+  pulled in a terminal thirty seconds ago is the one the user came there to select. So the cost was
+  paid over and over, and it was the last slow route left in the app.
+  Why it was slow is not what it looks like. Measured on Windows: a loopback port with something
+  listening accepts in **at most 16 ms over 30 attempts**; the same port with nothing behind it takes
+  **2.04 s to come back refused** — not to time out, to be *actively refused*. And `localhost`
+  resolves to `::1` as well as `127.0.0.1`, so httpx pays it on each in turn: **4.2 s**, capped by
+  the module's outer deadline at 2.0, to learn something the first millisecond had already settled.
+  None of that is reducible per attempt — the first fix tried, a TCP pre-check, would have paid the
+  identical 2.04 s. What is separable is **opening** the connection from **waiting for a reply**, and
+  they now have separate budgets: 250 ms to connect, fifteen times the slowest accept ever observed
+  here, while the read keeps the full two seconds so a daemon that is listening but slow to answer
+  still gets its time. Measured through the real module, paired on the same machine: **2,012 ms →
+  530 ms** for the default URL, **2,010 ms → 265 ms** for `127.0.0.1`, and **15 ms → 14 ms** against
+  something that answers — with an identical verdict in all three.
+  **The short budget is for this machine only.** An Ollama across a VPN can legitimately need longer
+  than 250 ms to accept, and reporting it unreachable to collect a fraction of a second would be
+  inventing a fact about someone's network — the exact failure the rest of that module exists to
+  avoid. Anything that is not `localhost`, `::1` or the `127/8` block keeps the budget it had.
 - **The folder of reverted work had no ceiling.** Every attempt a verify command rejects writes its
   full diff to `discarded/`, which is what makes that work recoverable — and nothing ever removed
   one. Measured: 3 files in one session, 7 eighteen hours later, ~2 KB each, growing forever. Small

--- a/chimera/providers/ollama.py
+++ b/chimera/providers/ollama.py
@@ -19,9 +19,11 @@ same shape and for the same reason as :class:`~chimera.api.posture.PostureFacts`
 languages, and a server that returned English prose would make the one line explaining why a feature
 is unavailable the one line the user cannot read.
 
-**The timeout is short and deliberate.** This is asked from a settings panel, and the configured URL
-may point at a machine that is off, asleep, or on the other side of a VPN. A settings row that hangs
-for thirty seconds is worse than one that says "nothing answered at this URL" in two.
+**The timeout is short and deliberate, and CONNECTING is budgeted apart from ANSWERING.** This is
+asked from a settings panel, and the configured URL may point at a machine that is off, asleep, or
+on the other side of a VPN. A settings row that hangs for thirty seconds is worse than one that says
+"nothing answered at this URL" in two. The split exists because those two waits have nothing in
+common on a machine with no Ollama: see :data:`LOCAL_CONNECT_TIMEOUT_S`.
 """
 
 from __future__ import annotations
@@ -36,6 +38,25 @@ _log = get_logger("providers.ollama")
 #: Seconds to wait for the tag list. Long enough for a local daemon that has to page itself back in,
 #: short enough that a URL pointing at a machine that is off does not freeze the settings row asking.
 DEFAULT_TIMEOUT_S = 2.0
+
+#: Seconds allowed to OPEN the connection when the URL names this machine.
+#:
+#: A port on this machine either has something listening on it or it does not, and the kernel knows
+#: which without asking anyone. Measured on Windows: a loopback port that IS listening accepts in at
+#: most 16 ms over 30 attempts, while a port with nothing behind it takes **2.04 s** to come back
+#: refused — and `localhost` resolves to both `::1` and `127.0.0.1`, so httpx pays that twice, for
+#: 4.2 s of waiting to learn something the first millisecond already settled.
+#:
+#: So the connect gets its own budget, fifteen times the slowest accept ever observed, and the read
+#: keeps the full one — a daemon that is listening but slow to answer is a different situation and
+#: still gets its time. Measured through this function, paired on one machine: **2,012 ms -> 530 ms**
+#: for `localhost` and **2,010 ms -> 265 ms** for `127.0.0.1` (one stack, so the wait is paid once),
+#: against **15 ms -> 14 ms** for a URL where something answers — same verdict in all three.
+#:
+#: Deliberately NOT applied to a remote URL. An Ollama across a VPN can legitimately need longer than
+#: this to accept, and reporting it unreachable to save a fraction of a second would be a lie about
+#: the user's machine — the exact failure the rest of this module exists to avoid.
+LOCAL_CONNECT_TIMEOUT_S = 0.25
 
 #: Why no list came back. ``""`` when one did — including when it was empty, which is an answer.
 Reason = Literal["", "no_url", "unreachable", "http_error", "not_ollama"]
@@ -57,6 +78,26 @@ class InstalledModels:
     reason: Reason = ""
 
 
+def _connect_budget(base_url: str, timeout_s: float) -> float:
+    """How long to spend opening the connection, which is not how long to spend waiting for a reply.
+
+    Loopback only. Everything else keeps the caller's budget, because a slow accept from a machine
+    across a network is normal and calling it unreachable would invent a fact about that machine.
+    """
+    from urllib.parse import urlsplit
+
+    try:
+        host = (urlsplit(base_url).hostname or "").lower()
+    except ValueError:  # a URL malformed enough that even splitting it fails
+        return timeout_s
+    on_this_machine = host == "localhost" or host == "::1" or host.startswith("127.")
+    if not on_this_machine:
+        return timeout_s
+    # `min`, not the constant: a caller who asked for a 50ms probe must not be handed a connect
+    # budget five times longer than the whole thing it asked for.
+    return min(LOCAL_CONNECT_TIMEOUT_S, timeout_s)
+
+
 def installed_models(base_url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> InstalledModels:
     """Ask the Ollama at ``base_url`` what it has pulled. Never raises.
 
@@ -73,21 +114,23 @@ def installed_models(base_url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> 
     except ImportError:  # pragma: no cover — httpx is a hard dependency
         return InstalledModels(base, False, reason="unreachable")
 
-    # The deadline bounds the WHOLE probe, not each connection attempt.
+    # Two bounds, because two different things can be slow and only one of them is interesting.
     #
-    # `timeout_s` is httpx's per-operation budget, and `localhost` resolves to both `::1` and
-    # `127.0.0.1`. When nothing is listening, neither refuses on every stack — so httpx tries them
-    # in turn and pays the full timeout each. Measured live: 4.4s against the 2.0s this module's
-    # own docstring promises, on every machine WITHOUT Ollama, which is most of them. And it is
-    # paid by the model picker as a whole, because listing calls this.
+    # The connect budget (see `LOCAL_CONNECT_TIMEOUT_S`) is what makes the common case fast: on a
+    # machine with no Ollama, `localhost` resolves to both `::1` and `127.0.0.1` and neither refuses
+    # promptly, so httpx tries them in turn and pays the connect budget twice.
     #
-    # An abandoned probe keeps running on its daemon thread and its answer is discarded — the same
-    # contract every other deadline here has, and harmless for a GET that changes nothing.
+    # The deadline behind it bounds the WHOLE probe, and still earns its place: it is the only thing
+    # covering a server that ACCEPTS and then never answers, which no per-operation timeout catches
+    # if the socket keeps dribbling bytes. An abandoned probe keeps running on its daemon thread and
+    # its answer is discarded — the same contract every other deadline here has, and harmless for a
+    # GET that changes nothing.
     from chimera.concurrency import call_with_deadline
 
+    budget = httpx.Timeout(timeout_s, connect=_connect_budget(base, timeout_s))
     try:
         response = call_with_deadline(
-            lambda: httpx.get(f"{base}/api/tags", timeout=timeout_s), timeout_s
+            lambda: httpx.get(f"{base}/api/tags", timeout=budget), timeout_s
         )
     except Exception as exc:  # noqa: BLE001 — an absent Ollama is a normal state, not a 500
         _log.debug("ollama tag list failed at %s: %s", base, exc)

--- a/tests/test_asking_a_dead_port_is_quick.py
+++ b/tests/test_asking_a_dead_port_is_quick.py
@@ -1,0 +1,151 @@
+"""Learning that nothing is listening should cost a fraction of a second, not two.
+
+The Settings screen asks the local Ollama what it has pulled every time a model picker mounts, and
+that question is deliberately never cached — a tag pulled in a terminal thirty seconds ago is the
+one the user came here to select. So the cost of asking is paid over and over, and on the machines
+where the answer is "nothing is there" it was the most expensive question the app asked.
+
+Why it was expensive is not what anyone would guess, so it is worth writing down. Measured on
+Windows: a loopback port with something listening accepts in at most 16 ms over 30 attempts. The
+same port with nothing behind it takes **2.04 s** to come back *refused* — not to time out, to be
+actively refused. And `localhost` resolves to `::1` as well as `127.0.0.1`, so the whole thing is
+paid twice: 4.2 s of waiting, capped by an outer deadline at 2.0 s, to learn something the first
+millisecond had already settled.
+
+None of that is reducible per attempt. What IS separable is opening the connection from waiting for
+a reply, and this file is about that split holding: short to connect when the address is on this
+machine, unchanged when it is not.
+
+Nothing here opens a socket. `httpx.get` is replaced and the budget it receives is read off the
+call, because what is under test is which budget is chosen — a real probe would test whether the
+machine running CI happens to be running Ollama.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from chimera.providers.ollama import DEFAULT_TIMEOUT_S, LOCAL_CONNECT_TIMEOUT_S, installed_models
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Answer every probe with an empty, valid tag list and keep the timeout it was given."""
+    seen: dict[str, Any] = {}
+
+    class _Ok:
+        status_code = 200
+
+        def json(self) -> Any:
+            return {"models": []}
+
+    def fake_get(url: str, **kwargs: Any) -> Any:
+        seen["url"] = url
+        seen["timeout"] = kwargs.get("timeout")
+        return _Ok()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    return seen
+
+
+def _connect_of(timeout: Any) -> float:
+    assert isinstance(timeout, httpx.Timeout), (
+        f"the probe was given {timeout!r}, which budgets connecting and reading together — "
+        "the whole point is that they are budgeted apart"
+    )
+    connect = timeout.connect
+    assert connect is not None
+    return float(connect)
+
+
+def test_a_port_on_this_machine_is_given_a_short_moment_to_accept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _capture(monkeypatch)
+    installed_models("http://localhost:11434")
+    connect = _connect_of(seen["timeout"])
+    assert connect == LOCAL_CONNECT_TIMEOUT_S
+    # The number that matters is not the constant, it is the ratio: this is what turns 2.04s of
+    # waiting into a quarter of one, twice over.
+    assert connect < DEFAULT_TIMEOUT_S / 4
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:11434",
+        "http://127.0.0.1:11434",
+        "http://127.1.2.3:11434",  # the whole 127/8 block is this machine, not just .0.0.1
+        "http://[::1]:11434",
+        "http://LOCALHOST:11434",  # a host is case-insensitive and users type it either way
+    ],
+)
+def test_every_way_of_naming_this_machine_gets_the_short_budget(
+    monkeypatch: pytest.MonkeyPatch, url: str
+) -> None:
+    seen = _capture(monkeypatch)
+    installed_models(url)
+    assert _connect_of(seen["timeout"]) == LOCAL_CONNECT_TIMEOUT_S
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://192.168.1.40:11434",  # the desktop in the next room
+        "http://ollama.lan:11434",  # named on the LAN
+        "https://ollama.example.com",  # across a VPN
+        "http://10.0.0.7:11434",
+    ],
+)
+def test_a_machine_that_is_not_this_one_keeps_the_full_budget(
+    monkeypatch: pytest.MonkeyPatch, url: str
+) -> None:
+    """The saving is worth a fraction of a second. Calling someone's VPN'd Ollama unreachable to
+    collect it would be inventing a fact about their machine, which is what this module exists to
+    not do."""
+    seen = _capture(monkeypatch)
+    installed_models(url)
+    assert _connect_of(seen["timeout"]) == DEFAULT_TIMEOUT_S
+
+
+def test_a_caller_asking_for_a_fast_probe_is_not_handed_a_slower_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`timeout_s` is the whole budget. A connect allowance longer than it would mean the deadline
+    fires first and the split silently stops applying."""
+    seen = _capture(monkeypatch)
+    installed_models("http://localhost:11434", timeout_s=0.05)
+    assert _connect_of(seen["timeout"]) == 0.05
+
+
+def test_the_read_budget_is_not_shortened_along_with_the_connect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A daemon that accepted and is slow to answer is a live server paging itself back in. It has
+    always been given the full wait and this change must not take it away."""
+    seen = _capture(monkeypatch)
+    installed_models("http://localhost:11434")
+    timeout = seen["timeout"]
+    assert timeout.read == DEFAULT_TIMEOUT_S
+    assert timeout.write == DEFAULT_TIMEOUT_S
+
+
+def test_a_url_too_broken_to_split_still_answers_instead_of_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """This is called to fill in a form. Whatever the user typed, the answer is a reason, not a 500."""
+    _capture(monkeypatch)
+    found = installed_models("http://[oops:11434")
+    assert found.reachable in (True, False)  # it returned at all, which is the assertion
+
+
+def test_what_the_probe_reports_did_not_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The split is about waiting, not about answers. A reachable Ollama with nothing pulled still
+    reads as reachable-and-empty, which is the distinction the whole module is built around."""
+    _capture(monkeypatch)
+    found = installed_models("http://localhost:11434")
+    assert found.reachable is True
+    assert found.models == ()
+    assert found.reason == ""


### PR DESCRIPTION
## The last slow route in the app

Asking the local Ollama what it has pulled cost **two seconds**, paid on every mount of a model
picker. That question is deliberately uncached — a tag pulled in a terminal thirty seconds ago is
the one the user came to Settings to select — so the cost was paid over and over.

## Why it was slow is not what it looks like

Measured on Windows:

- a loopback port that **is** listening accepts in **at most 16 ms** over 30 attempts;
- the same port with nothing behind it takes **2.04 s to come back _refused_** — not to time out,
  to be *actively refused*;
- `localhost` resolves to `::1` as well as `127.0.0.1`, so httpx pays it on each in turn: **4.2 s**,
  capped by the module's own deadline at 2.0, to learn something the first millisecond had settled.

None of that is reducible per attempt. The first fix considered — a TCP pre-check before the probe —
would have paid the **identical 2.04 s**, which is why it was measured before it was written.

## What is separable: opening from answering

They now have separate budgets. **250 ms to connect** — fifteen times the slowest accept observed
here — while the **read keeps the full two seconds**, because a daemon that is listening but slow to
answer is a different situation and still gets its time.

Measured through `installed_models` itself, paired on one machine:

| | before | after | |
|---|---:|---:|---|
| `localhost:11434` (the default) | 2012 ms | **530 ms** | 3.8× |
| `127.0.0.1:11434` | 2010 ms | **265 ms** | 7.6× |
| `available_models()` — what the picker waits on | 2017 ms | **543 ms** | same 396 models |
| a URL where something answers | 15 ms | 14 ms | unchanged |

Identical verdict in all four.

## The short budget is for this machine only

`localhost`, `::1` and the `127/8` block. An Ollama across a VPN can legitimately need longer than
250 ms to accept, and reporting it unreachable to collect a fraction of a second would be inventing
a fact about someone's network — the exact failure the rest of that module exists to avoid.

`0.0.0.0` and `[::]` were measured too: they already fail in tens of milliseconds and are left alone.
A grep of every other `httpx`/`urlopen` call in the tree found no second instance — all the others
target remote hosts, where the loopback refusal does not apply.

## Verification

- **14 new tests**, and six sabotages run against them — reverting each half of the change (no
  shortening / shortening the remote too / one combined budget / dropping the `min` / shortening the
  read as well / matching only `127.0.0.1` instead of `127/8`) makes at least one fail. Six for six.
- `4531 passed, 18 skipped` · `ruff` clean · `mypy` clean across 330 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)