### PR TITLE
fix(state): tell a format change from a corrupt file, and stamp the home

### DIFF
--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -440,6 +440,7 @@ def doctor(
     # paying LiteLLM's import to check is worth it — and where an unavailable LiteLLM has to degrade
     # to saying nothing, never to a warning that might be wrong. The five with settings fields are
     # never questioned; only what was discovered from the environment.
+    from chimera.core import state_version
     from chimera.providers.discovery import generic_providers, litellm_known
 
     discovered = generic_providers()
@@ -456,6 +457,18 @@ def doctor(
     table.add_row("Python", platform.python_version())
     table.add_row("Platform", platform.platform())
     table.add_row("Home (state dir)", str(settings.home))
+    # WHICH version wrote that directory, which nothing recorded until now: ~27 artefacts live under
+    # it and not one carried a version, so every question about an upgrade was answered by guessing.
+    # Stamped here rather than at import: `doctor` is the command whose job is to know the state of
+    # this machine, and stamping from a library import would write to disk on `import chimera`.
+    marca = state_version.stamp(settings.home)
+    if not marca.known:
+        estado = "[yellow]not recorded before now[/yellow]"
+    elif marca.chimera_version == __version__:
+        estado = marca.chimera_version
+    else:
+        estado = f"[yellow]{marca.chimera_version} -> {__version__}[/yellow]"
+    table.add_row("State written by", estado)
     table.add_row("Default model", settings.default_model)
     table.add_row(
         "Configured providers",

--- a/chimera/core/state_format.py
+++ b/chimera/core/state_format.py
@@ -1,0 +1,63 @@
+"""Telling "this file is corrupt" apart from "this file is the previous version".
+
+Five readers in this package skip a record they cannot validate and carry on, and the reason is
+sound: one hand-edited line must not cost every other memory, job or card. Each of them says so in a
+comment.
+
+What none of them could say is which of two very different things happened. A truncated last object
+is one bad record among fifty. A field that became required in this release is fifty bad records out
+of fifty — and the reader then returns an empty collection, which the store's own `save()` writes
+back over the file a moment later. The daemon does that every minute, with nobody watching, and the
+log carries fifty identical warnings that read like noise.
+
+So the rule is about the RATIO, not the record: losing a few entries is tolerance working, and
+losing all of them is a format that moved. In that case the load did not happen, and a store that
+did not load must not be allowed to persist what it thinks it holds.
+
+Deliberately not a schema version. That is a separate, larger change (a version stamp on the home,
+and a migration path); this is the guard that keeps the day it lands from being the day somebody's
+crontab is emptied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("core.state_format")
+
+
+class StaleFormatError(RuntimeError):
+    """Every record in a state file was rejected — the format moved, the file is not corrupt."""
+
+
+def looks_like_a_format_change(*, kept: int, skipped: int) -> bool:
+    """True when a file's records were rejected wholesale rather than individually.
+
+    One bad line among many is a bad line. Every line bad, with lines present, is this release
+    reading the previous release's file — and the difference decides whether the right answer is
+    "carry on with what loaded" or "do not touch this file".
+    """
+    return skipped > 0 and kept == 0
+
+
+def report(*, kept: int, skipped: int, what: str, path: Path) -> bool:
+    """Log the skips at the severity they deserve, and say whether the load is untrustworthy.
+
+    Returns True when the caller should treat the load as not having happened. The severity split is
+    the point: a handful of skipped records is a warning somebody may read later, and a wholesale
+    rejection is an error somebody has to read now, because the alternative is a file quietly
+    replaced with an empty one.
+    """
+    if not skipped:
+        return False
+    if looks_like_a_format_change(kept=kept, skipped=skipped):
+        _log.error(
+            "every %s in %s was rejected (%d of %d) — this looks like a file written by another "
+            "version, not a corrupt one; refusing to treat it as empty",
+            what, path, skipped, skipped,
+        )
+        return True
+    _log.warning("skipped %d malformed %s in %s (kept %d)", skipped, what, path, kept)
+    return False

--- a/chimera/core/state_version.py
+++ b/chimera/core/state_version.py
@@ -1,0 +1,93 @@
+"""Which version wrote the state directory, so a version can tell it is reading an older one.
+
+There are ~27 distinct artefacts under the home — `runs.jsonl`, `traces.jsonl`, `jobs.json`,
+`memory.json`, `memory.db`, `runs.db`, the session and skill files — and none of them carried a
+version. `grep schema_version|first_run|last_version|PRAGMA user_version` over the package returned
+nothing, so the process could not *detect* that it was running against an older layout, let alone do
+anything about it.
+
+The immediate value is not migrating anything. It is being able to SAY "this home was created by
+0.31 and you are on 0.48" — because without that, every question about an upgrade is answered by
+guessing, and the answers are indistinguishable from a bug.
+
+Deliberately small. One file, two fields, read on demand and never in a hot path. A migration
+registry belongs here later; putting one in now would be scaffolding around a house with no door.
+The behaviour that already exists — the tolerant readers, the optional field with an honest default,
+the SQLite column check in `memory/sqlite_store.py` — is the right pattern and stays where it is.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("core.state_version")
+
+FILENAME = "state_version.json"
+
+#: The layout number, bumped when an artefact under the home changes shape in a way a previous
+#: version cannot read. Separate from the package version on purpose: most releases change no file
+#: format at all, and tying the two would make every release look like a migration.
+STATE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class StateStamp:
+    """What a home says about itself. Every field may be empty on a home that predates the stamp."""
+
+    chimera_version: str = ""
+    state_version: int = 0
+
+    @property
+    def known(self) -> bool:
+        """False for a home written before this file existed — which is not the same as version 0.
+
+        The distinction is the whole point of an unknown: "created before we recorded it" and
+        "created by the first version that did" are different facts, and reporting the first as the
+        second invents evidence about a machine nobody looked at.
+        """
+        return bool(self.chimera_version) or self.state_version > 0
+
+
+def read(home: Path) -> StateStamp:
+    """What this home was stamped with, or an empty stamp. Never raises."""
+    path = Path(home) / FILENAME
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return StateStamp()
+    if not isinstance(data, dict):
+        return StateStamp()
+    return StateStamp(
+        chimera_version=str(data.get("chimera_version") or ""),
+        state_version=int(data.get("state_version") or 0),
+    )
+
+
+def stamp(home: Path) -> StateStamp:
+    """Record this version against the home, and return what was there BEFORE.
+
+    Returns the previous stamp so a caller can say what changed. Writing unconditionally rather than
+    only-if-absent, because the useful question is "which version last touched this", and a home
+    carried forward through five releases that only records the first answers a question nobody
+    asked.
+
+    Never raises: a home that cannot be stamped is a home that keeps working without the stamp,
+    which is strictly better than a process that will not start because of a bookkeeping file.
+    """
+    from chimera import __version__
+
+    anterior = read(home)
+    path = Path(home) / FILENAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"chimera_version": __version__, "state_version": STATE_VERSION}, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:  # pragma: no cover - disk-shaped failure
+        _log.debug("could not stamp the state directory: %s", exc)
+    return anterior

--- a/chimera/governance/audit.py
+++ b/chimera/governance/audit.py
@@ -290,13 +290,25 @@ class AuditLog:
         raise AssertionError("unreachable: the last attempt always writes")
 
     def entries(self) -> list[dict[str, Any]]:
+        """Every entry that parses, in order.
+
+        Per line, not per file. This was a list comprehension around a bare `json.loads`, so one
+        truncated line — the ordinary outcome of a crash during an append — made the whole log
+        unreadable, including the entries written BEFORE the crash, which are the ones an incident
+        needs. A line that does not parse is one entry lost, and `verify()` will report the chain
+        break at that point, which is the honest answer.
+        """
         if not self.path.exists():
             return []
-        return [
-            json.loads(line)
-            for line in self.path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
+        saida: list[dict[str, Any]] = []
+        for numero, line in enumerate(self.path.read_text(encoding="utf-8").splitlines(), 1):
+            if not line.strip():
+                continue
+            try:
+                saida.append(json.loads(line))
+            except ValueError:
+                _log.warning("unreadable audit line %d in %s", numero, self.path)
+        return saida
 
     def verify(self, entries: list[dict[str, Any]] | None = None) -> ChainCheck:
         """Walk the chain and report the first break.

--- a/chimera/kanban/board.py
+++ b/chimera/kanban/board.py
@@ -7,6 +7,7 @@ import threading
 import uuid
 from pathlib import Path
 
+from chimera.core.state_format import report
 from chimera.kanban.models import Column, KanbanCard
 from chimera.telemetry import get_logger
 
@@ -26,30 +27,54 @@ class KanbanBoard:
     def __init__(self, path: Path) -> None:
         self.path = Path(path)
         self._cards: dict[str, KanbanCard] = {}
+        #: True when the file could not be read, or nothing in it validated. A stale board does not
+        #: write: `save()` replaces the file wholesale.
+        self.stale = False
         # Re-entrant: the public mutators call `save()`, which takes it again.
         self._lock = threading.RLock()
         self.load()
 
     def load(self) -> None:
         self._cards = {}
+        self.stale = False
         if not self.path.exists():
             return
-        raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
+        # Inside a handler now. It sat outside, so the per-card tolerance below was unreachable for
+        # the one failure that actually happens — a write cut short — and a truncated file took the
+        # whole board down. `memory/store.py` learned this and wrote it in its own docstring.
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8") or "[]")
+        except (OSError, ValueError) as exc:
+            _log.error("could not read the kanban file %s: %s", self.path, exc)
+            self.stale = True
+            return
+        pulados = 0
         for item in raw:
             # Skip a single malformed card (schema drift, hand-edit) instead of aborting the whole
             # load — one bad entry must not make every board command crash.
             try:
                 card = KanbanCard.model_validate(item)
             except ValueError as exc:
-                _log.warning("skipping malformed kanban card: %s", exc)
+                _log.debug("malformed kanban card: %s", exc)
+                pulados += 1
                 continue
             self._cards[card.id] = card
+        self.stale = report(
+            kept=len(self._cards), skipped=pulados, what="kanban card", path=self.path
+        )
 
     def save(self) -> None:
         with self._lock:
             self._save_locked()
 
     def _save_locked(self) -> None:
+        if self.stale:
+            _log.error(
+                "refusing to write %s: it was not read successfully (truncated, or a format from "
+                "another version)",
+                self.path,
+            )
+            return
         self.path.parent.mkdir(parents=True, exist_ok=True)
         data = [card.model_dump() for card in self._cards.values()]
         # Atomic write: a crash mid-write must not truncate the board and lose every card.

--- a/chimera/memory/manager.py
+++ b/chimera/memory/manager.py
@@ -9,6 +9,7 @@ memory-merge (which must never overwrite existing history blindly).
 from __future__ import annotations
 
 import re
+import time
 import uuid
 from collections.abc import Callable
 
@@ -27,8 +28,18 @@ def _normalize(text: str) -> str:
 class MemoryManager:
     """Curates a :class:`MemoryStore`."""
 
-    def __init__(self, store: MemoryBackend, *, embed: EmbedFn | None = None) -> None:
+    def __init__(
+        self,
+        store: MemoryBackend,
+        *,
+        embed: EmbedFn | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
         self.store = store
+        #: Injected so a test can write a fact at a chosen time. `failover.py` takes its clock the
+        #: same way, and for the same reason: a timestamp nothing can control is a timestamp nothing
+        #: can assert.
+        self._clock = clock
         # Opt-in semantic recall: when an embedder is supplied, ``search`` ranks by cosine
         # similarity (bridges paraphrases keyword search can't). Absent/failing embedder ->
         # the keyword/FTS path always remains as a fallback.
@@ -61,6 +72,7 @@ class MemoryManager:
             source=source,
             provenance=provenance,
             project=project,
+            created_at=self._clock(),
         )
         self.store.add(item)
         return item

--- a/chimera/memory/models.py
+++ b/chimera/memory/models.py
@@ -43,4 +43,15 @@ class MemoryItem(BaseModel):
     #: ``None`` is the migration. Every fact written before this field existed has no project and is
     #: therefore global, which is what it always effectively was — nobody loses a memory by updating.
     project: str | None = None
+    created_at: float | None = None
+    """When this fact was written, as epoch seconds, or ``None`` for one written before the field.
+
+    ``None`` is the migration, exactly as ``project`` above: a memory that predates this has no age
+    and must not be given a plausible one — a fact stamped with the moment of the upgrade would
+    read as written today, which is the opposite of what it is.
+
+    Recency had no source before this. :func:`chimera.memory.value.rank` uses POSITION in the list
+    as the proxy and says so, and nothing could tell a reader that a `file:line` citation in a
+    six-month-old memory may have moved — the age was simply not recorded."""
+
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/chimera/memory/store.py
+++ b/chimera/memory/store.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Protocol
 
 from chimera.core.filelock import atomic_write_text, exclusively, read_text
+from chimera.core.state_format import report
 from chimera.memory.models import MemoryItem, MemoryKind
 from chimera.telemetry import get_logger
 
@@ -50,6 +51,8 @@ class MemoryStore:
         # processes) are serialised by the file lock instead — always taken second, so the ordering
         # is consistent and there is no cycle to deadlock on.
         self._lock = threading.RLock()
+        #: True when the file exists and NOTHING in it validated — see :mod:`chimera.core.state_format`.
+        self.stale = False
         self.load()
 
     def load(self) -> None:
@@ -71,18 +74,34 @@ class MemoryStore:
         if not isinstance(raw, list):
             _log.warning("memory store at %s is not a list; ignoring", self.path)
             return
+        pulados = 0
         for item in raw:
             # Skip a single malformed record (hand-edit, schema drift, truncated last object) instead
             # of aborting the whole load — one bad entry must not lose every other memory.
             try:
                 obj = MemoryItem.model_validate(item)
             except ValueError as exc:
-                _log.warning("skipping malformed memory record: %s", exc)
+                _log.debug("malformed memory record: %s", exc)
+                pulados += 1
                 continue
             self._items[obj.id] = obj
+        # All of them rejected is a file from another version, and this store is rewritten in full on
+        # every add. Refusing to write is the difference between "these facts did not load" and
+        # "these facts are gone".
+        self.stale = report(
+            kept=len(self._items), skipped=pulados, what="memory record", path=self.path
+        )
 
     def _write(self) -> None:
         """Serialise the current items to disk atomically. Assumes the caller holds the locks."""
+        if self.stale:
+            # A store that could not read the file does not know what the file holds. Writing what
+            # it thinks it holds turns "these facts did not load" into "these facts are gone".
+            _log.error(
+                "refusing to write %s: it was not read successfully (a format from another version)",
+                self.path,
+            )
+            return
         data = [item.model_dump() for item in self._items.values()]
         atomic_write_text(self.path, json.dumps(data, indent=2))
 

--- a/chimera/rag/store.py
+++ b/chimera/rag/store.py
@@ -160,13 +160,24 @@ class ChunkStore:
         self._conn.commit()
         return len(rows)
 
-    def embed_missing(self, embed: EmbedFn, *, limit: int = 100_000) -> int:
+    def embed_missing(self, embed: EmbedFn, *, limit: int = 100_000, embedder: str = "") -> int:
         """Embed the chunks that have no vector yet. Returns how many were embedded.
 
         Resumable by construction: a run that dies halfway leaves the vectors it wrote, and the next
         call picks up the rest. Nothing here retries a failed batch — a provider that is down should
         surface as "some chunks are not embedded" rather than as a loop nobody can stop.
+
+        ``embedder`` names the model producing the vectors, and changing it invalidates every vector
+        already stored. Nothing detected that: `embed_missing` only touches `WHERE vector IS NULL`,
+        so old vectors of the old dimension stayed forever; `_cosine` returns 0.0 when the lengths
+        differ, the `score > 0` filter then drops every one of them, and `stats()` kept counting
+        them as embedded. The index reported healthy and returned nothing. The `meta` table this
+        checks against existed with three accessors and no callers.
         """
+        # BEFORE selecting what is pending. Checking after the first batch does nothing in the
+        # case that matters — an index that is fully embedded has no pending rows, so the loop never
+        # runs and the stale vectors stay stale forever.
+        self._align_embedder(embed, embedder)
         pending = self._conn.execute(
             "SELECT ident, text FROM chunks WHERE vector IS NULL LIMIT ?", (limit,)
         ).fetchall()
@@ -175,6 +186,8 @@ class ChunkStore:
             batch = pending[start : start + EMBED_BATCH]
             try:
                 vectors = embed([row["text"] for row in batch])
+                if start == 0 and vectors and embedder:
+                    self._record_embedder(embedder, len(vectors[0]))
             except Exception as exc:  # noqa: BLE001 — a dead embedder is a degraded index, not a crash
                 _log.warning("embedding failed after %d chunks: %s", done, exc)
                 break
@@ -188,6 +201,48 @@ class ChunkStore:
             self._conn.commit()
             done += len(batch)
         return done
+
+    def _record_embedder(self, embedder: str, dimension: int) -> None:
+        """Store the signature of whatever produced the vectors now in the table."""
+        self.set_meta("embedder", f"{embedder}:{dimension}")
+
+    def _align_embedder(self, embed: EmbedFn, embedder: str) -> None:
+        """Drop every stored vector when the embedder that would produce them has changed.
+
+        Derived artefacts are not migrated, they are rebuilt: there is no conversion from one
+        model's vector space to another's. Keeping the old ones costs a silent, permanent recall
+        failure — `_cosine` returns 0.0 on a length mismatch, the `score > 0` filter drops them all,
+        and `stats()` goes on counting them as embedded. Dropping them costs one re-embed, in the
+        log, which is the honest price of changing embedder.
+
+        The signature is name AND dimension, so a provider that resizes a model under the same slug
+        is caught too — the case nobody would think to look for. Learning the dimension costs one
+        embed of one short string, and only when a signature was already recorded: an index built
+        before this field existed has no signature and is left exactly as it is, because treating an
+        unknown as a mismatch would throw away every existing index on upgrade.
+        """
+        anterior = self.get_meta("embedder")
+        if not embedder or not anterior:
+            return
+        try:
+            sonda = embed(["x"])
+        except Exception as exc:  # noqa: BLE001 — a dead embedder must not empty the index
+            _log.warning("could not check the embedder signature: %s", exc)
+            return
+        if not sonda:
+            return
+        assinatura = f"{embedder}:{len(sonda[0])}"
+        if anterior == assinatura:
+            return
+        apagados = self._conn.execute(
+            "UPDATE chunks SET vector = NULL WHERE vector IS NOT NULL"
+        ).rowcount
+        self._conn.commit()
+        _log.warning(
+            "embedder changed (%s -> %s); dropped %d vectors, they will be rebuilt",
+            anterior, assinatura, apagados,
+        )
+        self.set_meta("embedder", assinatura)
 
     def set_meta(self, key: str, value: str) -> None:
         self._conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", (key, value))

--- a/chimera/scheduler/store.py
+++ b/chimera/scheduler/store.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from uuid import uuid4
 
+from chimera.core.state_format import report
 from chimera.scheduler.models import CronJob
 from chimera.telemetry import get_logger
 
@@ -20,6 +21,10 @@ class CronStore:
         self.path = Path(path)
         self._jobs: dict[str, CronJob] = {}
         self._mtime: float | None = None
+        #: True when the file exists and NOTHING in it validated — a format from another version
+        #: rather than a corrupt file. A stale store refuses to write, because it does not know what
+        #: the file holds and this one is read by a daemon and rewritten by the next mutation.
+        self.stale = False
         self.load()
 
     def _read_disk(self) -> dict[str, CronJob] | None:
@@ -39,13 +44,23 @@ class CronStore:
             _log.warning("cron store root is not a JSON list, keeping current jobs")
             return None
         jobs: dict[str, CronJob] = {}
+        pulados = 0
         for item in raw:
             try:
                 job = CronJob.model_validate(item)
             except ValueError as exc:
-                _log.warning("skipping malformed cron entry: %s", exc)
+                _log.debug("malformed cron entry: %s", exc)
+                pulados += 1
                 continue
             jobs[job.id] = job
+        # Every entry rejected is a file written by another version, not a corrupt one — and `None`
+        # is already this method's word for "could not read it", which `load` handles by keeping
+        # what it has. Returning `{}` instead put an empty crontab in memory, and the next `add` or
+        # `remove` wrote that emptiness to disk. On the daemon that happens within a minute.
+        if report(kept=len(jobs), skipped=pulados, what="cron entry", path=self.path):
+            self.stale = True
+            return None
+        self.stale = False
         return jobs
 
     def load(self) -> None:
@@ -93,6 +108,14 @@ class CronStore:
             self._jobs.setdefault(jid, job)  # only ADD unknown jobs; never clobber our own updates
 
     def save(self) -> None:
+        if self.stale:
+            # Refused, loudly. A store that could not read the file does not know what the file
+            # holds, and writing what it thinks it holds is how an upgrade empties a crontab.
+            _log.error(
+                "refusing to write %s: it was not read successfully (a format from another version)",
+                self.path,
+            )
+            return
         self.path.parent.mkdir(parents=True, exist_ok=True)
         data = [job.model_dump() for job in self._jobs.values()]
         # Atomic write (unique temp + replace): the crontab is safety-critical — a plain write_text

--- a/tests/test_a_format_change_is_not_a_corrupt_file.py
+++ b/tests/test_a_format_change_is_not_a_corrupt_file.py
@@ -1,0 +1,161 @@
+"""One bad record is tolerance working. Every record bad is a file the next `save()` will erase.
+
+Five readers here skip what they cannot validate and carry on, each with a comment saying why: a
+hand-edit or a truncated last object must not cost every other entry. The rule is right and the
+severity was flat — the same warning either way, and the same empty collection returned.
+
+Empty is the dangerous part. The scheduler's store is read by a daemon every tick and written back
+by the next `add` or `remove`, so a `CronJob` field that becomes required in a release turns forty
+jobs into forty warnings nobody reads and then into `[]` on disk. The memory store has the same
+shape with a slower fuse.
+
+Two other readers had the opposite defect: a bare `json.loads` outside any handler, so a single
+truncated line took down the whole kanban board or the whole audit log — a lesson `memory/store.py`
+already learned and wrote down in its own docstring.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.core.state_format import looks_like_a_format_change
+from chimera.governance.audit import AuditLog
+from chimera.kanban.board import KanbanBoard
+from chimera.memory.store import MemoryStore
+from chimera.scheduler.store import CronStore
+
+# ------------------------------------------------------------------ the rule
+
+
+def test_one_bad_record_among_many_is_not_a_format_change() -> None:
+    assert looks_like_a_format_change(kept=49, skipped=1) is False
+
+
+def test_every_record_bad_is() -> None:
+    assert looks_like_a_format_change(kept=0, skipped=40) is True
+
+
+def test_an_empty_file_is_neither() -> None:
+    """A file with no records is not a format change — it is a file with no records, and refusing to
+    write to it would make a fresh install unusable."""
+    assert looks_like_a_format_change(kept=0, skipped=0) is False
+
+
+# ------------------------------------------------------------------ the crontab
+
+
+def _jobs(path: Path, *entries: dict[str, object]) -> None:
+    path.write_text(json.dumps(list(entries)), encoding="utf-8")
+
+
+VALIDO = {
+    "id": "a1", "name": "relatório", "trigger": "cron", "schedule": "* * * * *",
+    "action": "escreva", "enabled": True,
+}
+
+
+def test_a_crontab_from_another_version_is_not_read_as_empty(tmp_path: Path) -> None:
+    """The whole point. Two jobs that no longer validate are two jobs, not zero."""
+    caminho = tmp_path / "jobs.json"
+    _jobs(caminho, {"id": "a1", "campo_que_sumiu": 1}, {"id": "b2", "campo_que_sumiu": 2})
+
+    loja = CronStore(caminho)
+
+    assert loja.list() == []  # nothing loaded, which is honest
+    assert loja.stale is True  # and the store knows the load did not happen
+
+
+def test_it_refuses_to_overwrite_a_file_it_could_not_read(tmp_path: Path) -> None:
+    """The consequence that makes this worth a mechanism rather than a log line.
+
+    `save()` is called by the next `add` or `remove`, and the daemon reloads every tick. Without
+    this, an upgrade that adds a required field empties the crontab of a machine nobody is watching.
+    """
+    caminho = tmp_path / "jobs.json"
+    antes = json.dumps([{"id": "a1", "campo_que_sumiu": 1}])
+    caminho.write_text(antes, encoding="utf-8")
+
+    loja = CronStore(caminho)
+    loja.save()
+
+    assert caminho.read_text(encoding="utf-8") == antes
+
+
+def test_one_bad_job_among_good_ones_still_loads_the_good_ones(tmp_path: Path) -> None:
+    """Tolerance still works, and the store is not stale — this is the case the skip exists for."""
+    caminho = tmp_path / "jobs.json"
+    _jobs(caminho, VALIDO, {"id": "b2", "lixo": True})
+
+    loja = CronStore(caminho)
+
+    assert [j.id for j in loja.list()] == ["a1"]
+    assert loja.stale is False
+
+
+def test_a_healthy_store_still_saves(tmp_path: Path) -> None:
+    """The guard against a fix that makes the store read-only for everyone."""
+    caminho = tmp_path / "jobs.json"
+    _jobs(caminho, VALIDO)
+
+    loja = CronStore(caminho)
+    loja.remove("a1")
+
+    assert json.loads(caminho.read_text(encoding="utf-8")) == []
+
+
+def test_an_absent_file_is_not_stale(tmp_path: Path) -> None:
+    """A fresh install has no file, and a store that refused to write there would never start."""
+    loja = CronStore(tmp_path / "jobs.json")
+
+    assert loja.stale is False
+
+
+# ------------------------------------------------------------------ memory
+
+
+def test_memory_from_another_version_is_not_read_as_empty(tmp_path: Path) -> None:
+    caminho = tmp_path / "m.json"
+    caminho.write_text(json.dumps([{"conteudo": "sem id"}, {"conteudo": "outro"}]), encoding="utf-8")
+
+    loja = MemoryStore(caminho)
+
+    assert loja.stale is True
+
+
+def test_memory_refuses_to_overwrite_what_it_could_not_read(tmp_path: Path) -> None:
+    caminho = tmp_path / "m.json"
+    antes = json.dumps([{"conteudo": "sem id"}])
+    caminho.write_text(antes, encoding="utf-8")
+
+    loja = MemoryStore(caminho)
+    loja.save()
+
+    assert caminho.read_text(encoding="utf-8") == antes
+
+
+# ------------------------------------------------------------------ the two that crashed
+
+
+def test_a_truncated_kanban_file_does_not_take_the_board_down(tmp_path: Path) -> None:
+    """`json.loads` sat outside the handler, so the per-card tolerance below it was unreachable for
+    the one failure that actually happens: a write cut short."""
+    caminho = tmp_path / "kanban.json"
+    caminho.write_text('[{"id": "c1", "title": "meio', encoding="utf-8")
+
+    board = KanbanBoard(caminho)
+
+    assert board.cards() == []
+    assert board.stale is True
+
+
+def test_a_truncated_audit_log_still_reads_the_lines_before_it(tmp_path: Path) -> None:
+    """An append-only log truncated mid-line is the ordinary crash outcome, and the whole file was
+    unreadable because of it — including the entries written before the crash, which are the ones
+    an incident needs."""
+    caminho = tmp_path / "audit.jsonl"
+    caminho.write_text('{"type": "a", "prev": ""}\n{"type": "b", "pre', encoding="utf-8")
+
+    entradas = AuditLog(caminho).entries()
+
+    assert [e["type"] for e in entradas] == ["a"]

--- a/tests/test_a_memory_had_no_age.py
+++ b/tests/test_a_memory_had_no_age.py
@@ -1,0 +1,87 @@
+"""Nothing recorded when a fact was written, so nothing could say a citation had gone stale.
+
+`value.rank` uses POSITION in the list as the recency proxy and says so in its own docstring — which
+is the honest thing to write when the age is not available, and the age was not available: nothing
+in `MemoryItem` carried it.
+
+The cost is not the ranking. It is that a memory saying `agent.py:646 does X` reads exactly the same
+on the day it is written and six months later, after the line has moved — and a `file:line` citation
+makes a stale claim sound MORE authoritative, not less.
+
+`None` is the migration, exactly as `project` is one field above: a fact written before this existed
+has no age, and stamping it with the moment of the upgrade would make every old memory read as
+written today, which is the opposite of true.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.memory.manager import MemoryManager
+from chimera.memory.models import MemoryItem
+from chimera.memory.store import MemoryStore
+
+
+def _manager(tmp_path: Path, *, agora: float = 1_000_000.0) -> MemoryManager:
+    return MemoryManager(MemoryStore(tmp_path / "m.json"), clock=lambda: agora)
+
+
+def test_a_new_fact_carries_the_moment_it_was_written(tmp_path: Path) -> None:
+    item = _manager(tmp_path).add("o projeto usa Postgres")
+
+    assert item.created_at == 1_000_000.0
+
+
+def test_it_survives_the_round_trip(tmp_path: Path) -> None:
+    """A timestamp held only in memory answers nothing — the question is about a fact on disk that
+    has been there a while."""
+    _manager(tmp_path).add("o projeto usa Postgres")
+
+    voltou = MemoryStore(tmp_path / "m.json").all()[0]
+
+    assert voltou.created_at == 1_000_000.0
+
+
+def test_remember_stamps_it_too(tmp_path: Path) -> None:
+    """`remember` is the path the chat and the app both use, and `add` is what it calls — pinned
+    because a stamp only on the direct path would leave every user-written fact ageless."""
+    _op, item = _manager(tmp_path).remember("lembre que o voo é dia 12")
+
+    assert item.created_at == 1_000_000.0
+
+
+def test_a_fact_written_before_the_field_existed_has_no_age(tmp_path: Path) -> None:
+    """The migration. `None` means "we do not know", and that is the only true answer for a row
+    written by a version that did not record it."""
+    caminho = tmp_path / "m.json"
+    caminho.write_text(
+        json.dumps([{"id": "m1", "kind": "semantic", "content": "algo antigo"}]), encoding="utf-8"
+    )
+
+    assert MemoryStore(caminho).all()[0].created_at is None
+
+
+def test_an_old_fact_is_not_stamped_with_today(tmp_path: Path) -> None:
+    """The failure mode of a careless migration: filling the gap with `now` makes a six-month-old
+    memory read as written this morning — worse than not knowing, because it is confidently wrong.
+    """
+    caminho = tmp_path / "m.json"
+    caminho.write_text(
+        json.dumps([{"id": "m1", "kind": "semantic", "content": "algo antigo"}]), encoding="utf-8"
+    )
+    loja = MemoryStore(caminho)
+
+    loja.add(MemoryItem(id="m2", content="algo novo", created_at=2_000_000.0))
+
+    idades = {item.id: item.created_at for item in loja.all()}
+    assert idades == {"m1": None, "m2": 2_000_000.0}
+
+
+def test_the_clock_is_injected(tmp_path: Path) -> None:
+    """A timestamp nothing can control is a timestamp nothing can assert. `failover.py` takes its
+    clock the same way, for the same reason."""
+    primeiro = _manager(tmp_path, agora=10.0).add("a")
+    segundo = _manager(tmp_path, agora=20.0).add("b")
+
+    assert (primeiro.created_at, segundo.created_at) == (10.0, 20.0)

--- a/tests/test_a_vector_from_another_embedder_is_dead_weight.py
+++ b/tests/test_a_vector_from_another_embedder_is_dead_weight.py
@@ -1,0 +1,127 @@
+"""Changing embedder made the index return nothing, permanently, without one line in a log.
+
+`embed_missing` only touches `WHERE vector IS NULL`, so vectors written by a previous embedder stayed
+forever. `_cosine` returns 0.0 when the two lengths differ, the `score > 0` filter then drops every
+one of them, and `stats()` kept counting them as embedded. The index reported healthy and answered
+nothing — and `replace_all` deliberately preserves vectors by ident to avoid paying for a re-embed,
+so reindexing did not clear them either.
+
+The `meta` table that fixes this already existed, created on every open, with three accessors and
+**no callers anywhere in the repository**.
+
+A derived artefact is not migrated, it is rebuilt: there is no conversion from one model's vector
+space to another's. Dropping costs one re-embed and says so in the log; keeping costs a silent,
+permanent recall failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from chimera.rag.store import Chunk, ChunkStore
+
+
+def _chunks(n: int = 3) -> list[Chunk]:
+    return [
+        Chunk(path=f"a{i}.py", symbol=f"f{i}", kind="function", start_line=1, end_line=2,
+              text=f"def f{i}(): pass")
+        for i in range(n)
+    ]
+
+
+def _embedder(dim: int):
+    def embed(textos: list[str]) -> list[list[float]]:
+        return [[0.1] * dim for _ in textos]
+
+    return embed
+
+
+def test_a_new_embedder_rebuilds_the_vectors(tmp_path: Path) -> None:
+    """The whole point: the old vectors are gone and the new ones are written."""
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4), embedder="antigo")
+
+    reembedados = loja.embed_missing(_embedder(8), embedder="novo")
+
+    assert reembedados == 3
+    assert loja.stats()["embedded"] == 3
+
+
+def test_the_same_embedder_does_not_rebuild(tmp_path: Path) -> None:
+    """The guard against a fix that re-embeds the whole corpus on every run — which would cost real
+    money on a hosted embedder and make the resumability above worthless."""
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4), embedder="mesmo")
+
+    assert loja.embed_missing(_embedder(4), embedder="mesmo") == 0
+
+
+def test_the_same_name_at_a_different_size_still_rebuilds(tmp_path: Path) -> None:
+    """The name alone is not the signature. A provider that changes a model's dimension under the
+    same slug is exactly the case nobody would think to look for."""
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4), embedder="mesmo-nome")
+
+    assert loja.embed_missing(_embedder(16), embedder="mesmo-nome") == 3
+
+
+def test_an_index_that_never_recorded_one_is_not_wiped(tmp_path: Path) -> None:
+    """An index built before this field existed has vectors and no signature. Treating an unknown
+    signature as a mismatch would throw away every existing index on upgrade — the same reasoning
+    that makes an absent field mean "before this existed" rather than a value."""
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4))  # no name given, as the old caller did
+
+    assert loja.stats()["embedded"] == 3
+    assert loja.embed_missing(_embedder(4)) == 0
+
+
+def test_an_index_built_before_the_field_survives_being_named(tmp_path: Path) -> None:
+    """The upgrade case, and the one the test above could not show.
+
+    That one passes no embedder name, so the early return fires on the name and the signature check
+    is never reached — a sabotage that removed the "no signature recorded" half went undetected. An
+    index built by the previous release has vectors and no signature, and the FIRST run of this
+    release names its embedder. Treating that unknown as a mismatch throws away every existing index
+    on upgrade, which is the same rule an absent field follows everywhere else here.
+    """
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4))  # the old caller: no name, so nothing is recorded
+    assert loja.get_meta("embedder") == ""
+
+    reembedados = loja.embed_missing(_embedder(4), embedder="agora-com-nome")
+
+    # ZERO re-embeds, not "the vectors are there afterwards". Written the second way first, and it
+    # passed under sabotage: wiping the index rebuilds it, so the end state is identical either way
+    # and the only difference is the bill. On a hosted embedder over a real corpus that difference
+    # is the whole cost of the mistake.
+    assert reembedados == 0
+    assert loja.stats()["embedded"] == 3
+
+
+def test_the_signature_is_recorded(tmp_path: Path) -> None:
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4), embedder="modelo-x")
+
+    assert loja.get_meta("embedder") == "modelo-x:4"
+
+
+def test_a_dead_embedder_does_not_wipe_the_index(tmp_path: Path) -> None:
+    """The failure this must not turn into a data loss: an embedder that raises leaves the existing
+    vectors alone, because the signature is only compared once a real vector has come back."""
+    loja = ChunkStore(tmp_path / "i.sqlite3")
+    loja.replace_all(_chunks())
+    loja.embed_missing(_embedder(4), embedder="bom")
+
+    def morto(_textos: list[str]) -> list[list[float]]:
+        raise RuntimeError("provedor fora do ar")
+
+    loja.embed_missing(morto, embedder="outro")
+
+    assert loja.stats()["embedded"] == 3

