### PR TITLE
feat(cli): the reference gate fires on the pull request, not on the deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,24 @@ jobs:
             exit 1
           fi
 
+      # The grouping, which the documentation site renders. It used to live in the site's
+      # repository, so the check that every command lands in a theme could only run at DEPLOY time
+      # — after the release. Three times it caught the same omission and three times the download
+      # page sat on the previous version until somebody read a red deploy. `tests/` asserts the
+      # completeness on the pull request that adds the command; this asserts the file the site
+      # actually reads is what the module says.
+      - name: Regenerate the CLI theme grouping
+        run: uv run python -m chimera.cli.themes_dump > chimera/_cli_themes.json
+
+      - name: Fail if the CLI theme grouping is stale
+        run: |
+          if ! git diff --quiet -- chimera/_cli_themes.json; then
+            echo "::error::The command reference grouping is out of date. Run this and commit it:"
+            echo "  python -m chimera.cli.themes_dump > chimera/_cli_themes.json"
+            git --no-pager diff --stat -- chimera/_cli_themes.json
+            exit 1
+          fi
+
       # The drift gate: if the committed schema/types differ from a fresh regeneration, someone changed
       # a backend response model without running `gen:api`. Fail loudly with the fix.
       - name: Fail if the generated API types are stale

--- a/chimera/_cli_themes.json
+++ b/chimera/_cli_themes.json
@@ -1,0 +1,134 @@
+[
+  {
+    "key": "cli.themeSetup",
+    "commands": [
+      "init",
+      "doctor",
+      "version",
+      "features",
+      "maturity",
+      "migrate",
+      "models",
+      "secrets"
+    ]
+  },
+  {
+    "key": "cli.themeWork",
+    "commands": [
+      "chat",
+      "sessions",
+      "tui",
+      "assist",
+      "run",
+      "agent",
+      "deliver",
+      "solve",
+      "solve-batch",
+      "crew",
+      "crew-isolated",
+      "lifecycle",
+      "meta",
+      "explore",
+      "find",
+      "workflow",
+      "drift",
+      "scenarios"
+    ]
+  },
+  {
+    "key": "cli.themeFusion",
+    "commands": [
+      "fuse",
+      "fusion-receipts",
+      "orchestrate",
+      "brief",
+      "delegations"
+    ]
+  },
+  {
+    "key": "cli.themeMemory",
+    "commands": [
+      "memory",
+      "profile",
+      "playbook",
+      "skills",
+      "tools"
+    ]
+  },
+  {
+    "key": "cli.themeSkills",
+    "commands": [
+      "skills-library",
+      "skills-pending",
+      "skills-stats",
+      "skills-approve",
+      "skills-export",
+      "skills-import",
+      "skills-retire",
+      "skills-lifecycle",
+      "skills-evolve",
+      "skills-catalog",
+      "skills-install",
+      "skills-bundles",
+      "skills-bundle-enable",
+      "skills-bundle-disable",
+      "skills-uninstall",
+      "evolve"
+    ]
+  },
+  {
+    "key": "cli.themeAutomation",
+    "commands": [
+      "cron",
+      "kanban",
+      "project",
+      "agents"
+    ]
+  },
+  {
+    "key": "cli.themeServe",
+    "commands": [
+      "serve",
+      "app",
+      "mcp",
+      "a2a-card",
+      "acp"
+    ]
+  },
+  {
+    "key": "cli.themeSafety",
+    "commands": [
+      "guard",
+      "redteam",
+      "approve"
+    ]
+  },
+  {
+    "key": "cli.themeBench",
+    "commands": [
+      "bench",
+      "measure",
+      "bench-compare",
+      "swe-bench-compare",
+      "fusion-bench",
+      "cascade-bench",
+      "hierarchy-bench",
+      "skillcard-bench",
+      "schema-bench",
+      "sandbox-bench",
+      "memory-bench",
+      "memory-poison",
+      "probe-select",
+      "transfer-gate",
+      "evoclaw",
+      "rubric-grade",
+      "context-curve"
+    ]
+  },
+  {
+    "key": "cli.themeFun",
+    "commands": [
+      "pet"
+    ]
+  }
+]

