### PR TITLE
fix(providers): read the stop reason, and give the stream a second chance

### DIFF
--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -259,7 +259,13 @@ class AgentResult:
 
     answer: str
     steps: int
-    stopped_reason: str  # "final" | "max_steps" | "tool_loop" | "budget" | "spend" | "cancelled"
+    stopped_reason: str
+    """Why the loop ended: ``final`` | ``max_steps`` | ``tool_loop`` | ``budget`` | ``spend`` |
+    ``cancelled`` | ``context_stuck``.
+
+    ``context_stuck`` is its own value rather than folded into ``max_steps`` because the two need
+    opposite responses: one is a ceiling to raise, the other is a conversation that has nothing left
+    to compact and has to be started over."""
     transcript: list[MessageLike] = field(default_factory=list)
     tool_calls_made: int = 0
     # Token/cost accounting, summed across every model call in the run (0 when the backend reported
@@ -491,6 +497,10 @@ class Agent:
         # stopping, re-planning and force-compacting are all plausible answers and we have no
         # evidence about which one helps, so choosing here would bake in an unmeasured assumption.
         drift_reported = False
+        #: Set when compaction runs out of room while the prompt is still over the threshold. The
+        #: loop leaves through the same final turn `max_steps` uses, under its own reason: "raise
+        #: the ceiling" and "start a new conversation" are opposite advice.
+        contexto_travado: str | None = None
 
         for step in range(1, self.config.max_steps + 1):
             # Cooperative cancel, checked once per step. A model call in flight cannot be
@@ -592,6 +602,29 @@ class Agent:
                         "compacted at %d tokens (threshold %d of %d-token window)",
                         result.prompt_tokens, self._budget.threshold, self._budget.window,
                     )
+                else:
+                    # `compact`'s own docstring asks for this and nothing implemented it: "callers
+                    # should treat a no-op as 'this did not help' rather than retrying into the same
+                    # wall". A guard written in prose and not in code is the shape that has cost
+                    # this project before.
+                    #
+                    # Nothing left to compact and still over the threshold means the NEXT call sends
+                    # the same oversized prompt, costs the same money, and returns the same count.
+                    # The loop used to do that until `max_steps` — a full model call per step, all
+                    # of them unable to succeed. Stopping here answers with what the run has, under
+                    # its own reason, because "raise the step ceiling" and "start a new
+                    # conversation" are opposite advice.
+                    _log.warning(
+                        "context is stuck at %d tokens (threshold %d) and there is nothing left to "
+                        "compact; answering with what the run has",
+                        result.prompt_tokens, self._budget.threshold,
+                    )
+                    # The content of the call that just returned IS "what the run has": the
+                    # assistant message is only appended further down, on the branch this break
+                    # skips, so scanning the transcript afterwards finds the PREVIOUS step's answer
+                    # or nothing at all.
+                    contexto_travado = result.content
+                    break
             if not result.tool_calls:
                 # Narrate-instead-of-act guard: if asked to insist on action, push a described-but-
                 # unexecuted plan back once instead of accepting it as done. Only once, so a genuine
@@ -680,6 +713,15 @@ class Agent:
                 messages.append({"role": "assistant", "content": final.content})
                 return self._result(final.content, step, "tool_loop", messages, tool_calls_made,
                                     tool_names, usage, final.model, steplog=steplog, task=task)
