### PR TITLE
fix(security): a secret is given away by its place, not only by its shape

### DIFF
--- a/chimera/config.py
+++ b/chimera/config.py
@@ -672,6 +672,53 @@ class Settings(BaseSettings):
         default_factory=list, validation_alias="CHIMERA_TOOL_DENYLIST"
     )
 
+    @field_validator("api_base", mode="after")
+    @classmethod
+    def _api_base_is_local_or_encrypted(cls, value: str | None) -> str | None:
+        """Refuse a cleartext endpoint that is not this machine.
+
+        Every configured provider key is exported to the environment for LiteLLM to see, and this
+        value is applied to EVERY call — so pointing it at a third party sends whichever key that
+        provider matches to them. That is a footgun rather than an exploit, since somebody typed the
+        value, and the field exists for exactly the case that is safe: a self-hosted server on
+        loopback, where nothing crosses a network.
+
+        Plain HTTP to another host is the one reading with no legitimate version: a bearer token in
+        cleartext, to somewhere else. TLS is fine, loopback is fine, and unset — the ordinary case —
+        is untouched.
+
+        Compared after parsing, never by substring. `"localhost" in url` accepts
+        `http://evil.localhost.com`, and a check anyone can defeat by registering a domain is not a
+        check. A URL that will not parse is refused rather than assumed local: a string no parser
+        understands must not pass a guard whose whole job is to decide where it points.
+        """
+        if not value:
+            return value
+        import ipaddress
+        from urllib.parse import urlsplit
+
+        try:
+            parts = urlsplit(value)
+            scheme, host = parts.scheme.lower(), (parts.hostname or "").lower()
+        except ValueError:
+            scheme, host = "", ""
+        if scheme == "https":
+            return value
+        # Parsed as an address, not matched as a prefix. `host.startswith("127.")` was the first
+        # version of this line and it accepts `127.0.0.1.atacante.com` — the same substring mistake
+        # the docstring above warns about, made two lines below the warning.
+        try:
+            local = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            local = host == "localhost"
+        if not local:
+            raise ValueError(
+                f"CHIMERA_API_BASE={value!r} sends every provider key you have configured, in "
+                "cleartext, to a host that is not this machine. Use https://, or a loopback "
+                "address (127.0.0.1 / localhost) for a self-hosted server."
+            )
+        return value
+
     @field_validator("approval", mode="before")
     @classmethod
     def _approval_is_a_posture_word(cls, value: object) -> object:

--- a/chimera/core/redact.py
+++ b/chimera/core/redact.py
@@ -30,6 +30,49 @@ MASK = "[redacted]"
 #: var set to `1` or `true` would otherwise mask every digit in the file.
 _MIN_SECRET_LEN = 8
 
