### PR TITLE
fix: two refusals that named a remedy the code could not reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The skill install error blamed a limit that was not the one that bit.** Installing from the
+  catalogue failed with *"GitHub refused the request — most likely its hourly limit for anonymous
+  downloads. Try again later, or set `GITHUB_TOKEN`."* Measured at that moment: **55 of the 60
+  anonymous API calls were still unspent.**
+
+  Every clause was wrong. The refusal came from `raw.githubusercontent.com`, which serves the files
+  one per request — not from `api.github.com`, whose hourly limit the message described. Setting
+  `GITHUB_TOKEN` could not affect the failing request, because the header was attached only for
+  `api.github.com`: the advice was inert for the only failure that ever printed it. And 429 means
+  *ask again later*, so handling it beside 403 as a flat refusal threw away an answer the server had
+  already given, often with a `Retry-After` naming the wait.
+
+  The token now goes to both already-allowlisted hosts, checked against `_ALLOWED_HOSTS` itself so a
+  future entry cannot quietly become a third place credentials go. 429 gets a budget of its own with
+  exponential backoff, honouring `Retry-After` and capping the wait so a ten-minute ask becomes a
+  message rather than a stall. Measured against the live host: `dogfood` went from failing to
+  installing, absorbing a 429 on the way.
+
+  **Spacing the per-file requests was tried and is deliberately not here.** At 0.15s the throttle
+  arrived on the 2nd request against the 13th with no pause at all. That comparison is confounded —
+  consecutive probes share one bucket — which is exactly why it cannot ship as though it worked. The
+  note and the absent constant are guarded together, so neither can drift from the other.
+
+- **The write refusal pointed at a directory the file was inside.** A run declaring
+  `["C:/Users/.../sonda"]` as its write-region and asking to write `sonda/ZAP2.txt` was told the file
+  was *outside* that very directory. Patterns match the workspace-**relative** path, so an absolute
+  one matches nothing however it is spelled — the refusal was right, and what it said was not.
+
+  The agent did the only thing that message invites: it retried the same write four ways — bare name,
+  absolute forward-slash, `./` prefix, absolute backslash — spent its whole retry budget across three
+  attempts and about twelve minutes, and reported an environment fault. The identical run with
+  `["**"]` wrote the file on the first try in 57 seconds.
+
+  The refusal now carries the path **as compared**, says the region is a list of workspace-relative
+  globs, and when a declared pattern looks absolute names that pattern and what to write instead. A
+  path resolving outside the workspace and one hitting `ALWAYS_DENIED` get their own messages,
+  because those have different remedies and pointing at the region would send the reader nowhere.
+
 ## [0.49.2] - 2026-09-02
 
 ### Fixed

--- a/chimera/skills/bundles.py
+++ b/chimera/skills/bundles.py
@@ -125,25 +125,57 @@ def bundles_root(home: Path) -> Path:
 #: catalogue had no chance at all, and the error told the user their network was unreachable, which
 #: was true of that one connection and not of anything they could act on.
 #:
-#: Only transport failures are retried. A 404 will be a 404 next time, and repeating a 403 spends
-#: the same anonymous budget that caused it.
+#: Transport failures and 429s are retried; a 404 will be a 404 next time, and repeating a 403
+#: spends the same budget that caused it. 429 is the one status whose meaning IS "ask again
+#: later", so treating it as a refusal threw away an answer the server had already given.
 FETCH_ATTEMPTS = 3
 FETCH_BACKOFF_S = 0.4
