### PR TITLE
fix(receipts): a stop is not a run that never happened, and a cut is not an end

### DIFF
--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -94,6 +94,44 @@ export class ApiError extends Error {
   }
 }
 
+
+/** Read an SSE body frame by frame, and say whether the stream ENDED or was CUT.
+ *
+ *  Eight loops did this inline, and every one of them read `{ value, done }` with no `try` around
+ *  it and no check afterwards. A connection dropped mid-stream either threw an unhandled rejection
+ *  or — worse, and this is the common case — surfaced as `done: true`, so the loop exited exactly as
+ *  it does on a clean finish. The client could not tell a turn that finished from a turn whose
+ *  server went away, and `onError` never fired for the second.
+ *
+ *  Returns the reason the read failed, or `null` for a stream that ended on its own terms. Nothing
+ *  here judges whether a TERMINAL FRAME arrived — that is each caller's contract, not the
+ *  transport's.
+ */
+async function readFrames(
+  body: ReadableStream<Uint8Array>,
+  onFrame: (frame: string) => void,
+): Promise<string | null> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
+      let sep: number;
+      while ((sep = buffer.indexOf("\n\n")) !== -1) {
+        onFrame(buffer.slice(0, sep));
+        buffer = buffer.slice(sep + 2);
+      }
+    }
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  if (buffer.trim()) onFrame(buffer);
+  return null;
+}
+
 /** The reason a request was refused, when the server gave one.
  *
  *  Every refusal in this app used to reach the screen as "400 Bad Request" — the status line,
@@ -656,35 +694,27 @@ export async function streamKanbanRun(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      const block = buffer.slice(0, sep);
-      buffer = buffer.slice(sep + 2);
-      let event = "";
-      let payload = "";
-      for (const line of block.split("\n")) {
-        if (line.startsWith("event:")) event = line.slice(6).trim();
-        else if (line.startsWith("data:")) payload += line.slice(5).trim();
-      }
-      if (!payload) continue;
-      try {
-        const data = JSON.parse(payload);
-        if (event === "card") handlers.onCard?.(data as DispatchOutcome);
-        else if (event === "conflict") handlers.onConflict?.((data as { paths: string[] }).paths);
-        else if (event === "done") handlers.onDone?.(data as { worked: number; error?: string });
-      } catch {
-        // A frame we cannot parse is one frame lost, not a broken dispatch: the board is the
-        // source of truth and a refetch will show what actually happened.
-      }
+  const cut = await readFrames(res.body, (block) => {
+    let event = "";
+    let payload = "";
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) payload += line.slice(5).trim();
     }
-  }
+    if (!payload) return;
+    try {
+      const data = JSON.parse(payload);
+      if (event === "card") handlers.onCard?.(data as DispatchOutcome);
+      else if (event === "conflict") handlers.onConflict?.((data as { paths: string[] }).paths);
+      else if (event === "done") handlers.onDone?.(data as { worked: number; error?: string });
+    } catch {
+      // A frame we cannot parse is one frame lost, not a broken dispatch: the board is the
+      // source of truth and a refetch will show what actually happened.
+    }
+  });
+  // A cut connection reads as `done` on this API, so without this the dispatch ended exactly as it
+  // does on success — silently, over a board nobody knew was stale.
+  if (cut) handlers.onDone?.({ worked: 0, error: cut });
 }
 /** One obligation in a drafted spec, in both forms at once.
  *
@@ -872,20 +902,8 @@ export async function streamRun(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchRun(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchRun(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchRun(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 function dispatchRun(frame: string, h: RunStreamHandlers): void {
@@ -958,20 +976,8 @@ export async function streamLifecycle(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchLifecycle(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchLifecycle(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchLifecycle(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 function dispatchLifecycle(frame: string, h: LifecycleHandlers): void {
@@ -1248,20 +1254,8 @@ export async function streamCodeTurn(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchCodeTurn(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchCodeTurn(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchCodeTurn(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 function dispatchCodeTurn(frame: string, h: CodeTurnHandlers): void {
@@ -1621,20 +1615,8 @@ export async function streamAgents(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchAgents(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchAgents(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchAgents(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 function dispatchAgents(frame: string, h: AgentsStreamHandlers): void {
@@ -1708,20 +1690,8 @@ export async function streamExec(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchExec(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchExec(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchExec(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 /** Stop a running command AND everything it started.
@@ -1885,20 +1855,8 @@ export async function streamHierarchy(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchHierarchy(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchHierarchy(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchHierarchy(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }
 
 function dispatchHierarchy(frame: string, h: HierarchyStreamHandlers): void {
@@ -1981,18 +1939,6 @@ export async function streamCrew(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  for (;;) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer = (buffer + decoder.decode(value, { stream: true })).replace(/\r\n/g, "\n");
-    let sep: number;
-    while ((sep = buffer.indexOf("\n\n")) !== -1) {
-      dispatchHierarchy(buffer.slice(0, sep), handlers);
-      buffer = buffer.slice(sep + 2);
-    }
-  }
-  if (buffer.trim()) dispatchHierarchy(buffer, handlers);
+  const cut = await readFrames(res.body, (frame) => dispatchHierarchy(frame, handlers));
+  if (cut) handlers.onError?.(cut);
 }

--- a/apps/desktop/src/lib/stream-cut.test.ts
+++ b/apps/desktop/src/lib/stream-cut.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { streamCodeTurn, type CodeTurnHandlers } from "@/lib/api";
+
+/**
+ * A dropped connection ended the stream exactly the way a finished turn does.
+ *
+ * Eight loops read `{ value, done }` inline with no `try` around the read and no check afterwards.
+ * A connection cut mid-stream either threw an unhandled rejection or — the common case — surfaced
+ * as `done: true`, so the loop exited on the same branch a clean finish takes. `onError` never
+ * fired, and the screen kept showing a turn that was still in progress on a server that had gone
+ * away.
+ *
+ * This is the half that gives replay a trigger: nothing can recover from a drop it cannot see.
+ */
+
+function respostaQueCorta(pedacos: string[], erro?: Error): Response {
+  // One chunk per `pull`, with the error on a LATER pull rather than in `start`. Written the other
+  // way first — enqueue everything, then `controller.error()` — and the queued chunks are discarded
+  // by the stream, so the test asserted that a reader keeps what arrived while making sure nothing
+  // ever arrived.
+  const enc = new TextEncoder();
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < pedacos.length) {
+        controller.enqueue(enc.encode(pedacos[i++]));
+        return;
+      }
+      if (erro) controller.error(erro);
+      else controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+function quadro(evento: string, dados: unknown): string {
+  return `event: ${evento}\ndata: ${JSON.stringify(dados)}\n\n`;
+}
+
+function handlers(): CodeTurnHandlers & { onError: ReturnType<typeof vi.fn> } {
+  return {
+    onToken: vi.fn(),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  } as CodeTurnHandlers & { onError: ReturnType<typeof vi.fn> };
+}
+
+describe("a stream that was cut", () => {
+  it("reports an error instead of ending quietly", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      respostaQueCorta([quadro("token", { text: "Olá" })], new Error("network error")),
+    ));
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onError).toHaveBeenCalled();
+    expect(String(h.onError.mock.calls[0][0])).toContain("network");
+  });
+
+  it("keeps what already arrived", async () => {
+    // A cut is not a reason to discard the tokens the reader already saw — they were paid for and
+    // they are on screen.
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      respostaQueCorta([quadro("token", { text: "Olá" })], new Error("boom")),
+    ));
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onToken).toHaveBeenCalledWith("Olá");
+  });
+});
+
+describe("a stream that finished", () => {
+  it("does not report an error", async () => {
+    // The guard against a fix that calls every completed turn a failure — which would be the same
+    // defect with the sign flipped, and far more visible.
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      respostaQueCorta([quadro("token", { text: "pronto" }), quadro("done", { answer: "pronto" })]),
+    ));
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onDone).toHaveBeenCalled();
+    expect(h.onError).not.toHaveBeenCalled();
+  });
+
+  it("still delivers a frame with no trailing blank line", async () => {
+    // The last frame of a stream often arrives without its separator, and the old loop flushed the
+    // buffer after the read. That behaviour has to survive being moved into the helper.
+    vi.stubGlobal("fetch", vi.fn(async () =>
+      respostaQueCorta([`event: done\ndata: ${JSON.stringify({ answer: "fim" })}`]),
+    ));
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onDone).toHaveBeenCalled();
+  });
+});

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -839,7 +839,10 @@ class AutonomousAgent:
             # whole — discarding it would throw away a finished piece of work and, with
             # `max_attempts=1`, return a run with no attempts at all.
             if getattr(agent_result, "stopped_reason", "") == "cancelled":
