### PR TITLE
fix(installer): an update left the old version behind, and the app believed it

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -136,6 +136,16 @@ jobs:
               exit 1
               ;;
           esac
+          # And that it is the RIGHT version, not merely a non-zero one. The rule above was written
+          # for `0.0.0+source` and encodes "not zero"; a sidecar stamped with the PREVIOUS release
+          # passes it, which is the way a version is actually wrong — plausibly, not obviously.
+          # Empty on a manual dispatch, where there is no release to compare against.
+          ESPERADA="${{ github.event.release.tag_name }}"
+          ESPERADA="${ESPERADA#v}"
+          if [ -n "$ESPERADA" ] && [ "$VERSION" != "$ESPERADA" ]; then
+            echo "::error::the frozen sidecar reports $VERSION inside a $ESPERADA release"
+            exit 1
+          fi
 
       - name: Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **A freshly updated app reported the version it used to be.** Measured on a real machine
+  immediately after a real in-place update from 0.48.0 to 0.49.0: `chimera-desktop.exe` was 0.49.0
+  and `/api/version` said 0.48.0. The backend process was fresh — spawned by the new shell, same
+  second — so nothing had survived. A **file** had.
+
+  The frozen sidecar is a PyInstaller bundle whose names carry versions; NSIS overwrites what it is
+  given and leaves the rest, so upgrading MERGED the two releases and `_internal` ended up holding
+  both `chimera_agent-0.48.0.dist-info` and `chimera_agent-0.49.0.dist-info`.
+  `importlib.metadata.version("chimera-agent")` answers with the first it finds.
+
+  What it broke: the app kept offering an update to the version it already was — the badge never
+  went away, and the next launch asked again. Anything else keyed on the version was reading the
+  previous release. The installer now removes the sidecar bundle before writing the new one, after
+  killing the processes that hold it open and never before.
+
+  **The pipeline could not have caught it, and that is the part worth keeping.** There is already a
+  step called *"the frozen sidecar knows its own version"* — it ran, and it passed, because CI
+  builds into an empty tree where exactly one dist-info exists. The defect needs a previous install
+  to merge with. A check that runs where the effect cannot occur produces no evidence about it,
+  however green it is.
+
+  That guard also encoded *"not zero"* rather than *"the right one"*: written for a real
+  `0.0.0+source` defect, it would pass a sidecar stamped 0.48.0 inside a v0.49.0 build. It compares
+  against the release being built now.
+
+  Said plainly rather than left to be assumed: **nothing automated exercises an upgrade.** The tests
+  added here assert the fix is present and the guard is honest; only installing the previous release
+  and then the new one would assert that it works, and no test in this repository does that.
+
+
 - **For twenty-five minutes after every release, auto-update was broken for everyone.** The updater
   asks GitHub for `releases/latest/download/latest.json`, which resolves to whatever is called the
   latest release — and a release becomes latest the *instant* it is created, while `latest.json` is

--- a/apps/desktop/src-tauri/installer-hooks.nsh
+++ b/apps/desktop/src-tauri/installer-hooks.nsh
@@ -32,6 +32,29 @@
   ; Windows releases file handles asynchronously: the process is gone before its locks are. Without
   ; this pause the very next step can still meet a locked DLL, which is the failure being fixed.
   Sleep 1500
+
+  ; --- and then the directory goes, rather than being installed over.
+  ;
+  ; The frozen sidecar is a PyInstaller bundle: a pile of files whose NAMES carry versions. NSIS
+  ; overwrites what it is given and leaves everything else, so upgrading MERGED the two releases —
+  ; and `_internal` ended up holding both `chimera_agent-0.48.0.dist-info` and
+  ; `chimera_agent-0.49.0.dist-info`. `importlib.metadata.version("chimera-agent")` answers with the
+  ; first one it finds, so a freshly updated 0.49.0 app reported 0.48.0 of itself.
+  ;
+  ; What that broke, measured on a real machine after a real update: `/api/version` compared the
+  ; stale version against GitHub and kept saying "v0.49.0 available" on an app that WAS 0.49.0. The
+  ; badge never goes away, and the next launch offers the update again. Anything else keyed on the
+  ; version — receipts, telemetry, the update check itself — was reading the previous release.
+  ;
+  ; **CI cannot catch this**, and that is why it shipped. The pipeline's "the frozen sidecar knows
+  ; its own version" step builds into an empty tree, where there is exactly one dist-info; the defect
+  ; needs a PREVIOUS install to merge with. An instrument that cannot exhibit an effect produces no
+  ; evidence about it. Nothing here proves the upgrade path except an actual upgrade.
+  ;
+  ; Safe to wipe: everything under `sidecar-dist` is build output, replaced wholesale by this
+  ; installer. User data lives in the app data directory, which this does not touch.
+  DetailPrint "Removing the previous sidecar bundle…"
+  RMDir /r "$INSTDIR\sidecar-dist"
 !macroend
 
 !macro NSIS_HOOK_PREUNINSTALL

