### PR TITLE
fix(release): a release is not "latest" until it can be updated to

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -8,6 +8,10 @@ name: Build desktop installers
 # files (using the TAURI_SIGNING_PRIVATE_KEY secret), and a final job assembles a `latest.json` manifest
 # and publishes it to the Release so the app's in-place auto-updater can find + verify updates.
 #
+# The release is created with `--latest=false` and PROMOTED by the last job, once latest.json is
+# attached. `releases/latest/download/latest.json` is the updater's endpoint, so a release that
+# becomes "latest" before its manifest exists breaks auto-update for everyone until the build ends.
+#
 # A manual `gh workflow run desktop-release.yml` is a full DRY RUN: it builds every platform, signs,
 # and assembles latest.json as an artifact WITHOUT publishing anything. Do that before every release
 # (see RELEASING.md) — the manifest path used to be release-only, which is why v0.32.0-v0.32.2 were
@@ -381,6 +385,33 @@ jobs:
       # a release that goes red because a website was not notified would be a far worse outcome than
       # a website that updates on the nightly instead. `continue-on-error` covers the other half —
       # the site being down does not make this release wrong.
+      # THE RELEASE BECOMES "LATEST" HERE, and the position is the whole point.
+      #
+      # The updater endpoint is `releases/latest/download/latest.json`, which resolves to whatever
+      # GitHub calls the latest release. Published the ordinary way, a release becomes latest the
+      # INSTANT it is created — twenty-five minutes before this job attaches the manifest — and for
+      # that whole window the endpoint 404s and every installed app's update check fails. Silently,
+      # by design: the startup check swallows errors so it never nags. Measured on v0.49.0.
+      #
+      # So `RELEASING.md` says to create it with `--latest=false`, and this promotes it once the
+      # manifest is up. Until then the endpoint keeps resolving to the PREVIOUS release, which has
+      # a valid manifest naming a real version — old clients are offered that, which is correct,
+      # instead of meeting a 404.
+      #
+      # The failure mode improves too, and that is not a side effect. A build that dies halfway now
+      # leaves the previous release as latest: a broken release is simply not offered, rather than
+      # becoming the one everybody's updater points at and cannot read.
+      #
+      # `--latest=false` still fires `release: published`, so this workflow triggers exactly as
+      # before. A DRAFT would not have: drafts fire no release event at all, which is why the
+      # obvious "create it as a draft" version of this fix does not work.
+      - name: Mark the release as latest, now that the manifest is attached
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --latest
+
       - name: Tell the website a release is out
         # Reads the JOB's env, set above. Not `secrets.…` (unparseable in a step `if`, and it takes
         # the whole workflow file down with it), and not the step's own `env` (not in scope for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **For twenty-five minutes after every release, auto-update was broken for everyone.** The updater
+  asks GitHub for `releases/latest/download/latest.json`, which resolves to whatever is called the
+  latest release — and a release becomes latest the *instant* it is created, while `latest.json` is
+  attached by the last job of the installer build, after four platforms have finished. Measured on
+  v0.49.0: the endpoint returned **404** while the installers were still going up.
+
+  Nobody had noticed, and the reason is the property that makes the check pleasant: it swallows
+  every error so it never nags. A window in which no update can be found looks exactly like a
+  window in which there is no update.
+
+  Stable releases are now created with `--latest=false` and promoted by the workflow once the
+  manifest is attached. Until then the endpoint keeps resolving to the previous release, whose
+  manifest names a real version — old clients are offered that, which is correct, instead of
+  meeting a 404. **The failure mode improves too:** a build that dies halfway leaves the previous
+  release as latest, so a broken release is simply not offered rather than becoming the one every
+  updater points at and cannot read.
+
+  Not a draft, which is the obvious version of this fix and does not work: drafts fire no release
+  event, so neither workflow would start.
+
+- **The "new version available" panel asked a question it could not answer.** Its heading read
+  *"A new version (v0.49.0) is available. Update?"* over a panel whose only two buttons are *View
+  release* and *Dismiss*. Inside the installed app there is no third option to offer — the panel
+  lives in the webview, on the sidecar's http origin, with no IPC to the Rust updater — so the
+  question mark promised something that did not exist.
+
+  It states rather than asks now, and names what does start one: the tray's **Check for updates**.
+  That label exists in two tables in two languages — `Dialogo.menu` in Rust and `update.trayItem`
+  in the frontend — so a Rust test compares them per language and fails if they drift. Pointing at
+  a menu item spelled differently from the menu item would be worse than pointing at nothing,
+  because the reader concludes the feature is missing. The test caught a real mismatch on its first
+  run: the dictionaries are *defined* in a different order from `LANGS`, so comparing them by
+  position measured Italian against Chinese.
+
 ## [0.49.0] - 2026-09-02
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,9 +93,27 @@ uv run --no-sync python -m chimera.cli.schema_dump > chimera/_cli_snapshot.json
 # 3. CHANGELOG: rename [Unreleased] -> [X.Y.Z] - <date>   (STABLE ONLY — an rc previews the
 #    [Unreleased] section and leaves it alone; the stable is what names and dates it)
 # 4. commit, push, then:
-gh release create vX.Y.0 --title "..." --notes "..."            # stable
-gh release create vX.Y.0rc1 --prerelease --title "..." --notes "..."   # rc
+gh release create vX.Y.0 --latest=false --title "..." --notes "..."          # stable
+gh release create vX.Y.0rc1 --prerelease --title "..." --notes "..."        # rc
 ```
+
+**`--latest=false` on a stable release is not optional.** The updater's endpoint is
+`releases/latest/download/latest.json`, which resolves to whatever GitHub calls the latest release —
+and a release becomes latest the instant it is created, about twenty-five minutes before
+`desktop-release.yml` attaches the manifest. For that whole window the endpoint 404s and every
+installed app's update check fails, silently, because the startup check swallows errors so it never
+nags. Measured on v0.49.0.
+
+The last job of `desktop-release.yml` promotes it (`gh release edit --latest`) once the manifest is
+up. Until then the endpoint keeps resolving to the previous release, whose manifest names a real
+version — old clients are offered that, which is correct, instead of meeting a 404. It also means a
+build that dies halfway leaves the previous release as latest: a broken release is simply not
+offered.
+
+An rc needs no flag: `--prerelease` already keeps it out of "latest".
+
+Do **not** reach for `--draft` instead. A draft fires no release event at all, so neither workflow
+would start.
 
 Publishing fires two workflows: **publish.yml** (PyPI, via OIDC — no token) and
 **desktop-release.yml** (installers + signed updater artifacts + `latest.json`).

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1179,6 +1179,53 @@ mod tests {
         );
     }
 
+    /// The tray's label and the label the app's own panel tells you to look for are the same text.
+    ///
+    /// They live in two tables in two languages: `Dialogo.menu` here, and `update.trayItem` in
+    /// `i18n.tsx`. The panel that appears when a new version is found now says "update it from the
+    /// tray menu — «Verificar atualizações»", so a drift between them would send somebody hunting
+    /// for a menu item spelled differently from the menu item. Pointing at the wrong name is worse
+    /// than pointing at nothing, because the person concludes the feature is missing.
+    ///
+    /// Nothing else can catch this: one side is Rust and the other is TypeScript, they are shipped
+    /// in the same binary, and no compiler sees both.
+    #[test]
+    fn o_rotulo_da_bandeja_e_o_mesmo_dos_dois_lados() {
+        let fonte = include_str!("../../src/lib/i18n.tsx");
+
+        // Matched by LANGUAGE CODE, never by position — and that is not caution, it is a bug this
+        // test hit on its first run. The dictionaries are DEFINED in the file as en, pt, es, fr,
+        // de, zh, ja, it, pl, ru; `LANGS` (and so `DIALOGO`) orders them en, pt, es, fr, de, it,
+        // pl, zh, ja, ru. Zipping the two lists compared Italian against Chinese and reported a
+        // drift that did not exist. `os_idiomas_sao_os_mesmos_do_aplicativo` cannot catch this: it
+        // reads `LANGS`, which agrees, while the definitions below it do not.
+        let mut conferidos = 0;
+        for d in &DIALOGO {
+            let cabeca = format!("const {}: Dict = {{", d.codigo);
+            let dicionario = fonte
+                .split_once(cabeca.as_str())
+                .unwrap_or_else(|| panic!("o dicionario {} existe em i18n.tsx", d.codigo))
+                .1;
+            // Bounded at the next dictionary, so a missing key here cannot silently read the next
+            // language's value and pass.
+            let dicionario = dicionario.split_once("\n};").map_or(dicionario, |(head, _)| head);
+            let no_app = dicionario
+                .split_once("\"update.trayItem\": \"")
+                .unwrap_or_else(|| panic!("{}: nao tem update.trayItem", d.codigo))
+                .1
+                .split_once('"')
+                .expect("a string fecha")
+                .0;
+            assert_eq!(
+                d.menu, no_app,
+                "{}: o rotulo da bandeja no Rust e no i18n.tsx divergiram",
+                d.codigo
+            );
+            conferidos += 1;
+        }
+        assert_eq!(conferidos, DIALOGO.len(), "algum idioma nao foi conferido");
+    }
+
     #[test]
     fn a_url_yields_its_port() {
         assert_eq!(port_of("http://127.0.0.1:51234"), Some(51234));

--- a/apps/desktop/src/components/VersionBadge.test.tsx
+++ b/apps/desktop/src/components/VersionBadge.test.tsx
@@ -53,9 +53,32 @@ describe("the version badge", () => {
 
     await open();
 
-    expect(screen.getByText(/updates itself/i)).toBeInTheDocument();
     // The pip command updates the Python package. The user is looking at the bundle.
     expect(screen.queryByText(/pip install -U/)).toBeNull();
+  });
+
+  it("names the thing that starts the update, instead of asking a question it cannot answer",
+    async () => {
+      (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+
+      await open();
+
+      // The heading used to read "A new version is available. Update?" over a panel whose only two
+      // buttons are "View release" and "Dismiss". Inside the bundle there is no third option to
+      // offer: this panel is in the webview, on the sidecar's http origin, with no IPC to the Rust
+      // updater. A question mark promises an answer that does not exist.
+      expect(screen.queryByText(/Update\?/)).toBeNull();
+      // And it points at what DOES start one.
+      expect(screen.getByText(/Check for updates/)).toBeInTheDocument();
+      expect(screen.getByText(/tray menu/i)).toBeInTheDocument();
+    });
+
+  it("still asks in a browser, where the question has an answer", async () => {
+    // The control. Dropping the question everywhere would pass the test above and take away a
+    // reasonable prompt from the one place the panel really can tell you what to do next.
+    await open();
+
+    expect(screen.getByText(/Update\?/)).toBeInTheDocument();
   });
 
   it("stays quiet when there is nothing newer", async () => {

--- a/apps/desktop/src/components/VersionBadge.tsx
+++ b/apps/desktop/src/components/VersionBadge.tsx
@@ -72,9 +72,24 @@ export function VersionBadge() {
     <div className="relative">
       {open && (
         <div className="surface absolute bottom-full right-0 mb-2 w-72 space-y-3 p-3 text-sm shadow-elev">
-          <p className="text-foreground">{t("update.prompt", { latest })}</p>
+          {/* The native panel STATES; the browser one asks.
+              It used to ask in both: "A new version is available. Update?" — over a panel whose
+              only two buttons are "View release" and "Dismiss". A question mark promises an answer,
+              and inside the bundle there was none to give: this panel lives in the webview, on the
+              sidecar's http origin, with no IPC to the Rust updater (see `capabilities/default.json`
+              and `idioma_do_dialogo` in `main.rs`). It could not start an update if it wanted to.
+              In a browser the question is fair — the pip command below IS the answer. */}
+          <p className="text-foreground">
+            {native ? t("update.promptNative", { latest }) : t("update.prompt", { latest })}
+          </p>
+          {/* And it now names the thing that DOES start it. `update.trayItem` is the tray label,
+              which also exists in `main.rs` — two tables for one string, so a Rust test compares
+              them and fails if they drift. Pointing at a menu item spelled differently from the
+              menu item would be worse than pointing at nothing. */}
           <p className="text-xs text-muted-foreground">
-            {native ? t("update.howtoNative") : t("update.howto")}
+            {native
+              ? t("update.howtoNative", { item: t("update.trayItem") })
+              : t("update.howto")}
           </p>
           {native ? null : (
             <div className="flex items-center justify-between gap-2 rounded-chip bg-surface-2 px-2 py-1.5 ring-1 ring-hairline">

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -1128,8 +1128,10 @@ const en: Dict = {
   "settings.hint.mcpAutoload": "load configured servers at app start",
   "update.available": "v{latest} available",
   "update.prompt": "A new version (v{latest}) is available. Update?",
+  "update.promptNative": "A new version (v{latest}) is available.",
+  "update.trayItem": "Check for updates",
   "update.howtoNative":
-    "This app updates itself: it offers each new release at launch, verifies the signature, installs and restarts. Reopen it to be asked again, or read the release notes first.",
+    "Update it from the tray menu — \"{item}\" — or by closing and reopening the app. Either way it verifies the signature, installs in place and restarts.",
   "update.howto":
     "You are viewing this in a browser, so update the package: run the command below, or read the release notes.",
   "update.copy": "Copy",
@@ -2415,8 +2417,10 @@ const pt: Dict = {
     "carrega os servidores configurados ao iniciar o app",
   "update.available": "v{latest} disponível",
   "update.prompt": "Uma nova versão (v{latest}) está disponível. Atualizar?",
+  "update.promptNative": "Uma versão nova (v{latest}) está disponível.",
+  "update.trayItem": "Verificar atualizações",
   "update.howtoNative":
-    "Este aplicativo se atualiza sozinho: ele oferece cada versão nova ao abrir, confere a assinatura, instala e reinicia. Feche e abra de novo para ser perguntado outra vez, ou leia as notas da versão antes.",
+    "Atualize pelo menu da bandeja — \"{item}\" — ou fechando e abrindo o app. Nos dois casos ele confere a assinatura, instala no lugar e reinicia.",
   "update.howto":
     "Você está vendo isto num navegador, então atualize o pacote: rode o comando abaixo, ou leia as notas da versão.",
   "update.copy": "Copiar",
@@ -3713,8 +3717,10 @@ const es: Dict = {
     "carga los servidores configurados al iniciar la app",
   "update.available": "v{latest} disponible",
   "update.prompt": "Hay una nueva versión (v{latest}) disponible. ¿Actualizar?",
+  "update.promptNative": "Hay una versión nueva (v{latest}) disponible.",
+  "update.trayItem": "Buscar actualizaciones",
   "update.howtoNative":
-    "Esta app se actualiza sola: ofrece cada versión nueva al abrirse, verifica la firma, instala y reinicia. Ábrela de nuevo para que te lo vuelva a preguntar, o lee antes las notas de la versión.",
+    "Actualiza desde el menú de la bandeja — \"{item}\" — o cerrando y abriendo la app. En ambos casos verifica la firma, instala y reinicia.",
   "update.howto":
     "Estás viendo esto en un navegador, así que actualiza el paquete: ejecuta el comando de abajo, o lee las notas de la versión.",
   "update.copy": "Copiar",
@@ -5023,8 +5029,10 @@ const fr: Dict = {
   "update.available": "v{latest} disponible",
   "update.prompt":
     "Une nouvelle version (v{latest}) est disponible. Mettre à jour ?",
+  "update.promptNative": "Une nouvelle version (v{latest}) est disponible.",
+  "update.trayItem": "Rechercher des mises à jour",
   "update.howtoNative":
-    "Cette application se met à jour elle-même : elle propose chaque nouvelle version au lancement, vérifie la signature, installe et redémarre. Rouvrez-la pour qu'elle vous le redemande, ou lisez d'abord les notes de version.",
+    "Mettez à jour depuis le menu de la zone de notification — « {item} » — ou en fermant et rouvrant l'application. Dans les deux cas, la signature est vérifiée, l'installation se fait sur place et l'app redémarre.",
   "update.howto":
     "Vous consultez ceci dans un navigateur : mettez donc le paquet à jour avec la commande ci-dessous, ou lisez les notes de version.",
   "update.copy": "Copier",
@@ -6332,8 +6340,10 @@ const de: Dict = {
   "update.available": "v{latest} verfügbar",
   "update.prompt":
     "Eine neue Version (v{latest}) ist verfügbar. Aktualisieren?",
+  "update.promptNative": "Eine neue Version (v{latest}) ist verfügbar.",
+  "update.trayItem": "Nach Updates suchen",
   "update.howtoNative":
-    "Diese App aktualisiert sich selbst: Sie bietet jede neue Version beim Start an, prüft die Signatur, installiert und startet neu. Erneut öffnen, um wieder gefragt zu werden — oder vorher die Release-Notes lesen.",
+    "Aktualisieren Sie über das Tray-Menü — „{item}“ — oder indem Sie die App schließen und neu öffnen. In beiden Fällen wird die Signatur geprüft, an Ort und Stelle installiert und neu gestartet.",
   "update.howto":
     "Sie sehen dies im Browser — aktualisieren Sie also das Paket: mit dem Befehl unten, oder lesen Sie die Release-Notes.",
   "update.copy": "Kopieren",
@@ -7563,8 +7573,10 @@ const zh: Dict = {
   "settings.hint.mcpAutoload": "在应用启动时加载已配置的服务器",
   "update.available": "v{latest} 可用",
   "update.prompt": "有新版本（v{latest}）可用。要更新吗？",
+  "update.promptNative": "有新版本 (v{latest})。",
+  "update.trayItem": "检查更新",
   "update.howtoNative":
-    "这个应用会自己更新：每次启动时提议新版本，校验签名，安装并重启。重新打开它就会再问一次，或者先读发布说明。",
+    "从托盘菜单更新——「{item}」——或关闭后重新打开应用。两种方式都会校验签名、原地安装并重启。",
   "update.howto":
     "你是在浏览器里看这个的，所以请更新包：运行下面的命令，或者去读发布说明。",
   "update.copy": "复制",
@@ -8853,8 +8865,10 @@ const ja: Dict = {
   "update.available": "v{latest} が利用可能",
   "update.prompt":
     "新しいバージョン（v{latest}）が利用可能です。更新しますか？",
+  "update.promptNative": "新しいバージョン (v{latest}) があります。",
+  "update.trayItem": "アップデートを確認",
   "update.howtoNative":
-    "このアプリは自分で更新します。起動時に新しいリリースを提案し、署名を確かめ、インストールして再起動します。もう一度尋ねてほしければ開き直してください。先にリリースノートを読むこともできます。",
+    "トレイメニューの「{item}」から更新するか、アプリを閉じて開き直してください。どちらも署名を検証し、その場で更新して再起動します。",
   "update.howto":
     "これはブラウザで見ています。パッケージを更新してください — 下のコマンドを実行するか、リリースノートをご覧ください。",
   "update.copy": "コピー",
@@ -10155,8 +10169,10 @@ const it: Dict = {
   "settings.hint.mcpAutoload": "carica i server configurati all'avvio dell'app",
   "update.available": "v{latest} disponibile",
   "update.prompt": "È disponibile una nuova versione (v{latest}). Aggiornare?",
+  "update.promptNative": "È disponibile una nuova versione (v{latest}).",
+  "update.trayItem": "Controlla aggiornamenti",
   "update.howtoNative":
-    "Questa app si aggiorna da sola: propone ogni nuova versione all'avvio, verifica la firma, installa e riavvia. Riaprila per essere richiesto, oppure leggi prima le note di rilascio.",
+    "Aggiorna dal menu nella barra delle applicazioni — \"{item}\" — o chiudendo e riaprendo l'app. In entrambi i casi verifica la firma, installa e riavvia.",
   "update.howto":
     "Stai guardando questo in un browser, quindi aggiorna il pacchetto: esegui il comando qui sotto, oppure leggi le note di rilascio.",
   "update.copy": "Copia",
@@ -11450,8 +11466,10 @@ const pl: Dict = {
     "wczytuj skonfigurowane serwery przy starcie aplikacji",
   "update.available": "dostępna v{latest}",
   "update.prompt": "Dostępna jest nowa wersja (v{latest}). Zaktualizować?",
+  "update.promptNative": "Dostępna jest nowa wersja (v{latest}).",
+  "update.trayItem": "Sprawdź aktualizacje",
   "update.howtoNative":
-    "Ta aplikacja aktualizuje się sama: przy starcie proponuje każde nowe wydanie, sprawdza podpis, instaluje i restartuje. Otwórz ją ponownie, żeby zapytała jeszcze raz, albo najpierw przeczytaj informacje o wydaniu.",
+    "Zaktualizuj z menu w zasobniku — „{item}” — albo zamykając i otwierając aplikację. W obu przypadkach sprawdza podpis, instaluje w miejscu i uruchamia się ponownie.",
   "update.howto":
     "Oglądasz to w przeglądarce, więc zaktualizuj pakiet: uruchom polecenie poniżej albo przeczytaj informacje o wydaniu.",
   "update.copy": "Kopiuj",
@@ -12751,8 +12769,10 @@ const ru: Dict = {
     "загружать настроенные серверы при запуске приложения",
   "update.available": "доступна v{latest}",
   "update.prompt": "Доступна новая версия (v{latest}). Обновить?",
+  "update.promptNative": "Доступна новая версия (v{latest}).",
+  "update.trayItem": "Проверить обновления",
   "update.howtoNative":
-    "Это приложение обновляется само: при запуске предлагает каждый новый выпуск, проверяет подпись, устанавливает и перезапускается. Откройте его заново, чтобы вопрос появился снова, или сначала прочитайте примечания к выпуску.",
+    "Обновите через меню в трее — «{item}» — или закройте и откройте приложение. В обоих случаях подпись проверяется, установка идёт на месте, приложение перезапускается.",
   "update.howto":
     "Вы смотрите это в браузере, значит обновлять нужно пакет: выполните команду ниже или прочитайте примечания к выпуску.",
   "update.copy": "Копировать",

--- a/tests/test_a_release_is_not_latest_until_it_can_be_updated_to.py
+++ b/tests/test_a_release_is_not_latest_until_it_can_be_updated_to.py
@@ -1,0 +1,125 @@
+"""For twenty-five minutes after every release, auto-update was broken for everyone.
+
+The desktop updater asks GitHub for `releases/latest/download/latest.json`, which resolves to
+whatever GitHub calls the latest release. Published the ordinary way, a release becomes latest the
+*instant* it is created — and `latest.json` is attached by the last job of `desktop-release.yml`,
+after four platforms have finished building. Measured on v0.49.0: the endpoint returned **404** while
+the installers were still going up.
+
+Nobody had noticed, and the reason is the same property that makes the check pleasant: the startup
+check swallows every error so it never nags. A window in which no update can be found looks exactly
+like a window in which there is no update.
+
+The fix is two halves that have to stay together, which is what this file is for:
+
+  1. `RELEASING.md` says to create the release with ``--latest=false``;
+  2. the last job of the workflow promotes it with ``gh release edit --latest``, AFTER attaching
+     the manifest.
+
+Either half alone is worse than neither. The flag without the promotion leaves every release
+permanently not-latest — no client is ever offered anything again. The promotion without the flag is
+a no-op on a release that was already latest, and the window stays.
+
+Read out of the two files rather than asserted against a run, for the reason the neighbouring
+workflow test gives: a test cannot cut a release, but it can check the line that was missing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+RAIZ = Path(__file__).resolve().parent.parent
+FLUXO = RAIZ / ".github" / "workflows" / "desktop-release.yml"
+GUIA = RAIZ / "RELEASING.md"
+
+
+def _passos_do_manifesto() -> list[dict]:
+    dados = yaml.safe_load(FLUXO.read_text(encoding="utf-8"))
+    return dados["jobs"]["manifest"]["steps"]
+
+
+def _indice(passos: list[dict], agulha: str) -> int:
+    for i, passo in enumerate(passos):
+        if agulha in str(passo.get("run", "")) or agulha in str(passo.get("with", "")):
+            return i
+    raise AssertionError(f"nenhum passo do job `manifest` contém {agulha!r}")
+
+
+def _indice_do_anexo(passos: list[dict]) -> int:
+    """The step that ATTACHES the manifest to the release — not the one that writes it locally.
+
+    `latest.json` appears in four steps of this job: the one that builds it, the one that attaches
+    it, the dry-run upload, and a comment. Anchoring the order assertion on the first match compared
+    against the BUILD step, which meant moving the promotion to just before the attach still read as
+    "after" and passed. The sabotage that proves it is the one this helper exists for.
+    """
+    for i, passo in enumerate(passos):
+        if "action-gh-release" in str(passo.get("uses", "")) and "latest.json" in str(
+            passo.get("with", "")
+        ):
+            return i
+    raise AssertionError("nenhum passo anexa latest.json à release")
+
+
+def test_the_guide_tells_you_to_hold_the_release_back() -> None:
+    """The stable `gh release create` line carries `--latest=false`."""
+    linhas = [
+        linha
+        for linha in GUIA.read_text(encoding="utf-8").splitlines()
+        if linha.startswith("gh release create") and "--prerelease" not in linha
+    ]
+
+    assert linhas, "RELEASING.md no longer shows how to create a stable release"
+    for linha in linhas:
+        assert "--latest=false" in linha, (
+            "a stable release created without `--latest=false` becomes the updater's target "
+            f"before its manifest exists, and the endpoint 404s until the build ends: {linha}"
+        )
+
+
+def test_the_workflow_promotes_it_once_the_manifest_is_attached() -> None:
+    """And the ORDER is the fix, not the presence of the step."""
+    passos = _passos_do_manifesto()
+    anexa = _indice_do_anexo(passos)
+    promove = _indice(passos, "--latest")
+
+    assert promove > anexa, (
+        "the release is marked latest BEFORE its manifest is attached, which is the whole defect "
+        f"this guards (attach at step {anexa}, promote at step {promove})"
+    )
+
+
+def test_the_website_is_told_after_the_release_is_promoted() -> None:
+    """The site resolves download links at build time, so it must see a finished release.
+
+    Its own comment already says the notice is last because a half-uploaded release makes the site
+    skip it. Being latest is part of finished — a site notified first could publish a page for a
+    release the updater still cannot find.
+    """
+    passos = _passos_do_manifesto()
+
+    # Matched on the endpoint the notice POSTs to, not on the phrase `repository_dispatch` — that
+    # phrase appears only in the comment above the step, and a comment is not the thing that runs.
+    # The first version of this assertion looked for it and failed on correct code.
+    assert _indice(passos, "/dispatches") > _indice(passos, "--latest"), (
+        "the website is told before the release is promoted to latest"
+    )
+
+
+def test_a_prerelease_is_left_alone() -> None:
+    """An rc needs no flag — `--prerelease` already keeps it out of "latest".
+
+    The control for the first test: a rule that demanded `--latest=false` everywhere would also
+    demand it where it means nothing, and the guide would start teaching noise.
+    """
+    linhas = [
+        linha
+        for linha in GUIA.read_text(encoding="utf-8").splitlines()
+        if linha.startswith("gh release create") and "--prerelease" in linha
+    ]
+
+    assert linhas, "RELEASING.md no longer shows how to cut an rc"
+    for linha in linhas:
+        assert "--latest=false" not in linha, f"redundant on a prerelease: {linha}"


### PR DESCRIPTION
Two defects found by watching v0.49.0 publish.

## 1. The updater's endpoint 404s during every build

The updater asks for `releases/latest/download/latest.json`. A release becomes **latest the instant it is created** — twenty-five minutes before the last job attaches the manifest. Measured live on v0.49.0:

```
build dos instaladores : in_progress
assets do v0.49.0      : só os 3 do macOS arm64
latest.json            : HTTP 404
```

Nobody had noticed, and the reason is the property that makes the check pleasant: **it swallows every error so it never nags.** A window in which no update can be found looks exactly like a window in which there is no update.

Stable releases are created with `--latest=false` now, and the workflow promotes them once the manifest is attached. Until then the endpoint resolves to the *previous* release, whose manifest names a real version — old clients are offered that, which is correct, instead of meeting a 404.

**The failure mode improves too, and that is not a side effect.** A build that dies halfway leaves the previous release as latest: a broken release is simply not offered, rather than becoming the one every updater points at and cannot read.

Not a draft — the obvious version of this fix. Drafts fire no release event at all, so neither workflow would start.

## 2. The in-app panel asked a question it could not answer

> **A new version (v0.49.0) is available. Update?**
> [ View release ]  [ Dismiss ]

There is no third button, and inside the bundle there cannot be: the panel is in the webview, on the sidecar's http origin, with no IPC to the Rust updater. A question mark promises an answer that does not exist.

It states now, and names what *does* start one: the tray's **Check for updates**.

That label now exists in two tables in two languages — `Dialogo.menu` in Rust, `update.trayItem` in the frontend — so a Rust test compares them per language. Pointing at a menu item spelled differently from the menu item is worse than pointing at nothing, because the reader concludes the feature is missing.

## Verification

- **Five sabotages on the release ordering, all caught**, suite green before *and* after.
- One of them found the ordering assertion **anchored on the wrong step**: `latest.json` matches four steps of that job, and the first is the one that *writes* the file, not the one that *attaches* it — so moving the promotion to just before the attach still read as "after" and passed.
- The cross-language label test **caught a real mismatch on its first run**: the dictionaries are *defined* in a different order from `LANGS`, so comparing them by position measured Italian against Chinese. It matches by code now.
- Rust 28/28 · frontend 143 files / 1024 tests · `tsc` clean.

Four Python tests fail on my machine (`test_the_tool_that_was_not_installed`, one in `test_the_kernel_holds_the_boundary`) — **they reproduce identically on clean `main`**, predate this branch, and `test (windows)` is green in CI. Noted, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