-                return self._finalize_cancelled(task, attempts, plan, thread_id)
+                return self._finalize_cancelled(
+                    task, attempts, plan, thread_id,
+                    agent_result=agent_result, index=index, snapshot=snapshot,
+                )
             # Same argument as the comment above, for the other reason a worker cuts itself short.
             # A worker that stopped because the money ran out has produced a partial attempt, and
             # verifying, reviewing and RETRYING it are exactly "model calls the user has already
@@ -1288,6 +1291,10 @@ class AutonomousAgent:
         attempts: list[Attempt],
         plan: Plan | None,
         thread_id: str | None,
+        *,
+        agent_result: Any = None,
+        index: int = 0,
+        snapshot: Any = None,
     ) -> AutonomousResult:
         """Cooperative stop: the caller asked to cancel between attempts. Return a well-formed result
         (``success=False``, ``stopped_reason="cancelled"``) carrying the attempts completed so far.
@@ -1296,16 +1303,64 @@ class AutonomousAgent:
         was wrong, so it does NOT distill an anti-pattern card or credit a card failure (unlike the
         budget-exhausted return above). The checkpoint is cleared — a user-cancelled run is terminal,
         not resumable — and a receipt is persisted, mirroring the exhaustion path's construction.
+
+        ``agent_result`` is the attempt that was cut short, when there is one. Two of the three cancel
+        sites fire before any model call and pass nothing; the third fires with a worker that already
+        ran, and dropping THAT one was the defect. Its sibling :meth:`_finalize_capped` carries the
+        measurement in a comment: a receipt reading ``usd: null, attempts: []`` for a run that had
+        just spent money showed a paid run as free on the Cost screen.
+
+        ``snapshot`` lets the partial attempt record what it wrote. The files are NOT reverted —
+        whoever pressed Stop may want the work, and `guard.restore` only runs on the verified path —
+        so `reverted: false` with `diffs: []` read as "it changed nothing" about a workspace that had
+        changed. Recording is the fix; reverting would destroy work somebody may have wanted.
         """