--- a/tests/test_an_update_left_the_old_version_behind.py
+++ b/tests/test_an_update_left_the_old_version_behind.py
@@ -1,0 +1,110 @@
+"""A freshly updated app reported the version it used to be.
+
+Measured on a real Windows machine, immediately after a real in-place update from 0.48.0 to 0.49.0:
+
+    chimera-desktop.exe   ->  0.49.0     (the shell updated)
+    /api/version          ->  0.48.0     (the backend did not)
+
+The backend process was fresh — spawned by the new shell, same second — so nothing had survived.
+What had survived was a FILE. The frozen sidecar is a PyInstaller bundle whose names carry versions,
+NSIS overwrites what it is given and leaves the rest, and `_internal` ended up holding both::
+
+    chimera_agent-0.48.0.dist-info      (from the previous install)
+    chimera_agent-0.49.0.dist-info      (from this one)
+
+`importlib.metadata.version("chimera-agent")` answers with the first it finds. Renaming the stale
+directory and restarting made the same binary report 0.49.0 and `update_available=False`, which is
+what turns this from an argument into a diagnosis.
+
+**Why it shipped, and the part worth keeping:** the pipeline already has a step called *"the frozen
+sidecar knows its own version"*. It runs the binary and refuses `0.0.0*`. It passed — because CI
+builds into an empty tree, where there is exactly one dist-info. The defect needs a previous install
+to merge with, and CI never has one. A check that runs where the effect cannot occur produces no
+evidence about it, however green it is.
+
+That guard also encodes "not zero" rather than "the right one": a sidecar reporting 0.48.0 inside a
+v0.49.0 build would have passed it too. Both halves are tightened here.
+
+**What this file does NOT do**, said plainly rather than left to be assumed: it does not exercise an
+upgrade. Nothing automated does. The only check that would have caught this is installing the
+previous release, installing the new one over it, and asking the binary — on a Windows runner, twice
+per release. This asserts the fix is present and the guard is honest; it cannot assert that the fix
+works, and no test in this repository can.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+RAIZ = Path(__file__).resolve().parent.parent
+GANCHOS = RAIZ / "apps" / "desktop" / "src-tauri" / "installer-hooks.nsh"
+FLUXO = RAIZ / ".github" / "workflows" / "desktop-release.yml"
+
+
+def _preinstall() -> str:
+    texto = GANCHOS.read_text(encoding="utf-8")
+    corpo = texto.split("!macro NSIS_HOOK_PREINSTALL", 1)[1]
+    return corpo.split("!macroend", 1)[0]
+
+
+def test_the_installer_removes_the_previous_sidecar_bundle() -> None:
+    """Installing over it merges two releases; the older names win the metadata lookup."""
+    corpo = _preinstall()
+
+    assert "RMDir /r" in corpo and "sidecar-dist" in corpo, (
+        "the pre-install hook no longer wipes the sidecar bundle, so an upgrade merges the old "
+        "release into the new one and the app reports the version it used to be"
+    )
+
+
+def test_it_wipes_after_killing_what_holds_the_files_open() -> None:
+    """Order, not presence.
+
+    Windows will not delete a directory a running process has files open in. Wiping before the
+    `taskkill` would fail silently on exactly the machines that have the problem — the ones with
+    Chimera running, which is every machine being upgraded from inside the app.
+    """
+    corpo = _preinstall()
+
+    assert corpo.index("taskkill") < corpo.index("RMDir /r"), (
+        "the bundle is wiped before the processes holding it are killed, so on a running install "
+        "the delete quietly does nothing"
+    )
+    assert corpo.index("Sleep") < corpo.index("RMDir /r"), (
+        "no pause between killing the processes and deleting their files — Windows releases "
+        "handles asynchronously, which is the reason that Sleep exists at all"
+    )
+
+
+def test_the_pipeline_checks_the_version_it_is_building_not_merely_a_nonzero_one() -> None:
+    """The existing guard rejects `0.0.0*` and nothing else.
+
+    It was written for a real defect — every installer once reported `0.0.0+source` — and it fixed
+    that symptom. But a sidecar reporting 0.48.0 inside a v0.49.0 build passes it, which is a
+    version wrong in the way that actually happens: plausibly, not obviously.
+    """
+    texto = FLUXO.read_text(encoding="utf-8")
+    passo = texto.split("The frozen sidecar knows its own version", 1)
+    assert len(passo) == 2, "the pipeline no longer asks the frozen sidecar its version"
+    corpo = passo[1].split("- name:", 1)[0]
+
+    # The COMPARISON, not a mention of the tag. The first version of this assertion looked for
+    # `github.event.release.tag_name` anywhere in the step — and a sabotage that replaced the whole
+    # condition with `if false` left that line untouched and sailed through. Naming the input is not
+    # the property; using it to refuse is.
+    esperada = re.search(r'ESPERADA="\$\{\{ github\.event\.release\.tag_name \}\}"', corpo)
+    assert esperada, "the expected version is no longer taken from the release tag"
+
+    comparacao = re.search(r'"\$VERSION" != "\$ESPERADA"', corpo)
+    assert comparacao, (
+        "the step no longer compares the frozen sidecar's version against the release being built, "
+        "so a sidecar stamped with the PREVIOUS version passes — which is how a version is wrong "
+        "in practice: plausibly, not obviously"
+    )
+
+    # And that the mismatch is fatal rather than merely printed.
+    depois = corpo[comparacao.end():]
+    assert "exit 1" in depois.split("fi", 1)[0], (
+        "a mismatched version is reported and not refused — the build would ship it"
+    )


### PR DESCRIPTION
Found by updating a real machine from 0.48.0 to 0.49.0 and then asking the app what it was.

```
chimera-desktop.exe   ->  0.49.0     the shell updated
/api/version          ->  0.48.0     the backend did not
```

The backend process was **fresh** — spawned by the new shell, same second, child of it. Nothing had survived. A *file* had:

```
_internal\chimera_agent-0.48.0.dist-info      from the previous install
_internal\chimera_agent-0.49.0.dist-info      from this one
```

The frozen sidecar is a PyInstaller bundle whose names carry versions; NSIS overwrites what it is given and leaves the rest, so the upgrade **merged the two releases**. `importlib.metadata.version("chimera-agent")` answers with the first it finds.

Renaming the stale directory and restarting made the same binary report `0.49.0` and `update_available=False` — which is what turns this from an argument into a diagnosis.

**What it broke:** the app kept offering an update to the version it already was. The badge never went away and the next launch asked again. Anything keyed on the version read the previous release.

## The fix

The pre-install hook removes the bundle — **after** the `taskkill`s, never before, because Windows will not delete a directory a running process has files open in, and that is precisely the machine being upgraded. Everything under `sidecar-dist` is build output; user data lives elsewhere.

## The part worth keeping

**The pipeline could not have caught this.** There is already a step called *"the frozen sidecar knows its own version"*. It ran. It passed. CI builds into an empty tree where exactly one dist-info exists — the defect needs a previous install to merge with. A check that runs where the effect cannot occur produces no evidence about it, however green it is.

That guard also encoded *"not zero"* rather than *"the right one"*: written for a real `0.0.0+source` defect, it would pass a sidecar stamped 0.48.0 inside a v0.49.0 build. It compares against the release being built now.

## Verification

**Five sabotages, all caught**, green before *and* after. One found the third assertion checking that the tag was **mentioned** rather than **used** — replacing the whole condition with `if false` left the mention intact and sailed through. It pins the comparison and the `exit 1` now.

And said plainly rather than left to be assumed: **nothing automated exercises an upgrade.** These tests assert the fix is present and the guard is honest; only installing the previous release and then the new one over it would assert that it *works*. That is a Windows-runner job worth adding, and it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