+
+#: Throttling gets its own budget, because a 429 is a different animal from a dropped socket.
+#:
+#: `raw.githubusercontent.com` throttles a burst per network, and a skill is downloaded one file
+#: per request — the largest in the catalogue is fifty-five. Measured against that host with
+#: distinct files: the 429 arrives somewhere around the thirteenth to eighteenth request, and the
+#: bucket refills within tens of seconds. So a big skill WILL be throttled partway through, and
+#: waiting it out is the only thing that finishes the install.
+#:
+#: Spacing the requests was tried first and is deliberately not here: at 0.15s the throttle
+#: arrived SOONER than with no pause at all (2nd request against 13th). That comparison is
+#: confounded — consecutive probes share one bucket, so a later arm starts already penalised —
+#: which is the point: the measurement could not show pacing helping, so pacing is not shipped
+#: as though it did. Retrying is the mechanism the evidence does support.
+THROTTLE_ATTEMPTS = 5
+THROTTLE_BASE_S = 2.0
+THROTTLE_MAX_WAIT_S = 30.0
 
 
 def _get(url: str, *, accept: str = "application/vnd.github+json",
          limit: int = MAX_FILE_BYTES) -> bytes:
     """One bounded GET against an allowlisted host, retried on a dropped connection."""
     ultima: BundleError | None = None
-    for tentativa in range(FETCH_ATTEMPTS):
+    transporte = 0
+    estrangulado = 0
+    # Two budgets, not one shared counter: a link that drops sockets and a host that is asking us
+    # to slow down are different failures, and spending the retries of one on the other means a
+    # big install gives up on the throttle it was always going to meet.
+    while transporte < FETCH_ATTEMPTS and estrangulado < THROTTLE_ATTEMPTS:
         try:
             return _get_once(url, accept=accept, limit=limit)
         except _TransportError as exc:
+            transporte += 1
             ultima = BundleError(
                 f"could not reach the source after {FETCH_ATTEMPTS} attempts: {exc.original}"
             )
-            if tentativa < FETCH_ATTEMPTS - 1:
-                time.sleep(FETCH_BACKOFF_S * (tentativa + 1))
+            if transporte < FETCH_ATTEMPTS:
+                time.sleep(FETCH_BACKOFF_S * transporte)
+        except _ThrottledError as exc:
+            estrangulado += 1
+            ultima = BundleError(exc.message)
+            if estrangulado < THROTTLE_ATTEMPTS:
+                # The server's own number when it gave one, our doubling when it did not; capped
+                # either way, so a ten-minute Retry-After becomes a message and not a silent stall.
+                padrao = THROTTLE_BASE_S * (2 ** (estrangulado - 1))
+                time.sleep(min(exc.espera or padrao, THROTTLE_MAX_WAIT_S))
     assert ultima is not None  # the loop runs at least once
     raise ultima
 
@@ -154,6 +186,35 @@ class _TransportError(Exception):
     def __init__(self, original: Exception) -> None:
         super().__init__(str(original))
         self.original = original