--- a/tests/test_memory_graph_bench.py
+++ b/tests/test_memory_graph_bench.py
@@ -369,7 +369,11 @@ def test_bench_items_match_what_manager_add_builds(tmp_path: Path) -> None:
     stored = written.store.all()[0]
 
     reference = MemoryManager(MemoryStore(tmp_path / "reference.json")).add("Orion uses the queue.")
-    assert stored.model_dump(exclude={"id"}) == reference.model_dump(exclude={"id"})
+    # `created_at` is excluded alongside `id`, and for the same reason: it is the wall clock, and a
+    # bench whose output depends on when it ran is a bench whose seed does not determine its result.
+    # Ranking is unaffected — `value.rank` uses position, not this field.
+    ignorar = {"id", "created_at"}
+    assert stored.model_dump(exclude=ignorar) == reference.model_dump(exclude=ignorar)
     assert stored.id != reference.id  # the one field the bench controls
 
 

--- a/tests/test_the_home_did_not_know_who_made_it.py
+++ b/tests/test_the_home_did_not_know_who_made_it.py
@@ -1,0 +1,121 @@
+"""~27 artefacts under the home and not one of them said which version wrote it.
+
+    $ grep -rn "schema_version|migration_version|first_run|last_version|PRAGMA user_version" chimera/
+    (nothing)
+
+So the process could not detect it was reading an older layout — every question about an upgrade was
+answered by guessing, and a guess is indistinguishable from a bug to whoever is asking.
+
+This does not migrate anything, and that is deliberate. The value is being able to SAY "this home
+was created by 0.31 and you are on 0.48". A migration registry belongs here later; building one now
+would be scaffolding around a house with no door. What already exists — the tolerant readers, the
+optional field with an honest default, the column check in `memory/sqlite_store.py` — is the right
+pattern and stays where it is.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.core.state_version import FILENAME, STATE_VERSION, read, stamp
+
+
+def test_a_home_nobody_stamped_says_so(tmp_path: Path) -> None:
+    """`unknown` is its own answer. "Created before we recorded it" and "created by the first
+    version that did" are different facts, and reporting the first as the second invents evidence
+    about a machine nobody looked at."""
+    marca = read(tmp_path)
+
+    assert marca.known is False
+    assert marca.chimera_version == ""
+    assert marca.state_version == 0
+
+
+def test_stamping_records_this_version(tmp_path: Path) -> None:
+    from chimera import __version__
+
+    stamp(tmp_path)
+
+    marca = read(tmp_path)
+    assert marca.known is True
+    assert marca.chimera_version == __version__
+    assert marca.state_version == STATE_VERSION
+
+
+def test_stamping_returns_what_was_there_before(tmp_path: Path) -> None:
+    """The question worth answering is "what changed", and that needs the previous value — which is
+    gone the moment the new one is written."""
+    (tmp_path / FILENAME).write_text(
+        json.dumps({"chimera_version": "0.31.0", "state_version": 1}), encoding="utf-8"
+    )
+
+    anterior = stamp(tmp_path)
+
+    assert anterior.chimera_version == "0.31.0"
+    assert read(tmp_path).chimera_version != "0.31.0"
+
+
+def test_it_records_the_LAST_version_to_touch_the_home(tmp_path: Path) -> None:
+    """Written unconditionally, not only when absent: a home carried through five releases that
+    records only the first answers a question nobody asked."""
+    (tmp_path / FILENAME).write_text(
+        json.dumps({"chimera_version": "0.31.0", "state_version": 1}), encoding="utf-8"
+    )
+
+    stamp(tmp_path)
+    stamp(tmp_path)
+
+    assert read(tmp_path).chimera_version != "0.31.0"
+
+
+# ------------------------------------------------------------------ it never gets in the way
+
+
+def test_a_corrupt_stamp_reads_as_unknown(tmp_path: Path) -> None:
+    """This file is bookkeeping. A process that will not start because a bookkeeping file is
+    unreadable has turned a note into a dependency."""
+    (tmp_path / FILENAME).write_text("{isto nao e json", encoding="utf-8")
+
+    assert read(tmp_path).known is False
+
+
+def test_a_stamp_of_the_wrong_shape_reads_as_unknown(tmp_path: Path) -> None:
+    (tmp_path / FILENAME).write_text(json.dumps(["uma lista"]), encoding="utf-8")
+
+    assert read(tmp_path).known is False
+
+
+def test_stamping_an_unwritable_place_does_not_raise(tmp_path: Path) -> None:
+    """Same rule from the other side: a home that cannot be stamped keeps working without a stamp."""
+    ocupado = tmp_path / "arquivo"
+    ocupado.write_text("nao sou uma pasta", encoding="utf-8")
+
+    stamp(ocupado)  # must not raise
+
+    assert read(ocupado).known is False
+
+
+# ------------------------------------------------------------------ it is actually called
+
+
+def test_the_doctor_stamps_and_reports(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The wiring, asserted — because a module nothing calls is the exact defect this fixes.
+
+    `doctor` is the right caller: its job is to know the state of this machine, and stamping from a
+    library import would write to disk on `import chimera`.
+    """
+    from typer.testing import CliRunner
+
+    from chimera.cli.main import app
+    from chimera.config import get_settings
+
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path))
+    get_settings.cache_clear()
+    try:
+        saida = CliRunner().invoke(app, ["doctor"])
+
+        assert "State written by" in saida.stdout
+        assert read(tmp_path).known is True
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
Five defects in what the process writes to disk and reads back. Group E of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8).

