### PR TITLE
fix(publish): the wheel scanner could not run where it is run

### DIFF
--- a/chimera/core/redact.py
+++ b/chimera/core/redact.py
@@ -21,8 +21,17 @@ from __future__ import annotations
 import os
 import re
 
-#: Same markers the sandbox uses to strip the child environment. One list, one meaning of "secret".
-from chimera.sandbox.local import _SECRET_MARKERS
+#: What makes a variable NAME a credential. One list, one meaning of "secret", and it lives here
+#: rather than in the sandbox because this is the module the meaning belongs to — the sandbox strips
+#: the child environment with it, and this file masks values with it.
+#:
+#: It used to live in `chimera.sandbox.local`, and importing it from there is what made THIS module
+#: drag in the sandbox subsystem, `chimera.proc`, `chimera.telemetry` and finally `rich`. Nothing
+#: noticed until `scripts/scan_artifact.py` — which imports the patterns below to check a built
+#: wheel — ran for the first time in the publish job, where the package's runtime dependencies are
+#: deliberately not installed, and died on `No module named 'rich'` before scanning a single byte.
+#: Keep this module importable with the standard library alone.
+_SECRET_MARKERS = ("API_KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "CREDENTIAL", "PRIVATE_KEY")
 
 MASK = "[redacted]"
 

--- a/chimera/sandbox/local.py
+++ b/chimera/sandbox/local.py
@@ -11,12 +11,14 @@ import subprocess
 from contextlib import suppress
 from pathlib import Path
 
+# Env-var name fragments that mark a secret — scrubbed from the child env so an injected/rogue
+# command can't `echo $OPENROUTER_API_KEY` and exfiltrate provider keys (the gateway exports them to
+# os.environ). Defined in `chimera.core.redact`, which is the module the meaning belongs to, and
+# imported here because this file has always been where it was read. It used to be the other way
+# round, which made the redaction module drag in this whole subsystem.
+from chimera.core.redact import _SECRET_MARKERS
 from chimera.proc.stdio import kill_tree
 from chimera.sandbox.base import SandboxResult
-
-# Env-var name fragments that mark a secret — scrubbed from the child env so an injected/rogue command
-# can't `echo $OPENROUTER_API_KEY` and exfiltrate provider keys (the gateway exports them to os.environ).
-_SECRET_MARKERS = ("API_KEY", "SECRET", "TOKEN", "PASSWORD", "PASSWD", "CREDENTIAL", "PRIVATE_KEY")
 
 
 def _child_env() -> dict[str, str]:

--- a/tests/test_nobody_read_the_wheel.py
+++ b/tests/test_nobody_read_the_wheel.py
@@ -18,6 +18,7 @@ second list drifts from the first, and the first is the one with tests.
 
 from __future__ import annotations
 
+import os
 import zipfile
 from pathlib import Path
 
@@ -98,3 +99,40 @@ def test_a_binary_member_is_skipped(tmp_path: Path) -> None:
         z.writestr("chimera/logo.png", bytes(range(256)) * 8)
 
     assert scan(caminho) == []
+
+
+def test_it_runs_where_it_is_actually_run(tmp_path: Path) -> None:
+    """The gate must work with the standard library alone, because that is all the publish job has.
+
+    Every test above passes in an environment where `chimera` is installed with its runtime
+    dependencies. The publish job is not that environment: it installs build tooling, builds the
+    wheel, and runs this scanner — and nothing else. On 2026-09-01, the first time the gate ever
+    executed, it died on `ModuleNotFoundError: No module named 'rich'` before reading a single byte,
+    because `chimera.core.redact` imported `_SECRET_MARKERS` from `chimera.sandbox.local`, which
+    reaches `chimera.proc` and then `chimera.telemetry`.
+
+    The shape of that defect is worth naming: **a gate whose only execution path is the irreversible
+    operation it guards.** It had five green tests and had never run. This one runs it the way the
+    job does — `-S` drops site-packages, so a third-party import fails exactly as it would there.
+    """
+    import subprocess
+    import sys
+
+    raiz = Path(__file__).resolve().parents[1]
+    roda = subprocess.run(
+        [sys.executable, "-S", str(raiz / "scripts" / "scan_artifact.py"), str(_wheel(tmp_path, **LIMPO))],
+        capture_output=True,
+        text=True,
+        env={"PYTHONPATH": str(raiz), "PATH": os.environ.get("PATH", ""), "SYSTEMROOT": os.environ.get("SYSTEMROOT", "")},
+    )
+
+    # The control that keeps this honest: without it, `-S` silently keeping site-packages would make
+    # the test pass while proving nothing about the environment it claims to reproduce.
+    sem_terceiros = subprocess.run(
+        [sys.executable, "-S", "-c", "import rich"],
+        capture_output=True,
+        env={"PYTHONPATH": str(raiz), "PATH": os.environ.get("PATH", ""), "SYSTEMROOT": os.environ.get("SYSTEMROOT", "")},
+    )
+    assert sem_terceiros.returncode != 0, "`-S` did not remove third-party packages; this test proves nothing"
+
+    assert roda.returncode == 0, roda.stderr


### PR DESCRIPTION
## O que aconteceu

O portão que li o wheel em busca de credenciais, adicionado ontem no #289, **rodou pela primeira vez hoje** — na publicação da 0.48.0 — e morreu antes de ler um único byte:

```
File "scripts/scan_artifact.py", line 28
  from chimera.core.redact import _PATTERNS
...
ModuleNotFoundError: No module named 'rich'
```

O `chimera.core.redact` importava `_SECRET_MARKERS` do `chimera.sandbox.local`, então um módulo sobre mascarar strings alcançava o subsistema de sandbox, o `chimera.proc`, o `chimera.telemetry` e por fim o `rich`. O job do publish instala ferramenta de build e mais nada — de propósito, já que é ele que carrega o OIDC — então o import falha ali e só ali.

A lista de sete fragmentos de nome passa a morar no `redact.py`, que é o módulo a que o significado pertence, e o `sandbox/local.py` a importa de lá. Uma lista, um significado de "segredo", e a seta apontando para o outro lado.

## O defeito que vale nomear não é o import

É **um portão cujo único caminho de execução é a operação irreversível que ele guarda**. Ele tinha cinco testes verdes e nunca havia rodado — todos passavam num ambiente onde o `chimera` está instalado com as dependências de runtime, que não é o ambiente onde ele roda.

O teste novo executa o scanner do jeito que o job executa: `python -S`, que derruba os site-packages. Com um controle junto, afirmando que o `rich` de fato fica indisponível sob `-S` — sem ele, o teste passaria reproduzindo o ambiente errado e não provaria nada.

## Verificação

| | |
|---|---|
| Suíte | `4929 passed, 18 skipped` |
| ruff / mypy | limpo · 336 arquivos |
| Repro local | `PYTHONPATH=. python -S -c 'import chimera.core.redact'` falhava com `No module named 'rich'`, agora importa |
| Sabotagem | religar qualquer aresta de terceiro na cadeia do `redact.py` deixa o teste vermelho |

**Nada chegou ao PyPI.** O portão falhou fechado, que é a única coisa que ele acertou. A 0.48.0 está publicada como release e os instaladores foram construídos; falta republicar a wheel depois deste merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)