### PR TITLE
fix(scheduler): a brake, a dispatcher, and a schedule that stops stacking

### DIFF
--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -1075,6 +1075,59 @@
         },
         {
           "deprecated": false,
+          "help": "Run every job registered for an event.\n\nEvent jobs had no dispatcher. `cron add --event deploy` accepted the job and `cron list` showed\nit enabled, but nothing in the package ever called `fire_event` \u2014 so the job simply never ran,\nand its silence was indistinguishable from that of a job whose time had not come. The cron\ntrigger has the daemon and the webhook trigger has the webhook server; this is the third one's.\n\nMeant to be called from wherever the event actually happens \u2014 a git hook, a deploy step, a CI\njob. Dispatch is the same one the daemon uses, so a fired job behaves exactly like a scheduled\none: same agent, same spend caps, same receipt.",
+          "hidden": false,
+          "name": "fire",
+          "params": [
+            {
+              "help": "The event name to fire (as given to `cron add --event`).",
+              "kind": "argument",
+              "name": "event",
+              "opts": [
+                "event"
+              ],
+              "required": true,
+              "type": "str"
+            },
+            {
+              "help": "Model for the dispatched jobs.",
+              "kind": "option",
+              "name": "model",
+              "opts": [
+                "--model",
+                "-m"
+              ],
+              "required": false,
+              "type": "str"
+            },
+            {
+              "default": "6",
+              "help": "Max tool-calling steps per job.",
+              "kind": "option",
+              "name": "max_steps",
+              "opts": [
+                "--max-steps"
+              ],
+              "required": false,
+              "type": "int"
+            },
+            {
+              "default": "'.'",
+              "help": "Workspace root for tools.",
+              "kind": "option",
+              "name": "workspace",
+              "opts": [
+                "--workspace",
+                "-w"
+              ],
+              "required": false,
+              "type": "str"
+            }
+          ],
+          "path": "cron fire"
+        },
+        {
+          "deprecated": false,
           "help": "Propose crons from recurring tasks and create the ones you confirm.\n\nEach proposal is shown for explicit confirmation (the human-in-the-loop approval\nthat keeps automation creation under control); confirmed jobs are validated and\ncreated enabled. ``--yes`` confirms all (use deliberately).",
           "hidden": false,
           "name": "learn",

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -4728,6 +4728,70 @@ def cron_disable(job_id: str = typer.Argument(..., help="The job id to disable."
     console.print(f"[green]disabled[/green] {job_id}")
 
 
+@cron_app.command("fire")
+def cron_fire(
+    event: str = typer.Argument(..., help="The event name to fire (as given to `cron add --event`)."),
+    model: str = typer.Option(None, "--model", "-m", help="Model for the dispatched jobs."),
+    max_steps: int = typer.Option(6, "--max-steps", help="Max tool-calling steps per job."),
+    workspace: str = typer.Option(".", "--workspace", "-w", help="Workspace root for tools."),
+) -> None:
+    """Run every job registered for an event.
+
+    Event jobs had no dispatcher. `cron add --event deploy` accepted the job and `cron list` showed
+    it enabled, but nothing in the package ever called `fire_event` — so the job simply never ran,
+    and its silence was indistinguishable from that of a job whose time had not come. The cron
+    trigger has the daemon and the webhook trigger has the webhook server; this is the third one's.
+
+    Meant to be called from wherever the event actually happens — a git hook, a deploy step, a CI
+    job. Dispatch is the same one the daemon uses, so a fired job behaves exactly like a scheduled
+    one: same agent, same spend caps, same receipt.
+    """
+    import time
+
+    from chimera.providers import LLMGateway
+    from chimera.scheduler import Scheduler, make_agent_dispatch
+    from chimera.scheduler.delivery import make_deliver
+    from chimera.scheduler.job_runner import make_run_job
+
+    scheduler = Scheduler(_cron_store())
+    if not scheduler.jobs_for_event(event):
+        # Louder than an empty run: a typo in an event name is the likeliest way to sit waiting for
+        # something that will never happen, and "0 jobs" printed in green reads like success.
+        console.print(f"[yellow]no enabled job registered for event {event!r}[/yellow]")
+        raise typer.Exit(code=1)
+
+    settings = get_settings()
+    run_job = make_run_job(
+        settings=settings,
+        backend=LLMGateway(),
+        workspace=Path(workspace).resolve(),
+        model=model,
+        max_steps=max_steps,
+        usage_path=settings.home / "usage.jsonl",
+        warn=lambda linha: console.print(f"[yellow]{linha}[/yellow]"),
+    )
+    # Through `make_agent_dispatch`, not straight to `fire_event`. It is what turns a `JobOutcome`
+    # into the status the scheduler records — so a gate that rejected the work reads as `rejected`
+    # rather than as success — and it is where delivery happens. Without it a fired job would run,
+    # be recorded as ok whatever its gate said, and deliver nothing: a second dispatch path that
+    # quietly behaves differently from the daemon's is worse than no second path.
+    def _sem_job(_task: str) -> str:  # pragma: no cover - unreachable while run_job is given
+        raise AssertionError("cron fire always has the job; run_task should never be reached")
+
+    deliver = make_deliver(
+        settings.home / "scheduler" / "cron_results.jsonl",
+        warn=lambda linha: console.print(f"[yellow]{linha}[/yellow]"),
+    )
+    ran = scheduler.fire_event(
+        event, time.time(), make_agent_dispatch(_sem_job, deliver, run_job=run_job)
+    )
+    for job in ran:
+        cor = "green" if job.last_status == "ok" else "red"
+        console.print(f"[{cor}]{job.last_status}[/{cor}] {job.name} ({job.id})")
+        if job.last_error:
+            console.print(f"  {job.last_error}")
+
+
 @cron_app.command("learn")
 def cron_learn(
     min_occurrences: int = typer.Option(3, "--min", help="Min repeats to propose."),

--- a/chimera/scheduler/engine.py
+++ b/chimera/scheduler/engine.py
@@ -7,6 +7,7 @@ A separate runner (CLI/daemon) supplies the real clock.
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime
@@ -20,6 +21,46 @@ from chimera.scheduler.store import CronStore
 from chimera.telemetry import get_logger
 
 _log = get_logger("scheduler.engine")
+
+#: Consecutive failures after which a job is switched off.
+#:
+#: The counter was already exact — ``_record`` deliberately excludes a budget refusal, because the
+#: job never ran — and nothing acted on it: ``disable()`` had two callers and both are a person.
+#: So a job that started failing at 02:00 kept firing every tick until somebody read a table. The
+#: daily spend cap bounds the money but is the wrong instrument: it stops after paying, not on
+#: detecting.
+#:
+#: Five rather than two: a provider hiccup is not a broken job, and switching one off for a
+#: transient error is its own outage. This is a brake and not a delete — ``last_status``,
+#: ``last_error`` and the counter all survive, and ``cron enable`` puts the job back.
+FAIL_LIMIT = 5
+
+#: Share of a schedule's own interval that a job may be delayed, and the ceiling on that delay.
+#:
+#: Bounded twice on purpose. The fraction keeps a job written ``* * * * *`` from sliding past the
+#: next minute — an offset larger than the interval does not make a job late, it silently makes it
+#: a two-minute job. The absolute cap keeps a daily job from inheriting a tenth of a day: "every
+#: morning · 7h" firing at half past nine is a different promise from the one the screen made.
+JITTER_FRAC = 0.1
+JITTER_CAP_S = 300.0
+
+
+def _jitter(key: str, period: float) -> float:
+    """A stable offset in ``[0, min(JITTER_FRAC * period, JITTER_CAP_S))`` derived from ``key``.
+
+    Derived, not drawn. A random offset is redrawn on every restart, so the spread a deployment
+    converged on is lost each time the container comes up, and two jobs that happened to collide
+    keep colliding on a new pair of numbers. A hash of the id gives the same job the same slot
+    forever and different jobs different slots, with nothing stored.
+
+    An empty key means no offset, which is what keeps every caller that does not ask for a spread
+    on exactly the arithmetic it had.
+    """
+    if not key or period <= 0:
+        return 0.0
+    span = min(JITTER_FRAC * period, JITTER_CAP_S)
+    fraction = int(hashlib.sha256(key.encode("utf-8")).hexdigest()[:8], 16) / 0x1_0000_0000
+    return fraction * span
 
 
 def _dispatch_bounded(
@@ -39,7 +80,7 @@ def _dispatch_bounded(
     return call_with_deadline(lambda: dispatch(job), timeout)
 
 
-def _next_after(cron_expr: str, after_epoch: float) -> float:
+def _next_after(cron_expr: str, after_epoch: float, *, jitter_key: str = "") -> float:
     """The next epoch matching ``cron_expr``, read in the machine's own time zone.
 
     ``0 7 * * *`` means seven in the morning where the machine is, which is what every crontab has
@@ -55,16 +96,59 @@ def _next_after(cron_expr: str, after_epoch: float) -> float:
     local offset of a pre-1970 instant raises ``OSError: [Errno 22]``. The scheduler's own tests
     pass ``now=60``, so the naive form took the whole Windows suite down — on Linux and on WSL it is
     fine, which is why it reached CI. An aware datetime converts by arithmetic and never asks.
+
+    ``jitter_key`` spreads jobs that share a boundary. Dispatch is sequential, so fifteen jobs
+    written ``0 * * * *`` do not merely run slowly at ``:00`` — they delay every later tick behind
+    them. The offset only ever DELAYS, and is bounded by the schedule's own interval (see
+    :func:`_jitter`); an empty key returns the exact boundary, unchanged.
     """
     base = datetime.fromtimestamp(after_epoch, tz=UTC).astimezone()
-    return float(croniter(cron_expr, base).get_next(float))
+    ticker = croniter(cron_expr, base)
+    nxt = float(ticker.get_next(float))
+    if not jitter_key:
+        return nxt
+    # The interval is measured from the schedule itself rather than assumed, so `*/5` and `0 7 * * *`
+    # each get an offset proportional to what they actually promise.
+    period = float(ticker.get_next(float)) - nxt
+    return nxt + _jitter(jitter_key, period)
 
 
 class Scheduler:
     """Creates, lists and dispatches scheduled jobs over a :class:`CronStore`."""
 
-    def __init__(self, store: CronStore) -> None:
+    def __init__(
+        self, store: CronStore, *, fail_limit: int = FAIL_LIMIT, jitter: bool = True
+    ) -> None:
+        if fail_limit < 1:
+            # A limit of zero switches off a job that has never failed, which reads as "the
+            # scheduler is broken" to everyone. Refusing here is louder than a job that vanishes on
+            # its first tick.
+            raise ValueError(f"fail_limit must be at least 1, got {fail_limit}")
         self.store = store
+        self.fail_limit = fail_limit
+        #: Off for a caller that needs the exact boundary — a market open, a report due at midnight.
+        #: A spread that cannot be switched off is a spread people work around.
+        self.jitter = jitter
+
+    def _jitter_key(self, job: CronJob) -> str:
+        return job.id if self.jitter else ""
+
+    def _brake(self, job: CronJob) -> None:
+        """Switch a job off once it has failed ``fail_limit`` times in a row.
+
+        Called after the outcome is recorded, on every dispatch path. No delivery from here: the
+        engine takes no clock and no I/O, and the decision is visible everywhere the counter already
+        is — ``cron list``, ``cron doctor`` and ``/api/features`` all read this job.
+        """
+        if not job.enabled or job.consecutive_failures < self.fail_limit:
+            return
+        job.enabled = False
+        job.disabled_by = "brake"
+        _log.error(
+            "cron job %s (%s) switched off after %d consecutive failures; last error: %s",
+            job.name, job.id, job.consecutive_failures, job.last_error or "(none recorded)",
+        )
+        self.store.add(job)
 
     def schedule_cron(
         self,
@@ -91,8 +175,11 @@ class Scheduler:
         """
         if not croniter.is_valid(cron_expr):
             raise ValueError(f"invalid cron expression: {cron_expr!r}")
+        # Minted before the job, because the job's own id is what its schedule offset is derived
+        # from — the first `next_run` has to land in the same slot every later one will.
+        job_id = uuid.uuid4().hex[:8]
         job = CronJob(
-            id=uuid.uuid4().hex[:8],
+            id=job_id,
             name=name,
             trigger="cron",
             schedule=cron_expr,
@@ -101,7 +188,7 @@ class Scheduler:
             # Defend the "self-learned crons start disabled" invariant at the boundary, not just in
             # the learner: an agent-created cron must not fire until a human enables it.
             enabled=created_by != "agent",
-            next_run=_next_after(cron_expr, now),
+            next_run=_next_after(cron_expr, now, jitter_key=job_id if self.jitter else ""),
             workspace=workspace,
             deliver_to=deliver_to,
             verify=verify,
@@ -248,11 +335,18 @@ class Scheduler:
         is recent, the daemon is alive, the schedule is advancing — and every dispatch has lost.
         Told apart from :meth:`overdue` because the responses have nothing in common: one says look
         at the daemon, the other says look at the job.
+
+        A job the brake switched off is still reported, and that exception is the whole reason
+        ``disabled_by`` exists. Filtering on ``enabled`` alone would make the brake hide its own
+        findings in the one place someone goes to look for them: the most broken job on the machine
+        would be the only one missing from the list of broken jobs. A job a PERSON paused stays out
+        — they know.
         """
         return [
             job
             for job in self.store.list()
-            if job.enabled and job.consecutive_failures >= at_least
+            if (job.enabled or job.disabled_by == "brake")
+            and job.consecutive_failures >= at_least
         ]
 
     def jobs_for_event(self, event: str) -> list[CronJob]:
@@ -267,21 +361,30 @@ class Scheduler:
         """Enable a job; for cron jobs, (re)compute the next run from ``now``."""
         job = self.store.get(job_id)
         job.enabled = True
+        # The counter is cleared here and only here: re-enabling is somebody saying they dealt with
+        # the cause, and leaving it at the limit would switch the job off again on its next failure
+        # rather than after five — turning the brake into a one-strike rule for anything it has
+        # ever caught.
+        job.consecutive_failures = 0
+        job.disabled_by = ""
         if job.trigger == "cron":
-            job.next_run = _next_after(job.schedule, now)
+            job.next_run = _next_after(job.schedule, now, jitter_key=self._jitter_key(job))
         self.store.add(job)
         return job
 
     def disable(self, job_id: str) -> CronJob:
+        """Switch a job off by hand. Recorded as a human decision, so `failing()` stays quiet about
+        it — the person who paused it does not need a report telling them it is paused."""
         job = self.store.get(job_id)
         job.enabled = False
+        job.disabled_by = "human"
         self.store.add(job)
         return job
 
     def mark_ran(self, job: CronJob, now: float) -> None:
         job.last_run = now
         if job.trigger == "cron":
-            job.next_run = _next_after(job.schedule, now)
+            job.next_run = _next_after(job.schedule, now, jitter_key=self._jitter_key(job))
         self.store.add(job)
 
     def run_due(
@@ -335,6 +438,7 @@ class Scheduler:
                 _log.warning("cron job %s failed: %s", job.id, exc)
                 self._record(job, "error", f"{type(exc).__name__}: {exc}")
             self.mark_ran(job, now)
+            self._brake(job)
             ran.append(job)
         return ran
 
@@ -352,13 +456,32 @@ class Scheduler:
             job.consecutive_failures += 1
 
     def fire_event(self, event: str, now: float, dispatch: Callable[[CronJob], DispatchStatus | None]) -> list[CronJob]:
-        """Dispatch every job registered for ``event``. Returns those run."""
+        """Dispatch every job registered for ``event``. Returns those run.
+
+        Records the outcome, exactly as the cron path does. It used to swallow it: a bare
+        ``try/except`` around the dispatch and a log line, with no ``_record``. So an event job's
+        failures never touched ``last_status``, ``last_error`` or ``consecutive_failures`` — it
+        reported as healthy forever, which is the state the cron path's own comment says made a job
+        that had failed every tick for a month look fine, and the failure brake reads that counter.
+        """
         ran: list[CronJob] = []
         for job in self.jobs_for_event(event):
             try:
-                dispatch(job)
-            except Exception as exc:
+                veredito = dispatch(job)
+                if veredito == "rejected":
+                    self._record(
+                        job, "rejected",
+                        "the job ran and its verify command rejected the work, which was reverted",
+                    )
+                else:
+                    self._record(job, veredito or "ok", None)
+            except BudgetExceeded as exc:
+                _log.warning("event job %s refused on budget: %s", job.name, exc)
+                self._record(job, "budget", str(exc))
+            except Exception as exc:  # a failing job must not break the dispatcher
                 _log.warning("event job %s failed: %s", job.id, exc)
+                self._record(job, "error", f"{type(exc).__name__}: {exc}")
             self.mark_ran(job, now)
+            self._brake(job)
             ran.append(job)
         return ran

--- a/chimera/scheduler/models.py
+++ b/chimera/scheduler/models.py
@@ -66,6 +66,16 @@ class CronJob(BaseModel):
     action: str
     created_by: CreatedBy = "human"
     enabled: bool = True
+    disabled_by: str = ""
+    """Who switched this job off: ``""`` (running, or off before this field existed), ``"human"``,
+    or ``"brake"``.
+
+    Not decoration on ``enabled``. A job somebody deliberately paused and a job the scheduler
+    switched off after five straight failures are the same boolean and opposite facts, and
+    :meth:`~chimera.scheduler.engine.Scheduler.failing` — the report whose entire job is to name
+    broken jobs — filters on ``enabled``. Without this field the brake would HIDE its own findings
+    in the one place someone goes to look for them."""
+
     next_run: float | None = None
     last_run: float | None = None
     """When a dispatch was last ATTEMPTED. Says nothing about whether it worked — see

--- a/tests/test_a_job_that_only_fails_is_switched_off.py
+++ b/tests/test_a_job_that_only_fails_is_switched_off.py
@@ -1,0 +1,191 @@
+"""A job that fails on every tick was rescheduled, identically, forever.
+
+The counter was already right. `_record` increments `consecutive_failures` on every bad outcome and
+deliberately excludes a budget refusal — the job never ran, so nothing about it failed, and letting
+that climb would make a spending decision look like forty broken dispatches. That precision was
+built and then read by nobody: the only consumers are `failing()`, the `cron doctor` table and the
+JSON on `/api/features`, all of which report. `disable()` had exactly two callers, and both are a
+person — an HTTP route someone hits and a command someone types.
+
+So the instrument was built, calibrated, and never wired to an actuator. On a deployment with ~39
+agent-jobs and a paid key, a job that started failing at 02:00 kept firing every tick until somebody
+read a table. The daily spend cap bounds the money, but it is the wrong instrument: it stops *after
+paying*, not *on detecting*.
+
+Switching the job off is the conservative half of this. It stops the bleeding and leaves the
+evidence — `last_error`, `last_status` and the counter all survive, and `cron enable` puts it back.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.orchestration.budget import BudgetExceeded
+from chimera.scheduler.engine import FAIL_LIMIT, Scheduler
+from chimera.scheduler.store import CronStore
+
+
+def _sched(tmp_path: Path, **kwargs: object) -> Scheduler:
+    return Scheduler(CronStore(tmp_path / "jobs.json"), **kwargs)  # type: ignore[arg-type]
+
+
+def _tick_until(sch: Scheduler, dispatch: object, *, times: int) -> None:
+    """Advance the clock past each `next_run` so every tick actually dispatches.
+
+    Reads `next_run` rather than assuming it. Written with a hardcoded 61 for the first tick first,
+    and that was wrong the moment schedules gained an offset: a `* * * * *` job is due at 60 plus a
+    few seconds, so the first tick dispatched nothing and every count in this file was off by one.
+    """
+    for _ in range(times):
+        job = sch.store.list()[0]
+        sch.run_due((job.next_run or 0) + 1, dispatch)  # type: ignore[arg-type]
+
+
+def _explode(_job: object) -> None:
+    raise RuntimeError("o provedor recusou")
+
+
+def test_a_job_that_keeps_failing_stops_firing(tmp_path: Path) -> None:
+    """The whole point: the fifth failure is the last dispatch, not the fifth of forty."""
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    _tick_until(sch, _explode, times=FAIL_LIMIT)
+
+    assert sch.store.list()[0].enabled is False
+
+
+def test_it_does_not_switch_off_early(tmp_path: Path) -> None:
+    """A transient provider hiccup is not a broken job, and the limit is the whole judgement."""
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    _tick_until(sch, _explode, times=FAIL_LIMIT - 1)
+
+    assert sch.store.list()[0].enabled is True
+
+
+def test_one_success_clears_the_count(tmp_path: Path) -> None:
+    """The failure mode of a counter that only goes up: a job that fails on Mondays for two months
+    is switched off by arithmetic, having worked fine on fifty-eight days."""
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+    estado = {"n": 0}
+
+    def às_vezes(_job: object) -> None:
+        estado["n"] += 1
+        if estado["n"] != 3:
+            raise RuntimeError("falhou")
+
+    _tick_until(sch, às_vezes, times=FAIL_LIMIT + 2)
+
+    assert sch.store.list()[0].enabled is True
+
+
+def test_a_budget_refusal_never_switches_a_job_off(tmp_path: Path) -> None:
+    """`_record` already refuses to count this, and the reason is written there: the job never ran,
+    so nothing about it failed. Pinned here because that precision now decides whether a working
+    job keeps running — a spending decision must not read as forty broken dispatches."""
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    def sem_saldo(_job: object) -> None:
+        raise BudgetExceeded("daily cap reached")
+
+    _tick_until(sch, sem_saldo, times=FAIL_LIMIT + 3)
+
+    assert sch.store.list()[0].enabled is True
+
+
+def test_the_reason_survives_being_switched_off(tmp_path: Path) -> None:
+    """A job that is off and does not say why sends its owner to the server log.
+
+    The evidence has to outlive the decision: the counter, the last status and the last error are
+    what turn "why did this stop" into an answer instead of an investigation.
+    """
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    _tick_until(sch, _explode, times=FAIL_LIMIT)
+    job = sch.store.list()[0]
+
+    assert job.consecutive_failures >= FAIL_LIMIT
+    assert job.last_status == "error"
+    assert job.last_error and "o provedor recusou" in job.last_error
+
+
+def test_a_rejected_job_counts(tmp_path: Path) -> None:
+    """`rejected` means the job ran and its own verify command threw the work away. Repeating that
+    forever is exactly the state `_record`'s comment says made a nightly job look healthy while
+    producing nothing for a month."""
+    sch = _sched(tmp_path)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    _tick_until(sch, lambda _job: "rejected", times=FAIL_LIMIT)
+
+    assert sch.store.list()[0].enabled is False
+
+
+def test_the_limit_is_configurable(tmp_path: Path) -> None:
+    """A fixed constant would make this untestable at any other value, and undeployable for someone
+    whose provider is flakier than ours."""
+    sch = _sched(tmp_path, fail_limit=2)
+    sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+
+    _tick_until(sch, _explode, times=2)
+
+    assert sch.store.list()[0].enabled is False
+
+
+def test_a_switched_off_job_can_be_switched_back_on(tmp_path: Path) -> None:
+    """This is a brake, not a delete. Whoever fixes the cause needs one command, not a rebuild."""
+    sch = _sched(tmp_path)
+    job = sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+    _tick_until(sch, _explode, times=FAIL_LIMIT)
+
+    voltou = sch.enable(job.id, now=1000.0)
+
+    assert voltou.enabled is True
+    assert voltou.next_run and voltou.next_run > 1000.0
+    # The counter goes with it. Leaving it at the limit turns the brake into a one-strike rule for
+    # anything it has ever caught: the next single failure switches the job straight back off, and
+    # whoever fixed the cause sees it die again for a reason that is no longer true.
+    assert voltou.consecutive_failures == 0
+
+
+def test_a_re_enabled_job_gets_the_full_limit_again(tmp_path: Path) -> None:
+    """The assertion the counter reset exists for, stated as behaviour rather than as a field."""
+    sch = _sched(tmp_path)
+    job = sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+    _tick_until(sch, _explode, times=FAIL_LIMIT)
+    sch.enable(job.id, now=1000.0)
+
+    _tick_until(sch, _explode, times=FAIL_LIMIT - 1)
+
+    assert sch.store.list()[0].enabled is True
+
+
+def test_a_job_someone_paused_stays_out_of_the_failing_report(tmp_path: Path) -> None:
+    """The other half of `disabled_by`, and the reason it is not just a boolean.
+
+    A job the brake stopped must be reported — it is the most broken job on the machine. A job a
+    PERSON paused must not: they know, and a report that keeps naming it trains its reader to skip
+    the report. Same `enabled = False`, opposite facts.
+    """
+    sch = _sched(tmp_path)
+    job = sch.schedule_cron("relatório", "* * * * *", "escreva o relatório", now=0)
+    _tick_until(sch, _explode, times=FAIL_LIMIT - 1)  # failing, still on
+    sch.disable(job.id)
+
+    assert sch.failing() == []
+    assert sch.store.get(job.id).consecutive_failures == FAIL_LIMIT - 1
+
+
+@pytest.mark.parametrize("limite", [0, -1])
+def test_a_limit_of_zero_is_refused(tmp_path: Path, limite: int) -> None:
+    """A limit of zero switches off a job that has never failed — read as "the scheduler is broken"
+    by everyone. Refusing at construction is louder than a job that vanishes on its first tick."""
+    with pytest.raises(ValueError):
+        _sched(tmp_path, fail_limit=limite)

--- a/tests/test_a_scheduled_job_reports_what_happened.py
+++ b/tests/test_a_scheduled_job_reports_what_happened.py
@@ -45,8 +45,13 @@ def _depois(sched: Scheduler, dispatch: Any) -> CronJob:
 
     Read back rather than kept: the scheduler works on instances it loads from the store, so a
     local `CronJob` is a different object and would still hold the state from before the tick.
+
+    The due time is read from the job, not written as 60.0. Schedules carry a per-job offset now,
+    so a `* * * * *` job is due a few seconds past the minute — and the guard below is what turned
+    that into a legible failure instead of six tests quietly measuring nothing.
     """
-    ran = sched.run_due(60.0, dispatch)
+    devido = (sched.store.list()[0].next_run or 0.0) + 1
+    ran = sched.run_due(devido, dispatch)
     assert ran, "the job was not due, so nothing here is measuring a dispatch"
     return sched.store.list()[0]
 

--- a/tests/test_cron_budget.py
+++ b/tests/test_cron_budget.py
@@ -115,8 +115,11 @@ def test_a_real_failure_still_counts(tmp_path: Path) -> None:
     def boom(_job: CronJob) -> None:
         raise RuntimeError("broken")
 
-    sch.run_due(now=120, dispatch=boom)
-    sch.run_due(now=180, dispatch=boom)
+    # Two dispatches, each past its own boundary. Hardcoded 120/180 before schedules carried a
+    # per-job offset, and then the second tick fell BEFORE the next due time — so only one dispatch
+    # happened and the counter read 1, which looks like the counter being broken.
+    for _ in range(2):
+        sch.run_due(now=(sch.store.list()[0].next_run or 0) + 1, dispatch=boom)
 
     job = sch.store.list()[0]
     assert job.last_status == "error"

--- a/tests/test_cron_daemon.py
+++ b/tests/test_cron_daemon.py
@@ -14,12 +14,17 @@ def _scheduler(tmp_path: Path) -> Scheduler:
 
 def test_tick_fires_due_job_and_advances(tmp_path: Path) -> None:
     sch = _scheduler(tmp_path)
-    sch.schedule_cron("report", "* * * * *", "write the daily report", now=0)  # next_run = 60
+    job = sch.schedule_cron("report", "* * * * *", "write the daily report", now=0)
     fired: list[str] = []
-    daemon = CronDaemon(sch, lambda job: fired.append(job.name))
-    assert [j.name for j in daemon.tick(now=60)] == ["report"]  # due at t=60
+    daemon = CronDaemon(sch, lambda j: fired.append(j.name))
+    # Read rather than assumed. This said `now=60` when a minute schedule was due exactly on the
+    # minute; schedules now carry a per-job offset, so the boundary is 60 plus a few seconds. The
+    # offset stays ON here on purpose — this is the closest test to the real daemon, and it is
+    # where a spread that stopped a job firing at all would show.
+    devido = (job.next_run or 0) + 1
+    assert [j.name for j in daemon.tick(now=devido)] == ["report"]
     assert fired == ["report"]
-    assert daemon.tick(now=60) == []  # already advanced to t=120; not due again at 60
+    assert daemon.tick(now=devido) == []  # advanced past this tick; not due again
 
 
 def test_future_job_is_not_fired(tmp_path: Path) -> None:
@@ -83,10 +88,11 @@ def test_tick_reloads_jobs_added_out_of_process(tmp_path: Path) -> None:
     assert daemon.tick(now=60) == []  # daemon starts with no jobs
 
     # A *separate* process (its own store on the same file) schedules a cron.
-    Scheduler(CronStore(path)).schedule_cron("report", "* * * * *", "daily report", now=0)
+    job = Scheduler(CronStore(path)).schedule_cron("report", "* * * * *", "daily report", now=0)
 
-    # Without a restart, the daemon picks it up on the next tick and fires it.
-    assert [j.name for j in daemon.tick(now=60)] == ["report"]
+    # Without a restart, the daemon picks it up on the next tick and fires it. Due time read from
+    # the job rather than assumed to be the exact minute — schedules carry a per-job offset now.
+    assert [j.name for j in daemon.tick(now=(job.next_run or 0) + 1)] == ["report"]
     assert fired == ["report"]
 
 

--- a/tests/test_scheduler_silence.py
+++ b/tests/test_scheduler_silence.py
@@ -28,7 +28,7 @@ import pytest
 
 pytest.importorskip("croniter")
 
-from chimera.scheduler.engine import Scheduler  # noqa: E402
+from chimera.scheduler.engine import FAIL_LIMIT, Scheduler  # noqa: E402
 from chimera.scheduler.models import CronJob  # noqa: E402
 from chimera.scheduler.store import CronStore  # noqa: E402
 
@@ -197,9 +197,15 @@ def test_the_latest_comes_first(tmp_path: Path) -> None:
 def test_a_job_that_ran_and_failed_every_time_is_not_overdue_but_is_failing(tmp_path: Path) -> None:
     """The pair that is the whole point.
 
-    This job is dispatched on time, forever, and has never once succeeded. `overdue` says nothing —
-    correctly, the schedule is being honoured — and it is exactly the job somebody needs to hear
-    about. The two questions do not overlap and neither one alone is enough.
+    This job is dispatched on time and has never once succeeded. `overdue` says nothing — correctly,
+    the schedule is being honoured — and it is exactly the job somebody needs to hear about. The two
+    questions do not overlap and neither one alone is enough.
+
+    Written as "forever" and asserting twenty-four straight failures. That world no longer exists:
+    the failure brake switches a job off at `FAIL_LIMIT`, so the fifth dispatch is the last one. The
+    point survives the change and gets sharper — a braked job is STILL in `failing()`, and that is
+    the exception `disabled_by` exists for. Filtering the report on `enabled` alone would have made
+    the brake hide its own findings in the one place someone looks for them.
     """
     sched = _scheduler(tmp_path)
     job = _hourly(sched, "brief", 0.0)
@@ -212,10 +218,11 @@ def test_a_job_that_ran_and_failed_every_time_is_not_overdue_but_is_failing(tmp_
         agora = sched.store.get(job.id).next_run or agora
         sched.run_due(agora, explode)
 
+    parado = sched.store.get(job.id)
     assert sched.overdue(agora + 60, grace=HOUR) == [], "the schedule was honoured"
-    falhando = sched.failing(at_least=5)
-    assert [j.id for j in falhando] == [job.id]
-    assert sched.store.get(job.id).consecutive_failures == 24
+    assert [j.id for j in sched.failing(at_least=5)] == [job.id], "a braked job is still reported"
+    assert parado.consecutive_failures == FAIL_LIMIT
+    assert parado.enabled is False and parado.disabled_by == "brake"
 
 
 def test_a_healthy_job_is_in_neither_list(tmp_path: Path) -> None:

--- a/tests/test_scheduler_timezone.py
+++ b/tests/test_scheduler_timezone.py
@@ -47,7 +47,11 @@ def fuso(monkeypatch: pytest.MonkeyPatch):
 
 
 def _agendar(tmp_path: Path, expr: str, *, now: float = NOW) -> float:
-    sched = Scheduler(CronStore(tmp_path / "jobs.json"))
+    # No spread: these tests ask WHICH CLOCK an expression is read against, and the schedule offset
+    # is noise for that question — it moved "09:30" to "09:32" and the failure read as a timezone
+    # bug. The offset has its own tests; this file keeps the boundary exact so the minute it
+    # asserts is the minute the expression names.
+    sched = Scheduler(CronStore(tmp_path / "jobs.json"), jitter=False)
     job = sched.schedule_cron("resumo", expr, "diga bom dia", now=now)
     assert job.next_run is not None
     return job.next_run

--- a/tests/test_the_event_trigger_had_no_dispatcher.py
+++ b/tests/test_the_event_trigger_had_no_dispatcher.py
@@ -1,0 +1,125 @@
+"""An event job could be created, was listed as enabled, and could never fire.
+
+`Trigger` admits three values. `schedule_webhook` has a dispatcher — the webhook server calls
+`fire_webhook`. `schedule_cron` has one — the daemon calls `run_due`. `schedule_event` had none:
+`fire_event` was written, was covered by a unit test, and had no caller anywhere in `chimera/`.
+
+So `chimera cron add --event deploy` accepted the job, `cron list` showed it enabled with a
+schedule, and nothing ever ran it. The silence is identical to that of a job whose time has not
+come, which is the worst kind: there is nothing to notice.
+
+Two things were wrong and only one of them is the wiring. `fire_event` also swallowed the outcome —
+a bare `try/except` around `dispatch(job)` with a log line, and no `_record`. So an event job's
+failures never touched `last_status`, `last_error` or `consecutive_failures`: it would report as
+healthy forever, and the failure brake that reads that counter would never see it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.scheduler.engine import FAIL_LIMIT, Scheduler
+from chimera.scheduler.store import CronStore
+
+
+def _sched(tmp_path: Path) -> Scheduler:
+    return Scheduler(CronStore(tmp_path / "jobs.json"))
+
+
+def test_an_event_job_runs_when_its_event_fires(tmp_path: Path) -> None:
+    sch = _sched(tmp_path)
+    sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+    corridos: list[str] = []
+
+    sch.fire_event("deploy", 100.0, lambda job: corridos.append(job.name))  # type: ignore[arg-type,func-returns-value]
+
+    assert corridos == ["pós-deploy"]
+
+
+def test_another_event_does_not_run_it(tmp_path: Path) -> None:
+    """The guard against a dispatcher that fires everything: an event name that matches nothing is
+    the ordinary case, and running the whole crontab for it would be worse than running none."""
+    sch = _sched(tmp_path)
+    sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+    corridos: list[str] = []
+
+    sch.fire_event("git_push", 100.0, lambda job: corridos.append(job.name))  # type: ignore[arg-type,func-returns-value]
+
+    assert corridos == []
+
+
+# ------------------------------------------------------------------ the outcome it swallowed
+
+
+def test_a_failed_event_job_says_it_failed(tmp_path: Path) -> None:
+    """The second defect. Without this the job reports `ok` forever — the exact state the cron
+    path's own comment says made a job that had failed every tick for a month look healthy."""
+    sch = _sched(tmp_path)
+    sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+
+    def explode(_job: object) -> None:
+        raise RuntimeError("o healthcheck não respondeu")
+
+    sch.fire_event("deploy", 100.0, explode)  # type: ignore[arg-type]
+    job = sch.store.list()[0]
+
+    assert job.last_status == "error"
+    assert job.last_error and "healthcheck" in job.last_error
+    assert job.consecutive_failures == 1
+
+
+def test_a_successful_event_job_says_so(tmp_path: Path) -> None:
+    sch = _sched(tmp_path)
+    sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+
+    sch.fire_event("deploy", 100.0, lambda _job: None)  # type: ignore[arg-type]
+    job = sch.store.list()[0]
+
+    assert job.last_status == "ok"
+    assert job.consecutive_failures == 0
+    assert job.last_run == 100.0
+
+
+def test_one_failing_event_job_does_not_stop_the_others(tmp_path: Path) -> None:
+    """Same invariant the cron path holds: a failing job must not break the dispatcher."""
+    sch = _sched(tmp_path)
+    sch.schedule_event("primeiro", "deploy", "a")
+    sch.schedule_event("segundo", "deploy", "b")
+    vistos: list[str] = []
+
+    def um_falha(job: object) -> None:
+        vistos.append(job.name)  # type: ignore[attr-defined]
+        if job.name == "primeiro":  # type: ignore[attr-defined]
+            raise RuntimeError("falhou")
+
+    sch.fire_event("deploy", 100.0, um_falha)  # type: ignore[arg-type]
+
+    assert vistos == ["primeiro", "segundo"]
+
+
+def test_an_event_job_that_only_fails_is_switched_off_too(tmp_path: Path) -> None:
+    """The brake has to reach here, or the one trigger with no schedule to slow it down becomes the
+    one that can hammer a provider without limit."""
+    sch = _sched(tmp_path)
+    sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+
+    def explode(_job: object) -> None:
+        raise RuntimeError("falhou")
+
+    for _ in range(FAIL_LIMIT):
+        sch.fire_event("deploy", 100.0, explode)  # type: ignore[arg-type]
+
+    assert sch.store.list()[0].enabled is False
+
+
+def test_a_disabled_event_job_does_not_run(tmp_path: Path) -> None:
+    """And the brake has to hold: `jobs_for_event` is what decides, so a job switched off by the
+    brake must stop being selected rather than merely stop being reported."""
+    sch = _sched(tmp_path)
+    job = sch.schedule_event("pós-deploy", "deploy", "verifique o healthcheck")
+    sch.disable(job.id)
+    corridos: list[str] = []
+
+    sch.fire_event("deploy", 100.0, lambda j: corridos.append(j.name))  # type: ignore[arg-type,func-returns-value]
+
+    assert corridos == []

--- a/tests/test_the_schedule_does_not_stack_on_the_hour.py
+++ b/tests/test_the_schedule_does_not_stack_on_the_hour.py
@@ -1,0 +1,159 @@
+"""Every hourly job was due at exactly the same instant, and dispatch is sequential.
+
+`_next_after` returns the cron expression's exact boundary, so fifteen jobs written `0 * * * *` are
+all due on the same tick. `run_due` walks them one at a time with a 30-minute ceiling each, and the
+daemon ticks every 30 seconds — so a pile-up at `:00` does not merely run slowly, it delays every
+LATER tick behind it. Fifteen jobs at two minutes each is half an hour in which nothing else on the
+schedule can happen.
+
+The offset is derived from the job's id, not drawn at random, and that is the whole design: a random
+offset is redrawn on every restart, so the spread a deployment converged on is lost each time the
+container comes up — and two jobs that happened to collide keep colliding on a new pair of numbers.
+A hash of the id gives the same job the same slot forever, and different jobs different slots,
+without storing anything.
+
+Bounded twice: to a share of the interval, so a job that runs every minute is never pushed past the
+next minute, and to an absolute ceiling, so a daily job is late by minutes rather than by hours.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.scheduler.engine import JITTER_CAP_S, Scheduler, _jitter, _next_after
+from chimera.scheduler.store import CronStore
+
+HORA = 3600.0
+DIA = 86400.0
+
+
+def _sched(tmp_path: Path, **kwargs: object) -> Scheduler:
+    return Scheduler(CronStore(tmp_path / "jobs.json"), **kwargs)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------------ the spread
+
+
+def test_two_hourly_jobs_are_not_due_at_the_same_instant(tmp_path: Path) -> None:
+    """The whole point, stated as the thing that was false."""
+    sch = _sched(tmp_path)
+    a = sch.schedule_cron("a", "0 * * * *", "faça a", now=0)
+    b = sch.schedule_cron("b", "0 * * * *", "faça b", now=0)
+
+    assert a.next_run != b.next_run
+
+
+def test_a_pile_of_jobs_spreads_over_minutes(tmp_path: Path) -> None:
+    """Two differing is luck; the property is that a realistic pile actually thins out.
+
+    Fifteen is the number from the deployment this came from. The assertion is deliberately weak on
+    HOW they spread — a hash gives no guarantee of uniformity — and strong on the only thing that
+    matters: no tick carries the whole pile.
+    """
+    sch = _sched(tmp_path)
+    horarios = {
+        sch.schedule_cron(f"job{i}", "0 * * * *", "trabalhe", now=0).next_run for i in range(15)
+    }
+
+    assert len(horarios) >= 12
+
+
+def test_the_offset_is_the_same_after_a_restart(tmp_path: Path) -> None:
+    """What a random offset cannot do, and the reason this is a hash.
+
+    A fresh Scheduler over the same store — which is what a container restart is — must put the job
+    back in the slot it already had, or the spread a deployment converged on is redrawn every time
+    the process comes up.
+    """
+    sch = _sched(tmp_path)
+    job = sch.schedule_cron("relatório", "0 * * * *", "trabalhe", now=0)
+    antes = job.next_run
+
+    sch.mark_ran(job, 0.0)
+
+    assert job.next_run == antes
+
+
+def test_two_installs_of_the_same_schedule_do_not_collide(tmp_path: Path) -> None:
+    """Ids differ per install, so the same crontab on two machines lands on different seconds —
+    which is what stops a shared provider being hit by everyone at `:00`."""
+    a = _next_after("0 * * * *", 0.0, jitter_key="aaaaaaaa")
+    b = _next_after("0 * * * *", 0.0, jitter_key="bbbbbbbb")
+
+    assert a != b
+
+
+# ------------------------------------------------------------------ the bounds
+
+
+def test_a_minute_job_never_slides_into_the_next_minute() -> None:
+    """The invariant that keeps this from being a bug: an offset must be smaller than the interval.
+
+    A job written `* * * * *` that is pushed 90 seconds is not late — it has silently become a
+    two-minute job, and its owner has no way to see that from the schedule they wrote.
+    """
+    base = _next_after("* * * * *", 0.0)
+    for chave in ("a", "b", "c", "d", "e", "f", "0", "zzzzzzzz"):
+        atrasado = _next_after("* * * * *", 0.0, jitter_key=chave)
+        assert base <= atrasado < base + 60.0
+
+
+def test_a_daily_job_is_late_by_minutes_not_hours() -> None:
+    """The other bound. A tenth of a day is two and a half hours, and "every morning · 7h" firing
+    at half past nine is a different promise from the one the screen made."""
+    base = _next_after("0 7 * * *", 0.0)
+    for chave in ("a", "b", "c", "zzzzzzzz"):
+        assert base <= _next_after("0 7 * * *", 0.0, jitter_key=chave) <= base + JITTER_CAP_S
+
+
+def test_the_job_is_never_pulled_earlier() -> None:
+    """Jitter only ever delays. An offset that could go negative would fire a job before the time
+    its owner wrote, which is the one direction a schedule may not move."""
+    for expr in ("* * * * *", "0 * * * *", "0 7 * * *", "*/5 * * * *"):
+        base = _next_after(expr, 1000.0)
+        assert _next_after(expr, 1000.0, jitter_key="qualquer") >= base
+
+
+def test_no_key_means_no_offset() -> None:
+    """The escape hatch, and the reason every existing caller's arithmetic is unchanged."""
+    assert _next_after("0 * * * *", 0.0) == _next_after("0 * * * *", 0.0, jitter_key="")
+
+
+def test_an_empty_key_produces_no_offset_at_the_source() -> None:
+    """Asserted on the helper, not through `_next_after`, and that is the point.
+
+    The version above passes either way: `_next_after` returns early on an empty key, so the guard
+    inside `_jitter` is never reached and an inert guard reads as a working one. A sabotage that
+    removed it went undetected — which is exactly what an untested guard is for.
+    """
+    assert _jitter("", 3600.0) == 0.0
+    assert _jitter("qualquer", 0.0) == 0.0
+    assert _jitter("qualquer", -1.0) == 0.0
+
+
+def test_it_can_be_turned_off(tmp_path: Path) -> None:
+    """Someone whose job must fire at the exact boundary — a market open, a report due at midnight —
+    needs the boundary, and a spread they cannot switch off is a spread they will work around."""
+    sch = _sched(tmp_path, jitter=False)
+    a = sch.schedule_cron("a", "0 * * * *", "faça a", now=0)
+    b = sch.schedule_cron("b", "0 * * * *", "faça b", now=0)
+
+    assert a.next_run == b.next_run == _next_after("0 * * * *", 0.0)
+
+
+# ------------------------------------------------------------------ it still fires
+
+
+def test_a_jittered_job_still_becomes_due(tmp_path: Path) -> None:
+    """The failure a spread can quietly introduce: a job that is always a little in the future.
+
+    `due()` compares against `next_run`, and `mark_ran` recomputes it — so an offset applied at the
+    wrong end could push the boundary forward on every tick and the job would never run at all.
+    """
+    sch = _sched(tmp_path)
+    job = sch.schedule_cron("relatório", "* * * * *", "trabalhe", now=0)
+    corridos: list[str] = []
+
+    sch.run_due((job.next_run or 0) + 1, lambda j: corridos.append(j.name))  # type: ignore[arg-type,func-returns-value]
+
+    assert corridos == ["relatório"]


### PR DESCRIPTION
Three defects in the one component that runs unattended with a paid key. Group B of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8).

---

## 6 · A job that fails on every tick was rescheduled, identically, forever

The counter was already exact. `_record` increments on every bad outcome and **deliberately excludes a budget refusal** — the job never ran, so nothing about it failed, and letting that climb would make a spending decision look like forty broken dispatches.

That precision was built and read by nobody:

```
$ grep -rn "consecutive_failures" chimera/ --include=*.py   # only reporting surfaces
$ grep -rn "\.disable(" chimera/ --include=*.py
chimera/api/features.py:592   ← an HTTP route someone hits
chimera/cli/main.py:4727      ← a command someone types
```

Instrument built, calibrated, never wired to an actuator. Five consecutive failures now switch the job off. The daily spend cap bounds the money but is the wrong instrument: it stops **after paying**, not on detecting.

**This opened a hole, and closing it needed a field.** `failing()` filters on `enabled` — so a braked job would have vanished from the one report whose job is to name broken jobs. The most broken job on the machine would be the only one missing from the list. `CronJob.disabled_by` records who switched it off (`""` | `"human"` | `"brake"`), and `failing()` keeps reporting the brake's findings while staying quiet about a job a person paused — they know.

**Found by an existing test, not by the new ones.** `test_a_job_that_ran_and_failed_every_time_is_not_overdue_but_is_failing` went red, and it was right to.

## 7 · The event trigger had no dispatcher

`chimera cron add --event deploy` accepted the job, `cron list` showed it enabled with a schedule, and nothing in the package ever called `fire_event`:

```
$ grep -rn "fire_event" chimera/ tests/ --include=*.py
chimera/scheduler/engine.py:354   ← the definition
tests/test_scheduler.py:139       ← a test
```

Its silence was identical to that of a job whose time had not come. The cron trigger has the daemon and the webhook trigger has the webhook server; `chimera cron fire <event>` is the third one's — meant for a git hook, a deploy step, a CI job.

It goes through `make_agent_dispatch`, not straight to `fire_event`: that is what turns a `JobOutcome` into the status the scheduler records, so a gate that rejected the work reads as `rejected` rather than as success, and it is where delivery happens. A second dispatch path that quietly behaves differently from the daemon's is worse than no second path.

**And `fire_event` swallowed the outcome** — a bare try/except and a log line, no `_record`. An event job's failures never touched `last_status`, `last_error` or the counter, so it reported healthy forever. The brake reads that counter.

## 8 · Every hourly job was due at the same instant

Dispatch is sequential with a 30-minute ceiling per job, and the daemon ticks every 30 seconds. Fifteen jobs at `0 * * * *` do not merely run slowly at `:00` — they delay every **later** tick behind them.

Each job now carries an offset derived from its id. Derived, not drawn: a random offset is redrawn on every restart, so the spread a deployment converged on is lost each time the container comes up, and two jobs that happened to collide keep colliding on a new pair of numbers.

Bounded twice, and both bounds have a test:
- **by a share of the interval**, so a job written `* * * * *` never slides past the next minute — an offset larger than the interval does not make a job late, it silently makes it a two-minute job;
- **by an absolute ceiling**, so a daily job does not inherit a tenth of a day. "Every morning · 7h" firing at half past nine is a different promise from the one the screen made.

`Scheduler(jitter=False)` for a caller that needs the exact boundary — a market open, a report due at midnight.

---

## Verification

**Fourteen sabotages, fourteen caught** — after three escaped and exposed three of my own tests as weaker than they read. The sharpest: `test_no_key_means_no_offset` asserted through `_next_after`, which returns early on an empty key, so the guard inside `_jitter` was never reached and deleting it changed nothing. Now asserted on the helper directly.

The sabotages include the over-zealous direction of each fix: a one-strike brake, a brake that counts budget refusals, an offset with no fraction bound, one with no absolute bound, one that can pull a job *earlier*, and a manual pause that starts showing up in the failing report.

**Ten existing tests moved**, and the reason matters for review:

- **Nine** had a hardcoded `now` written when a `* * * * *` job was due at exactly 60. They now read `next_run` from the job. One of them — `test_a_scheduled_job_reports_what_happened` — has a guard (`assert ran, "the job was not due, so nothing here is measuring a dispatch"`) that turned this into a legible failure instead of six tests quietly measuring nothing.
- **One** described a world this change removes: a job failing twenty-four times running. It now asserts the sharper thing — the brake stops it at five, and a braked job is **still** in `failing()`.

`4579 passed, 18 skipped` · ruff and mypy (330 files) clean · CLI snapshot regenerated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)