---

## 17 · A file from another version was read as an empty file

Five readers skip a record they cannot validate and carry on, each with a comment saying why: one hand-edit or a truncated last object must not cost every other entry. **The rule is right.** The severity was flat, and the result was the same empty collection either way.

Empty is the dangerous half. The scheduler's store is read by a daemon every tick and written back by the next `add` or `remove` — so a `CronJob` field that becomes required in a release turns forty jobs into forty warnings nobody reads, and then into `[]` on disk, on a machine nobody is watching.

The rule is about the **ratio**, not the record: a few records lost is tolerance working; all of them lost, with records present, is this release reading the previous release's file. A store that did not load now refuses to write — it does not know what the file holds.

`CronStore` already had the right word for this (`_read_disk` returns `None` for "could not read it", and `load` then keeps what it has); it returned `{}` instead.

## 20 · Two readers crashed on one bad line

`json.loads` sat **outside** the handler in `kanban/board.py` and inside a bare list comprehension in `governance/audit.py`. A write cut short — the ordinary crash outcome for an append-only log — made the whole file unreadable, including the entries written *before* the crash, which are the ones an incident needs.

The lesson was already written down, with the cause, in `memory/store.py`'s own docstring.

## 18 · The home did not know which version wrote it

```
$ grep -rn "schema_version|migration_version|first_run|last_version|PRAGMA user_version" chimera/
(nothing)
```

