### PR TITLE
fix(publish): the wheel gate read what gitleaks had already read

### DIFF
--- a/scripts/scan_artifact.py
+++ b/scripts/scan_artifact.py
@@ -41,9 +41,46 @@ NOSSOS = (
     re.compile(r"/opt/data\b"),
 )
 
-#: A wheel legitimately contains this project's own documentation, and this project documents its
-#: own redaction patterns. A file whose whole job is to describe a secret's shape is not a leak.
+#: A last-resort path list, for scanning an artifact with no repository beside it. When the
+#: repository IS available, `_do_ultimo_commit` below subsumes this: these three are committed
+#: source like any other. A file whose whole job is to describe a secret's shape is not a leak.
 ISENTOS = ("chimera/core/redact.py", "scripts/scan_artifact.py", "scripts/pr_intent_scan.py")
+
+
+def _do_ultimo_commit(nome: str, bruto: bytes, repo: Path | None) -> bool:
+    """Whether this member is byte-identical to a file in the checked-out repository.
+
+    The scope this module claims in its own docstring is *what is assembled after the last commit*.
+    Committed source is covered by `gitleaks`, which runs on the same tree with `fetch-depth: 0` and
+    reads the history as well. Scanning it here a second time buys nothing and costs the gate its
+    credibility: on the first release it ever guarded, it stopped the publish on twenty-nine hits,
+    every one of them a fake key inside a test whose subject IS what a key looks like. You cannot
+    assert that `sk-…` is masked without writing something that matches `sk-…`.
+
+    The alternative was to keep extending `ISENTOS` — eight test files that day, more the next. That
+    is a path allowlist, and a path allowlist is exactly the hole you do not want in the files most
+    likely to hold a real key one day.
+
+    This is narrower than it looks, and that is the point: the comparison is on BYTES, so a member
+    at a path that exists in the repository but with different content is still read. To get a
+    credential past this you would have to commit it, and `gitleaks` fails the build when you do.
+    With no repository to compare against, nothing is skipped.
+    """
+    if repo is None:
+        return False
+    caminho = nome.replace("\\", "/")
+    # An sdist wraps everything in `<name>-<version>/`; a wheel's members are already repo-relative.
+    candidatos = [caminho, caminho.partition("/")[2]]
+    for c in candidatos:
+        if not c:
+            continue
+        arquivo = repo / c
+        try:
+            if arquivo.is_file() and arquivo.read_bytes() == bruto:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def _members(archive: Path) -> list[tuple[str, bytes]]:
@@ -60,11 +97,18 @@ def _members(archive: Path) -> list[tuple[str, bytes]]:
         return saida
 
 
-def scan(archive: Path) -> list[str]:
-    """Every line of ``archive`` that carries something that must not be published."""
+def scan(archive: Path, repo: Path | None = None) -> list[str]:
+    """Every line of ``archive`` that carries something that must not be published.
+
+    ``repo`` is the checked-out tree the artifact was built from. Members identical to a file in it
+    came from the last commit and are `gitleaks`' scope, not this one; pass ``None`` to read
+    everything, which is what happens when the artifact is scanned on its own.
+    """
     achados: list[str] = []
     for nome, bruto in _members(archive):
         if any(isento in nome.replace("\\", "/") for isento in ISENTOS):
+            continue
+        if _do_ultimo_commit(nome, bruto, repo):
             continue
         try:
             texto = bruto.decode("utf-8")
@@ -81,11 +125,23 @@ def scan(archive: Path) -> list[str]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("archives", nargs="+", type=Path)
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="the checked-out tree this was built from; members identical to a file in it are "
+        "`gitleaks`' scope, not this one. Point it at a directory that does not exist to read "
+        "everything.",
+    )
     args = parser.parse_args(argv)
+
+    repo = args.repo if args.repo and args.repo.is_dir() else None
+    if repo is None:
+        print("note: no repository to compare against — reading every member", file=sys.stderr)
 
     total = 0
     for archive in args.archives:
-        achados = scan(archive)
+        achados = scan(archive, repo)
         total += len(achados)
         for a in achados:
             print(f"[leak] {archive.name} :: {a}")

