### PR TITLE
fix(providers): what a failed call carried out of the process

### DIFF
--- a/chimera/api/app.py
+++ b/chimera/api/app.py
@@ -257,7 +257,6 @@ class PlanRequest(BaseModel):
     itself reads no files — it is a pure model call — but the field mirrors the run request's shape.)"""
 
 
-
 class RunRequest(CodeSeams):
     """An autonomous run: plan → execute → verify-or-revert → receipt.
 
@@ -451,6 +450,8 @@ def _persist_crashed_run(
         import json as _json
         from pathlib import Path as _Path
 
+        from chimera.core.redact import redact as _redact
+
         attempts = list(getattr(agent, "attempts", None) or [])
         rows = [
             {
@@ -472,7 +473,15 @@ def _persist_crashed_run(
             # The two fields that make this row readable as what it is, rather than as a run that
             # merely failed its verifier.
             "crashed": True,
-            "crash_reason": f"{type(cause).__name__}: {cause}"[:500],
+            # Redacted, and redacted BEFORE the cut. This is the one place a provider's error body
+            # reaches disk: a failed completion arrives as a LiteLLM exception whose message is the
+            # upstream response, and that body has been measured to carry an echoed prompt fragment
+            # and the provider's internal trace. (The API key itself does not survive — LiteLLM masks
+            # `Bearer …` on the way in — so what this protects is the user's own content.)
+            # `steplog.py` already writes through `redact` for exactly this reason; this row was
+            # written by hand and never picked it up. Truncating first would leave the front half of
+            # a secret that the cut split in two.
+            "crash_reason": _redact(f"{type(cause).__name__}: {cause}")[:500],
             "attempts": rows,
         }
         log = _Path(str(home)) / "runs.jsonl"
@@ -537,11 +546,17 @@ def build_api_app(
         a test or a bench comparing two configurations is asking for.
         """
         return settings_override or get_settings()
+
     store = SessionStore(settings.home / "sessions")
     manager = SessionManager(factory, store)
     guard = Depends(_require_token())
 
-    app = FastAPI(title="Chimera Desktop API", version="1", docs_url="/api/docs", openapi_url="/api/openapi.json")
+    app = FastAPI(
+        title="Chimera Desktop API",
+        version="1",
+        docs_url="/api/docs",
+        openapi_url="/api/openapi.json",
+    )
 
     # Cross-origin, only for the origins the operator named, and only when they named some.
     #