~27 artefacts under the home and not one carried a version, so the process could not *detect* it was reading an older layout — every upgrade question was answered by guessing, and a guess is indistinguishable from a bug to whoever is asking.

**This migrates nothing, on purpose.** The value is being able to say "this home was created by 0.31 and you are on 0.48". A migration registry belongs here later; building one now would be scaffolding around a house with no door. `doctor` stamps and reports it — a library import must not write to disk, and `doctor`'s job is already to know the state of this machine.

## 19 · Changing embedder made the RAG index return nothing, permanently, silently

`embed_missing` only touches `WHERE vector IS NULL`, so vectors from a previous embedder stayed forever. `_cosine` returns `0.0` on a length mismatch, the `score > 0` filter then drops every one, and `stats()` kept counting them as embedded. The index reported healthy and answered nothing — and `replace_all` deliberately preserves vectors by ident, so reindexing did not clear them either.

The `meta` table that fixes this **already existed**, created on every open, with three accessors and no callers anywhere in the repository.

A derived artefact is rebuilt, not migrated: there is no conversion between vector spaces. The signature is name **and** dimension, so a provider that resizes a model under the same slug is caught too. An index built before this field existed has no signature and is left alone — treating an unknown as a mismatch would throw away every existing index on upgrade.

## 21 · A memory had no age

