### PR TITLE
perf(ollama): the default names an address, not a name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ CHIMERA_DEEPSEEK_KEYS=
 CHIMERA_DEFAULT_MODEL=openrouter/openai/gpt-5.5
 
 # Custom endpoint for self-hosted / OpenAI-compatible servers (Ollama, vLLM, ...).
-# e.g. CHIMERA_API_BASE=http://localhost:11434  with CHIMERA_DEFAULT_MODEL=ollama/llama3
+# e.g. CHIMERA_API_BASE=http://127.0.0.1:11434  with CHIMERA_DEFAULT_MODEL=ollama/llama3
 CHIMERA_API_BASE=
 
 # Comma-separated fallback chain: if the primary model errors, the next is tried.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,17 @@ You could not choose which model answered you. The endpoint accepted one all alo
   than 250 ms to accept, and reporting it unreachable to collect a fraction of a second would be
   inventing a fact about someone's network — the exact failure the rest of that module exists to
   avoid. Anything that is not `localhost`, `::1` or the `127/8` block keeps the budget it had.
+- **And the default address changed with it: `127.0.0.1`, not `localhost`.** The two mean the same
+  machine, but one is a *name* and it resolves to two addresses — `::1` and `127.0.0.1` — so a client
+  with nothing to connect to tries them in turn and waits twice for the same answer. Naming the
+  address halves what is left: **530 ms → 265 ms**, measured through the same function, for an
+  identical verdict. It is also the more accurate description, since `127.0.0.1:11434` is what
+  Ollama itself binds by default.
+  The cost of being specific, stated rather than buried: an Ollama told to listen on `[::1]` only —
+  which takes deliberately setting `OLLAMA_HOST` — is no longer found at the default. That address
+  is a field on the Settings screen and the failure names it (*"nothing answered at
+  http://127.0.0.1:11434"*), so it explains its own fix. **A value you already set is untouched**:
+  a default is what applies when nothing was chosen, whether it came from `.env` or the screen.
 - **The folder of reverted work had no ceiling.** Every attempt a verify command rejects writes its
   full diff to `discarded/`, which is what makes that work recoverable — and nothing ever removed
   one. Measured: 3 files in one session, 7 eighteen hours later, ~2 KB each, growing forever. Small

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -118,7 +118,9 @@ class Settings(BaseSettings):
     stability_api_key: str | None = Field(default=None, validation_alias="STABILITY_API_KEY")
     elevenlabs_api_key: str | None = Field(default=None, validation_alias="ELEVENLABS_API_KEY")
     spotify_client_id: str | None = Field(default=None, validation_alias="SPOTIFY_CLIENT_ID")
-    spotify_client_secret: str | None = Field(default=None, validation_alias="SPOTIFY_CLIENT_SECRET")
+    spotify_client_secret: str | None = Field(
+        default=None, validation_alias="SPOTIFY_CLIENT_SECRET"
+    )
 
     # --- Default single model (Tier 1 / cheap tasks) ---
     #
@@ -296,7 +298,9 @@ class Settings(BaseSettings):
     # least ``min_overlap`` query terms (so a task with no strong match pays ZERO extra tokens instead
     # of dragging in ~irrelevant cards), and cap each card at ``max_lines``. These crush the token
     # overhead that failed the skillcard flip gate; see bench/skillcard/RESULTS.md.
-    skill_cards_min_overlap: int = Field(default=2, validation_alias="CHIMERA_SKILL_CARDS_MIN_OVERLAP")
+    skill_cards_min_overlap: int = Field(
+        default=2, validation_alias="CHIMERA_SKILL_CARDS_MIN_OVERLAP"
+    )
     skill_cards_max_lines: int = Field(default=3, validation_alias="CHIMERA_SKILL_CARDS_MAX_LINES")
     # M19-A1 flip-point: when on, card READING couples to skill EVOLVING (a run that can mint a
     # skill also reads the retrieved ones), instead of the independent `skill_cards` toggle. Stays
@@ -360,11 +364,17 @@ class Settings(BaseSettings):
     compact_schemas: bool = Field(default=False, validation_alias="CHIMERA_COMPACT_SCHEMAS")
 
     # --- Messaging bot tokens (only needed for the matching `chimera serve --<platform>`) ---
-    discord_bot_token: str | None = Field(default=None, validation_alias="CHIMERA_DISCORD_BOT_TOKEN")
-    telegram_bot_token: str | None = Field(default=None, validation_alias="CHIMERA_TELEGRAM_BOT_TOKEN")
+    discord_bot_token: str | None = Field(
+        default=None, validation_alias="CHIMERA_DISCORD_BOT_TOKEN"
+    )
+    telegram_bot_token: str | None = Field(
+        default=None, validation_alias="CHIMERA_TELEGRAM_BOT_TOKEN"
+    )
     slack_bot_token: str | None = Field(default=None, validation_alias="CHIMERA_SLACK_BOT_TOKEN")
     slack_app_token: str | None = Field(default=None, validation_alias="CHIMERA_SLACK_APP_TOKEN")
-    whatsapp_access_token: str | None = Field(default=None, validation_alias="CHIMERA_WHATSAPP_ACCESS_TOKEN")
+    whatsapp_access_token: str | None = Field(
+        default=None, validation_alias="CHIMERA_WHATSAPP_ACCESS_TOKEN"
+    )
     whatsapp_phone_number_id: str | None = Field(
         default=None, validation_alias="CHIMERA_WHATSAPP_PHONE_NUMBER_ID"
     )
@@ -417,9 +427,7 @@ class Settings(BaseSettings):
     # This default used to be `local`. That meant the shipped boundary was a confirmation prompt,
     # which is a boundary a person can wave through and an injected instruction cannot be stopped by.
     sandbox: str = Field(default="auto", validation_alias="CHIMERA_SANDBOX")
-    sandbox_image: str = Field(
-        default="python:3.12-slim", validation_alias="CHIMERA_SANDBOX_IMAGE"
-    )
+    sandbox_image: str = Field(default="python:3.12-slim", validation_alias="CHIMERA_SANDBOX_IMAGE")
     # Keep `<think>` blocks in the answer instead of filtering them out.
     #
     # Off by default because a reasoning block in `message.content` is never what the caller asked
@@ -551,8 +559,20 @@ class Settings(BaseSettings):
     # Base URL for a local Ollama server. A model like `ollama/llama3` runs on your machine with no
     # API key — set this only if Ollama listens somewhere other than the default. Reinforces the
     # fully-local, self-hostable path: `CHIMERA_DEFAULT_MODEL=ollama/llama3` and no key needed.
+    #
+    # `127.0.0.1`, NOT `localhost`, and the difference is measurable rather than stylistic. The two
+    # are the same machine, but `localhost` is a NAME that resolves to two addresses — `::1` and
+    # `127.0.0.1` — so a client with nothing to connect to tries both in turn and waits twice.
+    # Measured on Windows, where a loopback port with nothing behind it takes 2.04 s to come back
+    # refused: 530 ms through `localhost` against 265 ms through `127.0.0.1`, for the identical
+    # answer. Ollama's own default is `127.0.0.1:11434`, so this names what it actually binds.
+    #
+    # The cost of being specific: an Ollama told to listen on `[::1]` only — which takes deliberately
+    # setting `OLLAMA_HOST` — is no longer found at the default. That is a URL in Settings and the
+    # message names it ("nothing answered at http://127.0.0.1:11434"), so the failure explains its
+    # own fix. A value you set, by env or by the Settings screen, is untouched by this.
     ollama_base_url: str = Field(
-        default="http://localhost:11434", validation_alias="CHIMERA_OLLAMA_BASE_URL"
+        default="http://127.0.0.1:11434", validation_alias="CHIMERA_OLLAMA_BASE_URL"
     )
 
     # Inline completion in the editor: the model asked what comes after the cursor, and the hard
@@ -677,7 +697,8 @@ class Settings(BaseSettings):
         if word and word not in _POSTURE_WORDS:
             _log.warning(
                 "CHIMERA_APPROVAL=%r is not one of %s; ignoring it (no posture floor is stated).",
-                word, ", ".join(sorted(_POSTURE_WORDS)),
+                word,
+                ", ".join(sorted(_POSTURE_WORDS)),
             )
             return ""
         return word
@@ -700,8 +721,11 @@ class Settings(BaseSettings):
             )
             return "ask"
         if word not in _GOVERNANCE_WORDS:
