### PR TITLE
feat(code): a coding turn survives a dropped connection

### DIFF
--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -1531,6 +1531,34 @@
         "title": "CodeToolOut",
         "type": "object"
       },
+      "CodeTurnFramesOut": {
+        "description": "One coding turn's transcript from ``since`` onward, in the order its single writer stamped.\n\nThe mechanism existed for orchestration and not for this route, which is the one that costs the\nmost: a fan-out is recorded frame by frame and replayable, while a coding turn that lost its\nconnection was gone. Same shape on purpose \u2014 the client already owns a reducer that ignores a\n`seq` it has applied, and two shapes would mean two reducers and eventually two behaviours.",
+        "properties": {
+          "frames": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Frames",
+            "type": "array"
+          },
+          "seq": {
+            "title": "Seq",
+            "type": "integer"
+          },
+          "turn_id": {
+            "title": "Turn Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "turn_id",
+          "frames",
+          "seq"
+        ],
+        "title": "CodeTurnFramesOut",
+        "type": "object"
+      },
       "CodeTurnRequest": {
         "description": "One turn of a coding conversation.",
         "properties": {
@@ -9023,6 +9051,56 @@
           }
         },
         "summary": "Code Turn"
+      }
+    },
+    "/api/code/turns/{turn_id}": {
+      "get": {
+        "description": "Everything this turn emitted after ``since``, so a dropped stream costs nothing.\n\nThe same shape the orchestration route has had since it landed, on the route that actually\nneeded it: a coding turn is the most expensive thing this product does, and losing the\nconnection threw away work that had already been paid for while the bill stayed.\n\nThe frames go through the SAME handlers the live stream feeds, and a client that ignores a\n`seq` it has already applied gets one state whether it replayed first or not.\n\n404 for an id that was never recorded, never 200-with-nothing: an unknown turn and a turn\nwith no new frames are opposite instructions for a client deciding whether to keep asking.",
+        "operationId": "code_turn_frames_api_code_turns__turn_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "turn_id",
+            "required": true,
+            "schema": {
+              "title": "Turn Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Since",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodeTurnFramesOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Code Turn Frames"
       }
     },
     "/api/code/worth": {

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -402,6 +402,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/code/turns/{turn_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Code Turn Frames
+         * @description Everything this turn emitted after ``since``, so a dropped stream costs nothing.
+         *
+         *     The same shape the orchestration route has had since it landed, on the route that actually
+         *     needed it: a coding turn is the most expensive thing this product does, and losing the
+         *     connection threw away work that had already been paid for while the bill stayed.
+         *
+         *     The frames go through the SAME handlers the live stream feeds, and a client that ignores a
+         *     `seq` it has already applied gets one state whether it replayed first or not.
+         *
+         *     404 for an id that was never recorded, never 200-with-nothing: an unknown turn and a turn
+         *     with no new frames are opposite instructions for a client deciding whether to keep asking.
+         */
+        get: operations["code_turn_frames_api_code_turns__turn_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/code/worth": {
         parameters: {
             query?: never;
@@ -3245,6 +3275,25 @@ export interface components {
             observation: string;
             /** Ok */
             ok: boolean;
+        };
+        /**
+         * CodeTurnFramesOut
+         * @description One coding turn's transcript from ``since`` onward, in the order its single writer stamped.
+         *
+         *     The mechanism existed for orchestration and not for this route, which is the one that costs the
+         *     most: a fan-out is recorded frame by frame and replayable, while a coding turn that lost its
+         *     connection was gone. Same shape on purpose — the client already owns a reducer that ignores a
+         *     `seq` it has applied, and two shapes would mean two reducers and eventually two behaviours.
+         */
+        CodeTurnFramesOut: {
+            /** Frames */
+            frames: {
+                [key: string]: unknown;
+            }[];
+            /** Seq */
+            seq: number;
+            /** Turn Id */
+            turn_id: string;
         };
         /**
          * CodeTurnRequest
@@ -6842,6 +6891,39 @@ export interface operations {
                 content: {
                     "application/json": unknown;
                     "text/event-stream": string;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    code_turn_frames_api_code_turns__turn_id__get: {
+        parameters: {
+            query?: {
+                since?: number;
+            };
+            header?: never;
+            path: {
+                turn_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CodeTurnFramesOut"];
                 };
             };
             /** @description Validation Error */

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -1254,11 +1254,74 @@ export async function streamCodeTurn(
     handlers.onError?.(await streamRefusal(res));
     return;
   }
-  const cut = await readFrames(res.body, (frame) => dispatchCodeTurn(frame, handlers));
-  if (cut) handlers.onError?.(cut);
+  // The turn's durable identity and how far this client has read. Both come off the wire: the id
+  // rides in the first `session` frame, and every frame after it carries a `seq`.
+  let turnId = "";
+  let seq = 0;
+  const track = (frame: string) => {
+    const applied = dispatchCodeTurn(frame, handlers, seq);
+    if (applied.turnId) turnId = applied.turnId;
+    if (applied.seq > seq) seq = applied.seq;
+  };
+
+  const cut = await readFrames(res.body, track);
+  if (!cut) return;
+
+  // Resume ONCE, from where this client stopped reading. The work is still running on the server
+  // and is still being paid for; the only thing the drop took away was the client's view of it.
+  // Once, because a resume that can itself resume is a poll loop wearing a recovery's clothes —
+  // and if the second read fails too, the error is the honest answer.
+  if (!turnId) {
+    handlers.onError?.(cut);
+    return;
+  }
+  try {
+    const res2 = await fetch(apiUrl(`/api/code/turns/${turnId}?since=${seq}`), {
+      headers: authHeaders(),
+    });
+    if (!res2.ok) {
+      handlers.onError?.(cut);
+      return;
+    }
+    const body = (await res2.json()) as { frames: Record<string, unknown>[] };
+    for (const frame of body.frames) applyCodeTurnFrame(frame, handlers, seq);
+  } catch {
+    handlers.onError?.(cut);
+  }
 }
 
-function dispatchCodeTurn(frame: string, h: CodeTurnHandlers): void {
+/** What a dispatched frame told us about where we are in the stream. */
+interface Applied {
+  turnId: string;
+  seq: number;
+}
+
+/** Route one already-parsed frame to the handlers, unless it has been applied before.
+ *
+ *  `seen` is what makes replay idempotent, and it is the whole reason replay is safe: a client that
+ *  read up to `seq` asks the server for what came after, and anything that slips through anyway is
+ *  dropped here. Replay-then-live and live-only land on the same state.
+ */
+function applyCodeTurnFrame(
+  payload: Record<string, unknown>,
+  h: CodeTurnHandlers,
+  seen: number,
+): Applied {
+  const seq = Number(payload.seq ?? 0);
+  const turnId = String(payload.turn_id ?? "");
+  if (seq && seq <= seen) return { turnId, seq: 0 };
+  const event = String(payload.event ?? "");
+  if (event === "session") h.onSession?.(payload.session_id as string);
+  else if (event === "token") h.onToken?.(payload.text as string);
+  else if (event === "tool") h.onTool?.(payload as unknown as CodeToolEvent);
+  else if (event === "edit") h.onEdit?.(payload.path as string, payload.patch as string);
+  else if (event === "verified") h.onVerified?.(payload as unknown as CodeVerified);
+  else if (event === "done") h.onDone?.(payload as unknown as CodeTurnDone);
+  else if (event === "error") h.onError?.(payload.message as string);
+  return { turnId, seq };
+}
+
+function dispatchCodeTurn(frame: string, h: CodeTurnHandlers, seen = 0): Applied {
   let event = "message";
   let data = "";
   for (const line of frame.split("\n")) {
@@ -1267,20 +1330,17 @@ function dispatchCodeTurn(frame: string, h: CodeTurnHandlers): void {
     // streamed prose into a wall of runtogetherwords.
     else if (line.startsWith("data:")) data += line.slice(5).replace(/^ /, "");
   }
-  if (!data) return;
+  if (!data) return { turnId: "", seq: 0 };
   let payload: Record<string, unknown>;
   try {
     payload = JSON.parse(data);
   } catch {
-    return;
+    return { turnId: "", seq: 0 };
   }
-  if (event === "session") h.onSession?.(payload.session_id as string);
-  else if (event === "token") h.onToken?.(payload.text as string);
-  else if (event === "tool") h.onTool?.(payload as unknown as CodeToolEvent);
-  else if (event === "edit") h.onEdit?.(payload.path as string, payload.patch as string);
-  else if (event === "verified") h.onVerified?.(payload as unknown as CodeVerified);
-  else if (event === "done") h.onDone?.(payload as unknown as CodeTurnDone);
-  else if (event === "error") h.onError?.(payload.message as string);
+  // The SSE frame carries its name outside the JSON and the replayed frame carries it inside, so
+  // the wire shape is normalised here and there is exactly ONE place that routes an event to a
+  // handler. Two would eventually route them differently, which is the bug replay exists to avoid.
+  return applyCodeTurnFrame({ ...payload, event }, h, seen);
 }
 
 // --- Posture (how far the agent reaches, and when it stops to ask) ---

--- a/apps/desktop/src/lib/turn-replay.test.ts
+++ b/apps/desktop/src/lib/turn-replay.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { streamCodeTurn, type CodeTurnHandlers } from "@/lib/api";
+
+/**
+ * A dropped connection threw away work that was still running, and still being paid for.
+ *
+ * The server keeps every frame of a coding turn now, numbered, and answers "what came after N".
+ * This is the half that uses it: the client tracks the turn's id and how far it read, and on a cut
+ * asks once for the rest.
+ *
+ * Once, not in a loop — a resume that can itself resume is a poll wearing a recovery's clothes. And
+ * the `seq` guard is what makes it safe: a frame already applied is dropped, so replay-then-live
+ * and live-only land on the same state rather than on a doubled answer.
+ */
+
+function frame(evento: string, dados: unknown): string {
+  return `event: ${evento}\ndata: ${JSON.stringify(dados)}\n\n`;
+}
+
+function corta(pedacos: string[], erro?: Error): Response {
+  const enc = new TextEncoder();
+  let i = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < pedacos.length) {
+        controller.enqueue(enc.encode(pedacos[i++]));
+        return;
+      }
+      if (erro) controller.error(erro);
+      else controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+}
+
+type Espiadas = {
+  onSession: ReturnType<typeof vi.fn>;
+  onToken: ReturnType<typeof vi.fn>;
+  onDone: ReturnType<typeof vi.fn>;
+  onError: ReturnType<typeof vi.fn>;
+};
+
+function handlers(): CodeTurnHandlers & Espiadas {
+  return {
+    onSession: vi.fn(),
+    onToken: vi.fn(),
+    onDone: vi.fn(),
+    onError: vi.fn(),
+  } as CodeTurnHandlers & Espiadas;
+}
+
+/** A stream that dies after two tokens, and a replay endpoint holding the rest. */
+function cenario(resto: unknown[], { ok = true } = {}) {
+  const chamadas: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const alvo = String(url);
+      chamadas.push(alvo);
+      if (alvo.includes("/api/code/turns/")) {
+        return new Response(JSON.stringify({ turn_id: "t1", frames: resto, seq: 4 }), {
+          status: ok ? 200 : 500,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return corta(
+        [
+          frame("session", { session_id: "s1", turn_id: "t1" }),
+          frame("token", { text: "Olá", seq: 1 }),
+          frame("token", { text: " mundo", seq: 2 }),
+        ],
+        new Error("network error"),
+      );
+    }),
+  );
+  return chamadas;
+}
+
+describe("a coding turn whose stream was cut", () => {
+  it("asks for what it missed", async () => {
+    const chamadas = cenario([
+      { event: "token", text: "!", seq: 3 },
+      { event: "done", answer: "Olá mundo!", seq: 4 },
+    ]);
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(chamadas.some((u) => u.includes("/api/code/turns/t1?since=2"))).toBe(true);
+    expect(h.onDone).toHaveBeenCalled();
+  });
+
+  it("does not replay what it already showed", async () => {
+    // The guard the whole design turns on. The server may hand back a frame the client already
+    // applied — a resume from a cursor one behind, a retried request — and rendering "Olá" twice
+    // is a worse failure than the drop, because it looks like the model said it twice.
+    const chamadas = cenario([
+      { event: "token", text: "Olá", seq: 1 },
+      { event: "token", text: " mundo", seq: 2 },
+      { event: "token", text: "!", seq: 3 },
+    ]);
+    void chamadas;
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onToken.mock.calls.map((c: unknown[]) => c[0])).toEqual(["Olá", " mundo", "!"]);
+  });
+
+  it("reports the cut when the replay itself fails", async () => {
+    // Once only. If the second read fails too, the error is the honest answer — a client that kept
+    // asking would spin against a server that is gone.
+    cenario([], { ok: false });
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onError).toHaveBeenCalled();
+  });
+
+  it("reports the cut when there is no turn to ask about", async () => {
+    // A stream that died before its first frame has no id, so there is nothing to resume from and
+    // pretending otherwise would send a request to `/api/code/turns/`.
+    vi.stubGlobal("fetch", vi.fn(async () => corta([], new Error("gone"))));
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(h.onError).toHaveBeenCalled();
+  });
+});
+
+describe("a coding turn that finished", () => {
+  it("never asks for a replay", async () => {
+    // The guard against a client that quietly makes a second request on every successful turn.
+    const chamadas: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL) => {
+        chamadas.push(String(url));
+        return corta([
+          frame("session", { session_id: "s1", turn_id: "t1" }),
+          frame("token", { text: "pronto", seq: 1 }),
+          frame("done", { answer: "pronto", seq: 2 }),
+        ]);
+      }),
+    );
+    const h = handlers();
+
+    await streamCodeTurn({ message: "oi" }, h);
+
+    expect(chamadas.filter((u) => u.includes("/api/code/turns/"))).toEqual([]);
+    expect(h.onError).not.toHaveBeenCalled();
+  });
+});

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -24,6 +24,7 @@ pressing that button does not change what the agent is allowed to do.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import json
 import re
 import threading
@@ -62,6 +63,7 @@ from chimera.api.schemas import (
     CodeSessionMetaOut,
     CodeSessionOut,
     CodeSessionRawOut,
+    CodeTurnFramesOut,
     DeletedCountOut,
     DictationOut,
     TranscriptOut,
@@ -69,6 +71,7 @@ from chimera.api.schemas import (
 )
 from chimera.api.sse import SSE_RESPONSE
 from chimera.api.worth import WorthReport, summarize_worth
+from chimera.orchestration import runlog
 from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
@@ -1038,9 +1041,21 @@ def register_code_api(
 
         loop = asyncio.get_running_loop()
         queue: asyncio.Queue[tuple[str, Any] | None] = asyncio.Queue()
+        # This turn's durable identity, and the counter that makes replay safe. The orchestration
+        # route has had both since it landed; the coding turn — the most expensive route in the
+        # product — emitted frames with no number and kept none of them, so a dropped connection
+        # threw away work that had already been paid for. `runlog`'s own docstring says why the
+        # number is the load-bearing part: a client that has seen up to `seq` asks for what came
+        # after, and a reducer that ignores what it has makes replay-then-live and live-only
+        # converge on the same state.
+        turn_id = uuid.uuid4().hex
+        seq = itertools.count(1)
 
         def emit(event: str, payload: Any) -> None:
-            loop.call_soon_threadsafe(queue.put_nowait, (event, payload))
+            numbered = {**payload, "seq": next(seq)} if isinstance(payload, dict) else payload
+            if isinstance(numbered, dict):
+                runlog.append(settings.home, turn_id, event, numbered, area="code")
+            loop.call_soon_threadsafe(queue.put_nowait, (event, numbered))
 
         def on_token(text: str) -> None:
             emit("token", {"text": text})
@@ -1294,7 +1309,12 @@ def register_code_api(
         async def events() -> AsyncIterator[dict[str, str]]:
             # The session id first, so a client that minted a new conversation can address it from
             # the very first frame rather than after the turn it is already watching.
-            yield {"event": "session", "data": json.dumps({"session_id": session_id})}
+            yield {
+                "event": "session",
+                # The turn id rides with the session id because a client that loses the stream needs
+                # both: the session to reopen the conversation, and the turn to ask what it missed.
+                "data": json.dumps({"session_id": session_id, "turn_id": turn_id}),
+            }
             while True:
                 item = await queue.get()
                 if item is None:
@@ -1303,6 +1323,29 @@ def register_code_api(
                 yield {"event": event, "data": json.dumps(payload)}
 
         return EventSourceResponse(events())
+
+    @app.get(
+        "/api/code/turns/{turn_id}", dependencies=[guard], response_model=CodeTurnFramesOut
+    )
+    def code_turn_frames(turn_id: str, since: int = 0) -> dict[str, Any]:
+        """Everything this turn emitted after ``since``, so a dropped stream costs nothing.
+
+        The same shape the orchestration route has had since it landed, on the route that actually
+        needed it: a coding turn is the most expensive thing this product does, and losing the
+        connection threw away work that had already been paid for while the bill stayed.
+
+        The frames go through the SAME handlers the live stream feeds, and a client that ignores a
+        `seq` it has already applied gets one state whether it replayed first or not.
+
+        404 for an id that was never recorded, never 200-with-nothing: an unknown turn and a turn
+        with no new frames are opposite instructions for a client deciding whether to keep asking.
+        """
+        home = Path(settings.home)
+        if not runlog.exists(home, turn_id, area="code"):
+            raise HTTPException(status_code=404, detail="no such turn")
+        quadros = runlog.frames(home, turn_id, since=since, area="code")
+        maior = max((int(f.get("seq") or 0) for f in quadros), default=since)
+        return {"turn_id": turn_id, "frames": quadros, "seq": maior}
 
     @app.post("/api/code/posture", dependencies=[guard], response_model=PostureFacts)
     def code_posture(req: PostureQuery) -> PostureFacts:

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -218,6 +218,22 @@ class CodeExchangeOut(BaseModel):
     replaying one would put a button on a reopened conversation that cannot do what it says."""
 
 
+class CodeTurnFramesOut(BaseModel):
+    """One coding turn's transcript from ``since`` onward, in the order its single writer stamped.
+
+    The mechanism existed for orchestration and not for this route, which is the one that costs the
+    most: a fan-out is recorded frame by frame and replayable, while a coding turn that lost its
+    connection was gone. Same shape on purpose — the client already owns a reducer that ignores a
+    `seq` it has applied, and two shapes would mean two reducers and eventually two behaviours.
+    """
+
+    turn_id: str
+    frames: list[dict[str, Any]]
+    #: The highest `seq` in `frames`, or the `since` that was asked for when there are none. A
+    #: client stores this and asks again from it, which is what makes a second replay cheap.
+    seq: int
+
+
 class CodeSessionOut(BaseModel):
     id: str
     workspace: str

--- a/chimera/orchestration/runlog.py
+++ b/chimera/orchestration/runlog.py
@@ -38,14 +38,26 @@ MAX_RUNS = 50
 MAX_BYTES = 4 * 1024 * 1024
 
 
-def run_dir(home: Path, run_id: str) -> Path:
+#: Where a transcript lives, by the surface that produced it. Separate directories so a listing of
+#: one never has to filter out the other, and so pruning one cannot reach the other's runs.
+AREAS = ("orchestration", "code")
+
+
+def run_dir(home: Path, run_id: str, *, area: str = "orchestration") -> Path:
     """Where one run's transcript lives. The id is hex from `uuid4`, so it needs no sanitising —
     but it is checked anyway, because a path built from a request parameter is a path built from a
-    request parameter."""
+    request parameter.
+
+    ``area`` is checked against a fixed list rather than sanitised. It is not user input today, and
+    the day it becomes user input a whitelist is the difference between a directory name and a path
+    traversal — that is not a bet worth taking twice.
+    """
+    if area not in AREAS:
+        raise ValueError(f"unknown transcript area {area!r}")
     safe = "".join(ch for ch in run_id if ch.isalnum() or ch in "-_")[:64]
     if not safe:
         raise ValueError("empty run id")
-    return Path(home) / "orchestration" / safe
+    return Path(home) / area / safe
 
 
 @dataclass(frozen=True)
@@ -60,14 +72,16 @@ class RunSummary:
     done: bool
 
 
-def append(home: Path, run_id: str, event: str, payload: dict[str, Any]) -> None:
+def append(
+    home: Path, run_id: str, event: str, payload: dict[str, Any], *, area: str = "orchestration"
+) -> None:
     """Record one frame. Best-effort: a transcript that cannot be written must not fail the run.
 
     The run is the product and it is already being paid for; losing the record of it is bad, and
     losing the run to preserve the record would be worse.
     """
     try:
-        directory = run_dir(home, run_id)
+        directory = run_dir(home, run_id, area=area)
         directory.mkdir(parents=True, exist_ok=True)
         path = directory / "frames.jsonl"
         line = json.dumps({"event": event, **payload}, ensure_ascii=False, default=str)
@@ -80,7 +94,7 @@ def append(home: Path, run_id: str, event: str, payload: dict[str, Any]) -> None
         _log.debug("orchestration frame not persisted: %s", exc)
 
 
-def exists(home: Path, run_id: str) -> bool:
+def exists(home: Path, run_id: str, *, area: str = "orchestration") -> bool:
     """Whether this run was ever recorded.
 
     `frames()` cannot answer it: an unknown id and a run that has not produced anything past
@@ -88,12 +102,14 @@ def exists(home: Path, run_id: str) -> bool:
     — which are opposite instructions for a client deciding whether to keep polling.
     """
     try:
-        return (run_dir(home, run_id) / "frames.jsonl").exists()
+        return (run_dir(home, run_id, area=area) / "frames.jsonl").exists()
     except ValueError:
         return False
 
 
-def frames(home: Path, run_id: str, *, since: int = 0) -> list[dict[str, Any]]:
+def frames(
+    home: Path, run_id: str, *, since: int = 0, area: str = "orchestration"
+) -> list[dict[str, Any]]:
     """Every frame after ``since``, oldest first.
 
     A malformed line is skipped rather than fatal: the file is appended to from a live run, and a
@@ -101,7 +117,7 @@ def frames(home: Path, run_id: str, *, since: int = 0) -> list[dict[str, Any]]:
     frames it could have replayed.
     """
     try:
-        path = run_dir(home, run_id) / "frames.jsonl"
+        path = run_dir(home, run_id, area=area) / "frames.jsonl"
         raw = path.read_text(encoding="utf-8") if path.exists() else ""
     except (OSError, ValueError) as exc:
         _log.debug("orchestration transcript unreadable: %s", exc)

--- a/tests/test_a_coding_turn_can_be_replayed.py
+++ b/tests/test_a_coding_turn_can_be_replayed.py
@@ -1,0 +1,216 @@
+"""The most expensive route in the product kept no record of what it emitted.
+
+`runlog` exists, is tested, and its docstring states the argument exactly: *"close the app, reload
+the page, or lose the connection, and the answer was gone while the bill stayed. The cost was
+recorded and the product was not."* It was imported by one file — the orchestration API — and the
+coding turn, which costs more per call than anything else here, emitted frames with no number and
+kept none of them.
+
+The `seq` is the load-bearing part, not the file. A client that has read up to `seq` asks for what
+came after; anything it already applied is dropped. That is what makes replay-then-live and
+live-only land on the same state instead of two, and it is why the number is stamped at the single
+writer rather than counted by the reader.
+
+`404` for an unknown id, never `200` with an empty list: a turn that was never recorded and a turn
+with nothing new are opposite instructions for a client deciding whether to keep asking. The
+orchestration route's own comment records what the second answer cost there.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from chimera.orchestration import runlog
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    caminho = tmp_path / "home"
+    caminho.mkdir(parents=True, exist_ok=True)
+    return caminho
+
+
+@pytest.fixture
+def api_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """The real app over a temporary home, built the way `test_api.py` builds it.
+
+    The provider keys are cleared, and that is not tidiness. `build_api_app`'s session factory only
+    covers the CHAT path; the coding turn builds its own agent from the gateway — so the first
+    version of this fixture made a real, paid model call on a developer machine with a key in the
+    environment, and the assertion below passed because a live model answered. A test that spends
+    money is a test somebody eventually stops running.
+    """
+    from fastapi.testclient import TestClient
+
+    for chave in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+                  "DEEPSEEK_API_KEY"):
+        monkeypatch.delenv(chave, raising=False)
+
+    from chimera.api import build_api_app
+    from chimera.config import Settings
+    from chimera.interface.session import ChatSession
+
+    class _Agente:
+        def run(self, task: str, **_kwargs: Any) -> Any:
+            class _R:
+                answer = "olá"
+                steps = 1
+                stopped_reason = "final"
+                prompt_tokens = 10
+                completion_tokens = 2
+                usd = 0.001
+                tool_names: list[str] = []
+                model = "openrouter/test-model"
+
+            return _R()
+
+    settings = Settings(CHIMERA_HOME=str(tmp_path / "home"))  # type: ignore[call-arg]
+    return TestClient(build_api_app(lambda: ChatSession(_Agente()), settings=settings))
+
+
+# ------------------------------------------------------------------ the transcript
+
+
+def test_a_turn_is_recorded_where_orchestration_is_not(home: Path) -> None:
+    """Separate areas, so listing or pruning one never reaches the other's runs."""
+    runlog.append(home, "t1", "token", {"text": "olá", "seq": 1}, area="code")
+
+    assert (home / "code" / "t1" / "frames.jsonl").exists()
+    assert not (home / "orchestration" / "t1").exists()
+
+
+def test_frames_come_back_in_order(home: Path) -> None:
+    for i, texto in enumerate(["a", "b", "c"], start=1):
+        runlog.append(home, "t1", "token", {"text": texto, "seq": i}, area="code")
+
+    assert [f["text"] for f in runlog.frames(home, "t1", area="code")] == ["a", "b", "c"]
+
+
+def test_since_returns_only_what_is_new(home: Path) -> None:
+    """The whole mechanism in one assertion: a client that read three asks for what came after."""
+    for i in range(1, 6):
+        runlog.append(home, "t1", "token", {"text": str(i), "seq": i}, area="code")
+
+    assert [f["seq"] for f in runlog.frames(home, "t1", since=3, area="code")] == [4, 5]
+
+
+def test_an_unknown_turn_is_distinguishable_from_a_quiet_one(home: Path) -> None:
+    """`frames()` cannot tell them apart — both come back empty — and they are opposite
+    instructions for a client deciding whether to keep polling."""
+    runlog.append(home, "conhecido", "token", {"text": "a", "seq": 1}, area="code")
+
+    assert runlog.exists(home, "conhecido", area="code") is True
+    assert runlog.exists(home, "nunca-existiu", area="code") is False
+
+
+def test_an_area_it_does_not_know_is_refused(home: Path) -> None:
+    """Checked against a list rather than sanitised. It is not user input today; the day it is, a
+    whitelist is the difference between a directory name and a path traversal."""
+    with pytest.raises(ValueError, match="area"):
+        runlog.run_dir(home, "t1", area="../../etc")
+
+
+def test_a_truncated_tail_line_does_not_lose_the_rest(home: Path) -> None:
+    """The file is appended to by a LIVE turn, so the last line is routinely half-written when a
+    reader arrives. Refusing the whole transcript over it would lose the frames worth replaying."""
+    runlog.append(home, "t1", "token", {"text": "a", "seq": 1}, area="code")
+    caminho = home / "code" / "t1" / "frames.jsonl"
+    with caminho.open("a", encoding="utf-8") as h:
+        h.write('{"event": "token", "seq": 2, "text": "meio')
+
+    assert [f["seq"] for f in runlog.frames(home, "t1", area="code")] == [1]
+
+
+# ------------------------------------------------------------------ the route
+
+
+def test_the_route_replays_from_a_cursor(api_client: Any, home: Path) -> None:
+    for i in range(1, 4):
+        runlog.append(home, "t9", "token", {"text": str(i), "seq": i}, area="code")
+
+    resposta = api_client.get("/api/code/turns/t9?since=1")
+
+    assert resposta.status_code == 200
+    corpo = resposta.json()
+    assert [f["seq"] for f in corpo["frames"]] == [2, 3]
+    assert corpo["seq"] == 3
+
+
+def test_the_route_refuses_an_unknown_turn(api_client: Any) -> None:
+    assert api_client.get("/api/code/turns/nao-existe").status_code == 404
+
+
+def test_the_cursor_holds_when_there_is_nothing_new(api_client: Any, home: Path) -> None:
+    """`seq` echoes the `since` that was asked for, so a client polling a quiet turn does not walk
+    its cursor backwards to zero and replay everything on the next call."""
+    runlog.append(home, "t9", "token", {"text": "a", "seq": 1}, area="code")
+
+    corpo = api_client.get("/api/code/turns/t9?since=1").json()
+
+    assert corpo["frames"] == []
+    assert corpo["seq"] == 1
+
+
+def test_a_live_turn_numbers_its_frames(api_client: Any, home: Path) -> None:
+    """End to end: the numbers have to exist on the wire, or nothing downstream can use them."""
+    resposta = api_client.post(
+        "/api/code/turn", json={"message": "diga oi", "workspace": str(home)}
+    )
+
+    assert resposta.status_code == 200
+    quadros = [
+        json.loads(linha[6:])
+        for linha in resposta.text.splitlines()
+        if linha.startswith("data: ")
+    ]
+    assert quadros, "the turn emitted nothing"
+    assert quadros[0].get("turn_id"), "the first frame must carry the turn's identity"
+    assert all("seq" in q for q in quadros[1:]), "every frame after the first must be numbered"
+
+
+def test_a_live_turn_leaves_a_transcript_that_can_be_replayed(api_client: Any, home: Path) -> None:
+    """The end-to-end assertion that matters, and the one the wire-shape test above cannot make.
+
+    Checking that frames carry a `seq` proves they were numbered; it says nothing about whether any
+    of them reached disk. Two sabotages — removing the `runlog.append` outright, and writing to the
+    orchestration area instead — passed every other test in this file, because a turn that persists
+    nothing streams exactly like one that persists everything.
+    """
+    resposta = api_client.post(
+        "/api/code/turn", json={"message": "diga oi", "workspace": str(home)}
+    )
+    inicial = next(
+        json.loads(linha[6:]) for linha in resposta.text.splitlines() if linha.startswith("data: ")
+    )
+    turn_id = inicial["turn_id"]
+
+    # From the store, not from the response: this is what a client that lost the connection sees.
+    replay = api_client.get(f"/api/code/turns/{turn_id}?since=0")
+
+    assert replay.status_code == 200, "the turn kept no transcript"
+    quadros = replay.json()["frames"]
+    assert quadros, "the transcript is empty"
+    assert [q["seq"] for q in quadros] == sorted(q["seq"] for q in quadros)
+    # A TERMINAL frame, either kind. With no provider configured the turn ends in `error` and with
+    # one it ends in `done`; both are the turn's outcome, and a replaying client needs whichever
+    # happened. Asserting only `done` made this test depend on a key being present, which is the
+    # same as depending on the network.
+    assert any(q.get("event") in {"done", "error"} for q in quadros), "no outcome was recorded"
+
+
+def test_a_coding_turn_does_not_land_in_the_orchestration_listing(
+    api_client: Any, home: Path
+) -> None:
+    """Separate areas, asserted through the API rather than by reading a directory.
+
+    A coding turn filed under `orchestration/` would appear in the fan-out run list, where nothing
+    can render it — and it would be pruned by that list's ceiling, so a busy day of chat would
+    silently evict the fan-out transcripts somebody was keeping.
+    """
+    api_client.post("/api/code/turn", json={"message": "diga oi", "workspace": str(home)})
+
+    assert runlog.recent(home) == []


### PR DESCRIPTION
Item 22 of [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8) — the last one, and the largest.

**Based on #288**, which adds the `readFrames` this needs. Merge that first; this targets it rather than `main` so the diff shows only this change.

---

## The mechanism existed and was applied to one surface

`runlog` states the argument in its own docstring:

> close the app, reload the page, or lose the connection, and the answer was gone while the bill stayed. **The cost was recorded and the product was not.**

```
$ grep -rln "orchestration import runlog\|from chimera.orchestration import runlog" chimera/
chimera/api/orchestration_api.py   ← one file
```

The coding turn — the most expensive route in the product — emitted frames with no number and kept none of them.

## Server

Every frame gets a `seq` at the single writer, is appended under its own `code/` area, and `GET /api/code/turns/{id}?since=N` answers what came after.

**404 for an unknown id, never 200-with-nothing.** A turn that was never recorded and a turn with nothing new are opposite instructions for a client deciding whether to keep asking — the orchestration route's own comment records what the second answer cost there (a client resuming from a stale `localStorage` entry polling forever, showing an empty screen that looked like a slow one).

`runlog` gained an `area`, **checked against a fixed list rather than sanitised**: it is not user input today, and the day it is, a whitelist is the difference between a directory name and a path traversal. Separate areas also keep a chat turn out of the fan-out listing, whose 50-run ceiling would otherwise evict the orchestration transcripts somebody was keeping.

## Client

The turn's id rides in the first frame beside the session id, because a client that loses the stream needs both: the session to reopen the conversation, the turn to ask what it missed.

On a cut it asks **once**. A resume that can itself resume is a poll wearing a recovery's clothes, and if the second read fails the error is the honest answer.

Live frames and replayed frames route through **one** function. The SSE frame carries its event name outside the JSON and the replayed frame carries it inside, so the shape is normalised at the boundary — two routing functions would eventually route the same event differently, which is the bug replay exists to avoid. A `seq` already applied is dropped, and that is what makes replay-then-live and live-only land on one state rather than a doubled answer.

---

## Verification

**Twelve sabotages, twelve caught**, after two escaped and found the gap that mattered.

The end-to-end test asserted the **wire** — that frames carry a `seq` — and never that any of them reached disk. Removing the `runlog.append` outright, and writing to the orchestration area instead, both passed every other test in the file: **a turn that persists nothing streams exactly like one that persists everything.**

The new test that closed that gap then made a **real, paid provider call**. `build_api_app`'s session factory covers the chat path; the coding turn builds its own agent from the gateway, so on a machine with a key in the environment a live model answered and the assertion passed for that reason. The fixture now clears the provider keys, and the assertion accepts either terminal frame — a turn with no key ends in `error`, one with a key ends in `done`, and a replaying client needs whichever happened.

The client sabotages include the over-zealous direction: asking for a replay on every successful turn, and asking from zero instead of from where the client stopped.

`4570 passed, 18 skipped` (Python) · `987 passed` (desktop) · ruff, mypy (330 files) and `tsc --noEmit` clean · schema regenerated and committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)