+
+        if contexto_travado is not None:
+            # No further model call. The prompt that just came back over budget is the prompt the
+            # next one would send, so asking again would cost exactly what the last call cost and
+            # fail the same way — which is the loop this break exists to end.
+            messages.append({"role": "assistant", "content": contexto_travado})
+            return self._result(contexto_travado, step, "context_stuck", messages, tool_calls_made,
+                                tool_names, usage, self.config.model or "", steplog=steplog,
+                                task=task)
 
         # Budget exhausted: ask once more, without tools, for a final answer.
         final = self._step([*messages, {"role": "user", "content": "Provide your final answer now."}], spend=spend,

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -116,6 +116,22 @@ class CompletionResult(BaseModel):
     """Prompt-cache HITS the provider reported (billed at the read rate). None = unknown."""
     cache_write_tokens: int | None = None
     """Prompt-cache WRITES the provider reported (billed at the write rate). None = unknown."""
+    finish_reason: str = ""
+    """Why the provider stopped generating, verbatim: ``stop`` | ``length`` | ``tool_calls`` | …
+
+    Empty means the provider reported nothing, which is NOT the same as "it finished" — the same
+    three-state rule ``cache_read_tokens`` follows two fields up. Nothing here read this field until
+    now, and a response cut off at the output ceiling therefore arrived 200 OK and indistinguishable
+    from a complete one."""
+
+    truncated: bool = False
+    """True when generation stopped because it ran out of room, rather than because it was done.
+
+    Its own field because the consequences are structural, not cosmetic: a cut response can carry a
+    half-written tool-call argument, or lose the call entirely — and the loop then blames the model
+    for an empty-argument failure, or for "describing a plan instead of acting", when the sentence
+    was severed mid-word."""
+
     route_meta: dict[str, Any] | None = Field(default=None, repr=False)
     """Optional per-call fusion/cascade trace (UI-ready JSON). None for a plain single-model call."""
     raw: dict[str, Any] | None = Field(default=None, repr=False)
@@ -650,46 +666,54 @@ class LLMGateway:
         ``tool_calls``. Like :meth:`stream`, this is one direct call: NO fallback chain and NO cache
         (both meaningless for a live stream). Callers that need those keep using :meth:`complete`.
         """
-        import litellm  # lazy: heavy import, keep CLI startup fast
-
         resolved = self._resolve_model(model)
         self._require_credentials(resolved)
         call_kwargs = dict(self._provider_kwargs(), **kwargs)
         keys = self._key_order(resolved.split("/", 1)[0])
         if keys:
             call_kwargs["api_key"] = keys[0]
-        response = litellm.completion(
-            model=resolved,
-            messages=_to_message_dicts(messages),
-            temperature=temperature,
-            max_tokens=max_tokens,
-            tools=tools,
-            stream=True,
-            stream_options={"include_usage": True},  # ask the provider for a final usage chunk
-            # A native anthropic/gemini model (or a strict api_base) can reject the unknown
-            # stream_options param; drop_params lets LiteLLM strip what a provider doesn't support so
-            # the stream still runs (usage just comes back unknown) rather than erroring the whole turn.
-            drop_params=True,
-            **call_kwargs,
-        )
         content: list[str] = []
         tool_acc: dict[int, dict[str, Any]] = {}
         usage: dict[str, int | None] = {}
+        finish_reason = ""
         think = self._think_filter()
-        for chunk in response:
-            text = _delta_text(chunk)
-            if text:
-                # Filtered BEFORE it is accumulated, not only before it is displayed. The reasoning
-                # would otherwise stay in `content`, which is what goes back into the message list
-                # for the next turn — so it would be hidden from the user and still paid for, every
-                # turn, forever.
-                shown = think.feed(text) if think else text
-                if shown:
-                    content.append(shown)
-                    if on_delta is not None:
-                        on_delta(shown)
-            _delta_tool_calls(chunk, tool_acc)
-            _accumulate_stream_usage(chunk, usage)
+        try:
+            response = self._stream_once(
+                model=resolved,
+                messages=_to_message_dicts(messages),
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                stream=True,
+                stream_options={"include_usage": True},  # ask the provider for a final usage chunk
+                # A native anthropic/gemini model (or a strict api_base) can reject the unknown
+                # stream_options param; drop_params lets LiteLLM strip what a provider doesn't support so
+                # the stream still runs (usage just comes back unknown) rather than erroring the whole turn.
+                drop_params=True,
+                **call_kwargs,
+            )
+            for chunk in response:
+                razao = self._consume_chunk(chunk, content, tool_acc, usage, think, on_delta)
+                if razao:
+                    finish_reason = razao
+        except Exception as exc:
+            # The one recovery this path gets, and the bound on it is the whole design.
+            #
+            # `complete` walks candidates and rotates keys; this called the provider once with
+            # `keys[0]` and gave up — on the surface the product spends its time, because the coding
+            # turn streams by default. A 429 that `complete` survives killed the turn outright.
+            #
+            # Refused once anything has been shown: falling back then means replaying text the
+            # reader already read, or splicing another model's continuation onto a half sentence.
+            # Before the first delta nothing was shown and a retry is invisible. Once only, because
+            # `complete` has its own chain and a fallback that can fall back is a loop in disguise.
+            if content or tool_acc or action_for(classify(exc)) is RecoveryAction.ABORT:
+                raise
+            _log.warning("stream failed before any output (%s); falling back to a batch call", exc)
+            return self.complete(
+                messages, model=model, temperature=temperature, max_tokens=max_tokens, tools=tools,
+                **kwargs,
+            )
         if think:
             tail = think.flush()
             if tail:
@@ -704,7 +728,48 @@ class LLMGateway:
             completion_tokens=usage.get("completion_tokens"),
             cache_read_tokens=usage.get("cache_read_tokens"),
             cache_write_tokens=usage.get("cache_write_tokens"),
+            finish_reason=finish_reason,
+            truncated=finish_reason == "length",
         )
+
+    @staticmethod
+    def _stream_once(**kwargs: Any) -> Any:
+        """The single streaming provider call, as its own seam.
+
+        Extracted so the recovery around it can be driven by a test without a network — the reason
+        the missing fallback survived this long is that nothing could reach the failure.
+        """
+        import litellm  # lazy: heavy import, keep CLI startup fast
+
+        return litellm.completion(**kwargs)
+
+    def _consume_chunk(
+        self,
+        chunk: Any,
+        content: list[str],
+        tool_acc: dict[int, dict[str, Any]],
+        usage: dict[str, Any],
+        think: ThinkFilter | None,
+        on_delta: Callable[[str], None] | None,
+    ) -> str:
+        """Fold one streamed chunk into the accumulating result; return its stop reason, if any."""
+        text = _delta_text(chunk)
+        if text:
+            # Filtered BEFORE it is accumulated, not only before it is displayed. The reasoning
+            # would otherwise stay in `content`, which is what goes back into the message list
+            # for the next turn — so it would be hidden from the user and still paid for, every
+            # turn, forever.
+            shown = think.feed(text) if think else text
+            if shown:
+                content.append(shown)
+                if on_delta is not None:
+                    on_delta(shown)
+        _delta_tool_calls(chunk, tool_acc)
+        _accumulate_stream_usage(chunk, usage)
+        # Returned rather than written into `usage`: that dict holds token counts, and a string in
+        # it types as `int | None` everywhere it is read. The stop reason arrives on the terminal
+        # chunk, not in the usage block, and it is what tells a truncated stream from a short one.
+        return _delta_finish_reason(chunk)
 
     def embed(self, texts: list[str], *, model: str | None = None) -> list[list[float]]:
         """Embed a batch of texts into vectors (one call), for semantic memory recall.
@@ -733,6 +798,7 @@ class LLMGateway:
         tool_calls: list[ToolCall] | None = None
         prompt_tokens: int | None = None
         completion_tokens: int | None = None
+        finish_reason = _delta_finish_reason(response)  # same shape on a batch choice
         try:
             message = response.choices[0].message
             # Non-streaming lands here, and a local model reasons in tags whether or not anyone is
@@ -757,6 +823,8 @@ class LLMGateway:
             completion_tokens=completion_tokens,
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
+            finish_reason=finish_reason,
+            truncated=finish_reason == "length",
         )
 
     @staticmethod