-            _log.warning("CHIMERA_APPROVAL_MODE=%r is not one of %s; falling back to 'ask'.",
-                         word, ", ".join(sorted(_GOVERNANCE_WORDS)))
+            _log.warning(
+                "CHIMERA_APPROVAL_MODE=%r is not one of %s; falling back to 'ask'.",
+                word,
+                ", ".join(sorted(_GOVERNANCE_WORDS)),
+            )
             return "ask"
         return word
 

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -328,7 +328,7 @@ class LLMGateway:
             value = getattr(self.settings, field, None)
             if value and not os.environ.get(env_var):
                 os.environ[env_var] = value
-        # Point LiteLLM's Ollama provider at the configured local server (default localhost:11434), so
+        # Point LiteLLM's Ollama provider at the configured local server (default 127.0.0.1:11434), so
         # `CHIMERA_DEFAULT_MODEL=ollama/llama3` works out of the box — and a remote Ollama is one env var away.
         ollama_base = getattr(self.settings, "ollama_base_url", "") or ""
         if ollama_base and not os.environ.get("OLLAMA_API_BASE"):

--- a/docs/i18n/de/recipes.md
+++ b/docs/i18n/de/recipes.md
@@ -23,7 +23,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 Das war's — kein `OPENROUTER_API_KEY`, keine Cloud. Das Credential-Gate erkennt `ollama/…` (und
 `ollama_chat/…`) als lokale Laufzeit und lässt es durch. Läuft Ollama woanders,
