### PR TITLE
fix(receipts): the cost meter went quiet on exactly the expensive models

### DIFF
--- a/chimera/fusion/receipts.py
+++ b/chimera/fusion/receipts.py
@@ -35,13 +35,20 @@ class ModelPrice:
     output_per_m: float
 
 
+#: A free-tier slug bills nothing, and that is a measurement rather than a default.
+#:
+#: It used to be the first entry of the table below, which made the property "free beats its own
+#: paid family" depend on nothing ever being prepended in front of it — and `set_price` prepends.
+#: Folding the shipped catalogue in was enough to break it: `llama-3.3-70b-instruct:free` started
+#: pricing at the paid family rate, because the catalogue's `llama-3.3-70b-instruct` is a substring
+#: of it and now sat higher in the list. The rule was one `set_price` call away from breaking for
+#: anybody, so it stops being a position in a list and becomes a check of its own.
+_FREE_TIER = ModelPrice(0.0, 0.0)
+
 # Approximate public list prices (USD / 1M tokens) as of mid-2026, for cost *estimation* only.
 # Matched by substring against a normalized model id, longest/most-specific pattern first. Override
 # or extend with set_price(); an unmatched model yields an unknown (None) cost rather than a guess.
 _PRICES: list[tuple[str, ModelPrice]] = [
-    # ":free" first: any OpenRouter free-tier slug prices as measured-zero, and must win
-    # over its paid family substring (e.g. "llama-3.3-70b-instruct:free" vs "llama-3.3-70b").
-    (":free", ModelPrice(0.0, 0.0)),
     ("deepseek-r1", ModelPrice(0.55, 2.19)),
     ("deepseek-reasoner", ModelPrice(0.55, 2.19)),
     ("claude-sonnet", ModelPrice(3.0, 15.0)),
@@ -67,6 +74,40 @@ def set_price(pattern: str, price: ModelPrice) -> None:
     _PRICES.insert(0, (pattern.lower(), price))
 
 
+#: Whether the shipped catalogue's own prices have been folded into the table above.
+_catalog_registered = False
+
+
+def _ensure_catalog_registered() -> None:
+    """Fold the shipped catalogue's prices into the table, once, before the first lookup.
+
+    `register_catalog_prices()` was written for exactly this and nothing called it, so nine of the
+    fifteen models the app ships with resolved to *price unknown* — `claude-opus-5` at $5/$25 per
+    1M among them. The six that did resolve included the default, `deepseek-chat-v3.1`, which is
+    why it went unnoticed: the meter read correctly until somebody chose an expensive model, and
+    then went quiet at precisely the moment the number mattered.
+
+    **Called from the read, not from a startup hook.** A hook is a second code path that every new
+    entrypoint has to remember, and the CLI, the API, the sidecar and every bench are separate
+    entrypoints. `listing.remember_models` already states this rule about itself — refreshing as a
+    side effect of the picker being used, so "there is no second code path that has to remember to
+    run" — and this is the same rule applied to the same table from the other side.
+
+    After the exact-match pass would be wrong: `register_catalog_prices` prepends, so a price a
+    human typed with `set_price` must be registered *after* the catalogue to still win. Doing this
+    first preserves that order.
+    """
+    global _catalog_registered
+    if _catalog_registered:
+        return
+    # Set before the call, not after: `register_catalog_prices` calls `set_price`, and a future
+    # version of it that priced by consulting `resolve_price` would recurse forever otherwise.
+    _catalog_registered = True
+    from chimera.providers.catalog import register_catalog_prices
+
+    register_catalog_prices()
+
+
 #: Priced at zero, and that is a measurement rather than a default. A model on `ollama/`, `vllm/` or
 #: an LM Studio endpoint bills nothing to any provider — the cost is electricity, which is not what
 #: a dollar figure in a receipt is about. Treating it as *unknown* would be the more cautious-looking
@@ -78,17 +119,23 @@ _LOCAL_ZERO = ModelPrice(0.0, 0.0)
 def resolve_price(model: str) -> ModelPrice | None:
     """The list price for ``model``, or ``None`` if unknown (never guessed).
 
-    Four sources, most specific first, and the ORDER is the whole design:
+    Five sources, most specific first, and the ORDER is the whole design:
 
     1. **An exact match in the table.** ``set_price("openrouter/x/y", …)`` names one model, and
        somebody who named a model meant that model.
-    2. **The provider's own published price**, for this exact slug, from the index the model picker
+    2. **A `:free` slug**, which bills nothing. Above every substring pass because a free slug is a
+       paid model's id with a suffix, so any family pattern for that model matches it too. This used
+       to be the first row of the table and therefore depended on nothing ever being prepended in
+       front of it — a property one `set_price` call away from breaking, and folding the shipped
+       catalogue in is what broke it.
+    3. **The provider's own published price**, for this exact slug, from the index the model picker
        fetches (see :func:`chimera.providers.listing.known_price`). This is why the default model
        stopped reporting "price unknown": the table below is hand-maintained and knew about twenty
        families, while the index knows four hundred models and is refreshed by using the app.
-    3. **The table by family substring** — the original behaviour, unchanged, and still the answer
-       for every model the index has never seen (a local gateway, a vendor not on OpenRouter).
-    4. Local models, which bill nothing.
+    4. **The table by family substring** — the original behaviour, unchanged, and still the answer
+       for every model the index has never seen (a local gateway, a vendor not on OpenRouter). The
+       shipped catalogue is folded in here, once, on the first lookup.
+    5. Local models, which bill nothing.
 
     Why the index sits BETWEEN the two table lookups rather than after both: those patterns are
     substrings, and a substring is a guess about a family. ``deepseek-chat`` matched
@@ -99,10 +146,17 @@ def resolve_price(model: str) -> ModelPrice | None:
     from chimera.providers.gateway import _is_local_model
     from chimera.providers.listing import known_price
 
+    _ensure_catalog_registered()
     norm = model.lower()
     for pattern, price in _PRICES:
         if pattern == norm:
             return price
+
+    # Before every substring pass, including the catalogue's: a `:free` slug is the paid model's id
+    # with a suffix, so ANY family pattern for that model also matches it. An explicit exact-match
+    # `set_price` for the free slug still wins, above.
+    if ":free" in norm:
+        return _FREE_TIER
 
     live = known_price(model)
     if live is not None:

--- a/tests/test_the_expensive_models_had_no_price.py
+++ b/tests/test_the_expensive_models_had_no_price.py
@@ -1,0 +1,146 @@
+"""The cost meter worked on the cheap models and went silent on the expensive ones.
+
+`register_catalog_prices()` exists to feed the curated catalogue's prices into the receipt table.
+It has five tests. Nothing in the package ever called it, so it had never run outside a test, and
+nine of the fifteen catalogue models resolved to *price unknown*:
+
+    HOJE                                6/15 resolve a price
+    after register_catalog_prices()     15/15
+
+The nine were `claude-opus-5` ($5/$25 per 1M), `gpt-5.5` ($5/$30), `gemini-3.1-pro`, `kimi-k2`,
+`qwen3-max`, `glm-4.6`, `gpt-oss-20b`, `gpt-5.6-luna` and `gemini-2.5-flash`.
+
+**Why nobody noticed is the interesting half.** The default model, `deepseek-chat-v3.1`, is one of
+the six the hand-maintained table already covered, so the meter reads correctly for anyone who never
+changes it. It goes quiet exactly when somebody switches to an expensive model — which is the moment
+knowing the cost matters most. Same shape as a ruler that is accurate on a bad model and lies on a
+good one.
+
+The provider index (`known_price`) does cover some of these once the model picker has been opened
+and a listing fetched. That is real and it is not enough: it needs network, a warm cache, and the
+slug to be in the listing at that moment. The curated catalogue is what the app ships with, and it
+should price its own models from a cold start and offline.
+
+The registration is wired into `resolve_price` rather than into a startup hook for the reason the
+listing module already writes down about itself: there must not be a second code path that has to
+remember to run. A startup hook is what every new entrypoint forgets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from chimera.fusion import receipts
+from chimera.providers.catalog import CATALOG
+
+
+@pytest.fixture(autouse=True)
+def sem_indice(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """A cold start, and a table that goes back the way it was.
+
+    Two separate pieces of isolation, both load-bearing:
+
+    `known_price` is stubbed out because it reads `model-prices.json` from the home directory, and a
+    machine whose cache happens to be warm would make this test measure the developer's disk rather
+    than the code.
+
+    `_PRICES` is restored because `set_price` mutates a module-level list and several tests below
+    prepend to it. Without this they would leak into whatever runs next in the same process — and
+    the leak would be invisible when this file runs alone, which is the worst kind: green here, red
+    in the full suite, in a file nobody changed.
+    """
+    monkeypatch.setattr("chimera.providers.listing.known_price", lambda slug: None)
+    original = list(receipts._PRICES)
+    registrado = receipts._catalog_registered
+    yield
+    receipts._PRICES[:] = original
+    receipts._catalog_registered = registrado
+
+
+def test_every_catalogue_model_has_a_price_from_a_cold_start() -> None:
+    """The catalogue is what the app ships with. It must price its own models with no network."""
+    sem_preco = [e.slug for e in CATALOG if receipts.resolve_price(e.slug) is None]
+
+    assert sem_preco == [], (
+        f"{len(sem_preco)} of {len(CATALOG)} shipped models report an unknown cost: "
+        + ", ".join(sem_preco)
+    )
+
+
+def test_the_expensive_ones_in_particular() -> None:
+    """Named, because the aggregate above would still pass if the cheap six carried it.
+
+    These are the models where a missing price costs real money to not know about.
+    """
+    for slug, entrada, saida in [
+        ("openrouter/anthropic/claude-opus-5", 5.0, 25.0),
+        ("openrouter/openai/gpt-5.5", 5.0, 30.0),
+        ("openrouter/google/gemini-3.1-pro-preview", 2.0, 12.0),
+    ]:
+        preco = receipts.resolve_price(slug)
+
+        assert preco is not None, f"{slug} reports an unknown cost"
+        assert (preco.input_per_m, preco.output_per_m) == (entrada, saida), slug
+
+
+def test_a_price_somebody_typed_still_wins() -> None:
+    """The catalogue must not overwrite an explicit `set_price`.
+
+    Registration happens once, lazily, inside `resolve_price`; a `set_price` before the first
+    lookup would be shadowed if the catalogue were prepended after it. The order in `_PRICES` is
+    load-bearing and this is the case that would break silently — the number would simply be the
+    catalogue's instead of the one somebody chose.
+    """
+    receipts.set_price("openrouter/anthropic/claude-opus-5", receipts.ModelPrice(1.0, 2.0))
+
+    preco = receipts.resolve_price("openrouter/anthropic/claude-opus-5")
+
+    assert preco is not None
+    assert (preco.input_per_m, preco.output_per_m) == (1.0, 2.0)
+
+
+def test_a_model_outside_the_catalogue_is_still_unknown() -> None:
+    """Registering the catalogue must not turn "we do not know" into a guess.
+
+    An unknown price is a real answer the receipts depend on: the panel says the cost is unknown
+    rather than printing $0.00, and a spend cap that treated unknown as zero would never stop.
+    """
+    assert receipts.resolve_price("algum/modelo/que-nao-existe-em-lugar-nenhum") is None
+
+
+def test_a_free_slug_survives_anything_prepended_in_front_of_it() -> None:
+    """The property that broke while fixing the prices above, now pinned as a rule.
+
+    "A `:free` slug prices at zero, beating its own paid family" was a POSITION: `(":free", 0)` was
+    the first row of the table, and `set_price` prepends. Registering the shipped catalogue put
+    `llama-3.3-70b-instruct` in front of it and the free slug started billing at the paid rate.
+
+    The regression was caught by two existing tests, which is what a suite is for. What they could
+    not say is that the rule was fragile rather than wrong — any caller doing this would break it,
+    not just the catalogue. So the check below prepends a deliberately hostile pattern and requires
+    the free slug to hold.
+    """
+    receipts.set_price("llama-3.3-70b-instruct", receipts.ModelPrice(0.71, 0.71))
+
+    preco = receipts.resolve_price("openrouter/meta-llama/llama-3.3-70b-instruct:free")
+
+    assert preco is not None
+    assert (preco.input_per_m, preco.output_per_m) == (0.0, 0.0)
+
+
+def test_but_a_price_typed_for_the_free_slug_itself_still_wins() -> None:
+    """The exact-match pass is above the `:free` rule, and stays there.
+
+    Somebody who wrote the full free slug into `set_price` named that model. A free tier that
+    started charging — it happens — has to be expressible, or the honest-cost claim becomes a
+    hardcoded zero nobody can correct.
+    """
+    slug = "openrouter/meta-llama/llama-3.3-70b-instruct:free"
+    receipts.set_price(slug, receipts.ModelPrice(0.05, 0.05))
+
+    preco = receipts.resolve_price(slug)
+
+    assert preco is not None
+    assert (preco.input_per_m, preco.output_per_m) == (0.05, 0.05)


### PR DESCRIPTION
Primeiro achado da auditoria (onda 1 — backend).

## O defeito

`register_catalog_prices()` existe para alimentar a tabela de recibos com os preços do catálogo que o app embarca. Ela tem **cinco testes**. Nada no pacote a chamava, então ela nunca havia rodado fora de um teste:

```
partida a frio, sem índice do provedor     6/15 modelos do catálogo resolvem preço
depois de register_catalog_prices()       15/15
```

Os nove sem preço: `claude-opus-5` (US$ 5/25 por 1M), `gpt-5.5` (US$ 5/30), `gemini-3.1-pro`, `kimi-k2`, `qwen3-max`, `glm-4.6`, `gpt-oss-20b`, `gpt-5.6-luna` e `gemini-2.5-flash`.

## Por que ninguém notou — a metade que vale nomear

O **modelo padrão**, `deepseek-chat-v3.1`, é um dos seis que a tabela escrita à mão já cobria. Então o medidor lê certo para quem nunca troca de modelo, e **emudece exatamente quando alguém escolhe um modelo caro** — que é o momento em que saber o custo importa mais.

É a mesma forma da régua que é exata no caso barato e cala no caro.

⚠️ **Ressalva honesta:** o índice do provedor (`known_price`) cobre alguns desses depois que o seletor de modelos foi aberto e uma listagem foi buscada. Isso é real e não basta: exige rede, cache quente e o slug presente naquela listagem. O catálogo é o que o app embarca e deveria precificar os próprios modelos a frio e offline.

## Onde o registro foi ligado

**Na leitura, não num hook de startup.** O `listing.remember_models` já escreve essa regra sobre si mesmo — ele se atualiza como efeito colateral do seletor ser usado, para que *"não haja um segundo caminho de código que precise lembrar de rodar"*. O CLI, a API, o sidecar e cada bench são entrypoints separados, e cada um teria de lembrar.

## Consertar quebrou dois testes existentes, e eles estavam certos

`set_price` **prepende**, então dobrar o catálogo para dentro pôs `llama-3.3-70b-instruct` na frente da linha `(":free", 0)` e os slugs de tier grátis passaram a cobrar a tarifa paga da família. A suíte pegou.

O que a suíte **não** podia dizer é que a regra era **frágil**, não errada: *"grátis vence a própria família paga"* era uma **posição numa lista mutável**, a uma chamada de `set_price` de quebrar para qualquer um. Virou uma checagem própria, acima de toda passagem por substring — com o `set_price` de correspondência exata para o slug grátis ainda vencendo acima dela, porque um tier grátis que começa a cobrar precisa continuar sendo expressável.

O teste novo prepende um padrão deliberadamente hostil e exige que o grátis se mantenha.

## Verificação

| | |
|---|---|
| Suíte | `4943 passed, 18 skipped` |
| ruff / mypy | limpo · 338 arquivos |
| gitleaks | sem vazamento no diff |
| Isolamento | o fixture restaura `_PRICES`, que `set_price` muta globalmente — sem isso os testes vazariam para quem rodasse depois, e o vazamento seria invisível rodando o arquivo sozinho |

🤖 Generated with [Claude Code](https://claude.com/claude-code)