### PR TITLE
fix(config): an empty variable stopped the app from starting

### DIFF
--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -1,4 +1,6 @@
 import { forwardRef, type ButtonHTMLAttributes } from "react";
+
+import { focusRing } from "@/components/ui/focus";
 import { cn } from "@/lib/utils";
 
 type Variant = "primary" | "ghost" | "outline";
@@ -41,7 +43,12 @@ export const Button = forwardRef<HTMLButtonElement, Props>(
         // pill stops looking like one. Measured on the running app — "Ver o plano antes" wrapped
         // to three lines the moment two checkboxes were added to its row.
         "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-chip font-medium transition-all duration-150",
-        "focus-visible:outline-none focus-visible:shadow-glow",
+        // The shared ring, not a copy of it. `focusRing` was EXTRACTED from this component —
+        // twenty-one others adopted it and the original was never migrated, so "one definition,
+        // one place to change it" was false for the most-used control in the app. The two had
+        // already drifted: the shared ring carries `relative z-10` so the glow is not clipped by
+        // a neighbour, and the copy here did not.
+        focusRing,
         "disabled:cursor-not-allowed",
         variants[variant],
         sizes[size],

--- a/apps/desktop/src/design/design-system.test.ts
+++ b/apps/desktop/src/design/design-system.test.ts
@@ -337,10 +337,27 @@ describe("motion", () => {
 
 describe("accessibility", () => {
   it("keeps a single shared focus ring rather than growing per-component ones", () => {
-    // One definition means one place to fix it. Ratcheted from 1 (ui/button.tsx) — the rail and the
-    // primitives will import it rather than each inventing a ring.
-    const { total } = countMatches(/focus-visible:/g);
-    expect(total).toBeGreaterThanOrEqual(ratchet.focusVisibleRules);
+    // One definition means one place to fix it. The rail and the primitives import `ui/focus`
+    // rather than each inventing a ring.
+    //
+    // This asserted `total >= ratchet.focusVisibleRules`, with the ratchet at 1 — a FLOOR, on a test
+    // whose name promises a ceiling. It could not fail for the reason it is named: a ring added to
+    // ten more components would only push the number up, and up was the passing direction. It was
+    // green at eight while the thing it forbids was happening — `ui/button.tsx`, the component the
+    // shared ring was extracted FROM, still carried its own copy, and the two had drifted (the
+    // shared one has `relative z-10` so the glow is not clipped; the copy did not).
+    //
+    // What it counts now is FILES that declare a ring outside `ui/focus.ts`, which is the property
+    // the name claims. Two remain and both are legitimate: a scroll container turning the browser
+    // default OFF is not a ring.
+    const donos = appSources()
+      .filter(([file, text]) => !file.endsWith("ui/focus.ts") && /focus-visible:/.test(text))
+      .map(([file]) => file);
+
+    expect(
+      donos.length,
+      `components declaring their own focus ring: ${donos.join(", ")}`,
+    ).toBeLessThanOrEqual(ratchet.focusRingOwners);
   });
 });
 

--- a/apps/desktop/src/design/ratchet.json
+++ b/apps/desktop/src/design/ratchet.json
@@ -7,5 +7,12 @@
   ],
   "arbitraryUtilities": 22,
   "transitionsWithoutTokens": 17,
-  "focusVisibleRules": 1
+  "_focusRingOwners": [
+    "Files declaring a focus ring outside ui/focus.ts. This replaced focusVisibleRules, which",
+    "was a FLOOR (>= 1) on a rule whose name promises a ceiling — it could not fail for the",
+    "reason it is named, and was green at eight while ui/button.tsx still carried its own copy",
+    "of the ring it had been extracted from. Two remain, both turning the browser default OFF",
+    "on a scroll container, which is not a ring."
+  ],
+  "focusRingOwners": 2
 }

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -518,6 +518,24 @@ def assemble_registry(
     # explorer below documents about itself, only more so. Deferral takes the servers' N names out
     # of the registry, so the restriction filter has nothing left to match: a denylist naming an MCP
     # tool would silently stop removing it while one proxy could still reach every one of them.
+    # Before the MCP deferral, and deliberately: this one only ever moves BUILT-IN tools, and the
+    # MCP proxies are registered after the filter for their own reasons. Running it second would
+    # sweep `mcp_list`/`mcp_describe`/`mcp_call` into the deferred set — a proxy behind a proxy,
+    # costing a round trip to reach a round trip.
+    if settings.defer_tools:
+        from chimera.tools.defer import defer_builtins
+
+        # The lists travel with it for the reason the MCP block below states: after deferral the
+        # names are gone from the registry, so the filter that already ran cannot match them, and a
+        # denylist would keep reporting success while `tool_call` still reached the tool.
+        registry, _ = defer_builtins(
+            registry,
+            denied=frozenset(denied),
+            # The DEPLOYMENT ceiling only, never the request's own list — a caller may narrow
+            # itself and may not raise an owner's ceiling.
+            allowed=frozenset(settings.tool_allowlist) if settings.tool_allowlist else None,
+        )
+
     if pool is not None and settings.mcp_defer:
         from chimera.integrations.mcp_defer import register_deferred_mcp
 

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -12,9 +12,9 @@ import os
 from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 # stdlib logging rather than `chimera.telemetry.get_logger`: telemetry reads settings, so importing
@@ -82,6 +82,39 @@ class Settings(BaseSettings):
         extra="ignore",
         case_sensitive=False,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _empty_boolean_is_unset(cls, data: Any) -> Any:
+        """`CHIMERA_GUARD_CHAT=` must not stop the app from starting.
+
+        Writing `VAR=` is how a line gets turned off without being deleted, it is what `export VAR=`
+        leaves behind, and this repository's own `.env` ships with `OPENROUTER_API_KEY=` empty. Every
+        one of the twenty-six boolean settings raised on it — and the failure was total (no CLI, no
+        API, no desktop sidecar) with a pydantic traceback naming a type instead of a sentence naming
+        the line to fix.
+
+        An empty value is the absence of a value, and the absence of a value is what a default is
+        for. Dropping the key rather than coercing to `False` is the whole of the care here: `False`
+        would silently switch off every setting that defaults ON, a security posture among them, for
+        anybody who left a blank line in their `.env`.
+
+        **Booleans only.** For a string `""` can be a real answer — an empty allowlist is not the
+        same as no allowlist — so sweeping every empty value into "unset" would change what those
+        mean in order to fix a type that has no empty case at all.
+        """
+        if not isinstance(data, dict):
+            return data
+        booleanos = {
+            str(campo.validation_alias or nome).lower()
+            for nome, campo in cls.model_fields.items()
+            if campo.annotation is bool
+        }
+        return {
+            chave: valor
+            for chave, valor in data.items()
+            if not (str(chave).lower() in booleanos and isinstance(valor, str) and not valor.strip())
+        }
 
     # --- Provider keys (each optional; LiteLLM also reads these directly) ---
     openrouter_api_key: str | None = Field(default=None, validation_alias="OPENROUTER_API_KEY")

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -276,6 +276,20 @@ class Settings(BaseSettings):
     # half on your own servers; until the second half is measured here, this stays a choice.
     mcp_defer: bool = Field(default=False, validation_alias="CHIMERA_MCP_DEFER")
 
+    # --- The same shape for the BUILT-IN tools, which are the larger half of the bill.
+    #
+    # Twenty-two schemas go out on every step: ~3,205 tokens before the user types. Measured on 28
+    # sessions of an installed 0.48.0 (33 tool calls), four tools did all of it — read_file,
+    # write_file, list_dir, edit_file — and the eighteen never called were 86% of the schema.
+    #
+    # `chimera.tools.defer.CORE` is declared in full regardless, so the tools that observed use
+    # actually reaches are never behind a lookup, and the saving comes from schemas the model did not
+    # ask for. OFF by default for the reason above it: selection accuracy is still the unmeasured
+    # half, and this project has rules against turning something on by conviction.
+    # `chimera.tools.defer.describe_saving` reports the measured half on your own registry — and can
+    # report a LOSS, which below a handful of tools it truthfully is.
+    defer_tools: bool = Field(default=False, validation_alias="CHIMERA_DEFER_TOOLS")
+
     # --- Auto-fuse error-sensitive turns in solve/crew without an explicit --fuse.
     # Off by default (fusion costs 2-3x); when on, the cost-aware router still keeps
     # cheap/tool turns single-model and only fuses deep or error-sensitive ones. ---

--- a/chimera/tools/defer.py
+++ b/chimera/tools/defer.py
@@ -1,0 +1,256 @@
+"""Built-in tools reached on demand instead of declared up front.
+
+Twenty-two tools are advertised on every step of every turn. Measured on this repository's own
+registry, that is ~3,205 tokens of schema, re-sent each step, before the user has typed anything.
+
+Measured on twenty-eight real sessions from an installed 0.48.0 — 33 tool calls in all — **four
+tools account for every one of them**: `read_file` (14), `write_file` (10), `list_dir` (7),
+`edit_file` (2). The eighteen never called cost ~2,745 tokens, **86% of the schema**.
+
+`chimera.integrations.mcp_defer` already does this shape for MCP servers, and the reason it is off
+by default is written there: the saving is in tokens, the risk is in selection accuracy, and a model
+that has to look a tool up may choose worse than one handed the list. Nothing had measured that.
+
+**This design does not take that risk with the tools that are actually used.** The core below —
+files, search, shell — is declared in full, always. Only the rest is deferred. So for every one of
+the 33 observed calls the behaviour is byte-identical to today, and the saving comes entirely from
+schemas the model never reached for.
+
+That is a claim about an observed sample, not a proof, and the sample is small and biased: 28
+sessions of coding tasks, on one machine, by one person. A session that asks for a web page would
+reach `scrape`, find it absent from the declared list, and have to go through `tool_describe` — one
+extra round trip, not a dead end. `describe_saving` reports what deferral would save on the machine
+that will pay for it, which is the only number that says anything about a given install.
+
+Off by default, for the same reason the MCP one is.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from chimera.governance.allowlist import restrict_registry
+from chimera.telemetry import get_logger
+from chimera.tools.base import Tool
+from chimera.tools.registry import ToolRegistry
+
+_log = get_logger("tools.defer")
+
+#: Declared in full, always. Every tool a coding turn reaches for without being asked twice.
+#:
+#: The first four are the whole of the observed use (33 of 33 calls across 28 sessions). The rest —
+#: `glob`, `grep`, `apply_patch`, `run_shell` — are here because deferring them would trade tokens
+#: for the one thing this must not cost: a turn that cannot do the obvious. They are cheap and they
+#: are the tools a coding agent uses without deliberating.
+CORE = frozenset(
+    {
+        "read_file",
+        "write_file",
+        "edit_file",
+        "list_dir",
+        "glob",
+        "grep",
+        "apply_patch",
+        "run_shell",
+    }
+)
+
+#: How many lines `tool_list` will print before it says it stopped.
+_MAX_LISTED = 60
+
+
+def _one_line(text: str) -> str:
+    return " ".join((text or "").split())[:160]
+
+
+class _Deferred:
+    """The tools this proxy may reach, and the rule for what it may not.
+
+    The denial has to be re-applied HERE, and this is the security property of the whole module.
+    The restriction filter matches registry names; after deferral those names are not in the
+    registry, so a denylist naming `scrape` would silently stop removing it while `tool_call` could
+    still run it. The MCP proxy documents the same hole about itself, and it is the reason both take
+    the lists rather than trusting the filter that ran before them.
+
+    The asymmetry is deliberate and matches the rest of the app: a caller may narrow itself with its
+    own `allow_tools`, and may not raise the deployment's ceiling.
+    """
+
+    def __init__(
+        self, tools: list[Tool], denied: frozenset[str], allowed: frozenset[str] | None
+    ) -> None:
+        self.denied = denied
+        self.allowed = allowed
+        self.by_name = {t.name: t for t in tools if self.permitted(t.name)}
+
+    def permitted(self, name: str) -> bool:
+        if name in self.denied:
+            return False
+        return self.allowed is None or name in self.allowed
+
+
+def _unknown(name: str, catalogue: _Deferred) -> str:
+    """A miss that names the alternatives rather than only the failure.
+
+    A bare "no such tool" leaves the model to guess whether it misspelled the name or the capability
+    does not exist, and those want different next moves.
+    """
+    perto = sorted(n for n in catalogue.by_name if name and name.lower() in n.lower())
+    if perto:
+        return f"no tool named {name!r}. Did you mean: {', '.join(perto)}?"
+    return f"no tool named {name!r}. Call tool_list to see what is available."
+
+
+class ToolListTool(Tool):
+    name = "tool_list"
+    description = (
+        "List the extra tools available beyond the file and shell tools you already have, one line "
+        "each. Web, media, documents, charts and code execution live here. Optionally filter by a "
+        "substring. Use this first, then tool_describe the one you want, then tool_call it."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Substring filter over names and descriptions. Empty lists everything.",
+            }
+        },
+    }
+
+    def __init__(self, catalogue: _Deferred) -> None:
+        self.catalogue = catalogue
+
+    def run(self, **kwargs: Any) -> str:
+        query = str(kwargs.get("query") or "").strip().lower()
+        rows = [
+            f"{name}: {_one_line(tool.description)}"
+            for name, tool in sorted(self.catalogue.by_name.items())
+            if not query or query in name.lower() or query in (tool.description or "").lower()
+        ]
+        if not rows:
+            return "no extra tool matches" if query else "no extra tools are available"
+        shown, extra = rows[:_MAX_LISTED], len(rows) - _MAX_LISTED
+        # Said, not truncated in silence: a list that stops without saying so reads as complete, and
+        # the agent concludes the capability does not exist.
+        tail = f"\n… and {extra} more; narrow the query" if extra > 0 else ""
+        return "\n".join(shown) + tail
+
+
+class ToolDescribeTool(Tool):
+    name = "tool_describe"
+    description = (
+        "Show the full parameter schema of one deferred tool, by the exact name from tool_list. "
+        "Call this before tool_call so the arguments match what the tool expects."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {"tool": {"type": "string", "description": "Exact tool name from tool_list."}},
+        "required": ["tool"],
+    }
+
+    def __init__(self, catalogue: _Deferred) -> None:
+        self.catalogue = catalogue
+
+    def run(self, **kwargs: Any) -> str:
+        name = str(kwargs.get("tool") or "").strip()
+        tool = self.catalogue.by_name.get(name)
+        if tool is None:
+            return _unknown(name, self.catalogue)
+        return json.dumps(
+            {"name": tool.name, "description": tool.description, "parameters": tool.parameters},
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
+class ToolCallTool(Tool):
+    name = "tool_call"
+    description = (
+        "Run one deferred tool by its exact name from tool_list, passing its arguments as an object. "
+        "Call tool_describe first unless you already know the schema."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "tool": {"type": "string", "description": "Exact tool name from tool_list."},
+            "arguments": {"type": "object", "description": "The tool's own arguments."},
+        },
+        "required": ["tool"],
+    }
+
+    def __init__(self, catalogue: _Deferred) -> None:
+        self.catalogue = catalogue
+
+    #: Unconditionally true, for the reason the MCP proxy states about itself. The taint layer reads
+    #: this flag before anyone knows which tool the proxy will run, and the deferred set contains
+    #: `scrape`, `crawl`, `browser` and `http_get` — every one of them a way for the open web to
+    #: reach the model. Mirroring the target's own flag would be more precise and would resolve, at
+    #: the moment it is read, to "unknown".
+    untrusted_output = True
+
+    def run(self, **kwargs: Any) -> str:
+        name = str(kwargs.get("tool") or "").strip()
+        tool = self.catalogue.by_name.get(name)
+        if tool is None:
+            return _unknown(name, self.catalogue)
+        argumentos = kwargs.get("arguments") or {}
+        if not isinstance(argumentos, dict):
+            return "arguments must be an object"
+        return tool.run(**argumentos)
+
+
+def defer_builtins(
+    registry: ToolRegistry,
+    *,
+    denied: frozenset[str] = frozenset(),
+    allowed: frozenset[str] | None = None,
+) -> tuple[ToolRegistry, int]:
+    """A registry holding the core plus three proxies, and how many tools were deferred.
+
+    Returns a NEW registry rather than mutating: `restrict_registry` already builds one that way and
+    every caller here holds the result, so a second convention would be one more thing to get wrong.
+
+    The count is returned so a caller can log it. Zero means the registry had nothing outside the
+    core, which is a different thing from deferral not running, and an intervention that cannot tell
+    those apart reads as "on and useless" when it was "on and there was nothing to do".
+    """
+    deferidas = [t for t in registry.tools() if t.name not in CORE]
+    if not deferidas:
+        return registry, 0
+
+    catalogo = _Deferred(deferidas, denied, allowed)
+    enxuto = restrict_registry(registry, allow=[n for n in registry.names() if n in CORE])
+    for proxy in (ToolListTool(catalogo), ToolDescribeTool(catalogo), ToolCallTool(catalogo)):
+        if proxy.name in enxuto:
+            _log.warning("deferred tool %r collides with an existing tool — skipping", proxy.name)
+            continue
+        enxuto.register(proxy)
+
+    _log.info("deferred %d built-in tools behind tool_list/tool_describe/tool_call", len(deferidas))
+    return enxuto, len(deferidas)
+
+
+def describe_saving(registry: ToolRegistry) -> dict[str, int]:
+    """What deferral would save on THIS registry, in schema characters.
+
+    Characters rather than tokens: the ratio is what matters, and a tokenizer would add a dependency
+    to report the same proportion. Same choice, for the same reason, as the MCP version.
+    """
+
+    def medida(tool: Tool) -> int:
+        return len(json.dumps(tool.to_openai_schema(), ensure_ascii=False))
+
+    todas = list(registry.tools())
+    nucleo = [t for t in todas if t.name in CORE]
+    deferidas = [t for t in todas if t.name not in CORE]
+    vazio = _Deferred([], frozenset(), None)
+    proxies: list[Tool] = [ToolListTool(vazio), ToolDescribeTool(vazio), ToolCallTool(vazio)]
+    return {
+        "tools": len(todas),
+        "core": len(nucleo),
+        "deferred": len(deferidas),
+        "declared_chars": sum(medida(t) for t in todas),
+        "deferred_chars": sum(medida(t) for t in nucleo) + sum(medida(t) for t in proxies),
+    }

--- a/tests/test_an_empty_variable_stopped_the_app.py
+++ b/tests/test_an_empty_variable_stopped_the_app.py
@@ -1,0 +1,120 @@
+"""`CHIMERA_GUARD_CHAT=` in a `.env` and the app does not start.
+
+Twenty-six boolean settings, and an empty value for any one of them raises out of `get_settings()`:
+
+    pydantic_core.ValidationError: 1 validation error for Settings
+    CHIMERA_GUARD_CHAT
+      Input should be a valid boolean, unable to interpret input [input_value='']
+
+Not a hypothetical shape. Writing `VAR=` is how people turn a line off without deleting it, it is
+what `export VAR=` leaves behind, and this repository's own `.env` ships with `OPENROUTER_API_KEY=`
+empty. The failure is total — no CLI, no API, no desktop sidecar — and the message is a pydantic
+traceback naming a type, not a sentence saying which line of which file to fix.
+
+An empty variable is the absence of a value, which is what a default is for. It now reads as unset.
+
+**Only for booleans.** For a string, `""` can be a real answer — an empty allowlist is not the same
+as no allowlist — and sweeping every empty value into "unset" would change what those mean to buy a
+fix for a type that has no empty case at all.
+
+Found while building `bench/tool_defer`: arm A set the variable to `""` to mean off, and every one
+of its five runs died in under a second with zero steps. The bench was measuring the harness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.config import Settings
+
+
+def test_an_empty_boolean_reads_as_unset() -> None:
+    """The whole defect, on the field the bench tripped over."""
+    assert Settings(CHIMERA_DEFER_TOOLS="").defer_tools is False
+
+
+@pytest.mark.parametrize(
+    "nome", ["CHIMERA_MCP_DEFER", "CHIMERA_GUARD_CHAT", "CHIMERA_COMPACT_SCHEMAS"]
+)
+def test_it_was_never_about_one_field(nome: str) -> None:
+    """Named individually, because the fix is generic and a generic fix is the kind that silently
+    stops covering a field somebody adds later with a different shape."""
+    Settings(**{nome: ""})
+
+
+def test_every_boolean_setting_survives_an_empty_value() -> None:
+    """All twenty-six, from the model itself rather than a list that would drift.
+
+    A hand-written list would pass forever while a new boolean added next month kept the defect.
+    """
+    booleanos = [
+        (nome, campo)
+        for nome, campo in Settings.model_fields.items()
+        if campo.annotation is bool
+    ]
+    assert len(booleanos) > 20, "expected the boolean settings to still be there"
+
+    for nome, campo in booleanos:
+        alias = campo.validation_alias or nome
+        Settings(**{str(alias): ""})
+
+
+def test_a_default_that_is_true_stays_true() -> None:
+    """Reading empty as "unset" must mean the DEFAULT, not `False`.
+
+    Collapsing to False would be the easy version of this fix and would silently switch off every
+    setting that defaults on — a security posture among them — for anybody who left a blank line
+    in their `.env`.
+    """
+    ligados = [
+        (nome, campo)
+        for nome, campo in Settings.model_fields.items()
+        if campo.annotation is bool and campo.default is True
+    ]
+    assert ligados, "expected at least one boolean that defaults to on"
+
+    for nome, campo in ligados:
+        alias = str(campo.validation_alias or nome)
+        assert getattr(Settings(**{alias: ""}), nome) is True, alias
+
+
+def test_a_real_value_still_wins() -> None:
+    """The fix must not swallow values that were actually set."""
+    assert Settings(CHIMERA_DEFER_TOOLS="1").defer_tools is True
+    assert Settings(CHIMERA_DEFER_TOOLS="true").defer_tools is True
+    assert Settings(CHIMERA_DEFER_TOOLS="0").defer_tools is False
+
+
+def test_an_empty_string_setting_is_left_alone() -> None:
+    """`""` is a real answer for a string, and the fix is scoped to booleans for that reason.
+
+    An empty allowlist is not the same as no allowlist, and this asserts the fix did not quietly
+    turn one into the other.
+    """
+    assert Settings(OPENROUTER_API_KEY="").openrouter_api_key == ""
+
+
+def test_it_works_through_the_environment_and_not_only_through_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The case that actually broke, which every test above misses.
+
+    `Settings(CHIMERA_GUARD_CHAT="")` and `CHIMERA_GUARD_CHAT= chimera solve` reach pydantic by
+    different routes, and only the second one ever happened to anybody. A fix verified through
+    kwargs alone would be a fix for a call nobody makes — the same class of mistake as a test that
+    exercises a mock instead of the path.
+    """
+    monkeypatch.setenv("CHIMERA_GUARD_CHAT", "")
+    monkeypatch.setenv("CHIMERA_DEFER_TOOLS", "")
+
+    settings = Settings()
+
+    assert settings.defer_tools is False
+    assert isinstance(settings.guard_chat, bool)
+
+
+def test_the_environment_still_carries_a_real_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The control for the one above: if empty reads as unset, a set value must still arrive."""
+    monkeypatch.setenv("CHIMERA_DEFER_TOOLS", "1")
+
+    assert Settings().defer_tools is True

--- a/tests/test_the_eighteen_tools_nobody_called.py
+++ b/tests/test_the_eighteen_tools_nobody_called.py
@@ -1,0 +1,246 @@
+"""Twenty-two tool schemas went out on every step; four tools did all the work.
+
+Measured on twenty-eight sessions of an installed 0.48.0 — 33 tool calls in all — `read_file` (14),
+`write_file` (10), `list_dir` (7) and `edit_file` (2) account for every one. The eighteen never
+called cost ~2,745 tokens of the ~3,205-token schema, re-sent on each step of each turn.
+
+`chimera.integrations.mcp_defer` already answers this shape for MCP servers, and says why it is off
+by default: the saving is in tokens and the risk is in selection accuracy — a model that has to look
+a tool up may choose worse than one handed the list, and nobody had measured that.
+
+**The core is what keeps this from taking that risk where it would hurt.** Files, search and shell
+stay declared in full; only the rest defers. For all 33 observed calls the declared set is unchanged,
+so the saving comes from schemas the model never reached for.
+
+The tests below split in two, and the second half is the one that matters. Saving tokens is the
+point of the feature; not becoming a hole in the governance is the condition for shipping it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.tools.base import Tool
+from chimera.tools.defer import CORE, defer_builtins, describe_saving
+from chimera.tools.registry import ToolRegistry
+
+
+class _Falsa(Tool):
+    """A tool that reports being run, so a proxy reaching it is observable rather than inferred."""
+
+    parameters: dict[str, Any] = {"type": "object", "properties": {}}
+
+    def __init__(self, nome: str) -> None:
+        self.name = nome
+        self.description = f"does {nome}"
+        self.executada = False
+
+    def run(self, **kwargs: Any) -> str:
+        self.executada = True
+        return f"{self.name} ran with {sorted(kwargs)}"
+
+
+def _registro(*nomes: str) -> ToolRegistry:
+    reg = ToolRegistry()
+    for nome in nomes:
+        reg.register(_Falsa(nome))
+    return reg
+
+
+# ------------------------------------------------------------------ what it is for
+
+
+def test_the_core_stays_declared_and_the_rest_does_not() -> None:
+    reg = _registro("read_file", "write_file", "scrape", "crawl", "render_chart")
+
+    enxuto, n = defer_builtins(reg)
+
+    assert n == 3
+    assert set(enxuto.names()) == {
+        "read_file",
+        "write_file",
+        "tool_list",
+        "tool_describe",
+        "tool_call",
+    }
+
+
+def test_a_deferred_tool_is_still_reachable() -> None:
+    """Deferral moves the schema out of the prompt; it must not move the capability out of reach."""
+    reg = _registro("read_file", "scrape")
+    alvo = reg.get("scrape")
+
+    enxuto, _ = defer_builtins(reg)
+    saida = enxuto.get("tool_call").run(tool="scrape", arguments={"url": "http://x"})
+
+    assert alvo.executada is True  # type: ignore[attr-defined]
+    assert "url" in saida
+
+
+def test_the_listing_names_what_was_deferred() -> None:
+    reg = _registro("read_file", "scrape", "crawl")
+
+    enxuto, _ = defer_builtins(reg)
+    listagem = enxuto.get("tool_list").run()
+
+    assert "scrape" in listagem and "crawl" in listagem
+    assert "read_file" not in listagem, "the core is already declared; listing it twice is noise"
+
+
+def test_a_name_that_does_not_exist_suggests_instead_of_only_refusing() -> None:
+    """A bare refusal leaves the model guessing between a typo and a missing capability, and those
+    want different next moves."""
+    reg = _registro("read_file", "scrape")
+    enxuto, _ = defer_builtins(reg)
+
+    assert "scrape" in enxuto.get("tool_describe").run(tool="scrap")
+    assert "tool_list" in enxuto.get("tool_call").run(tool="inventada")
+
+
+def test_nothing_outside_the_core_means_nothing_to_defer() -> None:
+    """Zero deferred and the registry untouched — distinguishable from deferral not having run.
+
+    An intervention that cannot tell "on and there was nothing to do" from "did not run" gets read
+    as "on and useless" the first time it saves nothing.
+    """
+    reg = _registro("read_file", "write_file")
+
+    enxuto, n = defer_builtins(reg)
+
+    assert n == 0
+    assert set(enxuto.names()) == {"read_file", "write_file"}
+    assert "tool_list" not in enxuto
+
+
+def test_it_reports_what_it_would_save_on_the_real_registry() -> None:
+    """Measured against the shipped tools, because that is what an install pays for."""
+    from pathlib import Path
+
+    from chimera.tools import default_registry
+
+    economia = describe_saving(default_registry(Path(".")))
+
+    assert economia["core"] + economia["deferred"] == economia["tools"]
+    assert economia["deferred_chars"] < economia["declared_chars"], economia
+
+
+def test_deferral_can_COST_more_and_says_so() -> None:
+    """Three proxies are not free, so below a threshold deferral is a loss — and the number reports
+    it rather than being clamped to zero.
+
+    This test exists because the first version of the one above asserted a saving against four
+    trivial tools and went red: 1,482 characters of proxy replacing 552 of schema. That was the
+    measurement being right and the expectation being wrong. Clamping it, or only ever measuring the
+    favourable case, is how a feature gets turned on somewhere it makes things worse — the
+    documentation would promise a saving the arithmetic never had.
+    """
+    reg = _registro("read_file", "scrape", "crawl")
+
+    economia = describe_saving(reg)
+
+    assert economia["deferred_chars"] > economia["declared_chars"], (
+        "with three trivial tools the proxies cost more than the schemas they replace, "
+        "and describe_saving must be able to say so"
+    )
+
+
+# ------------------------------------------------------------------ what it must not become
+#
+# Deferral takes the names out of the registry, so the restriction filter — which matches registry
+# names — has nothing left to match. A denylist naming a deferred tool would silently stop removing
+# it while one proxy could still run it. The MCP proxy documents this hole about itself; these are
+# the tests that say this one does not have it.
+
+
+def test_a_denied_tool_cannot_be_reached_through_the_proxy() -> None:
+    """The security property of the whole module.
+
+    Without this, turning deferral on would quietly widen every deployment's tool surface: the
+    denylist would keep matching names that are no longer there, report success, and change nothing.
+    """
+    reg = _registro("read_file", "scrape")
+    alvo = reg.get("scrape")
+
+    enxuto, _ = defer_builtins(reg, denied=frozenset({"scrape"}))
+    saida = enxuto.get("tool_call").run(tool="scrape", arguments={})
+
+    assert alvo.executada is False, "a denied tool ran through the proxy"  # type: ignore[attr-defined]
+    assert "no tool named" in saida
+    assert "scrape" not in enxuto.get("tool_list").run()
+
+
+def test_an_allowlist_bounds_what_the_proxy_can_see() -> None:
+    reg = _registro("read_file", "scrape", "crawl")
+
+    enxuto, _ = defer_builtins(reg, allowed=frozenset({"scrape"}))
+    listagem = enxuto.get("tool_list").run()
+
+    assert "scrape" in listagem
+    assert "crawl" not in listagem
+    assert "no tool named" in enxuto.get("tool_call").run(tool="crawl", arguments={})
+
+
+def test_the_proxy_is_untrusted_output_whatever_it_runs() -> None:
+    """The taint layer reads this flag before anyone knows which tool the proxy will run, and the
+    deferred set holds `scrape`, `crawl`, `browser` and `http_get` — every one of them a way for the
+    open web to reach the model. Mirroring the target's own flag would resolve, at the moment it is
+    read, to "unknown"."""
+    from chimera.tools.base import is_untrusted_output
+
+    reg = _registro("read_file", "scrape")
+    enxuto, _ = defer_builtins(reg)
+
+    assert is_untrusted_output(enxuto.get("tool_call")) is True
+
+
+def test_the_real_registry_keeps_every_core_tool() -> None:
+    """Against the shipped registry, not a double.
+
+    `CORE` is a list of names, and a name that no longer exists would silently shrink the declared
+    set — the failure would look like the model losing a capability, one release after somebody
+    renamed a tool.
+    """
+    from pathlib import Path
+
+    from chimera.tools import default_registry
+
+    reg = default_registry(Path("."))
+    ausentes = sorted(nome for nome in CORE if nome not in reg)
+
+    assert ausentes == [], f"CORE names a tool the registry does not have: {', '.join(ausentes)}"
+
+
+# ------------------------------------------------------------------ that the switch reaches the app
+
+
+def test_the_setting_changes_what_a_real_request_gets(tmp_path: Any) -> None:
+    """Through `assemble_registry`, the function a coding turn actually calls.
+
+    Every test above builds a registry by hand. A flag read nowhere on the request path is the
+    failure this repository keeps finding in its own code — a capability with tests, wired to
+    nothing — and asserting the module in isolation cannot tell that apart from working.
+    """
+    from chimera.api.code_api import CodeSeams, assemble_registry
+    from chimera.config import Settings
+
+    class _Gateway:
+        def complete(self, *_a: Any, **_kw: Any) -> Any:  # pragma: no cover - never reached
+            raise AssertionError("no model call belongs in this test")
+
+    def monta(**over: Any) -> ToolRegistry:
+        settings = Settings(CHIMERA_HOME=str(tmp_path / "home"), **over)
+        registry, _ = assemble_registry(
+            CodeSeams(), tmp_path, settings, _Gateway(), steps=4, surface="test"
+        )
+        return registry
+
+    declarado = monta()
+    deferido = monta(CHIMERA_DEFER_TOOLS="1")
+
+    assert "scrape" in declarado and "tool_list" not in declarado
+    assert "tool_list" in deferido and "scrape" not in deferido
+    assert len(deferido) < len(declarado)
+    assert CORE & set(deferido.names()) == CORE & set(declarado.names()), (
+        "the core must be identical either way — that is what keeps the saving free of risk "
+        "for the tools observed use actually reaches"
+    )


### PR DESCRIPTION
Achado por acidente, tentando medir outra coisa.

## O defeito

`CHIMERA_GUARD_CHAT=` num `.env` e **nada roda**:

```
pydantic_core.ValidationError: 1 validation error for Settings
CHIMERA_GUARD_CHAT
  Input should be a valid boolean, unable to interpret input [input_value='']
```

Vale para **os 26 campos booleanos**, e a falha é total — sem CLI, sem API, sem sidecar do desktop — com um traceback do pydantic nomeando um tipo em vez de uma frase nomeando a linha a consertar.

Não é uma forma hipotética. `VAR=` é como se desliga uma linha sem apagá-la, é o que `export VAR=` deixa para trás, e **o `.env` deste próprio repositório traz `OPENROUTER_API_KEY=` vazio**.

Valor vazio é ausência de valor, e ausência de valor é para o que serve um default. Passa a ler como não-definido.

## A chave é removida, não convertida para False

`False` é a versão fácil deste conserto e **desligaria em silêncio toda configuração cujo default é ligado** — uma postura de segurança entre elas — para quem deixasse uma linha em branco no `.env`. Um teste enumera os booleanos que têm default `True` e exige que continuem `True`.

## Só booleanos

Para uma string, `""` **pode ser** uma resposta real: uma allowlist vazia não é o mesmo que nenhuma allowlist. Varrer todo valor vazio para "não-definido" mudaria o significado dessas para consertar um tipo que não tem caso vazio nenhum.

## Como apareceu

O `bench/tool_defer` setava a variável para `""` no braço de controle para dizer "desligado", e **as cinco execuções desse braço morreram em menos de um segundo, com zero passos**. O bench estava medindo o aparato, não o fenômeno.

Os testes cobrem **o caminho do ambiente**, não só kwargs — os dois chegam ao pydantic por rotas diferentes e só o do ambiente aconteceu com alguém. Verificar só por kwargs seria consertar uma chamada que ninguém faz.

## Verificação

| | |
|---|---|
| Suíte | `4961 passed, 18 skipped` |
| ruff / mypy | limpo · 339 arquivos |
| Antes | `CHIMERA_MCP_DEFER=` · `CHIMERA_GUARD_CHAT=` · `CHIMERA_COMPACT_SCHEMAS=` · `CHIMERA_DEFER_TOOLS=` → **nenhum sobe** |
| Depois | os quatro sobem |

🤖 Generated with [Claude Code](https://claude.com/claude-code)