-`CHIMERA_OLLAMA_BASE_URL=http://host:11434` setzen (Standard `http://localhost:11434`).
+`CHIMERA_OLLAMA_BASE_URL=http://host:11434` setzen (Standard `http://127.0.0.1:11434`).
 
 Lokale Modelle sind kleiner, das hier ist also das *schwache* Ende der
 [Goldlöckchen](../bench/local_lift/RESULTS.md)-Spanne — gut geeignet für `chimera solve`

--- a/docs/i18n/de/usage.md
+++ b/docs/i18n/de/usage.md
@@ -62,7 +62,7 @@ er zu kurz ist, um das Längen-Gate auszulösen.
 **Provider, Fallback & selbst gehostet.** Jeder LiteLLM-`provider/model`-Slug
 funktioniert (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`,
 …). Für einen selbst gehosteten / OpenAI-kompatiblen Server (Ollama, vLLM)
-`CHIMERA_API_BASE` setzen (z. B. `http://localhost:11434` mit
+`CHIMERA_API_BASE` setzen (z. B. `http://127.0.0.1:11434` mit
 `CHIMERA_DEFAULT_MODEL=ollama/llama3`). `CHIMERA_FALLBACK_MODELS`
 (kommagetrennt) setzen, um bei einem Fehler des primären Modells auf ein anderes
 auszuweichen. In `chat`/`tui` wechselt `/model <slug>` das Modell mitten in der

--- a/docs/i18n/es/recipes.md
+++ b/docs/i18n/es/recipes.md
@@ -23,7 +23,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 Eso es todo — sin `OPENROUTER_API_KEY`, sin nube. La barrera de credenciales reconoce
 `ollama/…` (y `ollama_chat/…`) como un runtime local y lo deja pasar. Si Ollama corre en otro
 lugar, configura `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (por defecto
-`http://localhost:11434`).
+`http://127.0.0.1:11434`).
 
 Los modelos locales son más pequeños, así que este es el extremo *débil* del rango
 [goldilocks](../bench/local_lift/RESULTS.md) — un buen ajuste para `chimera solve` (el plan +

--- a/docs/i18n/es/usage.md
+++ b/docs/i18n/es/usage.md
@@ -60,7 +60,7 @@ protección de la fusión incluso cuando es demasiado corto para activar la barr
 **Proveedores, fallback y auto-alojado.** Cualquier slug `provider/model` de LiteLLM funciona
 (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). Para un servidor
 auto-alojado / compatible con OpenAI (Ollama, vLLM) configura `CHIMERA_API_BASE` (p. ej.
-`http://localhost:11434` con `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Configura
+`http://127.0.0.1:11434` con `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Configura
 `CHIMERA_FALLBACK_MODELS` (separado por comas) para conmutar a otro modelo si el primario
 falla. En `chat`/`tui`, `/model <slug>` cambia el modelo a mitad de sesión.
 

--- a/docs/i18n/fr/recipes.md
+++ b/docs/i18n/fr/recipes.md
@@ -23,7 +23,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 C'est tout — pas de `OPENROUTER_API_KEY`, pas de cloud. La barrière d'identifiants reconnaît
 `ollama/…` (et `ollama_chat/…`) comme un runtime local et laisse passer. Si Ollama tourne
-ailleurs, définissez `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (`http://localhost:11434` par
+ailleurs, définissez `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (`http://127.0.0.1:11434` par
 défaut).
 
 Les modèles locaux sont plus petits, donc c'est l'extrémité *faible* de la plage

--- a/docs/i18n/fr/usage.md
+++ b/docs/i18n/fr/usage.md
@@ -62,7 +62,7 @@ pour déclencher la barrière de longueur.
 **Fournisseurs, repli & auto-hébergement.** N'importe quel slug LiteLLM `provider/model`
 fonctionne (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). Pour un
 serveur auto-hébergé / compatible OpenAI (Ollama, vLLM) définissez `CHIMERA_API_BASE` (par
-ex. `http://localhost:11434` avec `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Définissez
+ex. `http://127.0.0.1:11434` avec `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Définissez
 `CHIMERA_FALLBACK_MODELS` (séparés par des virgules) pour basculer vers un autre modèle si le
 principal échoue. Dans `chat`/`tui`, `/model <slug>` change de modèle en cours de session.
 

--- a/docs/i18n/it/recipes.md
+++ b/docs/i18n/it/recipes.md
@@ -22,7 +22,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 Tutto qui — niente `OPENROUTER_API_KEY`, niente cloud. Il gate delle credenziali riconosce
 `ollama/…` (e `ollama_chat/…`) come runtime locale e lo lascia passare. Se Ollama gira altrove,
-imposta `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (default `http://localhost:11434`).
+imposta `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (default `http://127.0.0.1:11434`).
 
 I modelli locali sono più piccoli, quindi questo è l'estremo *debole* della fascia
 [goldilocks](../bench/local_lift/RESULTS.md) — adatto a `chimera solve` (il piano +

--- a/docs/i18n/it/usage.md
+++ b/docs/i18n/it/usage.md
@@ -62,7 +62,7 @@ lunghezza.
 **Provider, fallback & self-hosted.** Qualsiasi slug `provider/model` di LiteLLM funziona
 (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). Per un server
 self-hosted / compatibile con OpenAI (Ollama, vLLM) imposta `CHIMERA_API_BASE` (es.
-`http://localhost:11434` con `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Imposta
+`http://127.0.0.1:11434` con `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Imposta
 `CHIMERA_FALLBACK_MODELS` (separati da virgola) per passare a un altro modello se il
 principale dà errore. In `chat`/`tui`, `/model <slug>` cambia il modello a metà sessione.
 

--- a/docs/i18n/ja/recipes.md
+++ b/docs/i18n/ja/recipes.md
@@ -16,7 +16,7 @@ export CHIMERA_DEFAULT_MODEL=ollama/llama3.1     # the `ollama/` prefix = local,
 chimera agent "Summarise this file in 3 bullets" -w .
 ```
 
-それだけです — `OPENROUTER_API_KEY` もクラウドも不要です。認証情報ゲートは `ollama/…`(および `ollama_chat/…`)をローカルランタイムとして認識し、通過させます。Ollamaを別の場所で実行している場合は、`CHIMERA_OLLAMA_BASE_URL=http://host:11434` を設定してください(デフォルトは `http://localhost:11434`)。
+それだけです — `OPENROUTER_API_KEY` もクラウドも不要です。認証情報ゲートは `ollama/…`(および `ollama_chat/…`)をローカルランタイムとして認識し、通過させます。Ollamaを別の場所で実行している場合は、`CHIMERA_OLLAMA_BASE_URL=http://host:11434` を設定してください(デフォルトは `http://127.0.0.1:11434`)。
 
 ローカルモデルは小さいため、これは[goldilocks](../bench/local_lift/RESULTS.md)レンジの*弱い*側です — `chimera solve`(計画+検証または差し戻しが弱いモデルを助けます)やオフラインでのプライバシーには適していますが、一発勝負のフロンティア級推論にはあまり向きません。組み合わせてください: ローカルをデフォルトにしつつ、難しい呼び出し用にクラウドの `CHIMERA_FALLBACK_MODELS` を設定するといった具合です。
 

--- a/docs/i18n/ja/usage.md
+++ b/docs/i18n/ja/usage.md
@@ -59,7 +59,7 @@ completionをキャッシュし、繰り返しのAPI呼び出しを省きます)
 **プロバイダー、フェイルオーバー、セルフホスト。** LiteLLMの `provider/model` スラッグは
 どれでも動作します(`openai/…`、`anthropic/…`、`gemini/…`、`ollama/…`、`openrouter/…`
 など)。セルフホスト/OpenAI互換サーバー(Ollama、vLLM)には `CHIMERA_API_BASE` を設定して
-ください(例: `CHIMERA_DEFAULT_MODEL=ollama/llama3` とともに `http://localhost:11434`)。
+ください(例: `CHIMERA_DEFAULT_MODEL=ollama/llama3` とともに `http://127.0.0.1:11434`)。
 プライマリがエラーになった場合に別のモデルへフェイルオーバーするには `CHIMERA_FALLBACK_MODELS`
 (カンマ区切り)を設定してください。`chat`/`tui` では、`/model <slug>` がセッション途中で
 モデルを切り替えます。

--- a/docs/i18n/pl/recipes.md
+++ b/docs/i18n/pl/recipes.md
@@ -22,7 +22,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 I to wszystko — bez `OPENROUTER_API_KEY`, bez chmury. Brama poświadczeń rozpoznaje `ollama/…`
 (oraz `ollama_chat/…`) jako lokalny runtime i przepuszcza go. Jeśli Ollama działa gdzie indziej,
-ustaw `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (domyślnie `http://localhost:11434`).
+ustaw `CHIMERA_OLLAMA_BASE_URL=http://host:11434` (domyślnie `http://127.0.0.1:11434`).
 
 Modele lokalne są mniejsze, więc jest to *słabszy* koniec zakresu
 [goldilocks](../bench/local_lift/RESULTS.md) — dobrze pasuje do `chimera solve` (plan +

--- a/docs/i18n/pl/usage.md
+++ b/docs/i18n/pl/usage.md
@@ -60,7 +60,7 @@ krótki krok dostaje ochronę fuzji nawet wtedy, gdy jest za krótki, by uruchom
 **Providerzy, fallback i self-hosted.** Działa dowolny slug LiteLLM `provider/model`
 (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). Dla serwera
 self-hosted / zgodnego z OpenAI (Ollama, vLLM) ustaw `CHIMERA_API_BASE`
-(np. `http://localhost:11434` z `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Ustaw
+(np. `http://127.0.0.1:11434` z `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Ustaw
 `CHIMERA_FALLBACK_MODELS` (rozdzielone przecinkami), by przełączyć się na inny model, gdy
 podstawowy zawiedzie. W `chat`/`tui`, `/model <slug>` przełącza model w trakcie sesji.
 

--- a/docs/i18n/pt/recipes.md
+++ b/docs/i18n/pt/recipes.md
@@ -21,7 +21,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 Só isso — sem `OPENROUTER_API_KEY`, sem nuvem. O gate de credenciais reconhece `ollama/…` (e
 `ollama_chat/…`) como um runtime local e deixa passar. Se o Ollama roda em outro lugar, defina
-`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (padrão `http://localhost:11434`).
+`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (padrão `http://127.0.0.1:11434`).
 
 Modelos locais são menores, então esta é a ponta *fraca* da faixa
 [goldilocks](../bench/local_lift/RESULTS.md) — um bom encaixe para `chimera solve` (plano +

--- a/docs/i18n/pt/usage.md
+++ b/docs/i18n/pt/usage.md
@@ -60,7 +60,7 @@ quando é curto demais para acionar o gate de tamanho.
 **Provedores, fallback & self-hosted.** Qualquer slug `provider/model` do LiteLLM
 funciona (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). Para um
 servidor self-hosted / compatível com OpenAI (Ollama, vLLM), defina `CHIMERA_API_BASE`
-(ex.: `http://localhost:11434` com `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Defina
+(ex.: `http://127.0.0.1:11434` com `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Defina
 `CHIMERA_FALLBACK_MODELS` (separado por vírgula) para trocar para outro modelo se o
 primário der erro. Em `chat`/`tui`, `/model <slug>` troca o modelo no meio da sessão.
 

--- a/docs/i18n/ru/recipes.md
+++ b/docs/i18n/ru/recipes.md
@@ -22,7 +22,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 Вот и всё — ни `OPENROUTER_API_KEY`, ни облака. Проверка учётных данных распознаёт `ollama/…` (и
 `ollama_chat/…`) как локальную среду и пропускает. Если Ollama работает на другой машине, задайте
-`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (по умолчанию `http://localhost:11434`).
+`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (по умолчанию `http://127.0.0.1:11434`).
 
 Локальные модели меньше, поэтому это *слабый* конец диапазона
 [золотой середины](../bench/local_lift/RESULTS.md) — хорошо подходит для `chimera solve` (план и

--- a/docs/i18n/ru/usage.md
+++ b/docs/i18n/ru/usage.md
@@ -60,7 +60,7 @@ CHIMERA_FUSION_SYNTHESIZER=openrouter/openai/gpt-4o-mini
 **Поставщики, запасные варианты и своё размещение.** Работает любой ярлык LiteLLM вида
 `поставщик/модель` (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…` и так далее).
 Для своего сервера, совместимого с OpenAI (Ollama, vLLM), задайте `CHIMERA_API_BASE` (например,
-`http://localhost:11434` вместе с `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Задайте
+`http://127.0.0.1:11434` вместе с `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Задайте
 `CHIMERA_FALLBACK_MODELS` (через запятую), чтобы переключаться на другую модель, когда основная даёт
 ошибку. В `chat` и `tui` команда `/model <ярлык>` меняет модель посреди сессии.
 

--- a/docs/i18n/zh/recipes.md
+++ b/docs/i18n/zh/recipes.md
@@ -21,7 +21,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 就这么简单——不需要 `OPENROUTER_API_KEY`，也不涉及云端。凭据检查会把 `ollama/…`（以及
 `ollama_chat/…`）识别为本地运行时并直接放行。如果 Ollama 运行在别处，设置
-`CHIMERA_OLLAMA_BASE_URL=http://host:11434`（默认是 `http://localhost:11434`）。
+`CHIMERA_OLLAMA_BASE_URL=http://host:11434`（默认是 `http://127.0.0.1:11434`）。
 
 本地模型体量更小，因此这属于[适度区间（goldilocks）](../bench/local_lift/RESULTS.md)里*偏弱*
 的一端——很适合 `chimera solve`（规划 + 验证或回滚能帮到一个较弱的模型），也适合追求离线隐私

--- a/docs/i18n/zh/usage.md
+++ b/docs/i18n/zh/usage.md
@@ -58,7 +58,7 @@ CHIMERA_FUSION_SYNTHESIZER=openrouter/openai/gpt-4o-mini
 **Provider、故障转移与自托管。** 任何 LiteLLM 的 `provider/model` 标识都可用
 （`openai/…`、`anthropic/…`、`gemini/…`、`ollama/…`、`openrouter/…` 等）。对于自托管 /
 OpenAI 兼容的服务器（Ollama、vLLM），设置 `CHIMERA_API_BASE`（例如
-`http://localhost:11434`，配合 `CHIMERA_DEFAULT_MODEL=ollama/llama3`）。设置
+`http://127.0.0.1:11434`，配合 `CHIMERA_DEFAULT_MODEL=ollama/llama3`）。设置
 `CHIMERA_FALLBACK_MODELS`（逗号分隔）可以在主模型报错时自动故障转移到另一个模型。在
 `chat`/`tui` 中，`/model <slug>` 可以在会话中途切换模型。
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -17,7 +17,7 @@ chimera agent "Summarise this file in 3 bullets" -w .
 
 That's it — no `OPENROUTER_API_KEY`, no cloud. The credential gate recognises `ollama/…` (and
 `ollama_chat/…`) as a local runtime and lets it through. If Ollama runs elsewhere, set
-`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (default `http://localhost:11434`).
+`CHIMERA_OLLAMA_BASE_URL=http://host:11434` (default `http://127.0.0.1:11434`).
 
 Local models are smaller, so this is the *weak* end of the [goldilocks](../bench/local_lift/RESULTS.md)
 range — a good fit for `chimera solve` (plan + verify-or-revert helps a weak model) and for offline

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,7 +55,7 @@ even when it is too short to trip the length gate.
 **Providers, fallback & self-hosted.** Any LiteLLM `provider/model` slug works
 (`openai/…`, `anthropic/…`, `gemini/…`, `ollama/…`, `openrouter/…`, …). For a
 self-hosted / OpenAI-compatible server (Ollama, vLLM) set `CHIMERA_API_BASE`
-(e.g. `http://localhost:11434` with `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Set
+(e.g. `http://127.0.0.1:11434` with `CHIMERA_DEFAULT_MODEL=ollama/llama3`). Set
 `CHIMERA_FALLBACK_MODELS` (comma-separated) to fail over to another model if the
 primary errors. In `chat`/`tui`, `/model <slug>` switches the model mid-session.
 

--- a/tests/test_asking_a_dead_port_is_quick.py
+++ b/tests/test_asking_a_dead_port_is_quick.py
@@ -28,7 +28,13 @@ from typing import Any
 import httpx
 import pytest
 
-from chimera.providers.ollama import DEFAULT_TIMEOUT_S, LOCAL_CONNECT_TIMEOUT_S, installed_models
+from chimera.config import Settings
+from chimera.providers.ollama import (
+    DEFAULT_TIMEOUT_S,
+    LOCAL_CONNECT_TIMEOUT_S,
+    _connect_budget,
+    installed_models,
+)
 
 
 def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
@@ -149,3 +155,43 @@ def test_what_the_probe_reports_did_not_change(monkeypatch: pytest.MonkeyPatch) 
     assert found.reachable is True
     assert found.models == ()
     assert found.reason == ""
+
+
+def test_the_shipped_default_names_an_address_and_not_a_name() -> None:
+    """`127.0.0.1`, not `localhost`, and the difference is measurable rather than stylistic.
+
+    Both mean this machine. But `localhost` is a NAME, and it resolves to two addresses — `::1` and
+    `127.0.0.1` — so a client with nothing to connect to tries them in turn and waits twice for the
+    same answer. Measured through `installed_models` on Windows: **530 ms** through the name against
+    **265 ms** through the address, for an identical verdict.
+
+    This is asserted rather than left as a comment because the two spellings look interchangeable,
+    and the one that reads as tidier is the slower one. Ollama's own default is `127.0.0.1:11434`,
+    so the specific address is also the more accurate description of what it binds.
+    """
+    padrao = Settings.model_fields["ollama_base_url"].default
+    assert padrao == "http://127.0.0.1:11434"
+    assert "localhost" not in padrao
+
+
+def test_the_shipped_default_is_one_of_the_urls_that_gets_the_short_budget() -> None:
+    """The default and the fast path have to agree, and nothing else checks that they do.
+
+    A default pointing somewhere `_connect_budget` does not recognise as this machine would keep the
+    full two seconds while every comment in the module claims otherwise — the change would look
+    applied and do nothing.
+    """
+    padrao = Settings.model_fields["ollama_base_url"].default
+    assert _connect_budget(padrao, DEFAULT_TIMEOUT_S) == LOCAL_CONNECT_TIMEOUT_S
+
+
+def test_a_url_the_user_set_is_not_overridden_by_the_new_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing a default must not reach into an install that already made this decision.
+
+    Someone running Ollama elsewhere — another host, another port, IPv6 on purpose — set this in
+    `.env` or on the Settings screen. A default is what applies when nothing was chosen, and that
+    boundary is the whole reason changing one is safe."""
+    monkeypatch.setenv("CHIMERA_OLLAMA_BASE_URL", "http://[::1]:11434")
+    assert Settings().ollama_base_url == "http://[::1]:11434"

--- a/tests/test_ollama_local.py
+++ b/tests/test_ollama_local.py
@@ -36,9 +36,16 @@ def test_non_local_model_still_requires_a_key(monkeypatch: Any) -> None:
 
 def test_ollama_base_url_is_exported_to_env(monkeypatch: Any) -> None:
     # Building the gateway points LiteLLM's Ollama provider at the configured local server.
+    #
+    # Compared against the setting rather than a literal, deliberately. What this test is for is the
+    # WIRING — that whatever is configured reaches LiteLLM — and spelling the default out here made
+    # it a second copy of a value that lives in `config.py`. The two then have to be changed in step,
+    # and the day they were not, this failed for a reason that had nothing to do with the export.
+    from chimera.config import Settings
+
     monkeypatch.delenv("OLLAMA_API_BASE", raising=False)
     LLMGateway()  # __init__ exports the base URL
-    assert os.environ.get("OLLAMA_API_BASE") == "http://localhost:11434"
+    assert os.environ.get("OLLAMA_API_BASE") == Settings().ollama_base_url
 
 
 def test_existing_ollama_api_base_is_not_overwritten(monkeypatch: Any) -> None:


### PR DESCRIPTION
## `127.0.0.1:11434`, not `localhost:11434`

The two mean the same machine, but one is a **name**, and it resolves to two addresses — `::1` and
`127.0.0.1`. A client with nothing to connect to tries them in turn and waits twice for the same
answer.

Measured through `installed_models`, paired on one machine:

| | |
|---|---:|
| `http://localhost:11434` | 530 ms |
| `http://127.0.0.1:11434` | **265 ms** |

Identical verdict. This is the other half of the connect-budget split in rc48: the budget made each
wait short, and this stops there being two of them.

It is also the more accurate description — Ollama binds `127.0.0.1:11434` by default, so the setting
now names what is actually listening rather than a name that might resolve anywhere.

## The cost of being specific

An Ollama told to listen on `[::1]` **only** — which takes deliberately setting `OLLAMA_HOST` — is
no longer found at the default. That address is a field on the Settings screen and the failure names
it (*"nothing answered at http://127.0.0.1:11434"*), so it explains its own fix.

**A value already set is untouched**, whether it came from `.env` or from the screen. A default is
what applies when nothing was chosen, and that boundary is the whole reason changing one is safe.

## Tests

Three new, each failing when the default is reverted:

- the default is an **address**, not a name;
- the default **agrees with the fast path** — one pointing somewhere `_connect_budget` does not
  recognise as this machine would look applied and do nothing;
- an explicitly set value still wins.

Two sabotages, both caught: reverting to `localhost` fails one test; `0.0.0.0` — which *looks* local
and is not recognised — fails two.

## It caught a test that was wrong for an unrelated reason

`test_ollama_base_url_is_exported_to_env` exists to prove the configured URL reaches LiteLLM, and
asserted the literal `http://localhost:11434` — making it **a second copy of a value that lives in
`config.py`**. Two places that must say the same thing, written separately, and the day they did not,
it failed for a reason that had nothing to do with the export.

It now compares against the setting, so it tests the wiring. Verified still load-bearing: removing
the export fails it, and exporting the wrong value fails it.

## Docs, in ten languages

The ten `recipes.md` **stated** the default and became false. The ten `usage.md` and `.env.example`
carried examples that stayed true but advised the slower spelling; updated for consistency.

## Verification

`4534 passed, 18 skipped` · frontend `978 passed` · `ruff` clean · `mypy` clean across 330 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)