### PR TITLE
fix(design): the button never adopted the ring it was extracted from

### DIFF
--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -1,4 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+import { focusRing } from "@/components/ui/focus";
 import { cn } from "@/lib/utils";
 
 type Variant = "primary" | "ghost" | "outline";
@@ -41,7 +43,12 @@ export const Button = forwardRef<HTMLButtonElement, Props>(
         // pill stops looking like one. Measured on the running app — "Ver o plano antes" wrapped
         // to three lines the moment two checkboxes were added to its row.
         "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-chip font-medium transition-all duration-150",
-        "focus-visible:outline-none focus-visible:shadow-glow",
+        // The shared ring, not a copy of it. `focusRing` was EXTRACTED from this component —
+        // twenty-one others adopted it and the original was never migrated, so "one definition,
+        // one place to change it" was false for the most-used control in the app. The two had
+        // already drifted: the shared ring carries `relative z-10` so the glow is not clipped by
+        // a neighbour, and the copy here did not.
+        focusRing,
         "disabled:cursor-not-allowed",
         variants[variant],
         sizes[size],

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -337,10 +337,27 @@ describe("motion", () => {
 
 describe("accessibility", () => {
   it("keeps a single shared focus ring rather than growing per-component ones", () => {
-    // One definition means one place to fix it. Ratcheted from 1 (ui/button.tsx) — the rail and the
-    // primitives will import it rather than each inventing a ring.
-    const { total } = countMatches(/focus-visible:/g);
-    expect(total).toBeGreaterThanOrEqual(ratchet.focusVisibleRules);
+    // One definition means one place to fix it. The rail and the primitives import `ui/focus`
+    // rather than each inventing a ring.
+    //
+    // This asserted `total >= ratchet.focusVisibleRules`, with the ratchet at 1 — a FLOOR, on a test
+    // whose name promises a ceiling. It could not fail for the reason it is named: a ring added to
+    // ten more components would only push the number up, and up was the passing direction. It was
+    // green at eight while the thing it forbids was happening — `ui/button.tsx`, the component the
+    // shared ring was extracted FROM, still carried its own copy, and the two had drifted (the
+    // shared one has `relative z-10` so the glow is not clipped; the copy did not).
+    //
+    // What it counts now is FILES that declare a ring outside `ui/focus.ts`, which is the property
+    // the name claims. Two remain and both are legitimate: a scroll container turning the browser
+    // default OFF is not a ring.
+    const donos = appSources()
+      .filter(([file, text]) => !file.endsWith("ui/focus.ts") && /focus-visible:/.test(text))
+      .map(([file]) => file);
+
+    expect(
+      donos.length,
+      `components declaring their own focus ring: ${donos.join(", ")}`,
+    ).toBeLessThanOrEqual(ratchet.focusRingOwners);
   });
 });
 

--- a/apps/desktop/src/design/ratchet.json
+++ b/apps/desktop/src/design/ratchet.json
@@ -7,5 +7,12 @@
   ],
   "arbitraryUtilities": 22,
   "transitionsWithoutTokens": 17,
-  "focusVisibleRules": 1
+  "_focusRingOwners": [
+    "Files declaring a focus ring outside ui/focus.ts. This replaced focusVisibleRules, which",
+    "was a FLOOR (>= 1) on a rule whose name promises a ceiling — it could not fail for the",
+    "reason it is named, and was green at eight while ui/button.tsx still carried its own copy",
+    "of the ring it had been extracted from. Two remain, both turning the browser default OFF",
+    "on a scroll container, which is not a ring."
+  ],
+  "focusRingOwners": 2
 }


### PR DESCRIPTION
Onda 2 da auditoria — frontend e design.

## O defeito

`ui/focus.ts` existe porque o anel de foco era definido uma vez só, **dentro do Button** — o que deixava o rail de ícones, a navegação principal do app, sem indicador de foco nenhum. Hoje **21 componentes** importam o anel compartilhado.

`ui/button.tsx` não é um deles. Ele ainda carrega a cópia de onde o anel foi extraído.

Ou seja, *"uma definição, um lugar para mudar"* era falso justamente para o controle mais usado do app. E as duas já tinham divergido:

```
compartilhado  focus-visible:outline-none  focus-visible:shadow-glow  focus-visible:relative  focus-visible:z-10
no botão       focus-visible:outline-none  focus-visible:shadow-glow
```

O `relative z-10` está lá para o brilho não ser cortado por um vizinho. O botão não tinha.

## O teste que existe para impedir isso não conseguia

Ele se chama **"keeps a single shared focus ring rather than growing per-component ones"** e afirmava:

```ts
expect(total).toBeGreaterThanOrEqual(ratchet.focusVisibleRules)   // ratchet: 1
```

Um **piso**, numa regra cujo nome promete um **teto**. Acrescentar um anel em mais dez componentes empurraria o número para **cima**, e para cima era a direção que passava. Ele estava verde em oito enquanto exatamente o que ele proíbe estava na árvore.

Agora conta **arquivos** que declaram anel fora do `ui/focus.ts`, com teto de dois. Os dois que sobram são legítimos: um container de rolagem desligando o padrão do browser não é um anel.

Verificado por sabotagem — acrescentar um anel ao `ui/panel.tsx` deixa vermelho e **nomeia o arquivo**:

```
components declaring their own focus ring: AppShell.tsx, panel.tsx, tabs.tsx:
expected 3 to be less than or equal to 2
```

## Verificação

| | |
|---|---|
| Testes do desktop | `1003 passed` |
| typecheck | limpo |
| design-system | 11 passed |
| Sabotagem | anel novo → vermelho com o arquivo nomeado |

🤖 Generated with [Claude Code](https://claude.com/claude-code)