--- a/chimera/cli/themes.py
+++ b/chimera/cli/themes.py
@@ -1,0 +1,181 @@
+"""How the command reference is grouped, and the guarantee that nothing falls out of it.
+
+`--help` is alphabetical, which is the right answer for someone who already knows the name and
+useless for someone who does not. These are the themes the documentation site renders.
+
+**This lived on the site until 0.48.0, and that is why it kept going stale.** The check that every
+command lands in a theme could only run where the list was, so it ran at *deploy* time — after the
+release. Three times it caught the same omission (`sessions`, then the installable skills
+catalogue, then `approve` and `secrets`), and all three times the download page sat on the previous
+version until somebody read a red deploy to find out why. A gate that fires after the thing it
+guards has already shipped is a report, not a gate.
+
+The list belongs where the commands are. Adding a command and forgetting the reference now fails on
+the pull request that adds it.
+
+The `key` of each theme is an identifier the site translates; nothing here reads it. It is kept
+verbatim rather than renamed so the move is a move and not a rename with a mapping layer to get
+wrong.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class Theme(NamedTuple):
+    """One group of the reference. `key` is the site's translation key for its title."""
+
+    key: str
+    commands: tuple[str, ...]
+
+
+THEMES: tuple[Theme, ...] = (
+    Theme(
+        "cli.themeSetup",
+        (
+            "init",
+            "doctor",
+            "version",
+            "features",
+            "maturity",
+            "migrate",
+            "models",
+            # Provider keys in the OS keychain instead of a `.env`, shipped in 0.48.0. Setup,
+            # because it is where a person puts a key before anything else works.
+            "secrets",
+        ),
+    ),
+    Theme(
+        "cli.themeWork",
+        (
+            "chat",
+            # Shipped with the persistent terminal conversation and never listed, so the reference
+            # described a CLI with one fewer command than the CLI has.
+            "sessions",
+            "tui",
+            "assist",
+            "run",
+            "agent",
+            "deliver",
+            "solve",
+            "solve-batch",
+            "crew",
+            "crew-isolated",
+            "lifecycle",
+            "meta",
+            "explore",
+            # Searching a repository by what the code DOES rather than by the string it contains.
+            # `chimera/rag/` had been in the tree since 0.44.0 with no entrance; `find` is it.
+            "find",
+            "workflow",
+            "drift",
+            "scenarios",
+        ),
+    ),
+    Theme("cli.themeFusion", ("fuse", "fusion-receipts", "orchestrate", "brief", "delegations")),
+    Theme("cli.themeMemory", ("memory", "profile", "playbook", "skills", "tools")),
+    Theme(
+        "cli.themeSkills",
+        (
+            # Shipped with the curated library and never listed, so the reference was one command
+            # short — and the site's own test failed on it every run, which means the site stopped
+            # deploying too. The gate was right; nobody was reading it.
+            "skills-library",
+            "skills-pending",
+            "skills-stats",
+            "skills-approve",
+            "skills-export",
+            "skills-import",
+            "skills-retire",
+            "skills-lifecycle",
+            "skills-evolve",
+            # The installable catalogue, shipped in 0.48.0rc10. Same lesson one release later:
+            # the gate caught it, the deploy went red, and the download page sat on the previous
+            # version until somebody read why. Browse, fetch, switch on, switch off, remove — in
+            # the order a person meets them.
+            "skills-catalog",
+            "skills-install",
+            "skills-bundles",
+            "skills-bundle-enable",
+            "skills-bundle-disable",
+            "skills-uninstall",
+            "evolve",
+        ),
+    ),
+    Theme("cli.themeAutomation", ("cron", "kanban", "project", "agents")),
+    Theme(
+        "cli.themeServe",
+        # `acp` is the agent side of the Agent Client Protocol — the mirror of the client half the
+        # Code screen uses. It belongs beside the other ways something outside reaches the agent.
+        ("serve", "app", "mcp", "a2a-card", "acp"),
+    ),
+    Theme(
+        "cli.themeSafety",
+        # `approve` answers a decision the kernel is waiting on, from anywhere — shipped in 0.48.0,
+        # because without a terminal the approval gate had been collapsing to a refusal. It belongs
+        # with the kernel it answers to, not with setup.
+        ("guard", "redteam", "approve"),
+    ),
+    Theme(
+        "cli.themeBench",
+        (
+            "bench",
+            # The rulers the agent's own comments tell you to use, and could not reach: the RAG
+            # recall bench and the reranker A/B had no export and no caller. `measure` is how they
+            # run. Named apart from `bench` because mounting it there shadowed the existing command.
+            "measure",
+            "bench-compare",
+            "swe-bench-compare",
+            "fusion-bench",
+            "cascade-bench",
+            "hierarchy-bench",
+            "skillcard-bench",
+            "schema-bench",
+            "sandbox-bench",
+            "memory-bench",
+            "memory-poison",
+            "probe-select",
+            "transfer-gate",
+            "evoclaw",
+            "rubric-grade",
+            "context-curve",
+        ),
+    ),
+    Theme("cli.themeFun", ("pet",)),
+)
+
+
+def _visible_top_level() -> list[str]:
+    """The commands a user can reach, read from the CLI itself rather than from the snapshot.
+
+    The snapshot is a committed file that can be stale; the app object cannot be. Reading the app
+    is what makes this gate fire on the pull request that adds a command, which is the entire point
+    of moving it here.
+    """
+    import typer.main
+
+    from chimera.cli.main import app
+
+    root = typer.main.get_command(app)
+    commands = getattr(root, "commands", None)
+    if not isinstance(commands, dict):  # pragma: no cover - the CLI is always a group
+        raise TypeError("the Chimera CLI is expected to expose subcommands")
+    return sorted(name for name, cmd in commands.items() if not getattr(cmd, "hidden", False))
+
+
+def unthemed() -> list[str]:
+    """Visible commands no theme claims. A release with any of these has an incomplete reference."""
+    claimed = {name for theme in THEMES for name in theme.commands}
+    return [name for name in _visible_top_level() if name not in claimed]
+
+
+def phantoms() -> list[str]:
+    """Theme entries naming a command that does not exist — a reference to a removed command."""
+    real = set(_visible_top_level())
+    return [name for theme in THEMES for name in theme.commands if name not in real]
+
+
+def build() -> list[dict[str, object]]:
+    """The themes as data, for the documentation site to render."""
+    return [{"key": theme.key, "commands": list(theme.commands)} for theme in THEMES]