--- a/tests/test_nobody_read_the_wheel.py
+++ b/tests/test_nobody_read_the_wheel.py
@@ -153,11 +153,17 @@ def test_it_runs_where_it_is_actually_run(tmp_path: Path) -> None:
 
 
 def _repo_falso(tmp_path: Path, arquivos: dict[str, str]) -> Path:
+    """A checked-out tree, written as BYTES.
+
+    `write_text` translates `\\n` to `\\r\\n` on Windows while `zipfile.writestr` does not, so the
+    two sides of a byte comparison differed by line ending alone and this fixture failed on Windows
+    only. The rule under test is content identity; the platform's newline policy is not part of it.
+    """
     raiz = tmp_path / "repo"
     for nome, conteudo in arquivos.items():
         destino = raiz / nome
         destino.parent.mkdir(parents=True, exist_ok=True)
-        destino.write_text(conteudo, encoding="utf-8")
+        destino.write_bytes(conteudo.encode("utf-8"))
     return raiz
 
 

--- a/tests/test_nobody_read_the_wheel.py
+++ b/tests/test_nobody_read_the_wheel.py
@@ -83,12 +83,23 @@ def test_an_ordinary_wheel_passes(tmp_path: Path) -> None:
 
 def test_the_redaction_module_is_exempt(tmp_path: Path) -> None:
     """A wheel carries this project's own source, and this project's source DESCRIBES the shapes of
-    secrets. A file whose whole job is to say what a key looks like is not a key."""
-    fonte = (Path(__file__).resolve().parents[1] / "chimera" / "core" / "redact.py").read_text(
-        encoding="utf-8"
-    )
+    secrets. A file whose whole job is to say what a key looks like is not a key.
 
