### PR TITLE
fix(desktop): the cost modes spoke English on a Portuguese wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The first-run wizard was translated except for four words.** Its cost-mode dropdown rendered
+  the raw values — `auto / cheap / balanced / premium` — in the middle of an otherwise fully
+  Portuguese screen. The labels already existed and were already translated: the Settings screen,
+  which sets the *same* variable, has been rendering them through `settings.value.*` all along.
+  Two vocabularies for one setting is the app disagreeing with itself about what you chose.
+
+  Only the label is translated. The value stays English because `CostMode` in
+  `providers/catalog.py` is a `Literal` and the server would refuse `"econômico"` — and that half
+  has its own assertion, because it is the half a careless fix breaks.
+
+  The rest of the class was checked rather than assumed: every other `Select` on the Settings
+  screen already passes `render=`, and the one that does not (`json` / `sqlite`) is naming file
+  formats, which is the same deliberate call that leaves `docker` untranslated beside it.
+
 ## [0.49.1] - 2026-09-02
 
 ### Fixed

--- a/apps/desktop/src/components/Onboarding.test.tsx
+++ b/apps/desktop/src/components/Onboarding.test.tsx
@@ -69,6 +69,36 @@ const combo = () => screen.getAllByRole("combobox")[0];
 const keyField = () => screen.getByLabelText(/API key/);
 
 describe("the first-run wizard", () => {
+  it("names the cost modes in the reader's language, and sends the server English", async () => {
+    // This wizard was fully translated except for four words: the cost-mode dropdown rendered its
+    // raw values — "auto / cheap / balanced / premium" — in the middle of a Portuguese screen. The
+    // labels already existed and were already translated; the Settings screen, which sets the SAME
+    // variable, was using them. Two vocabularies for one setting is the app disagreeing with itself
+    // about what you chose.
+    localStorage.setItem("chimera.lang", "pt");
+    try {
+      renderWithProviders(<Onboarding onSkip={() => {}} />);
+      await waitFor(() => expect(screen.getAllByRole("combobox").length).toBeGreaterThan(1));
+      const custo = within(screen.getAllByRole("combobox")[1]);
+
+      expect(custo.getByRole("option", { name: "econômico" })).toBeTruthy();
+      expect(custo.getByRole("option", { name: "equilibrado" })).toBeTruthy();
+      expect(custo.getByRole("option", { name: "automático" })).toBeTruthy();
+      expect(custo.queryByRole("option", { name: "cheap" })).toBeNull();
+
+      // The CONTROL, and the half a careless fix would break: `CostMode` in
+      // `providers/catalog.py` is a Literal, so the server refuses "econômico". Only the label is
+      // translated; the value stays English.
+      const valores = custo
+        .getAllByRole("option")
+        .map((o) => (o as HTMLOptionElement).value)
+        .sort();
+      expect(valores).toEqual(["auto", "balanced", "cheap", "premium"]);
+    } finally {
+      localStorage.removeItem("chimera.lang");
+    }
+  });
+
   it("offers the providers that serve a model, and none of the tool credentials", async () => {
     renderWithProviders(<Onboarding onSkip={() => {}} />);
     await waitFor(() => expect(screen.getByRole("option", { name: "Anthropic" })).toBeTruthy());

--- a/apps/desktop/src/components/Onboarding.tsx
+++ b/apps/desktop/src/components/Onboarding.tsx
@@ -192,9 +192,15 @@ export function Onboarding({ onSkip }: { onSkip: () => void }) {
               value={costMode}
               onChange={(e) => setCostMode(e.target.value)}
             >
+              {/* The VALUE stays English — `CostMode` in `providers/catalog.py` is a Literal and
+                  the server would refuse "econômico". Only the label is translated, and through the
+                  same keys the Settings screen already uses: this dropdown and the one in Settings
+                  set the identical variable, so two vocabularies for it would be the app disagreeing
+                  with itself about what the user chose. This one was rendering the raw value, which
+                  put "cheap / balanced / premium" on an otherwise fully translated wizard. */}
               {["auto", "cheap", "balanced", "premium"].map((m) => (
                 <option key={m} value={m}>
-                  {m}
+                  {t(`settings.value.${m}`)}
                 </option>
               ))}
             </select>


### PR DESCRIPTION
The first-run wizard, in Portuguese, with four English words in the middle of it:

```
Modo de custo
  ┌──────────────┐
  │ auto         │
  │ cheap        │
  │ balanced     │
  │ premium      │
  └──────────────┘
```

**The labels already existed and were already translated.** The Settings screen sets the *same* variable and has been rendering them through `settings.value.*` all along — `automático`, `econômico`, `equilibrado`. This dropdown was printing the raw value. Two vocabularies for one setting is the app disagreeing with itself about what the user chose.

## Only the label

The value stays English: `CostMode` in `providers/catalog.py` is a `Literal`, and the server would refuse `"econômico"`. That half carries its own assertion, because it is the half a careless fix breaks — **both sabotages caught**, including the one that translates the `value` too.

## The class, checked rather than assumed

Every other `Select` on the Settings screen already passes `render=`. The one that does not (`json` / `sqlite`) names file formats — the same deliberate call that leaves `docker` untranslated two rows below it, where the neighbouring `render` reads `v === "docker" ? v : t(…)`.

So this was the only instance, and that is measured, not hoped.

143 files / 1025 tests · `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