+#: Names that make a query parameter or a header a credential. Matched on the NAME, so the value
+#: never has to be recognised — which is the point: a token minted by a remote API has no shape a
+#: list can hold, and the parameter it arrives in does.
+_SENSITIVE_NAME = r"(?:api[_-]?key|apikey|access[_-]?token|auth|authorization|token|secret|password|passwd|pwd|sig|signature|session)"
+
+#: Structural leaks — a secret given away by WHERE it sits rather than by what it looks like.
+#:
+#: Six of seven shapes measured against the shape list below survived it intact: URL userinfo, a
+#: query parameter named `api_key`, an `Authorization` header, a cookie, a database DSN, and a
+#: Discord webhook path. None of them needs to be recognised; the place identifies them. That
+#: matters here specifically — delivery on the 24/7 deployment goes through a webhook whose URL IS
+#: the secret, and `steplog` writes every tool argument and result through this function.
+#:
+#: Every one keeps its context. `api_key=[redacted]` says a key was sent; a line reduced to
+#: `[redacted]` says only that a request happened, and the file exists to answer more than that.
+_PLACES = (
+    # scheme://user:SECRET@host — the password half of URL userinfo, never the user or the host.
+    re.compile(r"(?P<keep>://[^\s:/@]+:)(?P<hide>[^\s@/]+)(?P<tail>@)"),
+    # ?name=SECRET or &name=SECRET, where the NAME is what marks it.
+    re.compile(rf'(?P<keep>[?&]{_SENSITIVE_NAME}=)(?P<hide>[^\s&#"\']+)', re.IGNORECASE),
+    # A credential header inside a quoted argument — `curl -H 'x-api-key: …'`. First, because the
+    # line-anchored form below would otherwise swallow the closing quote and everything after it.
+    # This is the shape a tool observation actually carries; a header on its own line is the rarer
+    # one here, and writing only that missed the case the whole change is for.
+    re.compile(
+        rf"(?P<keep>['\"](?:{_SENSITIVE_NAME}|x-api-key|cookie|proxy-authorization)[ \t]*:[ \t]*)"
+        r"(?P<hide>[^'\"]+)(?P<tail>['\"])",
+        re.IGNORECASE,
+    ),
+    # A credential header on its own line, to the end of it. The value may contain spaces —
+    # `Authorization: Basic dXNlcjpzZW5oYQ==` is one value, not a scheme and a separate token.
+    re.compile(
+        rf"(?P<keep>^[ \t]*(?:{_SENSITIVE_NAME}|x-api-key|cookie|proxy-authorization)[ \t]*:[ \t]*)"
+        r"(?P<hide>\S.*)$",
+        re.IGNORECASE | re.MULTILINE,
+    ),
+    # A chat webhook path: the id/token tail is the credential, and the host says which service.
+    re.compile(
+        r"(?P<keep>https://(?:discord(?:app)?\.com|hooks\.slack\.com)/[^\s?]*?/)(?P<hide>[A-Za-z0-9_-]{16,})",
+        re.IGNORECASE,
+    ),
+)
+
 #: High-confidence shapes, as a second net. Deliberately narrow: a greedy pattern that redacted
 #: ordinary output would make the trace useless, and a useless trace gets turned off.
 _PATTERNS = (
@@ -60,11 +103,20 @@ def known_secrets() -> list[str]:
 
 
 def redact(text: str) -> str:
-    """Replace known secrets and credential-shaped strings in ``text``."""
+    """Replace known secrets, structurally-placed secrets, and credential-shaped strings.
+
+    Three nets, in order of confidence. The environment values are a guarantee over the set that
+    matters most; the places are structural and need no knowledge of the value; the shapes are a
+    guess at the string and are deliberately the narrowest of the three.
+    """
     if not text:
         return text
     for secret in known_secrets():
         text = text.replace(secret, MASK)
+    for pattern in _PLACES:
+        # The surrounding context is kept and only the captured value replaced. A line that reads
+        # `[redacted]` and nothing else cannot be diagnosed, which defeats the file's purpose.
+        text = pattern.sub(lambda m: f"{m.group('keep')}{MASK}{m.groupdict().get('tail') or ''}", text)
     for pattern in _PATTERNS:
         text = pattern.sub(MASK, text)
     return text

--- a/chimera/memory/manager.py
+++ b/chimera/memory/manager.py
@@ -12,6 +12,7 @@ import re
 import uuid
 from collections.abc import Callable
 
+from chimera.core.redact import redact
 from chimera.memory.models import EVERY_PROJECT, MemoryItem, MemoryKind
 from chimera.memory.semantic import EmbedFn, SemanticIndex
 from chimera.memory.store import MemoryBackend
@@ -100,6 +101,16 @@ class MemoryManager:
         from a tainted run also taints the stored item (poison must not launder itself
         into a previously clean fact).
         """
+        # Masked BEFORE the duplicate check, not after: the same fact written twice differs before
+        # masking and matches after, so redacting later would store it twice. And masked here rather
+        # than at the two call sites — `ChatSession` and the desktop turn both parse "remember
+        # that …" and hand the text over, and the next writer would be one forgotten call from the
+        # same hole.
+        #
+        # Memory is the surface with the longest reach: a fact written today is read back into the
+        # system prompt of every matching conversation from now on, and nothing re-reads it to
+        # notice. `redact` is narrow on purpose, which matters more here than anywhere else.
+        content = redact(content)
         duplicate = self._find_duplicate(content, key)
         if duplicate is None:
             return "ADD", self.add(

--- a/chimera/scheduler/delivery.py
+++ b/chimera/scheduler/delivery.py
@@ -12,7 +12,7 @@ is the difference between a feature every user of a desktop app can turn on and 
 of the app has set up.
 
 **The URL is a credential.** Whoever holds it can post into that channel, so it is never logged in
-full — :func:`redact` is used on every path that reports a failure.
+full — :func:`webhook_host_only` is used on every path that reports a failure.
 """
 
 from __future__ import annotations
@@ -100,8 +100,14 @@ def make_deliver(
     return deliver
 
 
-def redact(url: str) -> str:
-    """A webhook URL with its secret path removed, safe to put in a log or an error message."""
+def webhook_host_only(url: str) -> str:
+    """A webhook URL with its secret path removed, safe to put in a log or an error message.
+
+    Named `redact` until it collided with :func:`chimera.core.redact.redact`, which takes arbitrary
+    text and masks credentials inside it. Two functions with one name and different contracts is how
+    a caller reaches for the wrong one — and the wrong one here would leave the whole path in the
+    log, because a webhook URL has no credential SHAPE in it: the path IS the secret.
+    """
     try:
         parts = urllib.parse.urlparse(url)
     except ValueError:
@@ -159,8 +165,8 @@ def deliver_to_webhook(url: str, text: str, *, timeout: float = TIMEOUT_S) -> De
         # The body carries the reason (bad token, unknown channel, rate limit) and is worth keeping,
         # but it is written by a remote service — bounded before it goes anywhere near a log line.
         detalhe = (exc.read().decode("utf-8", "replace") or "")[:200].strip()
-        _log.warning("delivery to %s refused: HTTP %s", redact(url), exc.code)
+        _log.warning("delivery to %s refused: HTTP %s", webhook_host_only(url), exc.code)
         return Delivered(False, f"HTTP {exc.code}: {detalhe}" if detalhe else f"HTTP {exc.code}")
     except Exception as exc:  # noqa: BLE001 — a chat outage must not fail a job that worked
-        _log.warning("delivery to %s failed: %s", redact(url), type(exc).__name__)
+        _log.warning("delivery to %s failed: %s", webhook_host_only(url), type(exc).__name__)
         return Delivered(False, f"{type(exc).__name__}: {exc}")

--- a/tests/test_a_custom_endpoint_is_not_a_place_to_send_keys.py
+++ b/tests/test_a_custom_endpoint_is_not_a_place_to_send_keys.py
@@ -1,0 +1,78 @@
+"""`CHIMERA_API_BASE` points every call somewhere else, and every key is already in the environment.
+
+`_export_keys_to_env` puts every configured provider key into `os.environ` so LiteLLM can see them.
+`_provider_kwargs` applies `settings.api_base` — a single global — to every call. Set the base to a
+third-party OpenAI-compatible endpoint with `OPENAI_API_KEY` present, and the OpenAI key travels
+there. Nothing warns.
+
+This is a footgun, not an exploit: the person set the value. The field's own comment says what it is
+for — *"self-hosted/OpenAI-compatible servers (Ollama, vLLM)"* — which is the loopback case, and for
+that case nothing changes here. What changes is that a plain-HTTP base pointing at a host that is
+not this machine is refused, because sending a bearer token over cleartext to somewhere else is the
+one version of this that has no legitimate reading.
+
+The host is compared after parsing, never by substring. `"localhost" in url` accepts
+`http://evil.localhost.com`, and a check that can be defeated by naming a domain is not a check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.config import Settings
+
+
+def _base(url: str) -> Settings:
+    return Settings(CHIMERA_API_BASE=url)  # type: ignore[call-arg]
+
+
+PERMITIDOS = [
+    ("http://127.0.0.1:11434", "Ollama, o caso que o campo existe para servir"),
+    ("http://localhost:8000/v1", "vLLM local"),
+    ("http://[::1]:8080", "loopback IPv6"),
+    ("https://meu-gateway.exemplo.com/v1", "um endpoint remoto, mas sob TLS"),
+    ("HTTPS://MAIUSCULO.EXEMPLO.COM/v1", "esquema em maiúsculas ainda é TLS"),
+]
+
+RECUSADOS = [
+    ("http://gateway-de-terceiro.com/v1", "texto claro para outra máquina"),
+    ("http://evil.localhost.com/v1", "o domínio que derrota `\"localhost\" in url`"),
+    ("http://127.0.0.1.atacante.com/v1", "o mesmo truque com o endereço"),
+    ("HTTP://GATEWAY.COM/v1", "esquema em maiúsculas não escapa da regra"),
+]
+
+
+@pytest.mark.parametrize(("url", "porque"), PERMITIDOS)
+def test_a_legitimate_base_is_accepted(url: str, porque: str) -> None:
+    assert _base(url).api_base == url, porque
+
+
+@pytest.mark.parametrize(("url", "porque"), RECUSADOS)
+def test_cleartext_to_somewhere_else_is_refused(url: str, porque: str) -> None:
+    with pytest.raises(ValueError, match="CHIMERA_API_BASE"):
+        _base(url)
+
+
+def test_the_refusal_says_what_to_do() -> None:
+    """A rejected setting that does not say why is a setting somebody works around by deleting the
+    guard. The two legitimate answers are `https://` or a loopback address, and the message says
+    both."""
+    with pytest.raises(ValueError) as erro:
+        _base("http://gateway-de-terceiro.com/v1")
+
+    mensagem = str(erro.value)
+    assert "https" in mensagem
+    assert "localhost" in mensagem or "127.0.0.1" in mensagem
+
+
+def test_no_base_is_still_the_default() -> None:
+    """Unset is the ordinary case and must stay untouched — this guard exists for a value somebody
+    typed, and typing nothing is not a value."""
+    assert Settings().api_base is None
+
+
+def test_a_malformed_url_is_refused_rather_than_assumed_local() -> None:
+    """The safe default when parsing fails. Treating an unparseable base as loopback would let a
+    string that no parser understands past a check whose whole job is to decide where it points."""
+    with pytest.raises(ValueError, match="CHIMERA_API_BASE"):
+        _base("http://[isto-nao-e-um-host")

--- a/tests/test_a_secret_must_not_become_a_durable_fact.py
+++ b/tests/test_a_secret_must_not_become_a_durable_fact.py
@@ -1,0 +1,99 @@
+"""A secret typed after "remember that" went to disk whole, and came back inside future prompts.
+
+`grep -rn "redact|secret|sanitiz" chimera/memory/` returned nothing. The trace redacts, the crash
+reason redacts, the code session redacts — memory did not, and memory is the surface with the
+longest reach: a fact written today is read back into the system prompt of every matching
+conversation from now on.
+
+Fixed at the manager rather than at the two call sites. `ChatSession` and the desktop coding turn
+both parse "remember that …" and hand the text to `remember`, and any future writer would be one
+forgotten call away from the same hole — the same reasoning that put the memory admission gate on
+the default instead of on `code_api`.
+
+`redact` is narrow on purpose and that constraint is louder here than anywhere else: a memory this
+function mangles is a fact the agent will act on, forever, in a form nobody wrote. Most of the
+weight below is on what must survive untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.memory.manager import MemoryManager
+from chimera.memory.store import MemoryStore
+
+
+@pytest.fixture
+def memoria(tmp_path: Path) -> MemoryManager:
+    return MemoryManager(MemoryStore(tmp_path / "m.json"))
+
+
+SEGREDOS = [
+    ("a chave da produção é sk-proj-AAAAAAAAAAAAAAAAAAAAAA", "sk-proj-AAAAAAAAAAAAAAAAAAAAAA"),
+    ("o token é ghp_" + "B" * 30, "ghp_" + "B" * 30),
+    ("o banco fica em postgresql://postgres:senhaReal123@db.co:5432/x", "senhaReal123"),
+    ("o webhook é https://discord.com/api/webhooks/123/aBcDeF-gH1jKlMnOpQrStUvW",
+     "aBcDeF-gH1jKlMnOpQrStUvW"),
+    ("chame com Authorization: Bearer AbCdEfGhIjKlMnOpQrStUvWxYz012345", "AbCdEfGhIjKlMnOpQrStUvWxYz012345"),
+]
+
+
+@pytest.mark.parametrize(("texto", "segredo"), SEGREDOS)
+def test_a_secret_never_reaches_the_store(memoria: MemoryManager, texto: str, segredo: str) -> None:
+    _op, item = memoria.remember(texto, source="chat")
+
+    assert segredo not in item.content
+    assert all(segredo not in guardado.content for guardado in memoria.store.all())
+
+
+def test_the_fact_is_still_a_fact(memoria: MemoryManager) -> None:
+    """Masking must leave something worth recalling. "the production key is [redacted]" is a useful
+    memory — it says a key exists and where it belongs. `[redacted]` alone is not."""
+    _op, item = memoria.remember("a chave da produção é sk-proj-AAAAAAAAAAAAAAAAAAAAAA")
+
+    assert "chave da produção" in item.content
+    assert len(item.content) > 20
+
+
+# --------------------------------------------------------------- what must survive
+
+
+ORDINARIOS = [
+    "o projeto usa Postgres na porta 5432",
+    "o Bruno prefere respostas em português",
+    "a reunião de segunda é às 9h",
+    "o repositório é github.com/brcampidelli/chimera-agent",
+    "rodar os testes com `python -m pytest tests/ -q`",
+    "o build quebra quando o Node é menor que 20",
+]
+
+
+@pytest.mark.parametrize("texto", ORDINARIOS)
+def test_an_ordinary_fact_is_stored_verbatim(memoria: MemoryManager, texto: str) -> None:
+    """The constraint that matters most on this surface. A memory this mangles is a fact the agent
+    acts on, forever, in a form nobody wrote — and unlike a trace, nobody re-reads it to notice."""
+    _op, item = memoria.remember(texto)
+
+    assert item.content == texto
+
+
+# --------------------------------------------------------------- the machinery still works
+
+
+def test_dedup_still_sees_two_writes_of_the_same_secret_as_one(memoria: MemoryManager) -> None:
+    """Masking happens before the duplicate check, or the same fact written twice would land twice —
+    identical after masking, different before it."""
+    memoria.remember("a chave é sk-proj-AAAAAAAAAAAAAAAAAAAAAA")
+    op, _item = memoria.remember("a chave é sk-proj-AAAAAAAAAAAAAAAAAAAAAA")
+
+    assert op == "NOOP"
+
+
+def test_taint_still_travels(memoria: MemoryManager) -> None:
+    """The provenance rule is untouched: a fact learned during a run that read untrusted content is
+    still marked, and masking must not launder that."""
+    _op, item = memoria.remember("algo aprendido", provenance="tainted")
+
+    assert item.provenance == "tainted"

--- a/tests/test_cron_delivery.py
+++ b/tests/test_cron_delivery.py
@@ -23,7 +23,7 @@ from chimera.scheduler.delivery import (
     clip,
     deliver_to_webhook,
     payload_for,
-    redact,
+    webhook_host_only,
 )
 
 
@@ -221,7 +221,7 @@ def test_the_app_uses_this_sink_rather_than_one_of_its_own() -> None:
 def test_the_url_is_never_repeated_in_full() -> None:
     """A webhook URL is a credential: whoever holds it can post in that channel."""
     url = "https://discord.com/api/webhooks/123456789/segredo-que-nao-pode-vazar"
-    escondida = redact(url)
+    escondida = webhook_host_only(url)
 
     assert "segredo-que-nao-pode-vazar" not in escondida
     assert "123456789" not in escondida

--- a/tests/test_the_place_gives_the_secret_away.py
+++ b/tests/test_the_place_gives_the_secret_away.py
@@ -1,0 +1,122 @@
+"""Six of seven credential shapes went to disk intact, because none of them look like a credential.
+
+`redact` catches two things: values it can read out of this process's environment, and six string
+shapes. That is honest about its own limits — the module docstring says so — but it leaves a whole
+class untouched, and the class is not exotic. Measured, seven strings in, one masked:
+
+    INTACTO https://admin:p4ssw0rd@painel.interno/api
+    INTACTO https://api.exemplo.com/v1/dados?api_key=chave-de-teste-nao-real
+    INTACTO https://discord.com/api/webhooks/1234567890/aBcDeF-gH1jKl
+    INTACTO x-api-key: cabecalho-de-teste-nao-real
+    INTACTO postgresql://postgres:senha@db.supabase.co:5432/postgres
+    INTACTO Cookie: session=eyJhbGciOiJIUzI1NiJ9abcdef
+  MASCARADO sk-proj-AAAAAAAAAAAAAAAAAAAAAA
+
+None of the six needs to be recognised. The **place** gives them away: userinfo in a URL, a query
+parameter whose NAME is `api_key`, an `Authorization` header, a database DSN. A pattern list is
+guessing at the string; these are structural.
+
+This is not hypothetical here. Delivery on the 24/7 deployment goes through a Discord webhook whose
+URL *is* the secret, and `steplog` — which writes every tool's arguments and result to a file that
+lives for weeks — redacts with this function.
+
+Every fixture value below is a word, never a random-looking string. That is not cosmetic: a
+high-entropy value can be caught by a SHAPE rule on its own, so a test written with one cannot say
+which of the two mechanisms fired — and this whole change is the claim that the place is enough.
+It is also what the repository's own secret scanner requires, and rightly: no scanner can tell a
+test's fake key from a real one, so the fixture must not look like a key. An allowlist entry would
+have been the other way to make the gate quiet, and it would have carved the hole in this exact
+file.
+
+The quoted-header case says `wget --header=` and not `curl -H` for the same reason, and the reason
+corroborates the change: gitleaks' `curl-auth-header` rule fires on `curl -H 'x-api-key: …'` for
+ANY value, including `nao-e-real`, because it is not reading the value at all — it is reading the
+place. That is this pull request's thesis, arrived at independently by a different tool.
+
+The tests below spend as much weight on what must NOT be masked. A redactor that eats ordinary
+output makes the trace useless, and a useless trace gets turned off; that is written in the module's
+own docstring and it is the constraint that shapes every pattern here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.core.redact import MASK, redact
+
+VAZA = [
+    ("https://admin:p4ssw0rd-secreta@painel.interno/api", "p4ssw0rd-secreta", "userinfo de URL"),
+    ("veja https://api.exemplo.com/v1/d?api_key=chave-de-teste-nao-real agora",
+     "chave-de-teste-nao-real", "parâmetro cujo NOME é api_key"),
+    ("POST https://api.x.com/?token=token-de-teste-nao-real", "token-de-teste-nao-real", "token= na query"),
+    ("wget --header='x-api-key: cabecalho-de-teste-nao-real' https://api.x.com",
+     "cabecalho-de-teste-nao-real", "cabeçalho x-api-key"),
+    ("Authorization: Basic dXNlcjpzZW5oYQ==", "dXNlcjpzZW5oYQ==", "cabeçalho Authorization"),
+    ("Cookie: session=eyJhbGciOiJIUzI1NiJ9abcdef", "eyJhbGciOiJIUzI1NiJ9abcdef", "cookie"),
+    ("postgresql://postgres:senhaDoBanco123@db.supabase.co:5432/postgres",
+     "senhaDoBanco123", "senha num DSN de banco"),
+    ("https://discord.com/api/webhooks/1234567890/aBcDeF-gH1jKlMnOpQrStUvW",
+     "aBcDeF-gH1jKlMnOpQrStUvW", "o caminho de um webhook, que É o segredo"),
+]
+
+
+@pytest.mark.parametrize(("texto", "segredo", "porque"), VAZA)
+def test_a_secret_given_away_by_its_place_is_masked(texto: str, segredo: str, porque: str) -> None:
+    assert segredo not in redact(texto), porque
+
+
+@pytest.mark.parametrize(("texto", "segredo", "porque"), VAZA)
+def test_the_line_still_says_what_it_was(texto: str, segredo: str, porque: str) -> None:
+    """Masking must leave a diagnosable line. A trace that reads `[redacted]` and nothing else tells
+    whoever opens it that something happened to a URL — not which host, which parameter, or which
+    request. The point of the file is to answer that.
+    """
+    limpo = redact(texto)
+
+    assert MASK in limpo
+    assert len(limpo) > len(MASK) + 4
+
+
+# --------------------------------------------------------------- what must survive
+
+
+PRESERVAR = [
+    ("https://api.exemplo.com/v1/usuarios?page=2&limit=50", "paginação não é credencial"),
+    ("https://github.com/brcampidelli/chimera-agent/pull/283", "uma URL comum"),
+    ("veja o arquivo em https://exemplo.com/docs/guia.html#secao", "âncora e caminho"),
+    ("def somar(a: int, b: int) -> int:\n    return a + b", "código"),
+    ("Content-Type: application/json", "um cabeçalho que não é credencial"),
+    ("Accept-Language: pt-BR,pt;q=0.9", "outro"),
+    ("postgresql://db.supabase.co:5432/postgres", "um DSN SEM senha"),
+    ("https://api.exemplo.com/?query=como+redigir+segredos", "um parâmetro de busca"),
+    ("O erro foi: connection refused (ECONNREFUSED) em 127.0.0.1:5432", "uma mensagem de erro"),
+]
+
+
+@pytest.mark.parametrize(("texto", "porque"), PRESERVAR)
+def test_ordinary_text_is_untouched(texto: str, porque: str) -> None:
+    """The constraint that shapes every pattern above, and the one the module's docstring names: a
+    redactor that eats ordinary output makes the trace useless, and a useless trace gets turned
+    off."""
+    assert redact(texto) == texto, porque
+
+
+def test_a_host_is_never_masked() -> None:
+    """The host is what makes a leaked line diagnosable at all — and it is not the secret."""
+    assert "painel.interno" in redact("https://admin:senha-secreta@painel.interno/api")
+
+
+def test_the_parameter_name_survives_its_value() -> None:
+    """`api_key=[redacted]` says a key was sent; `[redacted]` says a request happened."""
+    assert "api_key=" in redact("https://x.com/?api_key=chave-de-teste-nao-real")
+
+
+def test_the_old_shapes_still_work() -> None:
+    """The first net is not replaced by the second. A regression here would trade one class of leak
+    for another, which is the failure mode of adding a layer instead of a rule."""
+    assert "sk-proj-AAAAAAAAAAAAAAAAAAAAAA" not in redact("chave sk-proj-AAAAAAAAAAAAAAAAAAAAAA aqui")
+    assert "ghp_" + "A" * 30 not in redact("token ghp_" + "A" * 30)
+
+
+def test_an_empty_string_is_returned_as_is() -> None:
+    assert redact("") == ""


### PR DESCRIPTION
Group D of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8), and it continues #282.

## 13 · Six of seven credential shapes went to disk intact

Measured, not read — seven strings through `redact`:

```
  INTACTO https://admin:p4ssw0rd-secreta@painel.interno/api
  INTACTO https://api.exemplo.com/v1/dados?api_key=A1b2C3d4E5f6G7h8I9j0
  INTACTO https://discord.com/api/webhooks/1234567890/aBcDeF-gH1jKlMnOpQ
  INTACTO x-api-key: 8f3a91bc44de27105ffe
  INTACTO postgresql://postgres:senhaDoBanco123@db.supabase.co:5432/post
  INTACTO Cookie: session=eyJhbGciOiJIUzI1NiJ9abcdef
MASCARADO sk-proj-AAAAAAAAAAAAAAAAAAAAAA
```

**None of the six needs to be recognised.** The *place* gives it away: userinfo in a URL, a query parameter whose NAME is `api_key`, an `Authorization` header, a database DSN, a chat webhook path. A pattern list guesses at the string; these are structural, and a token minted by a remote API has no shape a list can hold.

This is not hypothetical here. Delivery on the 24/7 deployment goes through a Discord webhook whose URL **is** the secret, and `steplog` — which writes every tool's arguments and result to a file that lives for weeks — redacts with this function.

**Every place keeps its context.** `api_key=[redacted]` says a key was sent; a line reduced to `[redacted]` says only that a request happened, and the file exists to answer more than that. The host is never masked — it is what makes a leaked line diagnosable, and it is not the secret.

**Nine must-not-touch cases** guard the other direction: pagination, ordinary URLs, code, `Content-Type`, a DSN *without* a password, a search query, an error message. A redactor that eats ordinary output makes the trace useless, and a useless trace gets turned off — the module's own docstring.

## 14 · Two functions were called `redact`

| | contract | used by |
|---|---|---|
| `delivery.redact` | strips a webhook's secret path — correct and strong | delivery failure logs |
| `core.redact.redact` | masks credentials inside arbitrary text | `steplog`, the crash reason, the code session |

A webhook URL has no credential *shape* in it, so reaching for the wrong one leaves the whole path in the log. Renamed to `webhook_host_only`.

## 15 · Memory wrote secrets to disk unredacted

```
$ grep -rn "redact|secret|sanitiz" chimera/memory/
(nothing)
```

The trace redacts, the crash reason redacts, the code session redacts. Memory did not — and memory has the longest reach of any surface here: a fact written today is read back into the system prompt of every matching conversation from now on, and nothing re-reads it to notice.

Masked in the **manager**, not at the call sites: `ChatSession` and the desktop turn both parse "remember that …" and hand the text over, and the next writer would be one forgotten call from the same hole. Same reasoning that put the memory gate on the default in #283.

**Before the duplicate check**, deliberately: after it, the same fact written twice differs before masking and matches after, so it would land twice. Six ordinary facts are pinned as stored verbatim — a memory this function mangles is one the agent acts on forever, in a form nobody wrote.

## 16 · `CHIMERA_API_BASE` in cleartext to another host is refused

`_export_keys_to_env` puts every configured key into `os.environ`; `_provider_kwargs` applies `api_base` — a single global — to every call. Point it at a third-party OpenAI-compatible endpoint with `OPENAI_API_KEY` present, and the OpenAI key travels there.

A **footgun, not an exploit**: somebody typed the value, and the case the field exists for is untouched — its own comment says "self-hosted/OpenAI-compatible servers (Ollama, vLLM)", which is loopback. TLS is fine. Cleartext to somewhere else is the one reading with no legitimate version.

The host is **parsed**, never matched as a substring. The first version of that line was `host.startswith("127.")`, which accepts `127.0.0.1.atacante.com` — the exact mistake the docstring two lines above warns about. Both traps are now test cases, along with `http://evil.localhost.com`.

---

## Verification

**Eleven sabotages, eleven caught**, including the over-zealous direction of every fix: masking a whole line instead of a value, treating every query parameter as sensitive, swallowing the host along with the userinfo, refusing `https://` too, and redacting *after* the dedup so a duplicate secret lands twice.

`4604 passed, 18 skipped` · ruff and mypy (330 files) clean.

**Note for merge order:** `core/redact.py` is also touched by #282, which adds callers rather than patterns; `config.py` is untouched elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)