-    assert scan(_wheel(tmp_path, chimera__core__redact__py=fonte)) == []
+    Two things were wrong with this test for its whole life. It passed `chimera__core__redact__py`,
+    which `_wheel` turns into `chimera/core/redact/py` — no suffix, so `TEXTO` dropped the member
+    before a byte was read and `== []` held without the exemption running. And its payload was
+    `redact.py`'s real source, which matches none of its own patterns (`sk|pk|rk)-...` is not
+    `sk-...`), so even read, there was nothing to exempt. It asserted that a file with no findings
+    has no findings.
+
+    The payload below does match, and the control puts the same bytes at a path that is not exempt.
+    """
+    payload = 'EXEMPLO = "sk-AAAABBBBCCCCDDDD1234"  # what a key looks like\n'
+
+    assert scan(_wheel(tmp_path, **{"chimera/core/redact.py": payload})) == []
+    assert scan(_wheel(tmp_path, **{"chimera/core/outro.py": payload})) != [], (
+        "the same bytes under a non-exempt name must be found, or this proves nothing about ISENTOS"
+    )
 
 
 def test_a_binary_member_is_skipped(tmp_path: Path) -> None:
@@ -136,3 +147,58 @@ def test_it_runs_where_it_is_actually_run(tmp_path: Path) -> None:
     assert sem_terceiros.returncode != 0, "`-S` did not remove third-party packages; this test proves nothing"
 
     assert roda.returncode == 0, roda.stderr
+
+
+# ------------------------------------------------------ what the last commit already accounted for
+
+
+def _repo_falso(tmp_path: Path, arquivos: dict[str, str]) -> Path:
+    raiz = tmp_path / "repo"
+    for nome, conteudo in arquivos.items():
+        destino = raiz / nome
+        destino.parent.mkdir(parents=True, exist_ok=True)
+        destino.write_text(conteudo, encoding="utf-8")
+    return raiz
+
+
+#: A test whose subject IS the shape of a key. It cannot be written without one.
+SOBRE_CHAVES = 'def test_a_key_is_masked():\n    assert redact("sk-AAAABBBBCCCCDDDD1234") == MASK\n'
+
+#: A real suffix. `TEXTO` drops anything else before a byte is read, which is how the exemption test
+#: above spent its whole life green without scanning a thing.
+ALVO = "tests/test_keys.py"
+
+
+def test_a_member_that_came_from_the_last_commit_is_not_read(tmp_path: Path) -> None:
+    """`gitleaks` runs on the same tree with `fetch-depth: 0`. Reading committed source here a
+    second time buys nothing, and on the first release this gate ever guarded it cost the publish:
+    twenty-nine hits, every one a fake key inside a test about what a key looks like."""
+    repo = _repo_falso(tmp_path, {ALVO: SOBRE_CHAVES})
+    wheel = _wheel(tmp_path, **{ALVO: SOBRE_CHAVES})
+
+    assert scan(wheel, repo) == []
+
+
+def test_the_same_path_with_different_bytes_is_still_read(tmp_path: Path) -> None:
+    """The one that decides whether this is a rule or a hole.
+
+    Comparing PATHS would let anything through under a name the repository happens to carry — which
+    is what `ISENTOS` does, and why it does not scale past three entries. The comparison is on
+    bytes, so a member the build altered is read even where the path is familiar.
+    """
+    repo = _repo_falso(tmp_path, {ALVO: SOBRE_CHAVES})
+    adulterado = SOBRE_CHAVES + '\nTOKEN = "sk-ZZZZYYYYXXXXWWWW9876"\n'
+    wheel = _wheel(tmp_path, **{ALVO: adulterado})
+
+    achados = scan(wheel, repo)
+
+    assert len(achados) == 2, achados
+
+
+def test_with_no_repository_everything_is_read(tmp_path: Path) -> None:
+    """Fail closed. A missing checkout must not read as "nothing to see" — that is how a gate ends
+    up green because the thing it compares against was not there."""
+    wheel = _wheel(tmp_path, **{ALVO: SOBRE_CHAVES})
+
+    assert scan(wheel, None) != []
+    assert scan(wheel, tmp_path / "nao-existe") != []


### PR DESCRIPTION
Sequência do #297. O portão rodou pela segunda vez e barrou o publish de novo — desta vez **funcionando**: 29 achados, todos chave falsa dentro de teste cujo assunto *é* a forma de uma chave. Não dá para afirmar que `sk-…` é mascarado sem escrever algo que case com `sk-…`.

## O escopo estava no docstring dele e não no código

O próprio módulo diz o que deveria varrer: *what is assembled after the last commit* — o que o `hatch_build.py` força para dentro, o `apps/desktop/dist` construído por um job anterior, o binário do PyInstaller. **Fonte commitado é escopo do `gitleaks`**, que roda na mesma árvore com `fetch-depth: 0`, histórico incluído, e passou verde nos 29.

Agora o portão pula membro **byte-a-byte idêntico** a um arquivo do repositório conferido.

A alternativa era estender o `ISENTOS` — uma allowlist por caminho, 8 entradas naquele dia e mais no seguinte, justamente nos arquivos mais propensos a guardar uma chave real um dia. Isto é mais estreito:

- **mesmo caminho com bytes diferentes continua sendo lido** — para passar uma credencial você teria que commitá-la, e aí o `gitleaks` derruba o build;
- **sem repositório para comparar, nada é pulado** (falha fechado).

## Verificação nos artefatos reais, não em fixture

```
uv build -o /tmp/dist
scan_artifact.py dist/*.whl dist/*.tar.gz          -> OK nos dois, exit 0
scan_artifact.py --repo /nao-existe dist/*.tar.gz  -> os 29 voltam
```

O segundo é o que diz que o pulo está agindo, em vez de o scanner ter quebrado.

## Dois testes passavam pelo motivo errado

E o segundo só apareceu porque consertar o primeiro o expôs:

1. `test_the_redaction_module_is_exempt` passava `chimera__core__redact__py`, que o helper vira `chimera/core/redact/py` — **sem sufixo**, então o `TEXTO` descartava o membro antes de ler um byte e o `== []` valia sem a isenção jamais rodar.
2. E o payload dele era o fonte real do `redact.py`, que **não casa com nenhum dos próprios padrões** (`sk|pk|rk)-…` não é `sk-…`). Mesmo lido, não havia o que isentar: ele afirmava que um arquivo sem achados não tem achados.

As duas metades agora têm controle que reprova se o membro não for de fato escaneado.

| | |
|---|---|
| Suíte | `4932 passed, 18 skipped` |
| ruff / mypy | limpo · 336 arquivos |
| gitleaks | sem vazamento no diff |

🤖 Generated with [Claude Code](https://claude.com/claude-code)