--- a/chimera/cli/themes_dump.py
+++ b/chimera/cli/themes_dump.py
@@ -1,0 +1,27 @@
+"""Dump the command reference's grouping as JSON to stdout.
+
+    python -m chimera.cli.themes_dump > chimera/_cli_themes.json
+
+The sibling of :mod:`chimera.cli.schema_dump`, and committed the same way. The snapshot says which
+commands exist; this says how the reference groups them, and the documentation site reads both out
+of the installed product rather than keeping its own copy.
+
+No version stamp, deliberately. The snapshot carries one because a reader needs to know which
+release a flag list belongs to; a grouping is not something you can be out of date about in that
+sense — it is either complete against the CLI or it is not, and `tests/` decides that on every
+pull request.
+"""
+
+from __future__ import annotations
+
+import json
+
+from chimera.cli.themes import build
+
+
+def main() -> None:
+    print(json.dumps(build(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_a_new_command_reaches_the_reference.py
+++ b/tests/test_a_new_command_reaches_the_reference.py
@@ -1,0 +1,81 @@
+"""A command that is not in the reference is a command nobody can find.
+
+This check existed, on the documentation site, and it worked — it caught the same omission three
+times. What it could not do was catch it in time: the list of themes lived in the site's repository,
+so the only place the check could run was the site's *deploy*, which happens after the release. All
+three times (`sessions`, the installable skills catalogue, then `approve` and `secrets`) the release
+shipped, the deploy went red, and the download page stayed on the previous version until somebody
+read the failure to find out why.
+
+Moving the list into this package moves the check to the pull request that adds the command. That is
+the whole change: same assertions, three days earlier, and the site now reads the grouping out of
+the product instead of keeping a second copy of it.
+
+The commands are read from the Typer app, not from `_cli_snapshot.json`. The snapshot is a committed
+file and can be stale; the app object is the CLI. Reading the snapshot would mean this gate passes
+whenever the person who added the command also forgot to regenerate — the two failures that most
+often arrive together.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from chimera.cli import themes
+
+ARQUIVO = Path(__file__).resolve().parents[1] / "chimera" / "_cli_themes.json"
+
+
+def test_every_visible_command_is_in_a_theme() -> None:
+    orfaos = themes.unthemed()
+
+    assert orfaos == [], (
+        f"not listed anywhere in the command reference: {', '.join(orfaos)}. "
+        "Add each one to a theme in chimera/cli/themes.py, then regenerate: "
+        "python -m chimera.cli.themes_dump > chimera/_cli_themes.json"
+    )
+
+
+def test_no_theme_names_a_command_that_does_not_exist() -> None:
+    """The other direction. A removed command leaves a reference entry that 404s, and a reference
+    with a dead link is worse than one that is merely incomplete: it looks maintained."""
+    fantasmas = themes.phantoms()
+
+    assert fantasmas == [], f"themes point at commands the CLI does not have: {', '.join(fantasmas)}"
+
+
+def test_no_command_is_in_two_themes() -> None:
+    """The reference is rendered theme by theme, so a command in two of them is printed twice, and
+    a reader has no way to tell which grouping was meant."""
+    todos = [nome for tema in themes.THEMES for nome in tema.commands]
+
+    duplicados = sorted({nome for nome in todos if todos.count(nome) > 1})
+
+    assert duplicados == [], f"listed under more than one theme: {', '.join(duplicados)}"
+
+
+def test_the_committed_json_is_what_the_module_says() -> None:
+    """The site reads the JSON, not the module. Without this the two drift and the gate above
+    guards a file nobody renders."""
+    gravado = json.loads(ARQUIVO.read_text(encoding="utf-8"))
+
+    assert gravado == themes.build(), (
+        "chimera/_cli_themes.json is stale. Regenerate it: "
+        "python -m chimera.cli.themes_dump > chimera/_cli_themes.json"
+    )
+
+
+def test_the_gate_can_actually_fail(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A guard that has never been seen to fail may be inert.
+
+    Every assertion above is green today, which is exactly the state in which a broken check is
+    indistinguishable from a working one. This drives the failure on purpose: hide a theme, and the
+    commands it held must be reported missing.
+    """
+    monkeypatch.setattr(themes, "THEMES", themes.THEMES[1:])
+
+    orfaos = themes.unthemed()
+
+    assert "doctor" in orfaos, orfaos
+    assert "secrets" in orfaos, orfaos


### PR DESCRIPTION
## O problema não era a checagem, era onde ela morava

"Todo comando está listado na referência" **já era verificado**, e funcionava — pegou a mesma omissão três vezes. O que ela não conseguia era pegar **a tempo**. A lista de temas morava no repositório do site, então o único lugar onde a asserção podia rodar era o **deploy do site**, que acontece depois da release.

Nas três vezes (`sessions`, o catálogo instalável de skills, e agora `approve` e `secrets`) a release saiu, o deploy ficou vermelho, e a página de download permaneceu na versão anterior até alguém ler a falha para descobrir o porquê.

**Um portão que dispara depois que a coisa que ele guarda já foi publicada é um relatório, não um portão.**

## O que muda

A lista vai para `chimera/cli/themes.py`, ao lado dos comandos que ela descreve, com os comentários que o site acumulou sobre cada adição tardia. O `python -m chimera.cli.themes_dump > chimera/_cli_themes.json` gera o arquivo que o site renderiza, guardado contra staleness exatamente como o `_cli_snapshot.json`.

## Dois detalhes que decidem se isto vale alguma coisa

**Os comandos são lidos do app do Typer, não do `_cli_snapshot.json`.** O snapshot é um arquivo commitado e pode estar velho; o objeto do app *é* o CLI. Ler o snapshot faria este portão passar sempre que quem esqueceu a referência também esqueceu de regenerar — que são as duas falhas que chegam juntas.

**O portão foi levado a falhar de propósito.** Anexar um comando de verdade ao CLI deixa o `test_every_visible_command_is_in_a_theme` vermelho, com o nome do comando e o conserto impressos:

```
not listed anywhere in the command reference: comando-de-sabotagem.
Add each one to a theme in chimera/cli/themes.py, then regenerate:
python -m chimera.cli.themes_dump > chimera/_cli_themes.json
```

Guarda que ninguém viu falhar pode estar inerte — foi o que aconteceu com o scanner do wheel duas vezes hoje.

## Verificação

| | |
|---|---|
| Suíte | `4937 passed, 18 skipped` |
| ruff / mypy | limpo · 338 arquivos |
| Sabotagem | comando real adicionado ao CLI → vermelho; removido → verde |
| gitleaks | sem vazamento no diff |

O site continua renderizando e traduzindo; ele só deixa de manter uma segunda cópia do que existe. Esse lado vai num PR à parte no `chimera-site`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)