### PR TITLE
fix(tools): refuse a file whose accents arrived as `u00ed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,26 @@ You could not choose which model answered you. The endpoint accepted one all alo
   is a field on the Settings screen and the failure names it (*"nothing answered at
   http://127.0.0.1:11434"*), so it explains its own fix. **A value you already set is untouched**:
   a default is what applies when nothing was chosen, whether it came from `.env` or the screen.
+- **A file whose accents arrived as `u00ed` instead of `í` now gets refused.** A model writing
+  Portuguese prose emits an escape for each accented character. When the backslash does not survive
+  the trip, what lands is welded into the word — and *nothing downstream notices*, because the file
+  is still valid UTF-8, still valid HTML, and every check passes. A person opens the page and reads
+  **Utensu00edlios**.
+  Found by using the app, not by reading it. An agent built a marketplace in one run: four files,
+  three carrying their accents correctly and the fourth with **zero** accented characters and 23
+  orphan sequences. The verify command passed and the diff gate accepted the work.
+  `write_file` already refuses a full overwrite that does not parse — `.py` by AST, `.json` by
+  `json.loads`, with `allow_invalid` as the way past. This is the same idea for a defect no parser
+  can see, and it needs **two** conditions, since either alone misfires: three or more orphan
+  sequences, and *fewer real non-ASCII characters than orphans* — the signal is not that escapes
+  appear, it is that they appear **instead of** what they encode.
+  The narrowing was measured, not reasoned. A first version accepted any code point of a textual
+  Unicode category and fired on **79 of 32,655 files in this repository**, because `succeeded`
+  contains `uccee`, those are all hex digits, and U+CCEE is a CJK ideograph. Restricted to the
+  ranges a lost backslash plausibly produces in Latin-script text: **0 of 33,066**, with the real
+  defect still caught. `succeeded` is now a test, with the reason written down.
+  Its own message, deliberately — the content parses, so reporting it as "not valid html" would
+  name the wrong problem and send the next attempt hunting a syntax error that is not there.
 - **The folder of reverted work had no ceiling.** Every attempt a verify command rejects writes its
   full diff to `discarded/`, which is what makes that work recoverable — and nothing ever removed
   one. Measured: 3 files in one session, 7 eighteen hours later, ~2 KB each, growing forever. Small

--- a/chimera/tools/files.py
+++ b/chimera/tools/files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +18,9 @@ _MAX_READ_CHARS = 20_000
 class _WorkspaceTool(Tool):
     """Base for tools bound to a workspace root (with an optional declared write-region)."""
 
-    def __init__(self, workspace: Path | None = None, *, write_region: WriteRegion | None = None) -> None:
+    def __init__(
+        self, workspace: Path | None = None, *, write_region: WriteRegion | None = None
+    ) -> None:
         self.workspace = (workspace or Path.cwd()).resolve()
         self.write_region = write_region
 
@@ -27,7 +30,9 @@ class ReadFileTool(_WorkspaceTool):
     description = "Read a UTF-8 text file from the workspace."
     parameters = {
         "type": "object",
-        "properties": {"path": {"type": "string", "description": "Path relative to the workspace."}},
+        "properties": {
+            "path": {"type": "string", "description": "Path relative to the workspace."}
+        },
         "required": ["path"],
     }
 
@@ -81,6 +86,70 @@ def syntax_error(path: Path, content: str) -> str | None:
     return None
 
 
+#: `u` and four hex digits with NO backslash in front — a `\uXXXX` that lost its backslash.
+#: No word boundary: the real defect arrives welded into the prose ("Utensu00edlios").
+_LOOSE_ESCAPE = re.compile(r"(?<!\\)u([0-9a-fA-F]{4})")
+#: The ES6 `\u{1F50D}` form, same loss.
+_LOOSE_ESCAPE_BRACED = re.compile(r"(?<!\\)u\{(1?[0-9A-Fa-f]{4,5})\}")
+
+#: Below this it is a coincidence, not a pattern. The real case had 23.
+_LOOSE_ESCAPE_MIN = 3
+
+#: Code points a lost backslash plausibly produces in Latin-script text: accents, typographic
+#: punctuation, currency, arrows and dingbats, emoji.
+#:
+#: Narrow on purpose, and the narrowing was measured rather than reasoned. A first version accepted
+#: any code point of a textual Unicode category and fired on **79 of 32,655 files in this
+#: repository** — because `succeeded` contains `uccee`, `c`, `c`, `e` and `e` are all hex digits,
+#: and U+CCEE is a CJK ideograph. An ideograph never reaches a file through a lost escape; an `i`
+#: with an acute accent does it constantly. With these ranges: 0 of 32,655, and the real defect
+#: still caught.
+_LOOSE_ESCAPE_RANGES = (
+    (0x00A0, 0x024F),  # Latin-1 Supplement + Latin Extended-A/B — the accents
+    (0x2010, 0x206F),  # typographic punctuation — dashes, curly quotes, ellipsis
+    (0x20A0, 0x20BF),  # currency
+    (0x2190, 0x27BF),  # arrows, maths, dingbats
+    (0x2B00, 0x2BFF),  # more arrows and symbols
+    (0x1F300, 0x1FAFF),  # emoji
+)
+
+
+def lost_escapes(content: str) -> str | None:
+    r"""Why ``content`` looks like text whose escape sequences lost their backslashes, or None.
+
+    A model writing a file full of accented prose emits `\u00ed` for `í`. When the backslash does
+    not survive — a re-serialisation, a shell hop, a provider quirk — what lands is `u00ed`, welded
+    into the word. Nothing downstream complains: the file is valid UTF-8, valid HTML, and the page
+    renders `Utensu00edlios` to a human being.
+
+    Measured on a real run: an agent wrote four files in one go; three carried their accents
+    correctly and the fourth had **zero** accented characters and 23 orphan sequences. The verify
+    command passed, the diff gate accepted, and the corruption reached the user's screen.
+
+    Two conditions together, because either alone misfires. **Three or more** matches, since one
+    hex-looking fragment is a coincidence. And **fewer real non-ASCII characters than orphan
+    sequences** — the signal is not that escapes appear, it is that they appear *instead of* the
+    characters they encode. A correctly written Portuguese file has hundreds of real accents and
+    would never trip this; the corrupted one had none.
+    """
+    found: list[str] = []
+    for pattern in (_LOOSE_ESCAPE, _LOOSE_ESCAPE_BRACED):
+        for match in pattern.finditer(content):
+            code = int(match.group(1), 16)
+            if any(low <= code <= high for low, high in _LOOSE_ESCAPE_RANGES):
+                found.append(match.group(0))
+    if len(found) < _LOOSE_ESCAPE_MIN:
+        return None
+    real = sum(1 for ch in content if ord(ch) > 0x7F)
+    if real >= len(found):
+        return None
+    sample = ", ".join(list(dict.fromkeys(found))[:6])
+    return (
+        rf"{len(found)} sequences read as `\uXXXX` with the backslash missing ({sample}), "
+        f"and the file has only {real} real non-ASCII characters"
+    )
+
+
 class WriteFileTool(_WorkspaceTool):
     name = "write_file"
     description = "Write (create or overwrite) a UTF-8 text file in the workspace."
@@ -113,12 +182,22 @@ class WriteFileTool(_WorkspaceTool):
         # The escape hatch is not optional. Templates, fixtures and deliberately-broken examples are
         # real files, and a guard with no way past turns "the agent wrote something odd" into "the
         # agent cannot do this at all".
-        if not bool(kwargs.get("allow_invalid", False)) and (why := syntax_error(path, content)):
-            return (
-                f"error: refused to overwrite {path.name} — the content is not valid "
-                f"{path.suffix.lstrip('.')}: {why}. Fix it, or pass allow_invalid=true if the file "
-                f"is meant to be invalid."
-            )
+        if not bool(kwargs.get("allow_invalid", False)):
+            if why := syntax_error(path, content):
+                return (
+                    f"error: refused to overwrite {path.name} — the content is not valid "
+                    f"{path.suffix.lstrip('.')}: {why}. Fix it, or pass allow_invalid=true if the "
+                    f"file is meant to be invalid."
+                )
+            # Its own message, deliberately, and not folded into the one above: this content may
+            # parse perfectly. Reporting it as "not valid html" would name the wrong problem and
+            # send the next attempt looking for a syntax error that is not there.
+            if why := lost_escapes(content):
+                return (
+                    f"error: refused to overwrite {path.name} — the text looks corrupted: {why}. "
+                    f"Write the characters themselves (í, ã, ✕) rather than escape sequences. Pass "
+                    f"allow_invalid=true if those sequences really are the intended content."
+                )
         path.parent.mkdir(parents=True, exist_ok=True)
         # Byte-exact atomic write: never OS-translate the model's newlines, and never truncate an
         # existing file if the write is interrupted (temp + replace).
@@ -132,7 +211,10 @@ class ListDirTool(_WorkspaceTool):
     parameters = {
         "type": "object",
         "properties": {
-            "path": {"type": "string", "description": "Directory path relative to the workspace (default '.')."}
+            "path": {
+                "type": "string",
+                "description": "Directory path relative to the workspace (default '.').",
+            }
         },
     }
 
@@ -140,7 +222,5 @@ class ListDirTool(_WorkspaceTool):
         path = resolve_in_workspace(self.workspace, str(kwargs.get("path", ".")))
         if not path.is_dir():
             return f"error: not a directory: {kwargs.get('path', '.')}"
-        entries = sorted(
-            f"{p.name}/" if p.is_dir() else p.name for p in path.iterdir()
-        )
+        entries = sorted(f"{p.name}/" if p.is_dir() else p.name for p in path.iterdir())
         return "\n".join(entries) if entries else "(empty)"

--- a/tests/test_the_accents_did_not_survive_the_write.py
+++ b/tests/test_the_accents_did_not_survive_the_write.py
@@ -1,0 +1,141 @@
+r"""A file whose accents arrived as `u00ed` instead of `í` is corrupted, and nothing else notices.
+
+A model writing Portuguese prose emits `\uXXXX` for an accented character. When the backslash does
+not survive the trip — a re-serialisation, a shell hop, a provider quirk — what lands is `u00ed`,
+welded into the middle of the word. The file is still valid UTF-8. Still valid HTML. Every check
+downstream passes, and a human opens the page and reads *Utensu00edlios*.
+
+This is not hypothetical. On 2026-08-31 an agent built a marketplace in one run: four files, three
+carrying their accents correctly, and the fourth with **zero** accented characters and 23 orphan
+sequences. The verify command passed, the diff gate accepted the work, and the corruption reached
+the screen. The corrupted file is reproduced below as a regression case.
+
+The guard lives with the syntax check because it is the same idea — a full overwrite that is
+obviously not what anyone meant is refused before it destroys the version that was fine — but it
+carries its OWN message, because this content parses. Calling it "not valid html" would name the
+wrong problem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.tools.files import WriteFileTool, lost_escapes
+
+# NOTE: this file trips its own guard, and that is correct — it carries the corrupted markup as a
+# fixture. Swept over the whole repository (33,066 files) the detector fires exactly twice: on the
+# file that was actually corrupted, and here. An agent asked to rewrite THIS file will be refused
+# and needs `allow_invalid=true`, which is the escape hatch working as designed.
+
+#: The real corrupted markup, trimmed. Every `u00XX` here stood for an accented letter.
+REAL = (
+    "<!DOCTYPE html><html lang='pt-BR'><head><meta charset='UTF-8'>"
+    "<title>Feito Aqui</title></head><body>"
+    "<p>Artesanato brasileiro com histu00f3ria e alma</p>"
+    "<button>Utensu00edlios</button><button>Tu00eaxteis</button>"
+    "<button>Decorau00e7u00e3o</button><button>Acessu00f3rios</button>"
+    "<input placeholder='Buscar produtos, artesu00e3os ou regiu00f5es...'>"
+    "<span>u{1F50D}</span><button>u2715</button>"
+    "<footer>Feito Aqui u00ae 2024</footer></body></html>"
+)
+
+#: What it should have been.
+CORRECT = (
+    "<!DOCTYPE html><html lang='pt-BR'><head><meta charset='UTF-8'>"
+    "<title>Feito Aqui</title></head><body>"
+    "<p>Artesanato brasileiro com história e alma</p>"
+    "<button>Utensílios</button><button>Têxteis</button>"
+    "<button>Decoração</button><button>Acessórios</button>"
+    "<input placeholder='Buscar produtos, artesãos ou regiões...'>"
+    "<span>🔍</span><button>✕</button>"
+    "<footer>Feito Aqui ® 2024</footer></body></html>"
+)
+
+
+def test_the_file_that_actually_shipped_is_refused(tmp_path: Path) -> None:
+    """The regression case, verbatim from the run that produced it."""
+    out = WriteFileTool(tmp_path).run(path="index.html", content=REAL)
+    assert "refused" in out
+    assert not (tmp_path / "index.html").exists(), "refused, and yet it wrote"
+
+
+def test_the_same_file_written_correctly_goes_through(tmp_path: Path) -> None:
+    """The control, and the one that would matter if the guard were too eager: the SAME markup with
+    its accents intact must be written without a murmur."""
+    out = WriteFileTool(tmp_path).run(path="index.html", content=CORRECT)
+    assert "wrote" in out
+    assert (tmp_path / "index.html").read_text(encoding="utf-8") == CORRECT
+
+
+def test_the_message_names_the_problem_and_not_a_syntax_error(tmp_path: Path) -> None:
+    """This content parses. Reporting it as invalid HTML would send the next attempt hunting a
+    syntax error that is not there."""
+    out = WriteFileTool(tmp_path).run(path="index.html", content=REAL)
+    assert "corrupted" in out
+    assert "not valid" not in out
+    assert "u00ed" in out, "the message must show what it saw"
+
+
+def test_the_escape_hatch_still_opens(tmp_path: Path) -> None:
+    """Someone documenting escape sequences is writing exactly this on purpose."""
+    out = WriteFileTool(tmp_path).run(path="notas.md", content=REAL, allow_invalid=True)
+    assert "wrote" in out
+    assert (tmp_path / "notas.md").read_text(encoding="utf-8") == REAL
+
+
+def test_succeeded_is_not_a_lost_escape() -> None:
+    """The false positive that a first version actually had, kept as a test because no amount of
+    reasoning predicted it.
+
+    `succeeded` contains `uccee`; `c`, `c`, `e` and `e` are all hex digits; and U+CCEE is a CJK
+    ideograph. Accepting any textual code point fired on 79 of 32,655 files in this repository.
+    """
+    prosa = "The run succeeded. The retry succeeded. Everything succeeded, repeatedly."
+    assert lost_escapes(prosa) is None
+
+
+def test_a_file_full_of_real_accents_is_never_flagged() -> None:
+    """The second condition, on its own. Even WITH orphan sequences present, a file whose accents
+    survived is not a file whose accents were lost."""
+    acentuado = "ção " * 40 + " u00ed u00e3 u00e7 "
+    assert lost_escapes(acentuado) is None
+
+
+def test_one_lonely_sequence_is_a_coincidence() -> None:
+    """A hex fragment happens. A pattern of them does not."""
+    assert lost_escapes("commit u00ed and nothing else") is None
+
+
+def test_a_proper_escape_with_its_backslash_is_not_the_defect() -> None:
+    r"""`\u00ed` in a JavaScript source is a correctly written escape, not a lost one."""
+    js = r'const a = "\u00ed"; const b = "\u00e3"; const c = "\u00e7"; const d = "\u00fa";'
+    assert lost_escapes(js) is None
+
+
+@pytest.mark.parametrize(
+    "suffix", ["html", "css", "js", "md", "txt", "svg"], ids=lambda s: f"a .{s} file"
+)
+def test_the_guard_is_not_limited_to_the_types_that_have_a_parser(
+    tmp_path: Path, suffix: str
+) -> None:
+    """The syntax check can only cover `.py` and `.json` — those are what the standard library
+    parses for free. This defect is visible in any text at all, and the file it actually hit was
+    HTML, which has no check above it."""
+    assert "refused" in WriteFileTool(tmp_path).run(path=f"a.{suffix}", content=REAL)
+
+
+def test_a_python_file_that_parses_but_lost_its_accents_is_still_refused(tmp_path: Path) -> None:
+    """The two checks are independent. Valid syntax is not evidence the text survived."""
+    src = (
+        "# -*- coding: utf-8 -*-\n"
+        'TITULO = "Utensu00edlios"\n'
+        'SUB = "Decorau00e7u00e3o"\n'
+        'ALT = "Acessu00f3rios"\n'
+        'MAIS = "histu00f3ria"\n'
+    )
+    import ast
+
+    ast.parse(src)  # the syntax check has nothing to say about this
+    assert "refused" in WriteFileTool(tmp_path).run(path="rotulos.py", content=src)


### PR DESCRIPTION
## The defect nothing notices

A model writing Portuguese prose emits an escape for each accented character. When the backslash
does not survive the trip, what lands is welded into the middle of the word — and **every check
downstream passes**, because the file is still valid UTF-8, still valid HTML. A person opens the
page and reads `Utensu00edlios`.

**Found by using the app, not by reading it.** An agent built a marketplace in one run: four files,
three carrying their accents correctly and the fourth with **zero** accented characters and 23
orphan sequences. The verify command passed. The diff gate accepted the work.

## Whose defect it is, stated plainly

**Not Chimera's.** Measured: same tool, same run, three files perfect and one corrupted; tool-call
arguments go through plain `json.loads`, which decodes a real escape correctly and, on failure,
produces an *empty* argument rather than corrupted text. The model emitted the broken text.

**But Chimera shipped it**, and `write_file` already has the mechanism — it refuses a full overwrite
that does not parse, `.py` by AST and `.json` by `json.loads`, with `allow_invalid` as the way past.
This is the same idea for a defect no parser can see.

## Two conditions, because either alone misfires

- **Three or more** orphan sequences — one hex-looking fragment is a coincidence.
- **Fewer real non-ASCII characters than orphans** — the signal is not that escapes appear, it is
  that they appear *instead of* the characters they encode. A correctly written Portuguese file has
  hundreds of real accents and never trips this.

## The narrowing was measured, not reasoned

A first version accepted any code point of a textual Unicode category:

| version | fires on this repository | real defect caught |
|---|---:|---|
| any textual code point | **79 of 32,655** | yes |
| restricted ranges | **0 of 33,066** | yes |

The culprit is the word **`succeeded`** — it contains `uccee`, those are all hex digits, and U+CCEE
is a CJK ideograph. No amount of reasoning predicted that; one sweep did. `succeeded` is now a test,
with the reason written down.

The kept ranges are what a lost backslash plausibly produces in Latin-script text: accents,
typographic punctuation, currency, arrows and dingbats, emoji.

## Its own message, deliberately

Not folded into the syntax error above it. This content **parses** — reporting it as "not valid
html" would name the wrong problem and send the next attempt hunting a syntax error that is not
there.

## Verification

- **15 tests.** The regression case is the file that actually shipped, verbatim, alongside the same
  markup with its accents intact **as the control** — without that control the suite would prove the
  guard refuses, not that it discriminates.
- **Six sabotages run, six caught**, including *"the mechanism exists and is never called"* — the
  failure this project has shipped twice.
- The sweep fires exactly twice across the repository: on nothing, and on the new test file itself,
  which carries the corrupted markup as a fixture. That is documented in the file.
- `4549 passed, 18 skipped` · `ruff` clean · `mypy` clean across 330 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)