+        if agent_result is not None:
+            attempts = [*attempts, self._partial_attempt(agent_result, index, snapshot)]
         self._emit(_ev_status("cancelled"))
         self._clear_checkpoint(thread_id)
-        last = attempts[-1].answer if attempts else ""
+        last = (getattr(agent_result, "answer", "") or "") or (attempts[-1].answer if attempts else "")
         self._emit(_ev_final(False, last))
         result = AutonomousResult(
             answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="cancelled"
         )
         self._persist_receipt(result, task)
         return result
+
+    def _partial_attempt(self, agent_result: Any, index: int, snapshot: Any = None) -> Attempt:
+        """An attempt that was cut short: what it cost, and what it left on disk.
+
+        Shared by the two stop paths, because the bookkeeping is the same and having it in one of
+        them was how the other went without it for so long. The meter is drained here — the overhead
+        it holds belongs to this attempt and would otherwise be billed to whatever runs next.
+        """
+        from chimera.orchestration.metering import add_usd
+
+        over_usd, over_prompt, over_completion = (
+            self.meter.take() if self.meter is not None else (0.0, 0, 0)
+        )
+        parcial = Attempt(index, getattr(agent_result, "answer", "") or "", False, False, False, False)
+        parcial.usd = add_usd(getattr(agent_result, "usd", None), over_usd)
+        parcial.overhead_usd = over_usd
+        parcial.prompt_tokens = int(getattr(agent_result, "prompt_tokens", 0) or 0) + over_prompt
+        parcial.completion_tokens = (
+            int(getattr(agent_result, "completion_tokens", 0) or 0) + over_completion
+        )
+        parcial.model = str(getattr(agent_result, "model", "") or "")
+        parcial.run_id = str(getattr(agent_result, "run_id", "") or "")
+        parcial.evidence = "none"
+        if snapshot is not None and self.guard is not None:
+            # Measured, not assumed, and the same call the verified path makes. `diff_productive:
+            # null` for an attempt that wrote a file is precisely the claim that field exists to
+            # prevent.
+            from chimera.evolution.diff_gate import diff_snapshots, unified_diffs
+
+            depois = _without_verifier_artifacts(self.guard.snapshot())
+            pdiff = diff_snapshots(snapshot, depois)
+            parcial.diff_productive = pdiff.is_productive
+            parcial.diff_summary = pdiff.audit_summary()
+            parcial.diffs = unified_diffs(snapshot, depois)
+        return parcial
 
     def _finalize_capped(
         self,
@@ -1333,22 +1388,10 @@ class AutonomousAgent:
         # the answer said "spend cap reached: $0.0030" while the receipt reported nothing, so the
         # Cost screen showed a paid run as free. A cap that hides its own spending is worse than
         # no cap: the number it exists to protect is the number it erases.
-        from chimera.orchestration.metering import add_usd
-
-        over_usd, over_prompt, over_completion = (
-            self.meter.take() if self.meter is not None else (0.0, 0, 0)
-        )
-        parcial = Attempt(index, agent_result.answer, False, False, False, False)
-        parcial.usd = add_usd(getattr(agent_result, "usd", None), over_usd)
-        parcial.overhead_usd = over_usd
-        parcial.prompt_tokens = int(getattr(agent_result, "prompt_tokens", 0) or 0) + over_prompt
-        parcial.completion_tokens = (
-            int(getattr(agent_result, "completion_tokens", 0) or 0) + over_completion
-        )
-        parcial.model = str(getattr(agent_result, "model", "") or "")
-        parcial.run_id = str(getattr(agent_result, "run_id", "") or "")
-        parcial.evidence = "none"
-        attempts = [*attempts, parcial]
+        # Through the shared helper, which was extracted FROM this block. Leaving the copy here
+        # would restore the condition that let the cancel path fall behind: the same bookkeeping
+        # written twice, corrected once.
+        attempts = [*attempts, self._partial_attempt(agent_result, index)]
 
         self._emit(_ev_status("stopped on budget"))
         self._clear_checkpoint(thread_id)

--- a/tests/test_stopping_is_not_the_same_as_never_having_run.py
+++ b/tests/test_stopping_is_not_the_same_as_never_having_run.py
@@ -1,0 +1,190 @@
+"""Pressing Stop threw away the attempt, its cost, and any record of what it had written.
+
+The two finalizers are siblings and only one of them was corrected. `_finalize_capped` carries a
+comment saying exactly what it cost to learn: *"returning here before the normal bookkeeping left a
+receipt reading `usd: null, attempts: []` for a run that had just spent money... the Cost screen
+showed a paid run as free. A cap that hides its own spending is worse than no cap."*
+
+`_finalize_cancelled` does that. The attempt is appended further down the loop, past the `return`,
+so a run stopped after the worker came back persists `attempts: []` — and `_CANCELLED_ANSWER`, which
+`agent.py` writes precisely so a stop does not read as "it produced nothing", is discarded with it.
+
+The second half is the workspace. `guard.restore` only runs on the normal path, so a stopped run
+leaves its files in place — correctly, because whoever pressed Stop may want the work — and the
+partial attempt says `reverted: false` with `diffs: []`, which reads as "it changed nothing". The
+right fix is to RECORD, not to revert: reverting would destroy work somebody may have wanted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.core.autonomous import AutonomousAgent, AutonomousConfig
+from chimera.core.checkpoint import WorkspaceGuard
+
+
+class _WorkerQueEscreveEPara:
+    """A worker that writes a file and reports it was cancelled — the shape site 842 handles."""
+
+    def __init__(self, workspace: Path, *, usd: float = 0.0031) -> None:
+        self.workspace = workspace
+        self.usd = usd
+        self.chamadas = 0
+
+    def run(self, *_args: Any, **_kwargs: Any) -> Any:
+        self.chamadas += 1
+        (self.workspace / "novo.py").write_text("print('meio do caminho')\n", encoding="utf-8")
+
+        class _R:
+            answer = "Stopped at your request. The work up to this point is in the transcript."
+            stopped_reason = "cancelled"
+            success = False
+            steps = 3
+            model = "prov/m"
+            prompt_tokens = 900
+            completion_tokens = 120
+            run_id = "r-42"
+
+        _R.usd = self.usd  # type: ignore[attr-defined]
+        return _R()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    (tmp_path / "ja_existia.py").write_text("x = 1\n", encoding="utf-8")
+    return tmp_path
+
+
+def _agente(workspace: Path, worker: Any) -> AutonomousAgent:
+    return AutonomousAgent(
+        worker,
+        config=AutonomousConfig(max_attempts=1),
+        guard=WorkspaceGuard(workspace),
+    )
+
+
+# ------------------------------------------------------------------ the attempt
+
+
+def test_a_stopped_run_still_has_the_attempt_it_paid_for(workspace: Path) -> None:
+    """The whole point, and the same assertion its sibling already carries."""
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert resultado.stopped_reason == "cancelled"
+    assert len(resultado.attempts) == 1
+
+
+def test_the_money_is_not_erased(workspace: Path) -> None:
+    """A run that called a model and reports `usd: null` shows a paid run as free — the exact
+    sentence written into `_finalize_capped` after it was measured on a real run."""
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace, usd=0.0031)).run("faça algo")
+
+    assert resultado.attempts[0].usd == pytest.approx(0.0031)
+    assert resultado.attempts[0].prompt_tokens == 900
+
+
+def test_the_answer_survives(workspace: Path) -> None:
+    """`agent.py` writes `_CANCELLED_ANSWER` precisely so a stop does not read as "it produced
+    nothing" — and the finalizer discarded it, restoring the meaning it exists to prevent."""
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert "Stopped at your request" in resultado.answer
+
+
+def test_the_run_id_joins_it_to_the_trace(workspace: Path) -> None:
+    """`AttemptReceipt.run_id` -> `traces.jsonl` is the one join this project documents, and an
+    attempt with no id is an attempt nothing can be looked up about."""
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert resultado.attempts[0].run_id == "r-42"
+
+
+# ------------------------------------------------------------------ the workspace
+
+
+def test_a_stopped_run_says_the_files_changed(workspace: Path) -> None:
+    """`reverted: false` with `diffs: []` reads as "it changed nothing", and the file is right there.
+
+    This is the field's own promise: `diff_productive` exists to answer whether an attempt did any
+    real work, and `null` for an attempt that wrote a file is the lie the field was added to stop.
+    """
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert resultado.attempts[0].diff_summary
+    assert resultado.attempts[0].diff_productive is True
+
+
+def test_the_files_are_left_alone(workspace: Path) -> None:
+    """RECORDED, not reverted. Whoever pressed Stop may want what the run wrote, and destroying it
+    to make a receipt tidy is the wrong trade."""
+    _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert (workspace / "novo.py").exists()
+    assert resultado_intacto(workspace)
+
+
+def resultado_intacto(workspace: Path) -> bool:
+    return (workspace / "ja_existia.py").read_text(encoding="utf-8") == "x = 1\n"
+
+
+def test_it_is_not_reported_as_reverted(workspace: Path) -> None:
+    """The flag has to keep meaning what it says: nothing was rolled back here."""
+    resultado = _agente(workspace, _WorkerQueEscreveEPara(workspace)).run("faça algo")
+
+    assert resultado.attempts[0].reverted is False
+
+
+# ------------------------------------------------------------------ the case with nothing to keep
+
+
+def test_a_stop_before_the_first_call_records_no_attempt(workspace: Path) -> None:
+    """The guard against inventing one. Two of the three cancel sites fire before any model call, and
+    an attempt that never happened must not appear in a receipt — a run stopped before it started
+    cost nothing and did nothing, and saying otherwise is the same fabrication in reverse.
+    """
+
+    class _NuncaChamado:
+        def run(self, *_args: Any, **_kwargs: Any) -> Any:  # pragma: no cover - never reached
+            raise AssertionError("o worker não deveria ser chamado")
+
+    agente = AutonomousAgent(
+        _NuncaChamado(),
+        config=AutonomousConfig(max_attempts=1),
+        guard=WorkspaceGuard(workspace),
+        should_stop=lambda: True,
+    )
+
+    resultado = agente.run("faça algo")
+
+    assert resultado.stopped_reason == "cancelled"
+    assert resultado.attempts == []
+
+
+def test_a_successful_run_is_untouched(workspace: Path) -> None:
+    """The ordinary path keeps its own bookkeeping — this change adds a branch, it does not move
+    the one that already worked."""
+
+    class _Termina:
+        def run(self, *_args: Any, **_kwargs: Any) -> Any:
+            (workspace / "feito.py").write_text("ok\n", encoding="utf-8")
+
+            class _R:
+                answer = "pronto"
+                stopped_reason = "final"
+                success = True
+                steps = 2
+                model = "prov/m"
+                prompt_tokens = 10
+                completion_tokens = 5
+                usd = 0.0
+                run_id = "r-1"
+
+            return _R()
+
+    resultado = _agente(workspace, _Termina()).run("faça algo")
+
+    assert resultado.stopped_reason != "cancelled"
+    assert len(resultado.attempts) == 1


### PR DESCRIPTION
Group F of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8) — items 23, 24 and 25. Item 22 (replay for the code turn) is the largest single item left and gets its own PR.

