### PR TITLE
feat(sandbox): stop asking about commands that cannot change anything

### DIFF
--- a/chimera/sandbox/confirm.py
+++ b/chimera/sandbox/confirm.py
@@ -209,4 +209,32 @@ def resolve_host_exec_confirm(
     # posture == "ask" (or anything unrecognised → treat as ask, the safe default)
     if interactive is None:
         interactive = _human_can_answer()
-    return _prompt if interactive else _make_headless_deny()
+    return _skip_what_only_reads(_prompt if interactive else _make_headless_deny())
+
+
+def _skip_what_only_reads(ask: HostExecConfirm) -> HostExecConfirm:
+    """Approve a command that can be PROVED to change nothing, without asking.
+
+    Only under ``ask``. ``deny`` means no host execution at all and stays absolute — somebody who
+    set it did not ask for a list of exceptions.
+
+    The reason this is worth a module: `ask` prompted for `ls` and `git status` exactly as it
+    prompts for `rm -rf /`, which in a working session is dozens of questions an hour about commands
+    that cannot change anything. The only outlet that pressure has is
+    ``CHIMERA_HOST_EXEC=allow`` — and a gate people switch off protects nothing. Asking too often is
+    not the cautious failure it looks like.
+
+    The classifier is an allowlist that refuses on any doubt, so a wrong answer here is a prompt,
+    never an execution. It does not replace `policy.py`: that one still sees every command,
+    including these.
+    """
+
+    def confirm(command: str) -> bool:
+        from chimera.tools.readonly import is_provably_readonly
+
+        if is_provably_readonly(command):
+            _log.debug("host-exec: %s reads only; not asking", command[:120])
+            return True
+        return ask(command)
+
+    return confirm

--- a/chimera/tools/readonly.py
+++ b/chimera/tools/readonly.py
@@ -1,0 +1,174 @@
+"""Commands that can be PROVED to only read, so the gate stops asking about `git status`.
+
+`CHIMERA_HOST_EXEC=ask` asks about every command equally: `ls`, `git status` and `rm -rf /` all get
+the same prompt. In a working session that is dozens of prompts an hour for commands that cannot
+change anything, and the pressure it creates has one outlet — `CHIMERA_HOST_EXEC=allow`, which
+removes the gate entirely. A gate people turn off protects nothing, so the cost of asking too often
+is measured in the questions it stops anyone from answering.
+
+**This is an allowlist, and it says no by default.** It is not a denylist made safer: `policy.py`
+keeps that job and keeps its own regexes. The two answer different questions — that one asks "is
+this obviously destructive", this one asks "can I be certain this changes nothing" — and only the
+second is allowed to skip a prompt. Anything not proved is `False`.
+
+The shape of a wrong answer here is a command that runs unasked, so every rule below refuses on
+doubt rather than resolving it:
+
+- the line must tokenise cleanly with `shlex`, and carry no shell metacharacter — one `;`, `|`, a
+  backtick, a redirect, and the string is more than one command;
+- the base command must be in a short table;
+- **every** flag must be in that command's own table. Not a prefix, not a heuristic: a flag nobody
+  listed is a flag nobody checked.
+
+The last rule is the one that matters, and it comes from a hard-won observation elsewhere: an
+argument parser and a shell disagree in ways nobody predicts — `-A20` glued together, bundled short
+flags, a tool that ignores `--`, an option that swallows the next token in one implementation and
+not another. This module does not try to win those arguments. It refuses whenever it is not certain,
+which makes every disagreement a prompt rather than an execution.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+#: Anything that makes a line more than one command, or that writes. Present in the raw string is
+#: enough — no attempt is made to decide whether a given `>` is "really" a redirect, because that
+#: decision is exactly the class of judgement this module refuses to make.
+_METACHARACTERS = (";", "|", "&", "`", "$(", ">", "<", "\n", "\r")
+
+#: Per command, the flags that are certain to keep it read-only.
+#:
+#: Empty tuple means "this command takes no flags we have checked", not "any flag is fine". A flag
+#: outside its command's tuple refuses the whole line.
+_READONLY: dict[str, frozenset[str]] = {
+    "pwd": frozenset(),
+    "whoami": frozenset(),
+    "date": frozenset(),
+    "uname": frozenset({"-a", "-s", "-r", "-m"}),
+    "ls": frozenset({"-l", "-a", "-la", "-al", "-h", "-lh", "-lah", "-1", "-t", "-r", "-R", "--color"}),
+    "cat": frozenset({"-n"}),
+    "head": frozenset({"-n"}),
+    "tail": frozenset({"-n"}),
+    "wc": frozenset({"-l", "-w", "-c"}),
+    "file": frozenset(),
+    "stat": frozenset(),
+    "du": frozenset({"-h", "-s", "-sh"}),
+    "df": frozenset({"-h"}),
+    "which": frozenset(),
+    # `echo` is deliberately ABSENT. It reads nothing and writes nothing, so it would be safe — and
+    # it buys nothing, because nobody is worn down by prompts for `echo`. It is also the stand-in
+    # every test in this repository uses for "some command", so allowlisting it would silently
+    # approve the sample in a dozen suites whose subject is whether the gate refuses.
+    # `rg`/`grep` write nothing, but their flag surface is wide and some of it executes — so only
+    # the handful actually used for reading is listed.
+    "rg": frozenset({"-n", "-i", "-l", "-c", "-w", "--no-heading", "--color", "-A", "-B", "-C"}),
+    "grep": frozenset({"-n", "-i", "-l", "-c", "-w", "-r", "-R", "-E", "-F", "-v", "-A", "-B", "-C"}),
+    "find": frozenset({"-name", "-type", "-maxdepth", "-iname", "-path"}),
+}
+
+#: Flags that take a VALUE, per command. A bundle of short flags is only safe when none of its
+#: letters expects one: `-rn` is two booleans and reads exactly like `-r -n`, while `-An` would be
+#: `-A n` in one parser and a bundle in another — and that disagreement is the thing this module
+#: exists to refuse rather than resolve.
+_TAKES_VALUE: dict[str, frozenset[str]] = {
+    "head": frozenset({"-n"}),
+    "tail": frozenset({"-n"}),
+    "rg": frozenset({"-A", "-B", "-C"}),
+    "grep": frozenset({"-A", "-B", "-C"}),
+    "find": frozenset({"-name", "-iname", "-type", "-maxdepth", "-path"}),
+}
+
+#: Any git flag that names a file to write. `git diff --output=x` writes `x` — a read-only
+#: subcommand with a writing flag, which is why the subcommand alone cannot be the whole answer.
+_GIT_WRITES_A_FILE = ("--output", "-o=")
+
+#: Read-only git subcommands, listed rather than derived. `git` is one binary with a hundred
+#: behaviours, and "starts with git" says nothing at all about whether it writes.
+_GIT_READONLY = frozenset({"status", "log", "diff", "show", "branch", "remote", "config", "blame",
+                           "describe", "rev-parse", "ls-files", "shortlog", "stash"})
+
+def is_provably_readonly(command: str) -> bool:
+    """True only when this command certainly changes nothing on the machine.
+
+    False is the answer for anything not proved, including anything this module has never heard of.
+    A caller may use True to skip a confirmation prompt; it must never read False as "dangerous".
+    """
+    if not command or not command.strip():
+        return False
+    if any(marca in command for marca in _METACHARACTERS):
+        return False
+    try:
+        partes = shlex.split(command)
+    except ValueError:
+        # An unbalanced quote. The shell and this parser would disagree about where the arguments
+        # end, and a disagreement is exactly what must not be resolved by guessing.
+        return False
+    if not partes:
+        return False
+
+    base, resto = partes[0], partes[1:]
+    if base == "git":
+        return _git_is_readonly(resto)
+    permitidas = _READONLY.get(base)
+    if permitidas is None:
+        return False
+    com_valor = _TAKES_VALUE.get(base, frozenset())
+    return all(_flag_ok(arg, permitidas, com_valor) for arg in resto)
+
+
+def _flag_ok(arg: str, permitidas: frozenset[str], com_valor: frozenset[str]) -> bool:
+    """Whether one argument is safe: a listed flag, or a plain (non-flag) operand.
+
+    Three shapes are accepted and each has a reason.
+
+    A listed flag, obviously. A NUMBER glued to a listed flag (`-A20`, `-n5`), because that is how
+    these tools are actually typed and an allowlist that refuses it covers a vocabulary nobody uses.
+    And a BUNDLE of short flags (`-rn`) when every letter is listed AND none of them takes a value —
+    `-rn` reads exactly like `-r -n` in every parser, while `-An` is `-A n` in one and a bundle in
+    another, which is the disagreement this module refuses rather than resolves.
+
+    Anything else, including a single letter nobody listed, is False.
+    """
+    if not arg.startswith("-"):
+        return True
+    if arg in permitidas:
+        return True
+    # A long flag is either listed verbatim above or unknown, and the bundle rule below already
+    # refuses it: `--x` leaves `-x` in `corpo`, whose first "letter" is `-`, and `--` is in nobody's
+    # table. Written as an explicit early return first, and a sabotage that deleted it changed no
+    # result — an unreachable guard reads as protection and is not, so it is gone.
+    corpo = arg[1:]
+    if not corpo:
+        return False
+    for i, ch in enumerate(corpo):
+        if ch.isdigit():
+            return corpo[i:].isdigit() and f"-{corpo[:i]}" in permitidas
+    # A bundle: every letter must be listed on its own, and none may expect a value.
+    return all(f"-{ch}" in permitidas and f"-{ch}" not in com_valor for ch in corpo)
+
+
+def _git_is_readonly(args: list[str]) -> bool:
+    """`git` is one binary with a hundred behaviours, so the subcommand decides and flags can veto."""
+    sub = next((a for a in args if not a.startswith("-")), "")
+    if sub not in _GIT_READONLY:
+        return False
+    # A read-only subcommand with a writing flag. `git diff --output=x` writes `x`, which is why
+    # the subcommand alone cannot be the whole answer even for the ones that only ever read.
+    if any(a.startswith(_GIT_WRITES_A_FILE) for a in args):
+        return False
+    resto = args[args.index(sub) + 1 :]
+    if sub == "stash":
+        # `git stash` with no argument SAVES. Only the listing forms read.
+        return bool(resto) and resto[0] in {"list", "show"}
+    if sub == "config":
+        # `git config a.b` reads; `git config a.b value` writes. `--get`/`--list` are explicit.
+        operandos = [a for a in resto if not a.startswith("-")]
+        return len(operandos) <= 1 and not any(
+            a in {"--add", "--unset", "--unset-all", "--replace-all", "--edit", "-e"} for a in resto
+        )
+    if sub in {"branch", "remote"}:
+        # Listing only. Any flag at all is refused here rather than enumerated: `-d`, `-D`, `-m`,
+        # `--set-upstream-to` all write, and the list of ways to write is longer than the list of
+        # ways to read.
+        return not resto or resto == ["-v"] or resto == ["--list"]
+    return True

--- a/tests/test_a_command_that_can_only_read.py
+++ b/tests/test_a_command_that_can_only_read.py
@@ -1,0 +1,232 @@
+"""The gate asked about `git status` exactly as it asks about `rm -rf /`.
+
+`CHIMERA_HOST_EXEC=ask` treats every command the same. In a working session that is dozens of
+prompts an hour for commands that cannot change anything, and the pressure has one outlet:
+`CHIMERA_HOST_EXEC=allow`, which removes the gate. **A gate people switch off protects nothing**, so
+asking too often costs more than it buys.
+
+This is an allowlist and it says no by default. It does not replace `policy.py` — that one asks "is
+this obviously destructive" and keeps its regexes; this one asks "can I be CERTAIN this changes
+nothing", and only the second answer is allowed to skip a prompt.
+
+The whole file is about the asymmetry. A wrong `True` runs a command nobody approved; a wrong
+`False` shows a prompt. So the must-refuse list below is long, deliberately, and includes every
+shape where a shell and a parser are known to disagree — bundled short flags, a number glued to a
+flag, an unbalanced quote, a subcommand that reads with one flag and writes with another.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.tools.readonly import is_provably_readonly
+
+SO_LEEM = [
+    "pwd",
+    "whoami",
+    "ls",
+    "ls -la",
+    "ls -lah src/",
+    "cat README.md",
+    "cat -n chimera/core/agent.py",
+    "head -n 20 pyproject.toml",
+    "tail -n 100 logs/app.log",
+    "wc -l chimera/core/agent.py",
+    "du -sh .",
+    "df -h",
+    "which python",
+    "file chimera/core/agent.py",
+    "rg -n TODO chimera/",
+    "rg -A 3 -B 3 def chimera/core/agent.py",
+    "grep -rn TODO chimera/",
+    "grep -A20 def chimera/core/agent.py",
+    "find . -name '*.py' -maxdepth 2",
+    "git status",
+    "git log --oneline -10",
+    "git diff",
+    "git diff main...HEAD",
+    "git show HEAD",
+    "git blame chimera/core/agent.py",
+    "git rev-parse HEAD",
+    "git branch",
+    "git branch -v",
+    "git remote -v",
+    "git stash list",
+    "git config user.name",
+    # `git status` reads whatever its flags say, and asserting otherwise was a premise of mine, not
+    # a property of git. The subcommand decides here; the exception is a flag that names a file to
+    # write, which `git diff --output=` does and which is in the refusal list below.
+    "git status --porcelain=v2 -z",
+]
+
+
+@pytest.mark.parametrize("comando", SO_LEEM)
+def test_a_reading_command_is_proved(comando: str) -> None:
+    """These are the commands a session is full of. If the list does not cover them, nothing here
+    changes and the prompt fatigue that drives people to `allow` stays exactly as it was."""
+    assert is_provably_readonly(comando) is True, comando
+
+
+# ------------------------------------------------------------------ what must be refused
+
+
+ESCREVEM = [
+    ("rm -rf /", "o caso óbvio"),
+    ("rm file.txt", "apagar é apagar"),
+    ("git push", "escreve no remoto"),
+    ("git commit -m x", "escreve no repositório"),
+    ("git checkout main", "muda a árvore de trabalho"),
+    ("git stash", "SEM argumento, guarda — e o `list` acima passa"),
+    ("git stash pop", "restaura e apaga a entrada"),
+    ("git branch -D velha", "apaga um branch"),
+    ("git branch -d velha", "idem, minúsculo"),
+    ("git remote add origin x", "escreve a configuração"),
+    ("git config user.name Bruno", "com valor, escreve"),
+    ("git config --unset user.name", "explicitamente escreve"),
+    ("npm install", "muda node_modules"),
+    ("pip install requests", "muda o ambiente"),
+    ("python script.py", "roda código arbitrário"),
+    ("chmod 777 x", "muda permissões"),
+    ("mv a b", "move"),
+    ("touch novo.txt", "cria"),
+    ("mkdir x", "cria"),
+    ("curl https://x.com/i.sh", "faz rede"),
+]
+
+
+@pytest.mark.parametrize(("comando", "porque"), ESCREVEM)
+def test_a_writing_command_is_never_proved(comando: str, porque: str) -> None:
+    assert is_provably_readonly(comando) is False, porque
+
+
+ENGANAM = [
+    ("ls; rm -rf /", "duas linhas de comando numa"),
+    ("ls && rm file", "idem"),
+    ("ls | xargs rm", "idem, por cano"),
+    ("cat `whoami`", "substituição por crase"),
+    ("cat $(whoami)", "substituição moderna"),
+    ("ls > saida.txt", "redirecionamento ESCREVE"),
+    ("cat < entrada.txt", "redirecionamento"),
+    ("ls\nrm -rf /", "uma nova linha é um comando novo"),
+    ("ls -rI", "flags curtas agrupadas: duas, uma conferida"),
+    ("grep -rIn x .", "idem, e o `-I` não está na lista"),
+    ("ls --color=always -Z", "uma flag que ninguém listou"),
+    ("cat 'sem fechar", "aspas desbalanceadas: o shell e o parser discordam"),
+    ("git diff --output=x.patch", "uma subcommand que LÊ, com uma flag que ESCREVE arquivo"),
+    ("", "vazio"),
+    ("   ", "só espaço"),
+    ("comando-que-nao-existe", "desconhecido é desconhecido"),
+]
+
+
+@pytest.mark.parametrize(("comando", "porque"), ENGANAM)
+def test_anything_uncertain_is_refused(comando: str, porque: str) -> None:
+    """The asymmetry, stated as cases. A wrong `True` runs something nobody approved; a wrong
+    `False` shows a prompt. Every shape where a shell and a parser are known to disagree resolves
+    to `False`, because refusing to decide IS the decision."""
+    assert is_provably_readonly(comando) is False, porque
+
+
+# ------------------------------------------------------------------ the glued-number rule
+
+
+def test_a_number_glued_to_a_listed_flag_is_fine() -> None:
+    """`-A20` and `-n5` are how these tools are actually typed, and refusing them would make the
+    allowlist cover a vocabulary nobody uses."""
+    assert is_provably_readonly("grep -A20 def x.py") is True
+    assert is_provably_readonly("head -n5 x.py") is True
+
+
+def test_a_letter_glued_to_a_listed_flag_is_not() -> None:
+    """`-rI` is TWO flags and only one was checked. The difference between this and the case above
+    is the whole reason the rule is written by hand instead of by prefix match."""
+    assert is_provably_readonly("grep -rI def x.py") is False
+
+
+def test_a_number_glued_to_an_unlisted_flag_is_not() -> None:
+    """The digit is not what makes it safe — the flag is."""
+    assert is_provably_readonly("ls -Z20") is False
+
+
+def test_a_bundle_containing_a_value_taking_flag_is_refused() -> None:
+    """`-n` and `-A` are both listed for grep, and `-nA` is still refused.
+
+    `-A` expects a value, so `-nA def x.py` is `-n -A def` to one parser and a bundle followed by
+    two operands to another — and which of those runs decides what `grep` actually searches. This
+    is the disagreement the module refuses rather than resolves, and a sabotage that dropped the
+    check passed every other test here: no case combined a boolean flag with a value-taking one.
+    """
+    assert is_provably_readonly("grep -nA def x.py") is False
+    assert is_provably_readonly("rg -nC TODO src/") is False
+
+
+def test_a_bundle_of_booleans_is_still_fine() -> None:
+    """The half that has to keep working, or the rule above just bans bundles."""
+    assert is_provably_readonly("grep -rn TODO chimera/") is True
+
+
+def test_an_unknown_long_flag_is_refused() -> None:
+    """Pinned as behaviour rather than as the early return it used to be: `--anything` reaches the
+    bundle rule, whose first letter is `-`, and `--` is in nobody's table."""
+    assert is_provably_readonly("ls --recursive-delete") is False
+    assert is_provably_readonly("grep --exec-something x .") is False
+
+
+# ------------------------------------------------------------------ it is actually wired
+
+
+class _Config:
+    """The two fields `resolve_host_exec_confirm` reads."""
+
+    def __init__(self, host_exec: str) -> None:
+        self.sandbox = "local"
+        self.host_exec = host_exec
+
+
+def test_a_reading_command_never_reaches_the_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wiring, and the point of the whole module. A classifier nothing calls changes nothing —
+    which is the defect shape this project has been finding all week."""
+    import chimera.sandbox.confirm as confirm_mod
+    from chimera.sandbox.confirm import resolve_host_exec_confirm
+
+    perguntado: list[str] = []
+    monkeypatch.setattr(confirm_mod, "_prompt", lambda cmd: perguntado.append(cmd) or True)
+    gate = resolve_host_exec_confirm(_Config("ask"), interactive=True)
+
+    assert gate is not None
+    assert gate("git status") is True
+    assert perguntado == [], "a command that changes nothing was still put to the user"
+
+
+def test_a_writing_command_still_reaches_the_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The other half. A gate that stopped asking about everything would be worse than no gate,
+    because it would look like one."""
+    import chimera.sandbox.confirm as confirm_mod
+    from chimera.sandbox.confirm import resolve_host_exec_confirm
+
+    perguntado: list[str] = []
+    monkeypatch.setattr(confirm_mod, "_prompt", lambda cmd: perguntado.append(cmd) or False)
+    gate = resolve_host_exec_confirm(_Config("ask"), interactive=True)
+
+    assert gate is not None
+    assert gate("rm -rf /tmp/x") is False
+    assert perguntado == ["rm -rf /tmp/x"]
+
+
+def test_deny_stays_absolute(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`deny` means no host execution at all, and somebody who set it did not ask for a list of
+    exceptions. Extending the skip to it would turn a posture into a suggestion."""
+    from chimera.sandbox.confirm import resolve_host_exec_confirm
+
+    gate = resolve_host_exec_confirm(_Config("deny"))
+
+    assert gate is not None
+    assert gate("git status") is False
+
+
+def test_allow_is_still_no_gate_at_all() -> None:
+    """`allow` returns None — "run as before" — and wrapping None would put a callback where the
+    tools expect its absence."""
+    from chimera.sandbox.confirm import resolve_host_exec_confirm
+
+    assert resolve_host_exec_confirm(_Config("allow")) is None

--- a/tests/test_host_exec_confirm.py
+++ b/tests/test_host_exec_confirm.py
@@ -390,7 +390,16 @@ def test_auto_detect_tty_resolves_to_the_interactive_prompt(monkeypatch: pytest.
 
     monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin(tty=True))
     gate = resolve_host_exec_confirm(_Settings("local", "ask"))  # no explicit `interactive`
-    assert gate is confirm_mod._prompt
+
+    # Asserted by BEHAVIOUR, not identity. The gate is wrapped now — a command that can be proved
+    # to change nothing is approved without a prompt — and `gate is _prompt` would fail for a
+    # change that alters nothing this test is about. What it must still show is that a command
+    # needing a decision reaches the interactive prompt.
+    perguntado: list[str] = []
+    monkeypatch.setattr(confirm_mod, "_prompt", lambda cmd: perguntado.append(cmd) or True)
+    gate = resolve_host_exec_confirm(_Settings("local", "ask"))
+    assert gate is not None and gate("rm -rf /tmp/x") is True
+    assert perguntado == ["rm -rf /tmp/x"]
 
 
 def test_auto_detect_no_tty_refuses(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_the_prompt_nobody_could_see.py
+++ b/tests/test_the_prompt_nobody_could_see.py
@@ -77,7 +77,16 @@ def test_a_real_terminal_still_gets_its_prompt(monkeypatch: pytest.MonkeyPatch) 
     """The control. Someone running `chimera solve` in their own terminal is the case the gate was
     written for, and a fix that refuses everywhere would be a different bug, not a fix."""
     monkeypatch.setattr(confirm_mod.sys, "stdin", _FakeStdin())
-    assert resolve_host_exec_confirm(_Settings("local", "ask")) is confirm_mod._prompt
+    # By behaviour, not identity: the gate is wrapped now — a command that can be PROVED to change
+    # nothing is approved without asking — so `is _prompt` would fail for a change that has nothing
+    # to do with what this test is about. What it must still show is that a command needing a
+    # decision reaches the terminal.
+    perguntado: list[str] = []
+    monkeypatch.setattr(confirm_mod, "_prompt", lambda cmd: perguntado.append(cmd) or True)
+    gate = resolve_host_exec_confirm(_Settings("local", "ask"))
+
+    assert gate is not None and gate("rm -rf /tmp/x") is True
+    assert perguntado == ["rm -rf /tmp/x"]
 
 
 def test_the_declaration_does_not_override_allow(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The first of the four decision items from [Nada Dá Erro](https://claude.ai/code/artifact/ecd2c5d5-9eb1-4a9d-8f8c-f0682b4695d8).

---

## The problem is prompt fatigue, not permissiveness

`CHIMERA_HOST_EXEC=ask` prompts for `ls` and `git status` exactly as it prompts for `rm -rf /`. In a working session that is dozens of questions an hour about commands that cannot change anything — and the pressure has exactly one outlet: `CHIMERA_HOST_EXEC=allow`, which removes the gate.

**A gate people switch off protects nothing.** Asking too often is not the cautious failure it looks like; it is how a well-designed gate becomes a switch.

## An allowlist that says no by default

Not a denylist made safer. `policy.py` keeps its job — "is this obviously destructive" — keeps its regexes, and still sees every command including these. This module answers a different question: **can I be certain this changes nothing**, and only that answer may skip a prompt.

Every rule refuses on doubt rather than resolving it:

- the line must tokenise with `shlex` and carry **no** metacharacter — one `;`, `|`, a backtick or a redirect and it is more than one command;
- the base command must be in a short table;
- **every** flag must be in that command's own table. A flag nobody listed is a flag nobody checked.

`git` is decided by subcommand, with the four whose behaviour depends on arguments handled by name: `stash` with no argument **saves**, `branch -D` deletes, `config` with a value writes, `remote add` writes. And any flag naming a file to write vetoes the whole line — `git diff --output=x` writes `x`, which is why the subcommand alone cannot be the answer even for the ones that only ever read.

## The asymmetry is the design

A wrong `True` runs a command nobody approved. A wrong `False` shows a prompt. So:

| | | why |
|---|---|---|
| `grep -A20 def x` | ✅ | a number glued to a listed flag is how these tools are typed |
| `grep -rn TODO .` | ✅ | two booleans, identical in every parser |
| `grep -nA def x` | ❌ | `-A` takes a value, so two parsers disagree about what follows |
| `grep -rI def x` | ❌ | `-I` is a second flag and nobody checked it |
| `cat 'sem fechar` | ❌ | unbalanced quote: the shell and `shlex` disagree about where arguments end |

**`echo` is deliberately absent.** It is safe, it buys nothing — nobody is worn down by prompts for `echo` — and it is the stand-in every test in this repository uses for "some command". Allowlisting it silently approved the sample in suites whose subject is whether the gate refuses.

Wired into `resolve_host_exec_confirm` for `ask` only. **`deny` stays absolute**: somebody who set it did not ask for a list of exceptions.

---

## Verification

**Fourteen sabotages, fourteen caught**, after two escaped:

- one was a **missing test** — no case combined a boolean flag with a value-taking one, so dropping that check changed nothing observable;
- the other found a guard of mine that was **unreachable**. An early return for `--long` flags whose deletion changed no result, because the bundle rule already refuses them (`--x` leaves `-x`, whose first "letter" is `-`, and `--` is in nobody's table). An unreachable guard reads as protection and is not, so it is gone and the behaviour is pinned instead.

Two existing tests moved from asserting the callback's **identity** to asserting its **behaviour**. `gate is _prompt` cannot survive the gate being wrapped, and what those tests exist to show — that a command needing a decision reaches the terminal — is unchanged and now asserted directly.

`4627 passed, 18 skipped` · ruff and mypy (331 files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)