@@ -792,7 +860,12 @@ class LLMGateway:
                     if isinstance(loaded, dict):
                         arguments = loaded
                 except json.JSONDecodeError:
-                    _log.warning("could not parse tool arguments: %r", raw_args)
+                    # DROPPED, not served with `arguments={}`. The append used to sit outside this
+                    # handler, so `{"path": "src/ap` — an argument string the provider cut in half —
+                    # became a call with no arguments, which ran, failed, and was counted against the
+                    # model as a repeat. An unparseable argument string is a call we did not receive.
+                    _log.warning("dropping tool call with unparseable arguments: %r", raw_args)
+                    continue
             elif isinstance(raw_args, dict):
                 arguments = raw_args
             parsed.append(
@@ -845,6 +918,18 @@ def _delta_tool_calls(chunk: Any, acc: dict[int, dict[str, Any]]) -> None:
                 slot["arguments"] += str(args)
 
 
+def _delta_finish_reason(chunk: Any) -> str:
+    """The stop reason a chunk or a batch response carries, or "".
+
+    One function for both shapes because both put it in the same place — `choices[0].finish_reason`
+    — and two readings of one field is how one of them quietly stops handling a provider.
+    """
+    try:
+        return str(getattr(chunk.choices[0], "finish_reason", "") or "")
+    except (AttributeError, IndexError, TypeError):
+        return ""
+
+
 def _finalize_stream_tool_calls(acc: dict[int, dict[str, Any]]) -> list[ToolCall] | None:
     """Turn accumulated tool-call fragments into ``ToolCall``s (JSON-parsing the arguments)."""
     if not acc:
@@ -862,7 +947,10 @@ def _finalize_stream_tool_calls(acc: dict[int, dict[str, Any]]) -> list[ToolCall
                 if isinstance(loaded, dict):
                     arguments = loaded
             except json.JSONDecodeError:
-                _log.warning("could not parse streamed tool arguments: %r", raw)
+                # Same rule as the batch path, and the duplication is why it needed saying twice:
+                # a half-received argument string is a call we did not get, not a call with none.
+                _log.warning("dropping streamed tool call with unparseable arguments: %r", raw)
+                continue
         calls.append(ToolCall(id=slot.get("id") or "", name=slot["name"], arguments=arguments))
     return calls or None
 

--- a/tests/test_a_cut_off_answer_is_not_a_finished_one.py
+++ b/tests/test_a_cut_off_answer_is_not_a_finished_one.py
@@ -1,0 +1,146 @@
+"""A response the provider truncated was indistinguishable from one the model finished.
+
+`finish_reason` appears six times in this package and every one of them is in `openai_compat.py`,
+where Chimera EMITS the field for its own clients. Nothing in `chimera/providers/` ever read it. So a
+call that hit the provider's output ceiling came back 200 OK, and the loop treated the fragment as
+the model's answer.
+
+The damage is a chain, and every link blames the model for something the provider did:
+
+1. the truncated argument string fails `json.loads`, and the call was appended anyway with
+   `arguments={}` — the `append` sits outside the `except`, on both the batch and the stream path;
+2. the tool then runs with no arguments, fails, and the loop breaker counts that as the model
+   repeating itself;
+3. and if the cut removed the call entirely, `tool_calls_made == 0` fires the action nudge, which
+   accuses the model of describing a plan instead of doing it — when it was cut mid-sentence.
+
+Reading one field turns a silent, mis-attributed failure into a named one. This is the family the
+project's own notes call the expensive kind: nothing errors, the number comes out, and the
+apparatus cannot show the defect.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.providers.gateway import LLMGateway, _finalize_stream_tool_calls
+
+
+class _Fn:
+    def __init__(self, name: str, arguments: str) -> None:
+        self.name = name
+        self.arguments = arguments
+
+
+class _Call:
+    def __init__(self, name: str, arguments: str, id: str = "c1") -> None:
+        self.id = id
+        self.function = _Fn(name, arguments)
+
+
+class _Msg:
+    def __init__(self, content: str = "", tool_calls: list[_Call] | None = None) -> None:
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    def __init__(self, message: _Msg, finish_reason: str | None = "stop") -> None:
+        self.message = message
+        self.finish_reason = finish_reason
+
+
+class _Resp:
+    def __init__(self, choice: _Choice, usage: Any = None) -> None:
+        self.choices = [choice]
+        self.usage = usage
+
+
+def _normalizar(finish_reason: str | None = "stop", **kwargs: Any) -> Any:
+    return LLMGateway._normalize(_Resp(_Choice(_Msg(**kwargs), finish_reason)), "m")  # noqa: SLF001
+
+
+# ------------------------------------------------------------------ the field nobody read
+
+
+def test_a_truncated_answer_says_it_was_truncated() -> None:
+    """The whole point. `length` is the provider saying "I stopped because I ran out of room"."""
+    assert _normalizar("length", content="A resposta começa e").truncated is True
+
+
+def test_a_finished_answer_does_not() -> None:
+    assert _normalizar("stop", content="pronto").truncated is False
+
+
+def test_a_tool_call_stop_is_not_truncation() -> None:
+    """`tool_calls` is the ordinary end of a step that asked for a tool, and reading it as truncation
+    would flag most of a healthy run."""
+    assert _normalizar("tool_calls", content="").truncated is False
+
+
+def test_a_provider_that_reports_nothing_is_not_called_truncated() -> None:
+    """Three states, not two. A provider that omits the field has told us nothing, and inventing
+    `False` there is the same mistake as inventing `True` — this is the rule `cache_read_tokens`
+    already follows one struct over."""
+    assert _normalizar(None, content="pronto").truncated is False
+    assert _normalizar(None, content="pronto").finish_reason == ""
+
+
+def test_the_raw_reason_survives() -> None:
+    """A boolean answers "was it cut"; the string answers "by what", which is what a provider's own
+    vocabulary carries — `content_filter` and `length` are both not-`stop` and need opposite
+    responses."""
+    assert _normalizar("content_filter", content="").finish_reason == "content_filter"
+
+
+# ------------------------------------------------------------------ the argument it half-wrote
+
+
+def test_a_half_written_argument_is_not_served_as_an_empty_one() -> None:
+    """Link 2 of the chain, batch path. `{"path": "src/ap` is a cut string, not a call with no
+    arguments — and running a tool with `{}` produces an error the model gets blamed for."""
+    resultado = _normalizar("length", tool_calls=[_Call("write_file", '{"path": "src/ap')])
+
+    assert resultado.tool_calls is None
+
+
+def test_a_whole_argument_is_still_parsed() -> None:
+    """The guard against fixing this by refusing every call."""
+    resultado = _normalizar("tool_calls", tool_calls=[_Call("read_file", '{"path": "x.py"}')])
+
+    assert resultado.tool_calls is not None
+    assert resultado.tool_calls[0].arguments == {"path": "x.py"}
+
+
+def test_a_call_with_genuinely_no_arguments_still_works() -> None:
+    """`{}` from the provider is a real call to a no-argument tool, and dropping it would break
+    every such tool — which is the over-correction this test exists to catch."""
+    resultado = _normalizar("tool_calls", tool_calls=[_Call("get_time", "{}")])
+
+    assert resultado.tool_calls is not None
+    assert resultado.tool_calls[0].arguments == {}
+
+
+def test_the_stream_path_refuses_the_same_fragment() -> None:
+    """Link 2, stream path. The same code twice, in two places, is how one of them stops matching —
+    and the streaming path is the one the desktop app actually uses."""
+    assert _finalize_stream_tool_calls({0: {"name": "write_file", "arguments": '{"path": "src/ap'}}) is None
+
+
+def test_the_stream_path_still_parses_a_whole_one() -> None:
+    acabado = _finalize_stream_tool_calls({0: {"id": "c1", "name": "read_file", "arguments": '{"path": "x"}'}})
+
+    assert acabado is not None
+    assert acabado[0].arguments == {"path": "x"}
+
+
+def test_one_broken_call_does_not_discard_the_good_ones() -> None:
+    """A step can declare several calls and only the last one is cut. Throwing away the whole step
+    would turn one truncated fragment into a wasted round-trip that was mostly usable."""
+    resultado = _normalizar(
+        "length",
+        tool_calls=[_Call("read_file", '{"path": "a.py"}', "c1"), _Call("write_file", '{"pa', "c2")],
+    )
+
+    assert resultado.tool_calls is not None
+    assert [c.name for c in resultado.tool_calls] == ["read_file"]

--- a/tests/test_compacting_into_the_same_wall.py
+++ b/tests/test_compacting_into_the_same_wall.py
@@ -1,0 +1,146 @@
+"""`compact` documented the guard, and the only caller in the repository did not implement it.
+
+Its docstring says it plainly: *"callers should treat a no-op as 'this did not help' rather than
+retrying into the same wall"*. `Agent._step` reads the returned flag only to set `record.compacted`,
+so when compaction has nothing left to give — the transcript is already down to `keep_recent`, and
+the prompt is still over the threshold — the loop compacts (no-op), pays for a full model call with
+the same oversized prompt, gets the same `prompt_tokens` back, and does it again until `max_steps`.
+
+A guard that ASSERTS in prose what the code does not do is the shape this project has been bitten by
+before, and this time the prose sits in the docstring of the function that needed the caller.
+
+Stopping is the honest response. Not another provider call: the next one costs exactly what the last
+one cost and cannot succeed, because nothing about the prompt changed. The loop already has the
+machinery — the same final turn `max_steps` uses, answering with what it has, under its own reason.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.core.agent import Agent, AgentConfig
+from chimera.core.context_budget import compact
+from chimera.providers.gateway import CompletionResult
+from chimera.tools.registry import ToolRegistry
+
+
+class _SempreGrande:
+    """A backend whose prompt is always over budget — the wall this test is about.
+
+    The count is absurd on purpose. `ContextBudget` takes its window from the MODEL name, not from
+    the backend, so a plausible-looking 1000 sat far under the default window's threshold and the
+    run finished normally — the test passed while measuring nothing.
+    """
+
+    def __init__(self, *, prompt_tokens: int = 10_000_000) -> None:
+        self.chamadas = 0
+        self.prompt_tokens = prompt_tokens
+
+    def complete(self, messages: list[Any], **_kwargs: Any) -> CompletionResult:
+        self.chamadas += 1
+        return CompletionResult(
+            content=f"resposta {self.chamadas}", model="m",
+            prompt_tokens=self.prompt_tokens, completion_tokens=5,
+        )
+
+
+def _agente(backend: Any, *, max_steps: int = 8) -> Agent:
+    return Agent(
+        backend,
+        ToolRegistry(),
+        AgentConfig(max_steps=max_steps, context_budget=0.6, detect_tool_loops=False),
+    )
+
+
+# ------------------------------------------------------------------ the wall
+
+
+def test_a_run_that_cannot_compact_stops_instead_of_paying(monkeypatch: Any) -> None:
+    """The whole point, counted in provider calls — which is what the defect actually cost."""
+    backend = _SempreGrande()
+
+    resultado = _agente(backend, max_steps=8).run("faça algo")
+
+    assert backend.chamadas <= 2, f"paid for {backend.chamadas} calls against an unchangeable prompt"
+    assert resultado.stopped_reason == "context_stuck"
+
+
+def test_it_says_which_wall_it_hit() -> None:
+    """`max_steps` and "compaction has nothing left" both end a turn early and need opposite
+    responses: one is a ceiling to raise, the other is a conversation to start over."""
+    resultado = _agente(_SempreGrande()).run("faça algo")
+
+    assert resultado.stopped_reason == "context_stuck"
+    assert resultado.stopped_reason != "max_steps"
+
+
+def test_it_answers_with_what_it_has() -> None:
+    """Stopping must not mean returning nothing. The run has done real work by this point and the
+    person asked a question — the same final turn `max_steps` already takes."""
+    assert _agente(_SempreGrande()).run("faça algo").answer
+
+
+# ------------------------------------------------------------------ the ordinary case
+
+
+def test_a_run_under_budget_is_untouched() -> None:
+    """The guard against a fix that stops every long conversation."""
+    backend = _SempreGrande(prompt_tokens=10)
+
+    resultado = _agente(backend).run("faça algo")
+
+    assert resultado.stopped_reason == "final"
+
+
+def test_compaction_that_helps_is_not_treated_as_stuck() -> None:
+    """The distinction the flag carries: a no-op is not the same as a compaction that shrank the
+    prompt. `compact` reports `changed`, and only `False` means there is nothing left to try."""
+    mensagens: list[Any] = [{"role": "system", "content": "s"}] + [
+        {"role": "user", "content": f"m{i}"} for i in range(20)
+    ]
+
+    _menores, mudou = compact(mensagens, keep_recent=6)
+
+    assert mudou is True
+
+
+def test_a_long_conversation_compacts_and_carries_on() -> None:
+    """The same distinction, asserted in the LOOP rather than in `compact` — which is where it is
+    decided, and where the version of this test that only called `compact` was not looking.
+
+    A run with a real transcript behind it goes over budget, compaction works, and the turn has to
+    continue. A brake that fires on a successful compaction would end every long conversation at its
+    first crowded step, and the helper test above could not have shown it.
+    """
+    class _GrandeUmaVez:
+        def __init__(self) -> None:
+            self.chamadas = 0
+
+        def complete(self, messages: list[Any], **_kwargs: Any) -> CompletionResult:
+            self.chamadas += 1
+            # Over budget on the first call, comfortable once the transcript has been compacted.
+            grande = 10_000_000 if self.chamadas == 1 else 10
+            return CompletionResult(
+                content="pronto", model="m", prompt_tokens=grande, completion_tokens=5
+            )
+
+    backend = _GrandeUmaVez()
+    historia: list[Any] = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    resultado = _agente(backend).run("faça algo", history=historia)
+
+    # `final`, not a second call. A turn whose model asks for no tool ends on its first step, so
+    # counting calls here asserted something the loop never does — and that version failed against
+    # the CORRECT code while still going red under the sabotage, which is a test passing for the
+    # wrong reason in the one direction that looks like success.
+    assert resultado.stopped_reason == "final"
+    assert resultado.answer == "pronto"
+
+
+def test_a_transcript_already_at_the_floor_reports_no_change() -> None:
+    """The precondition of the whole fix, asserted on `compact` itself: it does say so."""
+    mensagens: list[Any] = [{"role": "system", "content": "s"}, {"role": "user", "content": "m"}]
+
+    _iguais, mudou = compact(mensagens, keep_recent=6)
+
+    assert mudou is False

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -140,7 +140,11 @@ def test_stream_complete_survives_malformed_chunks(monkeypatch: pytest.MonkeyPat
 
     result = LLMGateway().stream_complete([Message(role="user", content="hi")], model="prov/m")
     assert result.content == "ok"
-    assert result.tool_calls is not None and result.tool_calls[0].arguments == {}  # bad args -> {}
+    # The junk chunk must not raise — that is what this test is for — and the half-written argument
+    # string is DROPPED. It used to become `arguments={}`, which ran the tool with nothing and got
+    # the model blamed for the failure; `{bad json` is a call we did not receive, not a call with no
+    # arguments. The text that did arrive is still returned.
+    assert result.tool_calls is None
 
 
 def test_fallback_models_split_from_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_the_streaming_path_had_no_second_chance.py
+++ b/tests/test_the_streaming_path_had_no_second_chance.py
@@ -1,0 +1,199 @@
+"""The best-built recovery in the repository does not run where the product spends its time.
+
+`complete` walks a chain: for every candidate model, for every key in the pool, classify the failure
+and decide whether to rotate the key, change the model or abort. `stream_complete` calls the provider
+once, with `keys[0]`, and its docstring says so — "NO fallback chain and NO cache (both meaningless
+for a live stream)".
+
+The cache half of that is right. The fallback half is what the coding turn runs on: `code_api`
+declares `stream: bool = True`, and `Agent._step` picks `stream_complete` whenever a token callback
+is present. So a 429 that `complete` would have survived by rotating a key kills the turn outright,
+on the one surface a person is watching.
+
+The fix here is deliberately the small half. Once a delta has reached the client, falling back means
+either replaying text the user already read or continuing from a partial answer, and neither is
+obviously right — so the fallback is refused after the first token, and that refusal has its own
+test. Before the first token nothing has been shown, and a retry is invisible and free.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from chimera.providers.gateway import CompletionResult, LLMGateway
+
+
+class _Erro(Exception):
+    """A provider error, spelled the way `classify` on this branch reads one.
+
+    The status goes in the MESSAGE as well as on the attribute. `classify` matches on the class name
+    and the text — reading the attribute first is a separate change on another branch — and a test
+    that leaned on the attribute would be asserting that branch's behaviour from this one, which is
+    the kind of coupling that makes a merge look like a regression.
+    """
+
+    def __init__(self, status: int, mensagem: str = "") -> None:
+        super().__init__(mensagem or f"{status} provider error")
+        self.status_code = status
+
+
+@pytest.fixture(autouse=True)
+def _com_chave(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_require_credentials` runs before the stream, so without a key nothing here reaches the
+    code under test — it fails on the credential check and every assertion reads as a pass."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+
+
+def _gateway(monkeypatch: pytest.MonkeyPatch, *, chamadas: list[str], falha: Exception | None,
+             deltas: list[str] | None = None) -> LLMGateway:
+    """A gateway whose streaming call fails as instructed and whose `complete` is recorded."""
+    gw = LLMGateway()
+
+    def _stream(**kwargs: Any) -> Any:
+        chamadas.append("stream")
+        if deltas:
+            for texto in deltas:
+                yield _chunk(texto)
+        if falha is not None:
+            raise falha
+
+    def _complete(*_args: Any, **_kwargs: Any) -> CompletionResult:
+        chamadas.append("complete")
+        return CompletionResult(content="resposta do fallback", model="m")
+
+    monkeypatch.setattr(gw, "_stream_once", _stream, raising=False)
+    monkeypatch.setattr(gw, "complete", _complete)
+    return gw
+
+
+def _chunk(texto: str) -> Any:
+    class _D:
+        content = texto
+        tool_calls = None
+
+    class _C:
+        delta = _D()
+        finish_reason = None
+
+    class _K:
+        choices = [_C()]
+        usage = None
+
+    return _K()
+
+
+# ------------------------------------------------------------------ it recovers
+
+
+def test_a_rate_limit_before_the_first_token_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The turn that used to die. Nothing was shown, so a retry costs the user nothing."""
+    chamadas: list[str] = []
+    resultado = _gateway(monkeypatch, chamadas=chamadas, falha=_Erro(429)).stream_complete(
+        [{"role": "user", "content": "oi"}]
+    )
+
+    assert chamadas == ["stream", "complete"]
+    assert resultado.content == "resposta do fallback"
+
+
+def test_an_overloaded_provider_falls_back_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    chamadas: list[str] = []
+    _gateway(monkeypatch, chamadas=chamadas, falha=_Erro(503)).stream_complete(
+        [{"role": "user", "content": "oi"}]
+    )
+
+    assert chamadas == ["stream", "complete"]
+
+
+# ------------------------------------------------------------------ it refuses to
+
+
+def test_a_failure_after_the_first_token_does_not_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bound, and the reason this fix is the small half.
+
+    Once text has reached the screen, falling back means either replaying what the reader already
+    read or splicing a second model's continuation onto a first model's half-sentence. Neither is
+    obviously right, so the stream fails the way it always did and the caller sees the error.
+    """
+    chamadas: list[str] = []
+    gw = _gateway(monkeypatch, chamadas=chamadas, falha=_Erro(429), deltas=["Olá"])
+    vistos: list[str] = []
+
+    with pytest.raises(_Erro):
+        gw.stream_complete([{"role": "user", "content": "oi"}], on_delta=vistos.append)
+
+    assert chamadas == ["stream"]
+    assert vistos == ["Olá"]
+
+
+def test_a_401_does_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad key is a reason TO retry, not a reason to stop — and this test said the opposite.
+
+    Written asserting that a 401 aborts, on the assumption that a wrong key is wrong twice. The
+    taxonomy disagrees and is right: `AUTH` maps to `ROTATE_KEY`, because a pool holds more than one
+    key and the second may be fine. The streaming path used `keys[0]` and nothing else, so this is
+    precisely the turn the fallback exists to save.
+    """
+    chamadas: list[str] = []
+    _gateway(monkeypatch, chamadas=chamadas, falha=_Erro(401)).stream_complete(
+        [{"role": "user", "content": "oi"}]
+    )
+
+    assert chamadas == ["stream", "complete"]
+
+
+def test_an_abort_reason_does_not_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A prompt too long for the stream is too long for the batch call: same messages, same model,
+    same ceiling. `CONTEXT_OVERFLOW` maps to `ABORT`, and paying for a second call that cannot
+    succeed is the one thing a recovery must not do."""
+    chamadas: list[str] = []
+    gw = _gateway(
+        monkeypatch, chamadas=chamadas, falha=_Erro(400, "maximum context length exceeded")
+    )
+
+    with pytest.raises(_Erro):
+        gw.stream_complete([{"role": "user", "content": "oi"}])
+
+    assert chamadas == ["stream"]
+
+
+def test_it_only_falls_back_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fallback that could itself fall back is a loop wearing a recovery's clothes."""
+    chamadas: list[str] = []
+    gw = LLMGateway()
+
+    def _stream(**_kwargs: Any) -> Any:
+        chamadas.append("stream")
+        raise _Erro(429)
+        yield  # pragma: no cover - makes this a generator
+
+    def _complete(*_args: Any, **_kwargs: Any) -> CompletionResult:
+        chamadas.append("complete")
+        raise _Erro(429)
+
+    monkeypatch.setattr(gw, "_stream_once", _stream, raising=False)
+    monkeypatch.setattr(gw, "complete", _complete)
+
+    with pytest.raises(_Erro):
+        gw.stream_complete([{"role": "user", "content": "oi"}])
+
+    assert chamadas == ["stream", "complete"]
+
+
+# ------------------------------------------------------------------ it still streams
+
+
+def test_a_healthy_stream_never_reaches_the_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ordinary path, unchanged — and the assertion that this did not become a gateway that
+    quietly answers every turn twice."""
+    chamadas: list[str] = []
+    gw = _gateway(monkeypatch, chamadas=chamadas, falha=None, deltas=["Olá", " mundo"])
+    vistos: list[str] = []
+
+    resultado = gw.stream_complete([{"role": "user", "content": "oi"}], on_delta=vistos.append)
+
+    assert chamadas == ["stream"]
+    assert vistos == ["Olá", " mundo"]
+    assert resultado.content == "Olá mundo"


### PR DESCRIPTION
Four defects on the path the desktop coding turn actually runs. Group C of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8).

---

## 9 · A truncated response was indistinguishable from a finished one

```
$ grep -rn "finish_reason" chimera/ --include=*.py
chimera/api/openai_compat.py:139   ← where Chimera EMITS it
chimera/api/openai_compat.py:178
chimera/api/openai_compat.py:209
chimera/api/openai_compat.py:273
chimera/api/openai_compat.py:279
chimera/api/openai_compat.py:288
```

Nothing in `chimera/providers/` read it. A call cut off at the provider's output ceiling came back **200 OK**, and the damage chain blames the model for three things the provider did:

1. the truncated argument string fails `json.loads` and the call is appended anyway with `arguments={}`;
2. the tool runs with nothing, fails, and the loop breaker counts that as the model repeating itself;
3. and if the cut removed the call entirely, `tool_calls_made == 0` fires the action nudge — which accuses the model of describing a plan instead of acting, when it was severed mid-word.

`CompletionResult` now carries `finish_reason` verbatim and `truncated`. Empty means the provider reported nothing, which is **not** the same as "it finished" — the three-state rule `cache_read_tokens` already follows two fields up.

## 10 · A half-received argument string became `arguments={}`

The `append` sat outside the `except`, on **both** the batch and the stream path. `{"path": "src/ap` is a call we did not receive, not a call with no arguments.

Dropped now — with three tests on the over-correction: a genuine `{}` for a no-argument tool still works, one bad call in a step does not discard the good ones, and the text that did arrive is still returned.

## 11 · `stream_complete` had no recovery, and it is the default path

`complete` walks candidates and rotates keys. `stream_complete` called the provider once with `keys[0]`, and its docstring said so — *"NO fallback chain and NO cache (both meaningless for a live stream)"*. The cache half is right.

`code_api` declares `stream: bool = True` and `Agent._step` picks the streaming call whenever a token callback is present, so a 429 that `complete` survives killed the turn outright, on the one surface a person is watching.

**Deliberately the small half.** It falls back to `complete` only **before the first delta**: once text has reached the reader, falling back means replaying what they already read or splicing another model's continuation onto a half sentence, and neither is obviously right. Never on an `ABORT` reason, where the second call cannot succeed. Once only.

One of my tests here had the taxonomy backwards — it asserted a 401 aborts, on the assumption that a wrong key is wrong twice. `AUTH` maps to `ROTATE_KEY` and is right to: a pool holds more than one key, and that is exactly the turn this fallback saves. Now tested with `CONTEXT_OVERFLOW`, which genuinely aborts.

The provider call is now `_stream_once`, its own seam — the reason this survived is that nothing could reach the failure.

## 12 · Compaction had no brake, and `compact`'s own docstring asked for one

> callers should treat a no-op as "this did not help" rather than retrying into the same wall

The only caller read the returned flag to set `record.compacted`. So with nothing left to compact and the prompt still over the threshold, the loop compacted (no-op), paid for a full call with the same oversized prompt, got the same count back, and repeated until `max_steps`.

A guard written in prose and not in code — the shape this project has been bitten by before, this time in the docstring of the function that needed the caller.

The loop now stops with `context_stuck`, its own `stopped_reason`, because "raise the ceiling" and "start a new conversation" are opposite advice. It answers with what the run has: the content of the call that just returned, because the assistant message is only appended on the branch this break skips.

---

## Verification

**Thirteen sabotages, thirteen caught**, after one escaped: treating a **successful** compaction as stuck went undetected, because the test for that case called `compact` directly and never reached the loop.

The replacement then failed against the *correct* code on its first writing — it counted provider calls, and a turn whose model asks for no tool ends on its first step. So it went red under sabotage **while also being wrong**, which is the shape that looks like success.

**Two existing tests moved.** `test_stream_complete_survives_malformed_chunks` asserted `bad args -> {}`, which is the defect this PR removes. And a test double of mine reported a plausible 1000-token prompt that sat far under the real window's threshold — `ContextBudget` takes its window from the model name, not from the backend — so it measured nothing.

`4574 passed, 18 skipped` · ruff and mypy (330 files) clean.

**Note for merge order:** touches `gateway.py`, as does #282, but in different regions (`_normalize` / `_parse_tool_calls` / `stream_complete` here; `_credential_error` and the `complete` fallback loop there). No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)