---

## 24 · Pressing Stop threw away the attempt and its cost

The two finalizers are siblings and only one was corrected. `_finalize_capped` carries the measurement in its own comment:

> returning here before the normal bookkeeping left a receipt reading `usd: null, attempts: []` for a run that had just spent money... the Cost screen showed a paid run as free. **A cap that hides its own spending is worse than no cap.**

`_finalize_cancelled` did exactly that. The attempt is appended further down the loop, past the `return`, so a run stopped after the worker came back persisted `attempts: []` — and `_CANCELLED_ANSWER`, which `agent.py` writes precisely so a stop does not read as "it produced nothing", went with it.

Only the **third** of the three cancel sites has anything to keep. The two that fire before a model call pass nothing and record nothing — an attempt that never happened must not appear in a receipt either, which is the same fabrication in reverse and has its own test.

## 25 · A stopped run left the workspace changed and said it had not

`guard.restore` runs only on the verified path, and that is correct: whoever pressed Stop may want what the run wrote. But the partial attempt reported `reverted: false` with `diffs: []`, which reads as "it changed nothing" — and `diff_productive: null` for an attempt that wrote a file is precisely the claim that field exists to prevent.

**Record, not revert.** The diff is measured with the same `diff_snapshots` call the verified path makes; the files are left alone; `reverted` keeps meaning what it says.