@@ -707,8 +722,9 @@ def build_api_app(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return [a.model_dump() for a in upsert_agent(live_settings().home, entry)]
 
-    @app.delete("/api/agents/registry/{agent_id}", dependencies=[guard],
-                response_model=list[AgentDefOut])
+    @app.delete(
+        "/api/agents/registry/{agent_id}", dependencies=[guard], response_model=list[AgentDefOut]
+    )
     def remove_agent_endpoint(agent_id: str) -> list[Any]:
         # Cards already filed under this agent's lane are deliberately untouched: they keep their
         # lane and stop being dispatched, which is recoverable. Deleting the work is not.
@@ -865,10 +881,7 @@ def build_api_app(
         # see `_already_counted`, and the measured $0.049 it was billing twice.
         turnos = load_usage(settings.home / "usage.jsonl")
         return summarize_usage(
-            turnos
-            + usage_from_runs(
-                settings.home / "runs.jsonl", already=_already_counted(turnos)
-            )
+            turnos + usage_from_runs(settings.home / "runs.jsonl", already=_already_counted(turnos))
         )
 
     @app.get("/api/runs", dependencies=[guard], response_model=list[RunReceiptOut])
@@ -954,9 +967,7 @@ def build_api_app(
         # The chain state travels with the entries. Every write pays for a digest of the entry
         # before it, and until now nothing ever walked it — so the log detected tampering the way an
         # unread smoke alarm detects fire.
-        return {
-            "events": events, "count": len(events), "populated": bool(events), "chain": chain
-        }
+        return {"events": events, "count": len(events), "populated": bool(events), "chain": chain}
 
     @app.get("/api/governance/sandbox", dependencies=[guard], response_model=SandboxStateOut)
     def governance_sandbox_endpoint() -> dict[str, Any]:
@@ -983,9 +994,12 @@ def build_api_app(
             isolated = False
         if isolated:
             backend = (
-                "docker" if configured == "docker"
-                else "seatbelt" if seatbelt_available()
-                else "bubblewrap" if bubblewrap_available()
+                "docker"
+                if configured == "docker"
+                else "seatbelt"
+                if seatbelt_available()
+                else "bubblewrap"
+                if bubblewrap_available()
                 else "isolated"
             )
         else:
@@ -1171,14 +1185,19 @@ def build_api_app(
                 # secret; the message is bounded and appended because without it "RuntimeError" is
                 # only marginally better than "failed".
                 _log.warning("run failed: %s: %s", type(exc).__name__, exc, exc_info=True)
-                emit("error", {
-                    "message": "the run failed",
-                    "reason": f"{type(exc).__name__}: {exc}"[:400],
-                    "run_id": run_id,
-                })
+                emit(
+                    "error",
+                    {
+                        "message": "the run failed",
+                        "reason": f"{type(exc).__name__}: {exc}"[:400],
+                        "run_id": run_id,
+                    },
+                )
                 _persist_crashed_run(settings.home, run_id, req, ws, auto, exc)
             finally:
-                _run_cancels.pop(run_id, None)  # done (or crashed): the run is no longer cancellable
+                _run_cancels.pop(
+                    run_id, None
+                )  # done (or crashed): the run is no longer cancellable
                 loop.call_soon_threadsafe(queue.put_nowait, None)  # sentinel: end of stream
 
         # Each run is independent (its own agent + workspace snapshot), so no per-session lock is
@@ -1670,7 +1689,9 @@ def build_api_app(
 
         ws = _resolve_fs_workspace(req.workspace)
         try:
-            resolve_exec_cwd(ws, req.cwd)  # pre-validate so a cwd escape is a clean 400, not a stream
+            resolve_exec_cwd(
+                ws, req.cwd
+            )  # pre-validate so a cwd escape is a clean 400, not a stream
         except ValueError as exc:
             raise HTTPException(status_code=400, detail="invalid cwd") from exc
         timeout = max(1.0, min(float(req.timeout), 3600.0))  # clamp to the shell tool's 1..3600 cap
@@ -1890,9 +1911,7 @@ def build_api_app(
     # Registered unconditionally: `schema_dump` builds the app through this function, so a route
     # behind a flag or a try-import would be present at runtime and absent from the schema, and
     # the drift gate would pass while the generated client was missing half the surface.
-    register_orchestration_api(
-        app, guard, workspace, settings, live_settings=live_settings
-    )
+    register_orchestration_api(app, guard, workspace, settings, live_settings=live_settings)
     # /api/lifecycle — plan → build → test → review, one frame per stage. Registered here and not
     # behind a flag for the same reason as above: `schema_dump` builds the app through this
     # function, so a conditional route would be present at runtime and missing from the schema.
@@ -2018,7 +2037,11 @@ def _audit_event(entry: dict[str, Any]) -> dict[str, Any]:
     seq = entry.get("seq", 0)
     etype = str(entry.get("type", ""))
     parts = [f"{k}={v}" for k, v in entry.items() if k not in ("seq", "type")]
-    return {"seq": int(seq) if isinstance(seq, int) else 0, "type": etype, "summary": " ".join(parts)}
+    return {
+        "seq": int(seq) if isinstance(seq, int) else 0,
+        "type": etype,
+        "summary": " ".join(parts),
+    }
 
 
 def _api_cascade_backend(gateway: SupportsComplete, settings: Settings) -> SupportsComplete:
@@ -2043,7 +2066,9 @@ def _api_cascade_backend(gateway: SupportsComplete, settings: Settings) -> Suppo
         entry=ladder.entry,
         log_path=settings.home / "routes.jsonl",
     )
-    return CascadeBackend(gateway, cast("SupportsComplete", fusion_for_role(gateway, settings)), config)
+    return CascadeBackend(
+        gateway, cast("SupportsComplete", fusion_for_role(gateway, settings)), config
+    )
 
 
 def resolve_verify(requested: str | None, workspace: Path) -> tuple[str | None, str]:
@@ -2126,7 +2151,9 @@ def _build_solve_agent(
         from chimera.fusion import FusionEngine, RoutedBackend, RoutingPolicy
 
         backend = _api_cascade_backend(gateway, settings)
-        escalate_backend = RoutedBackend(gateway, FusionEngine(gateway), RoutingPolicy(mode="always"))
+        escalate_backend = RoutedBackend(
+            gateway, FusionEngine(gateway), RoutingPolicy(mode="always")
+        )
     elif req.fuse:
         from chimera.fusion import FusionEngine, RoutedBackend, RoutingPolicy
 
@@ -2179,9 +2206,7 @@ def _build_solve_agent(
     # be answered rather than only refused) is the follow-up.
     steps = resolve_steps(req.max_steps)
     posture = resolve_posture(req.posture)
-    registry, ledger = assemble_registry(
-        req, ws, settings, gateway, steps=steps, surface="api:run"
-    )
+    registry, ledger = assemble_registry(req, ws, settings, gateway, steps=steps, surface="api:run")
     # insist_on_action: solve is task completion, so a described-but-unexecuted plan is pushed back
     # to actually run (mirrors the CLI worker config).
     cfg = AgentConfig(
@@ -2298,7 +2323,9 @@ def _build_solve_agent(
         # it would arm an acceptance criterion its owner never read, which is the same failure this
         # feature exists to fix wearing the opposite sign. An empty list is a different answer:
         # reviewed, and there is nothing to gate on.
-        checklist=RequirementChecklist(gateway, req.model) if req.requirements is not None else None,
+        checklist=RequirementChecklist(gateway, req.model)
+        if req.requirements is not None
+        else None,
         given_requirements=list(req.requirements) if req.requirements is not None else None,
         # Spec-grounded tests, only where they replace something weaker. The loop itself requires
         # no verifier and a non-empty requirement list before it uses this, so asking for it with

--- a/chimera/core/code_session.py
+++ b/chimera/core/code_session.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from chimera.core.agent import AgentResult, ToolActivity
+from chimera.core.redact import redact
 from chimera.providers.gateway import MessageLike
 from chimera.telemetry import get_logger
 
@@ -257,9 +258,20 @@ class CodeSessionStore:
         return self.root / f"{safe}.json"
 
     def save(self, session: CodeSession) -> None:
+        # Written through `redact`, the same way `steplog.py` has always written its trace, and for
+        # the same reason: this file keeps every tool observation of the conversation, and a tool
+        # that failed reports back the provider's own error body. That body has been measured to
+        # carry an echoed fragment of the prompt and the provider's internal routing trace.
+        #
+        # The cost, stated rather than hidden: this store is read BACK to continue a conversation, so
+        # a credential a user pasted into the chat comes back as `[redacted]` after a restart. Within
+        # the turn nothing changes — the messages are in memory unmasked — and a key does not belong
+        # in a transcript that outlives the session anyway. The patterns are narrow by design (six
+        # credential shapes plus this process's own environment secrets), so ordinary code and prose
+        # pass through untouched.
         path = self._path(session.session_id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(session.to_dict()), encoding="utf-8")
+        path.write_text(redact(json.dumps(session.to_dict())), encoding="utf-8")
 
     def load(self, session_id: str, agent: SupportsCodeRun) -> CodeSession:
         """Return the stored session, or a fresh one under that id if there is nothing stored.
@@ -311,23 +323,27 @@ class CodeSessionStore:
                 data = json.loads(path.read_text(encoding="utf-8"))
                 messages = [m for m in data.get("messages", []) if isinstance(m, dict)]
             except (OSError, ValueError) as exc:
-                _log.warning("code session %s unreadable, omitted from the list: %s", path.stem, exc)
+                _log.warning(
+                    "code session %s unreadable, omitted from the list: %s", path.stem, exc
+                )
                 continue
             title = ""
             for message in messages:
                 if message.get("role") == "user":
                     title = _title_of(str(message.get("content") or ""))
                     break
-            out.append({
-                "id": str(data.get("session_id") or path.stem),
-                "title": title,
-                "workspace": str(data.get("workspace") or ""),
-                # Turns, not messages: a user asking twice is two turns, but the transcript between
-                # them holds every tool call the agent made, and counting those would report a
-                # number that grows with the agent's verbosity rather than with the conversation.
-                "turns": sum(1 for m in messages if m.get("role") == "user"),
-                "updated_at": path.stat().st_mtime,
-            })
+            out.append(
+                {
+                    "id": str(data.get("session_id") or path.stem),
+                    "title": title,
+                    "workspace": str(data.get("workspace") or ""),
+                    # Turns, not messages: a user asking twice is two turns, but the transcript between
+                    # them holds every tool call the agent made, and counting those would report a
+                    # number that grows with the agent's verbosity rather than with the conversation.
+                    "turns": sum(1 for m in messages if m.get("role") == "user"),
+                    "updated_at": path.stat().st_mtime,
+                }
+            )
         out.sort(key=lambda m: float(m["updated_at"]), reverse=True)
         return out
 

--- a/chimera/fusion/engine.py
+++ b/chimera/fusion/engine.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from chimera.config import get_settings
+from chimera.core.redact import redact
 from chimera.providers.gateway import CompletionResult, Message, MessageLike, SupportsComplete
 from chimera.telemetry import get_logger
 
@@ -88,7 +89,9 @@ class FusionTrace:
     final: str
     usage: list[StageUsage] = field(default_factory=list)
     early_stopped: bool = False  # selective mode: probe agreed, panel+judge short-circuited
-    aggregation: Literal["synth", "vote"] = "synth"  # task-typed routing: synthesize vs majority-vote
+    aggregation: Literal["synth", "vote"] = (
+        "synth"  # task-typed routing: synthesize vs majority-vote
+    )
 
     def successful_panel(self) -> list[PanelResponse]:
         return [r for r in self.panel if r.error is None]
@@ -211,9 +214,7 @@ class FusionConfig:
     @classmethod
     def from_settings(cls) -> FusionConfig:
         s = get_settings()
-        mode: Literal["full", "selective"] = (
-            "selective" if s.fusion_mode == "selective" else "full"
-        )
+        mode: Literal["full", "selective"] = "selective" if s.fusion_mode == "selective" else "full"
         return cls(
             panel=list(s.fusion_panel),
             judge=s.fusion_judge,
@@ -237,7 +238,8 @@ def _content_text(content: object) -> str:
         return content
     if isinstance(content, list):
         return " ".join(
-            str(p.get("text", "")) for p in content
+            str(p.get("text", ""))
+            for p in content
             if isinstance(p, dict) and p.get("type") == "text"
         ).strip()
     return str(content) if content else ""
@@ -317,7 +319,9 @@ class FusionEngine:
 
     def _aggregate(
         self, messages: list[MessageLike], panel: list[PanelResponse]
-    ) -> tuple[str, str, Literal["synth", "vote"], CompletionResult | None, CompletionResult | None]:
+    ) -> tuple[
+        str, str, Literal["synth", "vote"], CompletionResult | None, CompletionResult | None
+    ]:
         """Aggregate the panel into a final answer, routing by task type when enabled.
 
         Returns ``(judge_analysis, final, aggregation, judge_result, synth_result)``. For a
@@ -422,7 +426,9 @@ class FusionEngine:
             _log.warning(
                 "fusion ignores model=%r — a panel has no single model. The panel actually running "
                 "is %s (judge=%s). Set FusionConfig.panel to choose.",
-                model, self.config.panel, self.config.judge,
+                model,
+                self.config.panel,
+                self.config.judge,
             )
         trace = self.run(messages)
         route_meta = {
@@ -479,7 +485,15 @@ class FusionEngine:
                 )
             except Exception as exc:  # one model failing must not sink the panel
                 _log.warning("panel model %s failed: %s", model, exc)
-                return PanelResponse(model=model, error=str(exc))
+                # Redacted and bounded, because this one is SERVED: it rides `route_meta` out to the
+                # desktop app and to `/v1/chat/completions`, and it was the only error surface in the
+                # app with no limit at all — one message per panel model, verbatim. A provider's
+                # error body is its own prose and can quote our prompt back at us.
+                #
+                # Kept as text rather than reduced to a category: which model said what is the reason
+                # anyone reads a fusion trace, and `FailoverReason` alone would flatten five distinct
+                # failures into one word. The first 200 characters carry the sentence that matters.
+                return PanelResponse(model=model, error=redact(str(exc))[:200])
 
         workers = max(1, min(self.config.max_workers, len(panel_models)))
         with ThreadPoolExecutor(max_workers=workers) as pool:
@@ -494,7 +508,9 @@ class FusionEngine:
             if r.error is None
         )
         if not answers:
-            return CompletionResult(content="No panel answers were produced.", model=self.config.judge)
+            return CompletionResult(
+                content="No panel answers were produced.", model=self.config.judge
+            )
         user = f"Task and context:\n{_conversation_text(messages)}\n\nCandidate answers:\n{answers}"
         return self.backend.complete(
             [Message(role="system", content=_JUDGE_SYSTEM), Message(role="user", content=user)],
@@ -525,7 +541,10 @@ class FusionEngine:
             f"Agreeing answers:\n{joined}"
         )
         return self.backend.complete(
-            [Message(role="system", content=_SYNTH_AGREED_SYSTEM), Message(role="user", content=user)],
+            [
+                Message(role="system", content=_SYNTH_AGREED_SYSTEM),
+                Message(role="user", content=user),
+            ],
             model=self.config.synthesizer,
             temperature=self.config.temperature,
         )

--- a/chimera/providers/failover.py
+++ b/chimera/providers/failover.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from enum import StrEnum
 
 
@@ -30,6 +31,7 @@ class FailoverReason(StrEnum):
     CONTENT_POLICY = "content_policy"  # blocked by the provider's policy
     MODEL_NOT_FOUND = "model_not_found"  # bad/unavailable model id
     TIMEOUT = "timeout"
+    NO_CREDIT = "no_credit"  # 402 / the account is out of money
     UNKNOWN = "unknown"
 
 
@@ -49,6 +51,11 @@ _ACTION: dict[FailoverReason, RecoveryAction] = {
     FailoverReason.CONTENT_POLICY: RecoveryAction.ABORT,
     FailoverReason.MODEL_NOT_FOUND: RecoveryAction.FALLBACK_MODEL,
     FailoverReason.TIMEOUT: RecoveryAction.FALLBACK_MODEL,
+    # ROTATE_KEY and not ABORT, deliberately: a key pool can hold keys on DIFFERENT accounts, and
+    # one of them may still have balance. Aborting would give up on money that exists. What changes
+    # versus the old UNKNOWN path is not the rotation — it is the cooldown below and the message the
+    # user finally gets, which says "top up" instead of showing a raw provider exception.
+    FailoverReason.NO_CREDIT: RecoveryAction.ROTATE_KEY,
     FailoverReason.UNKNOWN: RecoveryAction.ROTATE_KEY,
 }
 
@@ -58,27 +65,155 @@ _COOLDOWN: dict[FailoverReason, float] = {
     FailoverReason.RATE_LIMIT: 60.0,  # rate limited: back off 1 min
     FailoverReason.OVERLOADED: 15.0,
     FailoverReason.TIMEOUT: 15.0,
+    # Longer than AUTH's five minutes, because the remedies differ in kind: a wrong key is fixed by
+    # pasting the right one, while an empty balance is fixed by a payment clearing. Retrying an
+    # unfunded key every thirty seconds — what the UNKNOWN path did — is the one certainty here.
+    FailoverReason.NO_CREDIT: 900.0,
     FailoverReason.UNKNOWN: 30.0,
 }
 
 
+#: Response headers worth keeping when a provider call fails. These are what a support ticket asks
+#: for, and they are the only part of a failed response that is safe to quote back: an identifier the
+#: provider minted, not content we sent them.
+_TRACE_HEADERS = ("x-request-id", "x-oai-request-id", "cf-ray", "retry-after")
+
+
+@dataclass(frozen=True)
+class ProviderTrace:
+    """What a failed provider call left behind that is worth writing down.
+
+    Split from the error message on purpose. The message is prose the provider wrote and may quote
+    our prompt back at us; these are identifiers it minted, and they are what turns "my call failed"
+    into something a support desk can look up.
+    """
+
+    status: int | None = None
+    request_id: str | None = None
+    ray: str | None = None
+    retry_after: str | None = None
+
+    def as_suffix(self) -> str:
+        """A short ` [status=429 request_id=… ]` for a log line, or `""` when nothing was found."""
+        parts = [
+            f"{name}={value}"
+            for name, value in (
+                ("status", self.status),
+                ("request_id", self.request_id),
+                ("cf_ray", self.ray),
+                ("retry_after", self.retry_after),
+            )
+            if value is not None
+        ]
+        return f" [{' '.join(parts)}]" if parts else ""
+
+
+def status_of(exc: BaseException) -> int | None:
+    """The HTTP status behind ``exc``, if it carries one.
+
+    Every LiteLLM error class that wraps a response exposes ``status_code`` or a ``response`` with
+    one, and so does ``httpx.HTTPStatusError``. Reading it is what lets :func:`classify` decide from
+    a fact instead of from prose — see the note there.
+    """
+    for candidate in (
+        getattr(exc, "status_code", None),
+        getattr(getattr(exc, "response", None), "status_code", None),
+    ):
+        if isinstance(candidate, bool):  # bools are ints; a True here would read as status 1
+            continue
+        if isinstance(candidate, int):
+            return candidate
+    return None
+
+
+def trace_of(exc: BaseException) -> ProviderTrace:
+    """Pull the provider's own identifiers out of a failed call. Never raises."""
+    found: dict[str, str] = {}
+    headers = getattr(getattr(exc, "response", None), "headers", None)
+    if headers is not None:
+        for name in _TRACE_HEADERS:
+            try:
+                value = headers.get(name)
+            except Exception:  # noqa: BLE001 — a header bag that does not behave is not a crash
+                continue
+            if value:
+                found[name] = str(value)[:120]
+    return ProviderTrace(
+        status=status_of(exc),
+        request_id=found.get("x-request-id") or found.get("x-oai-request-id"),
+        ray=found.get("cf-ray"),
+        retry_after=found.get("retry-after"),
+    )
+
+
+#: Statuses that mean one thing and only one thing. Deliberately partial: 400 is context-overflow on
+#: one provider and content-policy on another, and 404 can be a bad model id or a bad route, so those
+#: keep going through the message.
+_BY_STATUS: dict[int, FailoverReason] = {
+    401: FailoverReason.AUTH,
+    403: FailoverReason.AUTH,
+    402: FailoverReason.NO_CREDIT,
+    429: FailoverReason.RATE_LIMIT,
+    502: FailoverReason.OVERLOADED,
+    503: FailoverReason.OVERLOADED,
+    504: FailoverReason.OVERLOADED,
+}
+
+
 def classify(exc: BaseException) -> FailoverReason:
-    """Map an exception to a :class:`FailoverReason` by its class name + message (SDK-agnostic)."""
+    """Map an exception to a :class:`FailoverReason`.
+
+    **Status first, prose second.** A status code is a fact the protocol defines; the message is
+    editorial, and a provider rewrites it without telling anyone. Measured against the real LiteLLM
+    exception classes, the prose path holds up better than expected — the class NAME carries most of
+    it — but two classes degrade when the wording changes: `ServiceUnavailableError` and
+    `InternalServerError` fall to UNKNOWN, and with them the action flips from `fallback_model` to
+    `rotate_key`, so a provider outage rotates keys instead of changing model.
+
+    The status path also makes 402 safe to detect. Matching the digits `402` in a message is a trap —
+    they turn up in model ids and token counts — which is why the prose branch below asks for the
+    words instead, and why the exact answer comes from the status when there is one.
+    """
+    if (status := status_of(exc)) is not None and status in _BY_STATUS:
+        return _BY_STATUS[status]
+
     name = type(exc).__name__.lower()
     msg = str(exc).lower()
 
     def any_in(text: str, *needles: str) -> bool:
         return any(n in text for n in needles)
 
-    if any_in(name, "authentication", "permission") or any_in(msg, "401", "403", "invalid api key", "no auth"):
+    if any_in(name, "authentication", "permission") or any_in(
+        msg, "401", "403", "invalid api key", "no auth"
+    ):
         return FailoverReason.AUTH
+    # Before RATE_LIMIT on purpose: `insufficient_quota` contains "quota" and would otherwise be
+    # read as "wait a minute" when it means "the account is empty". No bare "402" here — the digits
+    # appear in model ids and token counts, so the status path above is the only place that reads it.
+    if any_in(
+        msg,
+        "insufficient credit",
+        "insufficient_quota",
+        "insufficient funds",
+        "negative credit",
+        "add credits",
+        "billing hard limit",
+        "exceeded your current quota",
+    ):
+        return FailoverReason.NO_CREDIT
     if "ratelimit" in name or any_in(msg, "429", "rate limit", "quota", "too many requests"):
         return FailoverReason.RATE_LIMIT
-    if "contextwindow" in name or any_in(msg, "maximum context", "context length", "too many tokens", "reduce the length"):
+    if "contextwindow" in name or any_in(
+        msg, "maximum context", "context length", "too many tokens", "reduce the length"
+    ):
         return FailoverReason.CONTEXT_OVERFLOW
-    if "contentpolicy" in name or any_in(msg, "content policy", "content management policy", "flagged", "safety"):
+    if "contentpolicy" in name or any_in(
+        msg, "content policy", "content management policy", "flagged", "safety"
+    ):
         return FailoverReason.CONTENT_POLICY
-    if "notfound" in name or any_in(msg, "not a valid model", "no endpoints", "does not exist", "404", "model_not_found"):
+    if "notfound" in name or any_in(
+        msg, "not a valid model", "no endpoints", "does not exist", "404", "model_not_found"
+    ):
         return FailoverReason.MODEL_NOT_FOUND
     if "timeout" in name or any_in(msg, "timed out", "timeout"):
         return FailoverReason.TIMEOUT

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -30,6 +30,7 @@ from chimera.providers.failover import (
     RecoveryAction,
     action_for,
     classify,
+    trace_of,
 )
 from chimera.providers.prompt_cache import apply_cache_control
 from chimera.providers.thinking import ThinkFilter, strip_think
@@ -150,7 +151,11 @@ def _to_message_dicts(messages: list[MessageLike]) -> list[dict[str, Any]]:
         if not images:
             # No images to fold in — but drop the key if it is present-and-empty, since no provider
             # knows it and an empty list is not worth a round trip's risk.
-            out.append({k: v for k, v in message.items() if k != "images"} if "images" in message else message)
+            out.append(
+                {k: v for k, v in message.items() if k != "images"}
+                if "images" in message
+                else message
+            )
             continue
         out.append(
             Message(
@@ -225,23 +230,32 @@ class CredentialRejectedError(MissingCredentialsError):
 def _credential_error(exc: BaseException) -> CredentialRejectedError | None:
     """Translate a spent-all-credentials failure into an actionable error, or ``None`` if unrelated.
 
-    Only AUTH and RATE_LIMIT qualify. Both mean "your credentials are the problem": a rejected key,
-    or one whose quota/credit is gone. Everything else (a provider outage, a bad model slug, a
-    context overflow) keeps its original exception, because the original text is the useful part.
+    Only AUTH, NO_CREDIT and RATE_LIMIT qualify. All three mean "your credentials are the problem":
+    a rejected key, an empty balance, or a quota that is gone for now. Everything else (a provider
+    outage, a bad model slug, a context overflow) keeps its original exception, because the original
+    text is the useful part.
+
+    NO_CREDIT is separate from RATE_LIMIT because the two sentences a person needs are different, and
+    the wrong one wastes their night: a rate limit resets on its own, an empty account does not. It
+    used to land in UNKNOWN, which returns None here — so the single most likely failure for a
+    prepaid provider was the one that surfaced as a raw exception with no advice at all.
     """
     reason = classify(exc)
     if reason is FailoverReason.AUTH:
         what = "Every configured provider key was rejected (401/403)."
         fix = "Check the key is correct and still active"
+    elif reason is FailoverReason.NO_CREDIT:
+        what = "Every configured provider key is out of credit (402)."
+        fix = "Top up the account, or add a key billed to another one — waiting will not clear this"
     elif reason is FailoverReason.RATE_LIMIT:
-        what = "Every configured provider key is rate-limited or out of credit."
-        fix = "Wait for the limit to reset, top up the account, or add another key"
+        what = "Every configured provider key is rate-limited."
+        fix = "Wait for the limit to reset, or add another key"
     else:
         return None
     return CredentialRejectedError(
         f"{what} {fix} — the relevant variables are {list(_KEY_ENV_VARS.values())} "
-        "(or use a local model, e.g. CHIMERA_DEFAULT_MODEL=ollama/llama3, which needs no key). "
-        f"Provider said: {exc}"
+        "(or use a local model, e.g. CHIMERA_DEFAULT_MODEL=ollama/llama3, which needs no key)."
+        f"{trace_of(exc).as_suffix()} Provider said: {exc}"
     )
 
 
@@ -285,7 +299,9 @@ class LLMGateway:
     def __init__(self, settings: Settings | None = None) -> None:
         self._settings_override = settings
         self._rotators: dict[str, _KeyRotator] = {}
-        self._rotators_lock = threading.Lock()  # the fusion panel calls _key_order from many threads
+        self._rotators_lock = (
+            threading.Lock()
+        )  # the fusion panel calls _key_order from many threads
         # M15-C2: per-credential cooldown pool — a rate-limited/revoked key is rested, not hammered.
         self._cred_pool = CredentialPool()
         self._cache: CompletionCache | None = None
@@ -511,11 +527,26 @@ class LLMGateway:
                     last_exc = exc
                     reason = classify(exc)
                     action = action_for(reason)
-                    if api_key and reason in (FailoverReason.AUTH, FailoverReason.RATE_LIMIT,
-                                              FailoverReason.OVERLOADED, FailoverReason.TIMEOUT,
-                                              FailoverReason.UNKNOWN):
+                    if api_key and reason in (
+                        FailoverReason.AUTH,
+                        FailoverReason.RATE_LIMIT,
+                        FailoverReason.OVERLOADED,
+                        FailoverReason.TIMEOUT,
+                        FailoverReason.UNKNOWN,
+                    ):
                         self._cred_pool.penalize(api_key, reason)  # rest this credential
-                    _log.warning("model %s failed (%s -> %s): %s", candidate, reason.value, action.value, exc)
+                    # The provider's own identifiers go in the line, not just our verdict. Without
+                    # them "my call failed" is unanswerable by a support desk, and they are the one
+                    # part of a failed response safe to quote back — minted by the provider, never
+                    # containing anything we sent.
+                    _log.warning(
+                        "model %s failed (%s -> %s)%s: %s",
+                        candidate,
+                        reason.value,
+                        action.value,
+                        trace_of(exc).as_suffix(),
+                        exc,
+                    )
                     if action is RecoveryAction.ABORT:
                         raise  # context-overflow / content-policy: another key/model won't help
                     if action is RecoveryAction.FALLBACK_MODEL:
@@ -574,7 +605,6 @@ class LLMGateway:
             messages.append(Message(role="system", content=system))
         messages.append(Message(role="user", content=prompt))
         return self.complete(messages, model=model).content
-
 
     def _think_filter(self) -> ThinkFilter | None:
         """A fresh filter per call, or None when the user asked to keep the tags.

--- a/tests/test_the_two_places_a_body_still_got_out.py
+++ b/tests/test_the_two_places_a_body_still_got_out.py
@@ -1,0 +1,157 @@
+"""The two surfaces that still carried a provider's answer out: one to disk, one to the screen.
+
+A failed tool call reports back the provider's own error body, and that body has been measured to
+carry an echoed fragment of the prompt and the provider's internal routing trace. `steplog.py` has
+written through `redact` since it was born. These two never picked it up:
+
+- the **code session store**, which keeps every message of a conversation, tool observations
+  included, in a file that outlives the session;
+- the **fusion panel error**, which rides `route_meta` out to the desktop app and to
+  `/v1/chat/completions` — and was the only error surface in the app with no length limit at all.
+
+The session store is the delicate one, because it is read BACK to continue a conversation. The tests
+below spend most of their weight there: masking a transcript must not stop it being a transcript.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.core.code_session import CodeSession, CodeSessionStore
+from chimera.core.redact import MASK
+
+CHAVE = "sk-or-v1-thisisaverylongfakekeyvalue"
+
+
+class _AgentMudo:
+    """A code agent that is never called: these tests are about what is stored, not what is said."""
+
+    def run(self, *_args: Any, **_kwargs: Any) -> Any:  # pragma: no cover - nunca chamado
+        raise AssertionError("o agente nao deveria rodar neste teste")
+
+
+def _sessao(mensagens: list[dict[str, str]]) -> CodeSession:
+    return CodeSession(_AgentMudo(), session_id="s1", workspace="/tmp/w", messages=list(mensagens))
+
+
+# --------------------------------------------------------------------- a transcricao em disco
+
+
+def test_a_failed_tool_does_not_leave_the_providers_body_on_disk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The shape the audit actually found: `agent.py` turns a tool exception into an observation, and
+    the observation is a message like any other."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", CHAVE)
+    loja = CodeSessionStore(tmp_path)
+    loja.save(
+        _sessao(
+            [
+                {"role": "user", "content": "arrume o build"},
+                {"role": "tool", "content": f"error: tool 'complete' failed: 401 - Bearer {CHAVE}"},
+            ]
+        )
+    )
+    bruto = (tmp_path / "s1.json").read_text(encoding="utf-8")
+    assert CHAVE not in bruto
+    assert MASK in bruto
+
+
+def test_the_conversation_survives_being_masked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The assertion that decides whether this change is allowed to ship.
+
+    This store is read back to continue a session. If masking broke the round-trip — a file that no
+    longer parses, messages that lost their roles, a workspace that vanished — the fix would trade a
+    leak for a broken product.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", CHAVE)
+    loja = CodeSessionStore(tmp_path)
+    mensagens = [
+        {"role": "user", "content": "explique este arquivo"},
+        {"role": "assistant", "content": "ele monta a API"},
+        {"role": "tool", "content": f"error: 401 - Bearer {CHAVE}"},
+    ]
+    loja.save(_sessao(mensagens))
+
+    voltou = loja.load("s1", _AgentMudo())
+    assert voltou.workspace == "/tmp/w"
+    assert len(voltou.messages) == 3
+    assert [m["role"] for m in voltou.messages] == ["user", "assistant", "tool"]
+    assert voltou.messages[0]["content"] == "explique este arquivo"
+    assert voltou.messages[1]["content"] == "ele monta a API"
+    assert CHAVE not in json.dumps(voltou.messages)
+
+
+def test_ordinary_code_passes_through_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The failure mode a greedy redactor would have: masking the work itself.
+
+    `redact` is narrow on purpose — six credential shapes plus this process's own environment
+    secrets — and its own docstring says why: a pattern that redacted ordinary output would make the
+    file useless. This pins that, because widening the patterns later would break it here first.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", CHAVE)
+    codigo = (
+        "def somar(a: int, b: int) -> int:\n"
+        "    # sk é um prefixo curto, sk-1 não é uma chave, e este hash não é um token:\n"
+        "    hash = 'a1b2c3d4e5f6'\n"
+        "    return a + b\n"
+    )
+    loja = CodeSessionStore(tmp_path)
+    loja.save(_sessao([{"role": "assistant", "content": codigo}]))
+    assert loja.load("s1", _AgentMudo()).messages[0]["content"] == codigo
+
+
+def test_a_session_with_no_secret_is_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nothing to mask means nothing changes — the guard has no cost in the ordinary case."""
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    loja = CodeSessionStore(tmp_path)
+    mensagens = [{"role": "user", "content": "oi"}, {"role": "assistant", "content": "olá"}]
+    loja.save(_sessao(mensagens))
+    assert json.loads((tmp_path / "s1.json").read_text(encoding="utf-8"))["messages"] == mensagens
+
+
+# --------------------------------------------------------------------- o erro do painel, servido
+
+
+def _painel_com_erro(mensagem: str) -> str:
+    """Run one panel model that raises, and return the error string that would be served."""
+    from chimera.fusion.engine import FusionEngine
+
+    class _Explode:
+        def complete(self, *_args: Any, **_kwargs: Any) -> Any:
+            raise RuntimeError(mensagem)
+
+    engine = FusionEngine(_Explode())
+    respostas = engine._run_panel([{"role": "user", "content": "oi"}], ["m1"])  # noqa: SLF001
+    assert respostas[0].error is not None
+    return respostas[0].error
+
+
+def test_the_panel_error_does_not_carry_a_secret_to_the_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """This one is *served* — `route_meta` reaches the desktop app and `/v1/chat/completions`."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", CHAVE)
+    assert CHAVE not in _painel_com_erro(f"401 - Bearer {CHAVE}")
+
+
+def test_the_panel_error_is_bounded() -> None:
+    """It was the only error surface in the app with no limit at all, one message per panel model."""
+    assert len(_painel_com_erro("y" * 4000)) <= 200
+
+
+def test_the_panel_error_still_says_which_failure_it_was() -> None:
+    """Bounding must not turn a diagnosable trace into a shrug. Reducing this to a `FailoverReason`
+    would have flattened five distinct failures into one word — which is why it stays text."""
+    erro = _painel_com_erro("rate limit exceeded for this account")
+    assert "rate limit exceeded" in erro

--- a/tests/test_what_a_failed_call_leaves_behind.py
+++ b/tests/test_what_a_failed_call_leaves_behind.py
@@ -1,0 +1,306 @@
+"""What survives a failed provider call: the identifiers, the category, and nothing we sent.
+
+Three changes, one subject. When a completion fails, three things should be true and none of them
+were: the reason should be decided from a fact rather than from prose, an empty account should be
+told apart from a busy one, and the row that reaches disk should not carry the provider's answer
+back verbatim.
+
+The last one is the reason this file exists. A failed completion arrives as a LiteLLM exception whose
+message *is* the upstream response body, and that body has been measured to carry an echoed fragment
+of the prompt and the provider's internal routing trace. LiteLLM masks `Bearer …` on the way in, so
+the key is not the exposure — the user's own content is. `steplog.py` has written through `redact`
+for exactly this reason since it was born; the crashed-run row in `app.py` was written by hand and
+never picked it up.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.providers.failover import (
+    CredentialPool,
+    FailoverReason,
+    ProviderTrace,
+    action_for,
+    classify,
+    status_of,
+    trace_of,
+)
+
+
+class _Headers(dict[str, str]):
+    """Just enough of a header bag: case-insensitive `get`, like every HTTP library's."""
+
+    def get(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        for name, value in self.items():
+            if name.lower() == key.lower():
+                return value
+        return default
+
+
+class _Response:
+    def __init__(self, status: int, headers: dict[str, str] | None = None) -> None:
+        self.status_code = status
+        self.headers = _Headers(headers or {})
+
+
+class _ProviderError(Exception):
+    """Shaped like the LiteLLM errors the gateway actually catches: a status and a response."""
+
+    def __init__(
+        self, message: str, *, status: int | None = None, headers: dict[str, str] | None = None
+    ) -> None:
+        super().__init__(message)
+        if status is not None:
+            self.status_code = status
+            self.response = _Response(status, headers)
+
+
+# --------------------------------------------------------------------------- status over prose
+
+
+@pytest.mark.parametrize(
+    ("status", "esperado"),
+    [
+        (401, FailoverReason.AUTH),
+        (403, FailoverReason.AUTH),
+        (402, FailoverReason.NO_CREDIT),
+        (429, FailoverReason.RATE_LIMIT),
+        (502, FailoverReason.OVERLOADED),
+        (503, FailoverReason.OVERLOADED),
+        (504, FailoverReason.OVERLOADED),
+    ],
+    ids=lambda v: str(v),
+)
+def test_the_status_decides_even_when_the_words_are_new(
+    status: int, esperado: FailoverReason
+) -> None:
+    """A provider rewrites its error prose without telling anyone; it does not rewrite the protocol.
+
+    The message here says nothing a substring match would recognise — which is the point. Measured
+    against the real LiteLLM classes the prose path holds up better than expected, because the class
+    NAME carries most of it, but `ServiceUnavailableError` and `InternalServerError` do fall through
+    to UNKNOWN when the wording changes, and with them the action flips from `fallback_model` to
+    `rotate_key`: a provider outage would rotate keys instead of changing model.
+    """
+    assert (
+        classify(_ProviderError("something the provider decided to say today", status=status))
+        is esperado
+    )
+
+
+def test_without_a_status_the_words_still_work() -> None:
+    """The prose path is not replaced, it is only outranked. A transport-level error carries no
+    status at all, and everything that worked before this change has to keep working."""
+    assert classify(_ProviderError("Error code: 401 - invalid api key")) is FailoverReason.AUTH
+    assert classify(_ProviderError("request timed out")) is FailoverReason.TIMEOUT
+    assert (
+        classify(_ProviderError("maximum context length is 8192"))
+        is FailoverReason.CONTEXT_OVERFLOW
+    )
+
+
+def test_a_status_we_cannot_read_unambiguously_falls_through_to_the_words() -> None:
+    """400 is a context overflow on one provider and a policy block on another, and 404 can be a bad
+    model or a bad route. Mapping those from the number would be inventing certainty."""
+    assert (
+        classify(_ProviderError("maximum context length exceeded", status=400))
+        is FailoverReason.CONTEXT_OVERFLOW
+    )
+    assert (
+        classify(_ProviderError("not a valid model id", status=404))
+        is FailoverReason.MODEL_NOT_FOUND
+    )
+
+
+def test_a_bool_is_not_a_status() -> None:
+    """`True` is an `int` in Python, and an object that sets `status_code = True` would otherwise be
+    read as HTTP 1."""
+    exc = _ProviderError("boom")
+    exc.status_code = True  # type: ignore[attr-defined]
+    assert status_of(exc) is None
+
+
+# --------------------------------------------------------------------------- empty vs busy
+
+
+def test_an_empty_account_is_not_a_busy_one() -> None:
+    """The two need different sentences from the user, and the wrong one costs them the night: a
+    rate limit clears on its own, an empty balance never does."""
+    assert classify(_ProviderError("Insufficient credits", status=402)) is FailoverReason.NO_CREDIT
+    assert classify(_ProviderError("rate limit exceeded", status=429)) is FailoverReason.RATE_LIMIT
+
+
+@pytest.mark.parametrize(
+    "frase",
+    [
+        "Insufficient credits. Add more using the settings page",
+        "insufficient_quota: You exceeded your current quota",
+        "Your account has a negative credit balance",
+        "billing hard limit has been reached",
+    ],
+)
+def test_the_words_for_no_money_are_read_before_the_words_for_wait(frase: str) -> None:
+    """`insufficient_quota` contains "quota", which the rate-limit branch matches. Without ordering
+    these first, the most likely failure on a prepaid account reads as "wait a minute"."""
+    assert classify(_ProviderError(frase)) is FailoverReason.NO_CREDIT
+
+
+def test_the_digits_402_in_a_message_are_not_a_payment_problem() -> None:
+    """The trap I set for myself and then avoided: `402` as a bare substring matches model ids and
+    token counts. The status path is the only place that number is read."""
+    assert (
+        classify(_ProviderError("model deepseek-402b returned 402 tokens"))
+        is not FailoverReason.NO_CREDIT
+    )
+
+
+def test_an_unfunded_key_is_rested_for_longer_than_a_wrong_one() -> None:
+    """The remedies differ in kind — a wrong key is fixed by pasting the right one, an empty balance
+    by a payment clearing. Under UNKNOWN it was retried every thirty seconds.
+
+    Asserted through the pool rather than by reading the table, so this tests the cooldown that is
+    actually applied and not a number that might have stopped being consulted.
+    """
+    agora = [0.0]
+    pool = CredentialPool(clock=lambda: agora[0])
+    pool.penalize("sem-saldo", FailoverReason.NO_CREDIT)
+    pool.penalize("chave-errada", FailoverReason.AUTH)
+    pool.penalize("ocupada", FailoverReason.RATE_LIMIT)
+
+    agora[0] = 310.0  # passou o descanso de AUTH (300s) e o de RATE_LIMIT (60s)
+    disponiveis = pool.available(["sem-saldo", "chave-errada", "ocupada"])
+    assert "chave-errada" in disponiveis
+    assert "ocupada" in disponiveis
+    assert "sem-saldo" not in disponiveis, "uma conta vazia voltou a ser tentada em cinco minutos"
+
+
+def test_no_credit_still_tries_the_other_keys() -> None:
+    """Not ABORT: a pool can hold keys billed to different accounts, and one may still have money.
+    Aborting would give up on funds that exist."""
+    assert action_for(FailoverReason.NO_CREDIT) is action_for(FailoverReason.AUTH)
+
+
+# --------------------------------------------------------------------------- the identifiers
+
+
+def test_the_providers_identifiers_are_kept() -> None:
+    """These are what a support desk asks for, and the only part of a failed response safe to quote
+    back — minted by the provider, never containing anything we sent."""
+    exc = _ProviderError(
+        "rate limited",
+        status=429,
+        headers={"X-Request-Id": "req_abc123", "CF-RAY": "8f2a-GRU", "Retry-After": "30"},
+    )
+    trace = trace_of(exc)
+    assert trace == ProviderTrace(
+        status=429, request_id="req_abc123", ray="8f2a-GRU", retry_after="30"
+    )
+    suffix = trace.as_suffix()
+    for esperado in ("status=429", "request_id=req_abc123", "cf_ray=8f2a-GRU", "retry_after=30"):
+        assert esperado in suffix
+
+
+def test_an_error_with_no_headers_produces_nothing_rather_than_noise() -> None:
+    """A transport failure never reached a server. An empty suffix keeps the log line clean instead
+    of decorating it with four `None`s."""
+    assert trace_of(_ProviderError("dns lookup failed")).as_suffix() == ""
+
+
+def test_a_header_bag_that_misbehaves_does_not_take_the_run_down() -> None:
+    """This runs on the failure path. Something odd in a header must not turn a provider error into
+    a crash inside the error handler."""
+
+    class _Explode:
+        def get(self, _name: str, _default: Any = None) -> Any:
+            raise RuntimeError("this header bag is broken")
+
+    exc = _ProviderError("boom")
+    exc.response = type("R", (), {"status_code": 500, "headers": _Explode()})()  # type: ignore[attr-defined]
+    assert trace_of(exc).status == 500  # the status still made it through
+
+
+def test_the_identifiers_do_not_carry_the_body() -> None:
+    """The split is the whole design: the message is prose the provider wrote and may quote our
+    prompt back at us; the trace is identifiers. Only the second is safe to repeat."""
+    exc = _ProviderError(
+        "401 - {'metadata': {'echoed_prompt': 'SEGREDO DO USUARIO'}}",
+        status=401,
+        headers={"X-Request-Id": "req_1"},
+    )
+    assert "SEGREDO" not in trace_of(exc).as_suffix()
+
+
+# --------------------------------------------------------------------------- nothing we sent, on disk
+
+
+def _crash_row(tmp_path: Path, cause: BaseException) -> dict[str, Any]:
+    from chimera.api.app import _persist_crashed_run
+
+    _persist_crashed_run(tmp_path, "run-1", object(), tmp_path, [], cause)
+    linhas = [
+        ln
+        for ln in (tmp_path / "runs.jsonl").read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    assert linhas, "nenhuma linha gravada"
+    return json.loads(linhas[-1])
+
+
+def test_the_provider_body_does_not_reach_the_disk_with_a_secret_in_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The one place a provider's answer is persisted. A key set in the environment is a known secret
+    to the redactor, so if the body echoes it back, the row must not."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-v1-averyrealsecretvalue")
+    cause = _ProviderError(
+        "401 - {'error': {'metadata': {'received_authorization': 'Bearer sk-or-v1-averyrealsecretvalue'}}}",
+        status=401,
+    )
+    row = _crash_row(tmp_path, cause)
+    assert "sk-or-v1-averyrealsecretvalue" not in row["crash_reason"]
+    assert row["crashed"] is True
+
+
+def test_the_row_is_redacted_before_it_is_cut_and_not_after(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Truncating first would leave the front half of a secret the cut split in two — which is worse
+    than either, because it looks redacted.
+
+    The padding is measured, not guessed. `_ProviderError: ` is 16 characters, so 464 more put the
+    secret's first character at position 480 — twenty characters short of the 500-byte cut. Get this
+    wrong in the other direction and the cut removes the whole secret on its own, and the test passes
+    whichever order the code uses: that is exactly what the first version of this test did, and only
+    reverting the fix revealed it.
+    """
+    segredo = "sk-or-v1-secretsecretsecret"  # 27 chars: 20 survive the cut, 7 fall past it
+    monkeypatch.setenv("OPENROUTER_API_KEY", segredo)
+    preenchimento = "x" * (480 - len("_ProviderError: "))
+    bruta = f"_ProviderError: {preenchimento}{segredo}"
+
+    # The precondition, asserted on the INPUT. Checking the output length instead would fail against
+    # correct code, because masking makes the row shorter than the cut — measured: 490 when redacted
+    # first, 500 when cut first.
+    assert len(bruta) > 500 and bruta.index(segredo) < 500 < bruta.index(segredo) + len(segredo)
+
+    row = _crash_row(tmp_path, _ProviderError(f"{preenchimento}{segredo}"))
+    assert "sk-or-v1-secret" not in row["crash_reason"]
+
+
+def test_the_row_still_says_what_went_wrong(tmp_path: Path) -> None:
+    """Redaction must not turn a diagnosable row into a blank one. The exception class and the
+    non-secret part of the message are the reason anyone opens this file."""
+    row = _crash_row(tmp_path, _ProviderError("the model refused the request", status=400))
+    assert "_ProviderError" in row["crash_reason"]
+    assert "the model refused the request" in row["crash_reason"]
+
+
+def test_the_row_is_still_bounded(tmp_path: Path) -> None:
+    """A provider that answers with a megabyte of JSON must not write a megabyte into runs.jsonl."""
+    row = _crash_row(tmp_path, _ProviderError("y" * 5000))
+    assert len(row["crash_reason"]) <= 500


### PR DESCRIPTION
A failed provider call reports back the provider's own error body, and that body was measured to carry an echoed fragment of the prompt and the provider's internal routing trace. `steplog.py` has written through `redact` since it was born. Three surfaces never picked it up.

## The three that leaked

| surface | where it goes | why it matters |
|---|---|---|
| `crash_reason` on `/api/runs` | `app.py:475` | served to the client |
| the code session store | `code_session.py` | a **file that outlives the session**, and is read back to continue it |
| the fusion panel error | `engine.py` → `route_meta` | reaches the desktop app and `/v1/chat/completions`; was the only error surface in the app with **no length limit at all** |

The session store is the delicate one, because masking it must not stop it being a transcript. The tests spend most of their weight there: the round-trip is asserted — roles, order, workspace, content — not just the absence of the secret.

`redact` stays narrow on purpose (six credential shapes plus this process's own environment secrets), and a test pins that ordinary code passes through untouched. Widening the patterns later breaks it there first, which is the point.

## Classification, in the same pass

`classify` read the exception's **text** before its **status**, so an account out of money took the `UNKNOWN` path: the gateway waited, retried the same key, and told the user nothing they could act on.

- the HTTP status decides first when there is one
- `402` maps to a new `NO_CREDIT`
- the word check for it runs **before** the rate-limit one, because `insufficient_quota` contains "quota"

`NO_CREDIT` → `ROTATE_KEY`, not `ABORT`: a pool can hold keys billed to different accounts, and one being empty says nothing about the next. What changes against the old path is the **900-second cooldown** — waiting does not refill an account — and a message that says to top up or add a key on another account, instead of implying patience will help.

## `ProviderTrace`

Carries the four identifiers a provider gives for a failed call — `x-request-id`, `x-oai-request-id`, `cf-ray`, `retry-after` — into the log line and the credential error, so a support ticket has something to quote.

It never raises. `status_of` skips bools (`isinstance(True, int)` is true, and a `status` attribute that is a bool would otherwise index the table). `trace_of` returns an empty trace rather than failing while handling a failure.

## Verification

Sabotage-verified in two rounds. The one worth recording: **"redact after truncating" passed the first time** — the padding happened to put the whole secret past the 500-character cut. Fixed by placing the secret so it straddles the boundary (starts at char 480, 27 chars long). The follow-up length assertion then broke against the *correct* code, because masking shortens the string; fixed by asserting the precondition on the **input** rather than the output.

`4582 passed, 18 skipped` at the time this was written (before the receipts branch added six more).

🤖 Generated with [Claude Code](https://claude.com/claude-code)