+
+
+class _ThrottledError(Exception):
+    """A 429: the host asked us to slow down, which is a request and not a refusal.
+
+    Carries the wait the server named, so the retry honours it instead of guessing, and the
+    message a person should see if every attempt is throttled. Never leaves this module.
+    """
+
+    def __init__(self, message: str, espera: float) -> None:
+        super().__init__(message)
+        self.message = message
+        self.espera = espera
+
+
+def _retry_after(exc: urllib.error.HTTPError, padrao: float) -> float:
+    """The wait the server asked for, in seconds, or ``padrao`` when it named none we can read.
+
+    `Retry-After` is defined as either a number of seconds or an HTTP date. Only the numeric form
+    is read: the date form needs a clock both ends agree on, and reading it wrong buys a wait
+    measured in hours. Anything unparseable falls back rather than raising — a malformed header
+    is not a reason to fail an install that a short pause would have fixed.
+    """
+    bruto = (exc.headers.get("Retry-After") or "").strip() if exc.headers else ""
+    try:
+        segundos = float(bruto)
+    except ValueError:
+        return padrao
+    return segundos if segundos > 0 else padrao
 
 
 def _get_once(url: str, *, accept: str = "application/vnd.github+json",
@@ -169,9 +230,16 @@ def _get_once(url: str, *, accept: str = "application/vnd.github+json",
     # A token if the environment offers one. Not required — one API call per install fits inside
     # the anonymous ceiling — but somebody installing a dozen skills in a sitting should not have
     # to wait for an hour they were never told about.
+    #
+    # It goes to BOTH allowlisted hosts, and that is a correction rather than a widening. Files
+    # are fetched one per request from `raw.githubusercontent.com`, which throttles harder than
+    # the API and was the host actually refusing — so sending the token only to `api.github.com`
+    # left the advice printed on failure ("set GITHUB_TOKEN") unable to affect the request that
+    # failed. Both are GitHub's own hosts and both were already in `_ALLOWED_HOSTS`; the test is
+    # against that tuple, so a future entry cannot quietly become a third place credentials go.
     token = os.environ.get("GH_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
     headers = {"User-Agent": _USER_AGENT, "Accept": accept}
-    if token and parsed.hostname == "api.github.com":
+    if token and parsed.hostname in _ALLOWED_HOSTS:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(url, headers=headers)  # noqa: S310 -- scheme and host checked above
     try:
@@ -187,12 +255,19 @@ def _get_once(url: str, *, accept: str = "application/vnd.github+json",
         if exc.code == 404:
             raise BundleError(f"not found at the source: {url}") from exc
         if exc.code in (403, 429):
-            # The unauthenticated GitHub API allows 60 requests an hour, and a person who has just
-            # installed three skills has no way to know that is what happened.
-            raise BundleError(
-                "GitHub refused the request — most likely its hourly limit for anonymous "
-                "downloads. Try again later, or set GITHUB_TOKEN."
-            ) from exc
+            # Name the host. The two throttle for different reasons on different clocks —
+            # `api.github.com` allows sixty an hour unauthenticated, `raw.githubusercontent.com`
+            # throttles a burst per network — and a message that blames the wrong one sends the
+            # reader to the wrong remedy. Both accept the token, so the advice holds for either.
+            hospedeiro = parsed.hostname or "GitHub"
+            recado = (
+                f"{hospedeiro} refused the request (HTTP {exc.code}) — its rate limit for "
+                "unauthenticated downloads. Try again in a few minutes, or set GITHUB_TOKEN."
+            )
+            if exc.code == 429:
+                # A request to wait, not a refusal: hand it to `_get`, which retries.
+                raise _ThrottledError(recado, _retry_after(exc, 0.0)) from exc
+            raise BundleError(recado) from exc
         raise BundleError(f"the source answered {exc.code}") from exc
     except BundleError:
         raise

--- a/chimera/tools/write_region.py
+++ b/chimera/tools/write_region.py
@@ -72,16 +72,64 @@ class WriteRegion:
             return True
         return any(fnmatch.fnmatch(rel, pat) for pat in self.patterns)
 
+    def looks_absolute(self) -> list[str]:
+        """Declared patterns that look like absolute paths, which can never match anything.
+
+        Patterns are matched against the workspace-RELATIVE path, so an absolute one — a drive
+        letter, a leading slash, or a UNC prefix — cannot match any write however it is spelled.
+        Worth naming rather than merely refusing: it is a caller mistake with an exact remedy, and
+        the refusal it produces is indistinguishable from a genuinely out-of-region write.
+        """
+        suspeitos = []
+        for p in self.patterns:
+            if p.startswith("/") or p.startswith("//") or (len(p) > 1 and p[1] == ":"):
+                suspeitos.append(p)
+        return suspeitos
+
     def check(self, path: Path) -> str | None:
-        """Return an error string if the write is disallowed, else None."""
+        """Return an error string if the write is disallowed, else None.
+
+        The message has to carry three things the caller cannot see from the refusal alone: the
+        path AS COMPARED (workspace-relative, which is not what they passed), what the region
+        actually is (globs, not a directory), and — when the region cannot match anything at all —
+        that fact, because otherwise every path they try produces the same refusal.
+
+        Measured before this was written: a run given an absolute directory as its region tried the
+        same write four ways — bare name, absolute forward-slash, ``./`` prefix, absolute backslash
+        — and got a message naming a directory the file was plainly inside, every time. It then
+        spent its whole retry budget and reported an environment fault. The refusal was correct;
+        nothing in it pointed at the one thing that was wrong.
+        """
         if self.allows(path):
             return None
         rel = self._rel(path)
-        target = rel if rel is not None else str(path)
-        return (
-            f"error: write to {target!r} is outside the declared write-region "
-            f"({', '.join(self.patterns) or 'workspace'}) — refused"
+        if rel is None:
+            return (
+                f"error: write to {str(path)!r} resolves outside the workspace "
+                f"({self.workspace}) — refused"
+            )
+        if any(_under(rel, denied) for denied in ALWAYS_DENIED):
+            # A different refusal with a different remedy: no declared region can grant these, so
+            # offering the region as the thing to adjust would send the reader somewhere useless.
+            return (
+                f"error: write to {rel!r} is never permitted — {', '.join(ALWAYS_DENIED)} hold the "
+                "machinery the workspace is governed by, and no write-region can grant them"
+            )
+        recado = (
+            f"error: write to {rel!r} (relative to the workspace) does not match the declared "
+            f"write-region, which is a list of workspace-relative globs: "
+            f"{', '.join(self.patterns) or 'workspace'} — refused"
         )
+        absolutos = self.looks_absolute()
+        if absolutos:
+            um = len(absolutos) == 1
+            recado += (
+                f". Note that {', '.join(repr(a) for a in absolutos)} "
+                f"{'looks' if um else 'look'} like an absolute path"
+                f"{'' if um else 's'}, and an absolute pattern matches nothing here: use a glob "
+                "relative to the workspace, such as '**' for everything or 'src/**' for one directory"
+            )
+        return recado
 
 
 def refuse_write(workspace: Path, path: Path, region: WriteRegion | None) -> str | None:

--- a/tests/test_the_refusal_pointed_at_a_directory_the_file_was_inside.py
+++ b/tests/test_the_refusal_pointed_at_a_directory_the_file_was_inside.py
@@ -1,0 +1,105 @@
+"""A write-region given an absolute directory refused every write and explained none of it.
+
+Measured on a live run: the region was declared as ``["C:/Users/.../sonda"]`` and the agent asked to
+write ``sonda/ZAP2.txt``. Patterns are matched against the workspace-RELATIVE path, so an absolute
+one matches nothing, ever — but the refusal read:
+
+    error: write to 'ZAP2.txt' is outside the declared write-region
+           (C:/Users/brcam/Desktop/chimera-teste-0492/sonda) - refused
+
+which names a directory the file is plainly inside. The agent did the only thing that message
+invites: it retried the same write four ways — bare name, absolute forward-slash, ``./`` prefix,
+absolute backslash — burned its whole retry budget across three attempts and about twelve minutes,
+and reported an environment fault. The identical run with ``["**"]`` wrote the file on the first
+try in 57 seconds.
+
+The refusal itself was right. What was missing was any way to tell an out-of-region write from a
+region that cannot match anything at all, and those need different remedies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.tools.write_region import ALWAYS_DENIED, WriteRegion
+
+
+@pytest.fixture
+def ws(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def test_an_absolute_pattern_still_refuses(ws: Path) -> None:
+    """The behaviour does not change — only what the refusal says about it."""
+    regiao = WriteRegion([str(ws / "sonda")], ws)
+    assert regiao.check(ws / "sonda" / "ZAP.txt") is not None
+
+
+def test_the_refusal_names_the_path_as_compared(ws: Path) -> None:
+    regiao = WriteRegion(["src/**"], ws)
+    recado = regiao.check(ws / "docs" / "nota.md")
+    assert recado is not None
+    assert "'docs/nota.md'" in recado, (
+        "the caller passed an absolute path; the comparison used the relative one, and quoting the "
+        "bare filename is what made a file inside the named directory look like it was outside"
+    )
+
+
+def test_the_refusal_says_the_region_is_globs(ws: Path) -> None:
+    regiao = WriteRegion(["src/**"], ws)
+    recado = regiao.check(ws / "docs" / "nota.md")
+    assert recado is not None
+    assert "glob" in recado, "reading the region as a directory is the mistake being corrected"
+
+
+@pytest.mark.parametrize(
+    "padrao",
+    ["C:/Users/x/proj", "/home/x/proj", "//servidor/compartilhado/proj", "D:/dados"],
+)
+def test_an_absolute_pattern_is_named_as_the_thing_that_cannot_match(ws: Path, padrao: str) -> None:
+    regiao = WriteRegion([padrao], ws)
+    recado = regiao.check(ws / "arquivo.txt")
+    assert recado is not None
+    assert "absolute" in recado
+    assert "'**'" in recado, "name the remedy, not just the fault"
+    assert padrao in recado, "name WHICH pattern, so a caller with several can find it"
+
+
+def test_a_relative_region_that_simply_does_not_match_says_nothing_about_absolutes(ws: Path) -> None:
+    """The absolute hint must not fire on an ordinary miss, or it becomes noise on every refusal."""
+    regiao = WriteRegion(["src/**"], ws)
+    recado = regiao.check(ws / "docs" / "nota.md")
+    assert recado is not None
+    assert "absolute" not in recado
+
+
+def test_a_matching_write_is_still_allowed(ws: Path) -> None:
+    regiao = WriteRegion(["**"], ws)
+    assert regiao.check(ws / "qualquer" / "coisa.txt") is None
+
+
+def test_outside_the_workspace_is_its_own_message(ws: Path, tmp_path_factory) -> None:
+    fora = tmp_path_factory.mktemp("fora")
+    regiao = WriteRegion(["**"], ws)
+    recado = regiao.check(fora / "x.txt")
+    assert recado is not None
+    assert "outside the workspace" in recado, (
+        "a path that never reached the region check must not be reported as a region miss"
+    )
+
+
+@pytest.mark.parametrize("negado", ALWAYS_DENIED)
+def test_the_never_writable_set_does_not_blame_the_region(ws: Path, negado: str) -> None:
+    """No region can grant these, so pointing at the region would send the reader nowhere."""
+    regiao = WriteRegion(["**"], ws)
+    recado = regiao.check(ws / negado / "algo")
+    assert recado is not None
+    assert "never permitted" in recado
+    assert "does not match the declared" not in recado
+
+
+def test_looks_absolute_only_flags_the_absolute_ones(ws: Path) -> None:
+    regiao = WriteRegion(["src/**", "C:/proj", "*.py", "/etc/x"], ws)
+    assert regiao.looks_absolute() == ["C:/proj", "/etc/x"]

--- a/tests/test_the_remedy_the_error_named_could_not_reach_the_host_that_refused.py
+++ b/tests/test_the_remedy_the_error_named_could_not_reach_the_host_that_refused.py
@@ -1,0 +1,264 @@
+"""Installing a skill died on a 429 and blamed a limit that was not the one that bit.
+
+Measured while installing two skills from the catalogue in a row, on a machine with 55 of the 60
+anonymous API calls still unspent: the install failed and said *"GitHub refused the request — most
+likely its hourly limit for anonymous downloads. Try again later, or set GITHUB_TOKEN."*
+
+Three things were wrong with that, and none of them raised so much as a warning:
+
+* The refusal came from ``raw.githubusercontent.com``, which is where the files are fetched one per
+  request — not from ``api.github.com``, whose hourly limit the message describes.
+* Setting ``GITHUB_TOKEN``, the remedy it prints, **could not affect the failing request**: the
+  header was attached only when the host was ``api.github.com``. The advice was inert for the only
+  failure that ever printed it.
+* HTTP 429 means *ask again later*. It was handled beside 403 as a flat refusal, so the one status
+  that carries its own remedy — often with a ``Retry-After`` naming the wait — was the one status
+  never retried.
+
+The tests drive the module's own fetch path with a stub opener, so a revert of any single fix fails
+here rather than needing a live host and a real throttle to reproduce.
+"""
+
+from __future__ import annotations
+
+import io
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from chimera.skills import bundles
+
+RAW = "https://raw.githubusercontent.com/o/r/main/skills/x/SKILL.md"
+API = "https://api.github.com/repos/o/r/git/trees/main:skills/x"
+
+
+def _http_error(url: str, code: int, retry_after: str | None = None) -> urllib.error.HTTPError:
+    """An HTTPError shaped like the real one, headers included."""
+    import email.message
+
+    headers = email.message.Message()
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    return urllib.error.HTTPError(url, code, "throttled", headers, io.BytesIO(b"rate-limited"))
+
+
+class _Resposta:
+    """The context-manager shape `urlopen` returns."""
+
+    def __init__(self, corpo: bytes) -> None:
+        self._corpo = corpo
+
+    def read(self, _n: int = -1) -> bytes:
+        return self._corpo
+
+    def __enter__(self) -> _Resposta:
+        return self
+
+    def __exit__(self, *_: object) -> bool:
+        return False
+
+
+@pytest.fixture
+def espiao(monkeypatch: pytest.MonkeyPatch):
+    """Capture every request the module makes, and script the answers by attempt number."""
+    pedidos: list[urllib.request.Request] = []
+    respostas: list[object] = []
+
+    def falso_urlopen(req: urllib.request.Request, timeout: float = 0) -> object:
+        pedidos.append(req)
+        proxima = respostas.pop(0) if respostas else _Resposta(b"corpo")
+        if isinstance(proxima, Exception):
+            raise proxima
+        return proxima
+
+    monkeypatch.setattr(bundles.urllib.request, "urlopen", falso_urlopen)
+    monkeypatch.setattr(bundles.time, "sleep", lambda _s: None)  # no real waiting in a test
+    return pedidos, respostas
+
+
+# --------------------------------------------------------------------------------------------
+# 1. The remedy the message names must reach the host that refused
+
+
+def test_the_token_reaches_the_host_that_actually_serves_the_files(
+    espiao, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pedidos, _ = espiao
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+
+    bundles._get_once(RAW, accept="*/*")
+
+    enviado = pedidos[-1].get_header("Authorization")
+    assert enviado == "Bearer t0ken", (
+        "the files are fetched from raw.githubusercontent.com, so a token that never goes there "
+        "cannot help the request that fails — which is the request the message blames"
+    )
+
+
+def test_the_token_still_reaches_the_api_host(espiao, monkeypatch: pytest.MonkeyPatch) -> None:
+    pedidos, _ = espiao
+    monkeypatch.setenv("GITHUB_TOKEN", "t0ken")
+
+    bundles._get_once(API)
+
+    assert pedidos[-1].get_header("Authorization") == "Bearer t0ken"
+
+
+def test_no_token_means_no_header(espiao, monkeypatch: pytest.MonkeyPatch) -> None:
+    pedidos, _ = espiao
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    bundles._get_once(RAW, accept="*/*")
+
+    assert pedidos[-1].get_header("Authorization") is None
+
+
+def test_credentials_go_nowhere_but_the_two_allowlisted_hosts() -> None:
+    """The widening is a correction, not a hole: the check is the allowlist itself."""
+    fonte = Path(bundles.__file__).read_text(encoding="utf-8")
+    assert 'if token and parsed.hostname in _ALLOWED_HOSTS:' in fonte
+    assert bundles._ALLOWED_HOSTS == ("api.github.com", "raw.githubusercontent.com")
+
+
+# --------------------------------------------------------------------------------------------
+# 2. A 429 is a request to wait, so it is retried
+
+
+def test_a_429_is_retried_and_can_succeed(espiao) -> None:
+    _, respostas = espiao
+    respostas.extend([_http_error(RAW, 429), _Resposta(b"o arquivo")])
+
+    assert bundles._get(RAW, accept="*/*") == b"o arquivo", (
+        "429 means ask again later; failing on the first one throws away the answer the server gave"
+    )
+
+
+def test_a_403_is_not_retried(espiao) -> None:
+    """Repeating a 403 spends the same budget that caused it — the distinction is the point."""
+    pedidos, respostas = espiao
+    respostas.extend([_http_error(RAW, 403), _Resposta(b"nunca chega aqui")])
+
+    with pytest.raises(bundles.BundleError):
+        bundles._get(RAW, accept="*/*")
+    assert len(pedidos) == 1
+
+
+def test_a_429_that_never_clears_still_fails_with_a_readable_message(espiao) -> None:
+    pedidos, respostas = espiao
+    respostas.extend([_http_error(RAW, 429) for _ in range(bundles.THROTTLE_ATTEMPTS)])
+
+    with pytest.raises(bundles.BundleError) as capturado:
+        bundles._get(RAW, accept="*/*")
+    assert "raw.githubusercontent.com" in str(capturado.value)
+    assert len(pedidos) == bundles.THROTTLE_ATTEMPTS, "give up after the budget, not before it"
+
+
+def test_throttling_has_its_own_budget_and_does_not_spend_the_transport_one(espiao) -> None:
+    """A 55-file install meets the throttle around the 13th file; three tries never finish it.
+
+    Measured against `raw.githubusercontent.com` with distinct files: the 429 lands somewhere near
+    the thirteenth request and the bucket refills within tens of seconds. Sharing one counter with
+    dropped-socket retries is what made a big skill unfinishable.
+    """
+    _, respostas = espiao
+    respostas.extend([_http_error(RAW, 429) for _ in range(bundles.FETCH_ATTEMPTS)])
+    respostas.append(_Resposta(b"chegou"))
+
+    assert bundles._get(RAW, accept="*/*") == b"chegou"
+    assert bundles.THROTTLE_ATTEMPTS > bundles.FETCH_ATTEMPTS
+
+
+def test_the_waits_grow_when_the_server_names_no_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a Retry-After, back off exponentially — a flat pause re-enters the same burst."""
+    dormidas: list[float] = []
+    respostas: list[object] = [_http_error(RAW, 429) for _ in range(3)] + [_Resposta(b"ok")]
+
+    def urlopen(req: urllib.request.Request, timeout: float = 0) -> object:
+        proxima = respostas.pop(0)
+        if isinstance(proxima, Exception):
+            raise proxima
+        return proxima
+
+    monkeypatch.setattr(bundles.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(bundles.time, "sleep", dormidas.append)
+
+    bundles._get(RAW, accept="*/*")
+
+    assert dormidas == [2.0, 4.0, 8.0], f"esperava a dobra, veio {dormidas}"
+
+
+def test_pacing_was_tried_and_is_deliberately_not_shipped() -> None:
+    """The docstring records a refuted intervention; the code must match what it says.
+
+    Spacing the per-file requests was implemented, measured, and removed: at 0.15s the throttle
+    arrived on the 2nd request against the 13th with no pause at all. That comparison is confounded
+    (consecutive probes share one bucket), which is exactly why it cannot be shipped as though it
+    worked. This guards the pair — the note stays true and the constant stays gone.
+    """
+    fonte = Path(bundles.__file__).read_text(encoding="utf-8")
+    assert not hasattr(bundles, "FILE_PACING_S")
+    assert "Spacing the requests was tried first and is deliberately not here" in fonte
+
+
+def test_the_wait_the_server_asked_for_is_the_wait_taken(monkeypatch: pytest.MonkeyPatch) -> None:
+    dormidas: list[float] = []
+    respostas: list[object] = [_http_error(RAW, 429, retry_after="7"), _Resposta(b"ok")]
+
+    def urlopen(req: urllib.request.Request, timeout: float = 0) -> object:
+        proxima = respostas.pop(0)
+        if isinstance(proxima, Exception):
+            raise proxima
+        return proxima
+
+    monkeypatch.setattr(bundles.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(bundles.time, "sleep", dormidas.append)
+
+    bundles._get(RAW, accept="*/*")
+
+    assert 7.0 in dormidas, "Retry-After names the wait; guessing instead ignores what was said"
+
+
+def test_an_absurd_retry_after_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ten-minute wait must surface as a message, not as an install that appears to hang."""
+    dormidas: list[float] = []
+    respostas: list[object] = [_http_error(RAW, 429, retry_after="600"), _Resposta(b"ok")]
+
+    def urlopen(req: urllib.request.Request, timeout: float = 0) -> object:
+        proxima = respostas.pop(0)
+        if isinstance(proxima, Exception):
+            raise proxima
+        return proxima
+
+    monkeypatch.setattr(bundles.urllib.request, "urlopen", urlopen)
+    monkeypatch.setattr(bundles.time, "sleep", dormidas.append)
+
+    bundles._get(RAW, accept="*/*")
+
+    assert max(dormidas) <= bundles.THROTTLE_MAX_WAIT_S
+
+
+@pytest.mark.parametrize("bruto", ["", "Wed, 21 Oct 2026 07:28:00 GMT", "abacaxi", "-5", "0"])
+def test_an_unreadable_retry_after_falls_back_instead_of_raising(bruto: str) -> None:
+    erro = _http_error(RAW, 429, retry_after=bruto or None)
+    assert bundles._retry_after(erro, 2.0) == 2.0
+
+
+# --------------------------------------------------------------------------------------------
+# 3. The message names the host and the code it actually got
+
+
+def test_the_message_names_the_host_and_the_status(espiao) -> None:
+    _, respostas = espiao
+    respostas.append(_http_error(API, 403))
+
+    with pytest.raises(bundles.BundleError) as capturado:
+        bundles._get(API)
+
+    recado = str(capturado.value)
+    assert "api.github.com" in recado
+    assert "403" in recado, "blaming an hourly limit when the answer was something else misdirects"
+
+

--- a/tests/test_write_region.py
+++ b/tests/test_write_region.py
@@ -25,7 +25,11 @@ def test_patterns_gate_paths(tmp_path: Path) -> None:
     assert region.allows(tmp_path / "README.md") is True
     assert region.allows(tmp_path / "config" / "secrets.py") is False
     err = region.check(tmp_path / "config" / "secrets.py")
-    assert err is not None and "outside the declared write-region" in err and "config/secrets.py" in err
+    # The wording changed in `test_the_refusal_pointed_at_a_directory_the_file_was_inside`: "outside
+    # the declared write-region" read as a directory comparison, which is not the comparison made.
+    # What this test protects is unchanged — the refusal names the path AS COMPARED.
+    assert err is not None and "does not match the declared write-region" in err
+    assert "config/secrets.py" in err
 
 
 # --- tool integration -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Both of these were found by *using* the app rather than reading it, and they are the same defect
wearing two hats: an error that prescribes a fix, where the fix cannot affect the failure being
described. The refusals themselves were correct; what they said was not.

**Installing a skill** failed with *"GitHub refused — most likely its hourly limit for anonymous
downloads. Try again later, or set `GITHUB_TOKEN`."* Measured at that moment: 55 of the 60 anonymous
API calls were still unspent. The 429 came from `raw.githubusercontent.com`, which serves the files
one per request; the token was attached only for `api.github.com`, so the printed remedy could not
reach the request that failed; and 429 — the one status meaning *ask again later* — was handled
beside 403 as a flat refusal and never retried.

**Writing a file** with an absolute `write_region` was told the file was outside the very directory
the message printed. Patterns match the workspace-relative path, so an absolute one matches nothing
however it is spelled. The agent retried the same write four ways, burned three attempts and twelve
minutes, and reported an environment fault. The identical run with `["**"]` wrote it on the first
try in 57 seconds.

## Measured

| | before | after |
|---|---|---|
| `dogfood` install (3 files) | failed | **installs**, absorbing one 429 |
| write with an absolute region | 3 attempts, nothing written, ~700s | message names the pattern and the fix |
| write with `["**"]` | — | first try, 57s |

## An intervention that is deliberately NOT here

Spacing the per-file requests was implemented, measured, and removed: at 0.15s the throttle arrived
on the **2nd** request against the **13th** with no pause at all. That comparison is confounded —
consecutive probes share one throttle bucket, so a later arm starts already penalised — which is
exactly why it cannot ship as though it worked. Retrying is the mechanism the evidence supports.
The docstring records the refutation and a test guards the note and the absent constant together,
so neither can drift from the other.

## How to test

```bash
python -m pytest tests/test_the_remedy_the_error_named_could_not_reach_the_host_that_refused.py tests/test_the_refusal_pointed_at_a_directory_the_file_was_inside.py tests/test_write_region.py -q
```

28 tests. Each fix was **sabotaged individually** and a test failed in every case — 9 of 9 sabotages
caught, suite green before and after the matrix. One sabotage passed on the first pass; it was the
sabotage that was wrong (a local variable where the test checks a module attribute), not the test,
and it was redone.

Full suite: 5000 pass, 4 fail — the same four that already failed on this machine before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