### The duplication that caused this

The bookkeeping now lives in one `_partial_attempt`, used by both finalizers.

My first version extracted the helper and **left the copy inside `_finalize_capped`** — which is exactly the condition that let the cancel path fall behind in the first place: the same rule written twice, corrected once. Found by a sabotage whose anchor matched twice instead of once.

## 23 · A dropped connection ended a stream exactly like a finished one

```
$ grep -c "await reader.read()" apps/desktop/src/lib/api.ts
8   ← before
1   ← after (inside the helper)
```

Eight loops read `{ value, done }` inline, with no `try` around the read and no check afterwards. A connection cut mid-stream either threw an unhandled rejection or — the common case — surfaced as `done: true`, so the loop exited on the same branch a clean finish takes. `onError` never fired, and the screen kept showing a turn in progress against a server that had gone away.

All eight now go through one `readFrames`, which returns the reason the read failed or `null`. It deliberately does **not** judge whether a terminal frame arrived — that is each caller's contract, not the transport's.

This is the half that gives replay a trigger: **nothing can recover from a drop it cannot see.**

---

## Verification

**Eleven sabotages, eleven caught**, including the over-zealous direction of each fix: inventing an attempt that never ran, reverting instead of recording, calling every finished turn cut, and swallowing the last frame of a stream that has no trailing blank line.

One test fixture of mine was wrong and the sabotage pass found it: `enqueue` everything then `controller.error()` discards the queued chunks, so the test asserting "a reader keeps what already arrived" was making sure nothing ever arrived. Rewritten to deliver one chunk per `pull` with the error on a later one.

`4558 passed, 18 skipped` (Python) · `982 passed` (desktop) · ruff, mypy (330 files) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)