`value.rank` uses position in the list as the recency proxy and says so in its docstring, which is the honest thing to write when the age is not available. It was not available.

The cost is not the ranking. A memory saying `agent.py:646 does X` reads identically on the day it is written and six months later after the line moved — and a `file:line` citation makes a stale claim sound *more* authoritative.

`None` is the migration, as `project` already is: stamping an old fact with the moment of the upgrade would make every one of them read as written today.

---

## Verification

**Fifteen sabotages, fifteen caught**, after two escaped:

- one found a **plain omission** — I added `created_at` and wrote no test for it at all;
- one found an assertion measuring the wrong thing. `test_an_index_built_before_the_field_survives_being_named` checked that the index was populated afterwards — but wiping an index rebuilds it, so the end state is identical either way and the only difference is **the bill**. It now asserts zero re-embeds, which on a hosted embedder over a real corpus is the whole cost of the mistake.

One existing test moved: `test_bench_items_match_what_manager_add_builds` compares a hand-built item against what `add` produces, and caught the new field immediately — which is what it exists for. `created_at` is excluded alongside `id`, because it is the wall clock and a bench whose output depends on when it ran is a bench whose seed does not determine its result.

`4582 passed, 18 skipped` · ruff and mypy (332 files) clean · CLI snapshot regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)