### PR TITLE
fix: three surfaces that said more than they knew

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,14 @@ CHIMERA_DEEPSEEK_KEYS=
 # --- Default models (LiteLLM-style "provider/model" slugs) ---
 # Single fast model used for Tier 1 and cheap tasks. Any LiteLLM slug works
 # (openai/..., anthropic/..., gemini/..., ollama/..., openrouter/..., etc.).
-CHIMERA_DEFAULT_MODEL=openrouter/openai/gpt-5.5
+#
+# This line IS the product default (chimera/config.py `default_model`), and it is set here
+# rather than merely described because this file gets copied to `.env` as-is. It read
+# `openrouter/openai/gpt-5.5` until 2026-09-03 — 5.00/30.00 per million against the real
+# default's 0.25/0.95, so copying the example silently ran every cheap task on a model 20x
+# dearer on input and 31x on output. `test_the_example_config_agrees_with_the_code` keeps the
+# two from parting again.
+CHIMERA_DEFAULT_MODEL=openrouter/deepseek/deepseek-chat-v3.1
 
 # Custom endpoint for self-hosted / OpenAI-compatible servers (Ollama, vLLM, ...).
 # e.g. CHIMERA_API_BASE=http://127.0.0.1:11434  with CHIMERA_DEFAULT_MODEL=ollama/llama3
@@ -152,12 +159,19 @@ CHIMERA_AUTO_FUSE=off
 # panel — best quality, but it costs real money on every fused turn.
 #
 # Budget tip: for cheap-but-reliable fusion, this panel works well and stays fast:
-#   CHIMERA_FUSION_PANEL=openrouter/deepseek/deepseek-chat,openrouter/openai/gpt-4o-mini,openrouter/meta-llama/llama-3.3-70b-instruct
+#   CHIMERA_FUSION_PANEL=openrouter/deepseek/deepseek-chat,openrouter/meta-llama/llama-3.3-70b-instruct,openrouter/z-ai/glm-4.6
 # Avoid OpenRouter ":free" model slugs in a panel: they rate-limit (HTTP 429) under
 # real load, so fusion silently degrades to whatever paid model is left in the panel.
-CHIMERA_FUSION_PANEL=openrouter/anthropic/claude-opus-4-8,openrouter/openai/gpt-5.5,openrouter/google/gemini-3.1-pro
-CHIMERA_FUSION_JUDGE=openrouter/anthropic/claude-opus-4-8
-CHIMERA_FUSION_SYNTHESIZER=openrouter/anthropic/claude-opus-4-8
+#
+# The three lines below ARE the code's defaults, and until 2026-09-03 they were none of the
+# three. They named `claude-opus-4-8` and `gemini-3.1-pro`, both withdrawn from OpenRouter —
+# so a copied example failed at call time — and they set the judge to the panel's own first
+# member, which is the judge grading its own answer. That is the exact defect the comment
+# above `_DEFAULT_JUDGE` in chimera/config.py records having been fixed once already; the
+# example file had quietly kept a copy of it.
+CHIMERA_FUSION_PANEL=openrouter/anthropic/claude-opus-5,openrouter/openai/gpt-5.5,openrouter/google/gemini-3.1-pro-preview
+CHIMERA_FUSION_JUDGE=openrouter/deepseek/deepseek-r1
+CHIMERA_FUSION_SYNTHESIZER=openrouter/anthropic/claude-opus-5
 
 # Selective fusion (ON by default). Probe the first CHIMERA_FUSION_PROBE_K panel models;
 # if they agree closely (a cheap LOCAL text-similarity check, no extra model call), skip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   globs, and when a declared pattern looks absolute names that pattern and what to write instead. A
   path resolving outside the workspace and one hitting `ALWAYS_DENIED` get their own messages,
   because those have different remedies and pointing at the region would send the reader nowhere.
+- **The MCP Test button proved the server and said nothing about the agent.** A SQLite server was
+  registered, Test connected, answered *ok* and listed all four of its tools by name. The run that
+  followed made **twenty-two tool calls over nineteen minutes and not one of them was from that
+  server**, because `mcp_autoload` is off by default. Nothing on the screen said so — *"it works"*
+  and *"you can use it"* looked identical while only one was true.
+
+  Test answers both now. When a run started right now would get none of these tools, the screen says
+  so beside the green result — the server *does* work, so the caveat sits next to the verdict rather
+  than replacing it — and the reason splits three ways because the remedies differ: the toggle is
+  off (turn it on; no relaunch needed, the servers connect lazily on the first turn), the servers
+  have not connected yet (the next run picks this one up), or they connected before this server
+  existed (they are connected once per process — restart).
+
+  Two things it deliberately does not do. It does not build the connection pool to find out:
+  `connectors()` spawns a subprocess per configured server, and a screen asking *"will the agent see
+  this?"* must not be the thing that connects them. And the reason crosses the wire as an enum, not a
+  sentence — the app ships in ten languages, and a server-side English string is one line in the
+  wrong one.
+
+- **"Verified" described an instant and was read as the delivery.** A run finished with
+  `verified: True`, `evidence: verifier`, and the verifier's own output in the receipt:
+  `Ran 20 tests in 0.001s / OK`. Running the same command against the tree that run left behind:
+  **20 failures out of 20 executions.** Not flaky — impossible. The diff the same receipt carried
+  explained it: the verified version had a line the delivered file did not, and restoring that one
+  line gave 20/20. Something wrote after the moment the verdict describes.
+
+  This does not try to name what wrote. That was never established from the artifacts, and a guess in
+  a receipt is worse than a gap. It makes the claim **checkable** instead — a digest of the tree as
+  verified, another at receipt time, and the answer on the row, with the per-attempt digest kept so a
+  reader can recompute it rather than believe it.
+
+  `delivered_matches_verified` is three-valued on purpose. `null` means nothing looked, and is
+  deliberately not `true`: defaulting to the stronger claim would stamp it on every row already in
+  the file. `verified` itself is untouched — it was true when it was given, and the Runs list shows
+  the caveat beside the verdict, never instead of it.
+
+- **The example config set a default 20× dearer than the code's, and two withdrawn models.**
+  `.env.example` tells the reader to copy it to `.env`, so its assignments are not documentation —
+  they are what a new install runs on. It set `CHIMERA_DEFAULT_MODEL=openrouter/openai/gpt-5.5`
+  (5.00/30.00 per million) while the real default was `deepseek-chat-v3.1` (0.25/0.95): **20× on
+  input, 31× on output**, silently. Its fusion panel named `claude-opus-4-8` and `gemini-3.1-pro`,
+  both gone from OpenRouter, so a copied example failed at call time. And its judge was the panel's
+  own first member — the judge grading its own answer, which is the exact defect the comment above
+  `_DEFAULT_JUDGE` records having been fixed once already. The example file had quietly kept a copy.
+
+  Nothing caught it, because the live drift gate reads `Settings()` and `Settings()` never reads this
+  file in a test process. A new offline test holds the narrower invariant: an active assignment must
+  agree with the code default it sets, must not make the judge a panellist or its vendor-mate, and
+  must not ship a `:free` slug the file's own comment warns against.
+
+- **Four catalogue entries were out of date**, all checked against the live index rather than
+  assumed: `llama-3.3-70b-instruct` 0.71/0.71 → **0.10/0.32**, `deepseek-chat-v3.1` 0.55/1.65 →
+  **0.25/0.95**, `z-ai/glm-4.6` 0.50/2.00 → **0.55/2.20**, and `mistral-small-3.2`'s window 256k →
+  **131k**. `glm-4.6` is the one worth naming: it got *dearer*. Anything written on the assumption
+  that prices only ever fall would have read that entry as still correct.
 
 ## [0.49.2] - 2026-09-02
 

--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -5253,6 +5253,28 @@
             "title": "Ok",
             "type": "boolean"
           },
+          "reaches_agent": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reaches Agent"
+          },
+          "reaches_agent_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reaches Agent Reason"
+          },
           "tools": {
             "items": {
               "$ref": "#/components/schemas/McpToolOut"
@@ -6785,6 +6807,17 @@
             },
             "title": "Attempts",
             "type": "array"
+          },
+          "delivered_matches_verified": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Delivered Matches Verified"
           },
           "paused": {
             "title": "Paused",

--- a/apps/desktop/src/components/Mcp.tsx
+++ b/apps/desktop/src/components/Mcp.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Plug, Trash2, Check, X, Loader2, Plus, ExternalLink } from "lucide-react";
+import { Plug, Trash2, Check, X, Loader2, Plus, ExternalLink, TriangleAlert } from "lucide-react";
 import {
   addMcpServer,
   getConfig,
@@ -76,6 +76,21 @@ function ServerRow({
         </div>
       </div>
 
+      {/* "It works" and "the agent can use it" are different facts. A server can connect, list its
+          tools, and still reach no run — autoload is off by default, and the servers are connected
+          once per process. Measured: a server tested green and the next run made twenty-two tool
+          calls over nineteen minutes without one of them being its. The green block below stays
+          green, because the server DOES work; this line is what was missing beside it. */}
+      {result?.reaches_agent === false && (
+        <div className="flex items-start gap-1.5 rounded-chip border border-warn/30 bg-warn/10 px-3 py-2 text-xs text-warn-foreground">
+          <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            {result.reaches_agent_reason === "added_after_connect"
+              ? t("mcp.reach.addedAfterConnect")
+              : t("mcp.reach.autoloadOff")}
+          </span>
+        </div>
+      )}
       {result && result.ok && (
         <div className="rounded-xl2 bg-ok/[0.06] px-3 py-2 ring-1 ring-ok/15">
           <div className="mb-1 flex items-center gap-1.5 text-xs font-medium text-ok-foreground">

--- a/apps/desktop/src/components/Runs.tsx
+++ b/apps/desktop/src/components/Runs.tsx
@@ -13,13 +13,31 @@ function truncate(text: string, n: number): string {
   return text.length > n ? `${text.slice(0, n)}…` : text;
 }
 
-/** The run's terminal verdict as a tone-coded badge: paused (warn) → passed (ok) → failed (bad). */
+/** The run's terminal verdict as a tone-coded badge: paused (warn) → passed (ok) → failed (bad).
+ *
+ *  A passed run can also carry the one caveat that undoes what "passed" is read to mean: the tree on
+ *  disk is no longer the tree that verdict was about. Measured — a receipt said `verified: True` with
+ *  the verifier's own `Ran 20 tests ... OK` stored beside it, and the delivered files failed all
+ *  twenty. The verdict was true when it was given, so it stays; the caveat sits next to it rather
+ *  than replacing it. Only `false` shows: `null` means nothing looked, and a badge for that would
+ *  put a warning on every receipt written before the check existed.
+ */
 function StatusBadge({ run, t }: { run: RunReceipt; t: TFunc }) {
   if (run.paused) return <Badge tone="warn">{t("runs.paused")}</Badge>;
-  return run.success ? (
-    <Badge tone="ok">{t("runs.passed")}</Badge>
-  ) : (
-    <Badge tone="bad">{t("runs.failed")}</Badge>
+  const moveu = run.delivered_matches_verified === false;
+  return (
+    <>
+      {run.success ? (
+        <Badge tone="ok">{t("runs.passed")}</Badge>
+      ) : (
+        <Badge tone="bad">{t("runs.failed")}</Badge>
+      )}
+      {moveu && (
+        <Badge tone="warn" title={t("runs.deliveryMoved.why")}>
+          {t("runs.deliveryMoved")}
+        </Badge>
+      )}
+    </>
   );
 }
 

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -4909,6 +4909,10 @@ export interface components {
             error: string | null;
             /** Ok */
             ok: boolean;
+            /** Reaches Agent */
+            reaches_agent?: boolean | null;
+            /** Reaches Agent Reason */
+            reaches_agent_reason?: string | null;
             /** Tools */
             tools: components["schemas"]["McpToolOut"][];
         };
@@ -5610,6 +5614,8 @@ export interface components {
             answer: string;
             /** Attempts */
             attempts: components["schemas"]["AttemptReceiptOut"][];
+            /** Delivered Matches Verified */
+            delivered_matches_verified?: boolean | null;
             /** Paused */
             paused: boolean;
             /**

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -553,6 +553,8 @@ const en: Dict = {
   "runs.empty":
     'No runs yet — start one on the Task tab, or run `chimera solve "…" --verify "…"` from the CLI.',
   "runs.passed": "passed",
+  "runs.deliveryMoved": "files changed after",
+  "runs.deliveryMoved.why": "The verdict was true when it was given. The files on disk are no longer the ones it was about.",
   "runs.failed": "failed",
   "runs.paused": "paused",
   "runs.verifyCmd": "Verify",
@@ -1113,6 +1115,8 @@ const en: Dict = {
   "mcp.testFailed": "The test connect failed.",
   "mcp.connected": "connected · {n} tools",
   "mcp.toolsExposed": "{n} tools exposed",
+  "mcp.reach.autoloadOff": "Works, but no run can use it yet — loading MCP servers at start is off.",
+  "mcp.reach.addedAfterConnect": "Works, but it arrived after the servers connected — restart the app.",
   "mcp.autoloadOff":
     "Autoload is off — configured servers are saved but not loaded into the agent. Turn on MCP autoload in Settings (needs a restart) to make their tools callable. Test proves a server is live either way.",
   "mcp.note":
@@ -1836,6 +1840,8 @@ const pt: Dict = {
   "runs.empty":
     'Nenhuma execução ainda — inicie uma na aba Tarefa, ou rode `chimera solve "…" --verify "…"` pelo CLI.',
   "runs.passed": "aprovada",
+  "runs.deliveryMoved": "arquivos mudaram depois",
+  "runs.deliveryMoved.why": "O veredito era verdadeiro quando foi dado. Os arquivos em disco já não são os que ele julgou.",
   "runs.failed": "falhou",
   "runs.paused": "pausada",
   "runs.verifyCmd": "Verificação",
@@ -2401,6 +2407,8 @@ const pt: Dict = {
   "mcp.testFailed": "A conexão de teste falhou.",
   "mcp.connected": "conectado · {n} ferramentas",
   "mcp.toolsExposed": "{n} ferramentas expostas",
+  "mcp.reach.autoloadOff": "Funciona, mas nenhuma execução pode usar ainda — carregar servidores MCP no início está desligado.",
+  "mcp.reach.addedAfterConnect": "Funciona, mas entrou depois que os servidores conectaram — reinicie o aplicativo.",
   "mcp.autoloadOff":
     "O autoload está desligado — os servidores configurados são salvos, mas não carregados no agente. Ative o autoload de MCP nas Configurações (requer reinício) para tornar as ferramentas chamáveis. O Testar prova que um servidor está ativo de qualquer forma.",
   "mcp.note":
@@ -3131,6 +3139,8 @@ const es: Dict = {
   "runs.empty":
     'Aún no hay ejecuciones — inicia una en la pestaña Tarea, o ejecuta `chimera solve "…" --verify "…"` desde el CLI.',
   "runs.passed": "aprobada",
+  "runs.deliveryMoved": "archivos cambiaron después",
+  "runs.deliveryMoved.why": "El veredicto era cierto cuando se dio. Los archivos en disco ya no son los que juzgó.",
   "runs.failed": "fallida",
   "runs.paused": "pausada",
   "runs.verifyCmd": "Verificación",
@@ -3701,6 +3711,8 @@ const es: Dict = {
   "mcp.testFailed": "La conexión de prueba falló.",
   "mcp.connected": "conectado · {n} herramientas",
   "mcp.toolsExposed": "{n} herramientas expuestas",
+  "mcp.reach.autoloadOff": "Funciona, pero ninguna ejecución puede usarlo aún: cargar servidores MCP al inicio está desactivado.",
+  "mcp.reach.addedAfterConnect": "Funciona, pero se añadió después de conectar los servidores: reinicia la aplicación.",
   "mcp.autoloadOff":
     "El autoload está desactivado — los servidores configurados se guardan pero no se cargan en el agente. Activa el autoload de MCP en Ajustes (requiere reinicio) para que sus herramientas sean invocables. Probar demuestra que un servidor está activo en cualquier caso.",
   "mcp.note":
@@ -4436,6 +4448,8 @@ const fr: Dict = {
   "runs.empty":
     'Aucune exécution pour l\'instant — lancez-en une dans l\'onglet Tâche, ou exécutez `chimera solve "…" --verify "…"` depuis le CLI.',
   "runs.passed": "réussie",
+  "runs.deliveryMoved": "fichiers modifiés après",
+  "runs.deliveryMoved.why": "Le verdict était vrai au moment donné. Les fichiers sur le disque ne sont plus ceux qu'il jugeait.",
   "runs.failed": "échouée",
   "runs.paused": "en pause",
   "runs.verifyCmd": "Vérification",
@@ -5012,6 +5026,8 @@ const fr: Dict = {
   "mcp.testFailed": "La connexion de test a échoué.",
   "mcp.connected": "connecté · {n} outils",
   "mcp.toolsExposed": "{n} outils exposés",
+  "mcp.reach.autoloadOff": "Fonctionne, mais aucune exécution ne peut encore l'utiliser : le chargement des serveurs MCP au démarrage est désactivé.",
+  "mcp.reach.addedAfterConnect": "Fonctionne, mais ajouté après la connexion des serveurs : redémarrez l'application.",
   "mcp.autoloadOff":
     "L'autoload est désactivé — les serveurs configurés sont enregistrés mais pas chargés dans l'agent. Activez l'autoload MCP dans les Paramètres (nécessite un redémarrage) pour rendre leurs outils appelables. Tester prouve qu'un serveur est actif dans tous les cas.",
   "mcp.note":
@@ -5747,6 +5763,8 @@ const de: Dict = {
   "runs.empty":
     'Noch keine Läufe — starte einen im Tab Aufgabe, oder führe `chimera solve "…" --verify "…"` im CLI aus.',
   "runs.passed": "bestanden",
+  "runs.deliveryMoved": "Dateien danach geändert",
+  "runs.deliveryMoved.why": "Das Urteil war zum Zeitpunkt richtig. Die Dateien auf der Platte sind nicht mehr die beurteilten.",
   "runs.failed": "fehlgeschlagen",
   "runs.paused": "pausiert",
   "runs.verifyCmd": "Verifikation",
@@ -6324,6 +6342,8 @@ const de: Dict = {
   "mcp.testFailed": "Der Test-Verbindungsaufbau ist fehlgeschlagen.",
   "mcp.connected": "verbunden · {n} Tools",
   "mcp.toolsExposed": "{n} Tools bereitgestellt",
+  "mcp.reach.autoloadOff": "Funktioniert, aber noch kein Lauf kann es nutzen — das Laden der MCP-Server beim Start ist aus.",
+  "mcp.reach.addedAfterConnect": "Funktioniert, wurde aber nach dem Verbinden der Server hinzugefügt — App neu starten.",
   "mcp.autoloadOff":
     "Autoload ist aus — konfigurierte Server werden gespeichert, aber nicht in den Agenten geladen. Aktiviere MCP-Autoload in den Einstellungen (Neustart nötig), damit ihre Tools aufrufbar werden. Testen beweist ohnehin, dass ein Server live ist.",
   "mcp.note":
@@ -7022,6 +7042,8 @@ const zh: Dict = {
   "runs.empty":
     '还没有运行 —— 在「任务」标签页开始一个，或在 CLI 中执行 `chimera solve "…" --verify "…"`。',
   "runs.passed": "通过",
+  "runs.deliveryMoved": "之后文件已变更",
+  "runs.deliveryMoved.why": "该判定在做出时是真的。磁盘上的文件已不是它所判定的那些。",
   "runs.failed": "失败",
   "runs.paused": "已暂停",
   "runs.verifyCmd": "验证",
@@ -7558,6 +7580,8 @@ const zh: Dict = {
   "mcp.testFailed": "测试连接失败。",
   "mcp.connected": "已连接 · {n} 个工具",
   "mcp.toolsExposed": "暴露了 {n} 个工具",
+  "mcp.reach.autoloadOff": "可以连接，但运行还用不上——启动时加载 MCP 服务器已关闭。",
+  "mcp.reach.addedAfterConnect": "可以连接，但它是在服务器连接之后添加的——请重启应用。",
   "mcp.autoloadOff":
     "自动加载已关闭 — 已配置的服务器会保存但不会加载到智能体中。在设置中开启 MCP 自动加载（需重启）以使其工具可调用。无论如何，测试都能证明服务器是否在线。",
   "mcp.note":
@@ -8284,6 +8308,8 @@ const ja: Dict = {
   "runs.empty":
     'まだ実行がありません — 「タスク」タブで開始するか、CLI で `chimera solve "…" --verify "…"` を実行してください。',
   "runs.passed": "合格",
+  "runs.deliveryMoved": "判定後にファイルが変更",
+  "runs.deliveryMoved.why": "判定はその時点では正しかったものです。ディスク上のファイルはもう判定対象のものではありません。",
   "runs.failed": "失敗",
   "runs.paused": "一時停止",
   "runs.verifyCmd": "検証",
@@ -8849,6 +8875,8 @@ const ja: Dict = {
   "mcp.testFailed": "テスト接続に失敗しました。",
   "mcp.connected": "接続済み · {n} ツール",
   "mcp.toolsExposed": "{n} ツールを公開",
+  "mcp.reach.autoloadOff": "接続できますが、実行はまだ使えません — 起動時の MCP サーバー読み込みがオフです。",
+  "mcp.reach.addedAfterConnect": "接続できますが、サーバー接続後に追加されました — アプリを再起動してください。",
   "mcp.autoloadOff":
     "オートロードはオフです — 設定済みサーバーは保存されますが、エージェントには読み込まれません。設定で MCP オートロードを有効にする（再起動が必要）とツールが呼び出し可能になります。テストはいずれにせよサーバーが稼働中か証明します。",
   "mcp.note":
@@ -9581,6 +9609,8 @@ const it: Dict = {
   "runs.empty":
     'Ancora nessuna esecuzione — avviane una nella scheda Attività, o lancia `chimera solve "…" --verify "…"` dalla CLI.',
   "runs.passed": "superata",
+  "runs.deliveryMoved": "file cambiati dopo",
+  "runs.deliveryMoved.why": "Il verdetto era vero quando è stato dato. I file su disco non sono più quelli giudicati.",
   "runs.failed": "fallita",
   "runs.paused": "in pausa",
   "runs.verifyCmd": "Verifica",
@@ -10154,6 +10184,8 @@ const it: Dict = {
   "mcp.testFailed": "La connessione di prova è fallita.",
   "mcp.connected": "connesso · {n} strumenti",
   "mcp.toolsExposed": "{n} strumenti esposti",
+  "mcp.reach.autoloadOff": "Funziona, ma nessuna esecuzione può ancora usarlo: il caricamento dei server MCP all'avvio è disattivato.",
+  "mcp.reach.addedAfterConnect": "Funziona, ma è stato aggiunto dopo la connessione dei server: riavvia l'applicazione.",
   "mcp.autoloadOff":
     "Il caricamento automatico è spento — i server configurati sono salvati ma non caricati nell'agente. Attiva l'autoload MCP nelle Impostazioni (richiede un riavvio) per rendere i loro strumenti chiamabili. La prova dimostra comunque che un server è attivo.",
   "mcp.note":
@@ -10880,6 +10912,8 @@ const pl: Dict = {
   "runs.empty":
     'Jeszcze brak przebiegów — zacznij jeden w zakładce Zadanie albo uruchom `chimera solve "…" --verify "…"` z CLI.',
   "runs.passed": "zaliczony",
+  "runs.deliveryMoved": "pliki zmienione później",
+  "runs.deliveryMoved.why": "Ten werdykt był prawdziwy w chwili wydania. Pliki na dysku to już nie te, które oceniał.",
   "runs.failed": "nieudany",
   "runs.paused": "wstrzymany",
   "runs.verifyCmd": "Weryfikacja",
@@ -11450,6 +11484,8 @@ const pl: Dict = {
   "mcp.testFailed": "Testowe połączenie nie powiodło się.",
   "mcp.connected": "połączony · narzędzia: {n}",
   "mcp.toolsExposed": "udostępnione narzędzia: {n}",
+  "mcp.reach.autoloadOff": "Działa, ale żadne uruchomienie jeszcze go nie użyje — wczytywanie serwerów MCP na starcie jest wyłączone.",
+  "mcp.reach.addedAfterConnect": "Działa, ale został dodany po połączeniu serwerów — zrestartuj aplikację.",
   "mcp.autoloadOff":
     "Automatyczne ładowanie jest wyłączone — skonfigurowane serwery są zapisane, ale nie wczytane do agenta. Włącz autoload MCP w Ustawieniach (wymaga restartu), żeby ich narzędzia dało się wywoływać. Test i tak dowodzi, że serwer żyje.",
   "mcp.note":
@@ -12180,6 +12216,8 @@ const ru: Dict = {
   "runs.empty":
     'Запусков пока нет — начните один на вкладке «Задача» или выполните `chimera solve "…" --verify "…"` в командной строке.',
   "runs.passed": "пройден",
+  "runs.deliveryMoved": "файлы изменены после",
+  "runs.deliveryMoved.why": "Вердикт был верен в момент вынесения. Файлы на диске — уже не те, о которых он был.",
   "runs.failed": "провален",
   "runs.paused": "приостановлен",
   "runs.verifyCmd": "Проверка",
@@ -12753,6 +12791,8 @@ const ru: Dict = {
   "mcp.testFailed": "Проверочное подключение не удалось.",
   "mcp.connected": "подключён · инструментов: {n}",
   "mcp.toolsExposed": "открыто инструментов: {n}",
+  "mcp.reach.autoloadOff": "Работает, но ни один запуск пока не может это использовать — загрузка MCP-серверов при старте отключена.",
+  "mcp.reach.addedAfterConnect": "Работает, но добавлен после подключения серверов — перезапустите приложение.",
   "mcp.autoloadOff":
     "Автозагрузка выключена — настроенные серверы сохранены, но в агента не загружаются. Включите автозагрузку MCP в настройках (нужен перезапуск), чтобы их инструменты стали вызываемыми. Проверка в любом случае доказывает, что сервер жив.",
   "mcp.note":

--- a/chimera/api/mcp_api.py
+++ b/chimera/api/mcp_api.py
@@ -78,17 +78,62 @@ def test_server(home: Path, name: str) -> dict[str, Any]:
     ``{ok:true, tools:[{name, description}], error:null}`` on a real connect; ``{ok:false, tools:[],
     error}`` on ANY failure (unknown server, connect timeout, missing ``mcp`` extra, handshake error).
     The error string is a short class-name-based summary — it never carries an env value or a traceback.
+
+    ``ok`` answers "does this server work". ``reaches_agent`` answers the question the person
+    clicking Test is actually asking — "can the agent use it" — and the two are not the same. See
+    :func:`_reach`.
     """
     servers = load_servers(_mcp_path(home))
     cfg = next((s for s in servers if s.name == name), None)
     if cfg is None:
-        return {"ok": False, "tools": [], "error": "no such server"}
+        return {"ok": False, "tools": [], "error": "no such server", **_reach(name)}
     try:
         tools = _live_test(cfg)
-        return {"ok": True, "tools": tools, "error": None}
+        return {"ok": True, "tools": tools, "error": None, **_reach(name)}
     except Exception as exc:  # noqa: BLE001 — every failure becomes a short, secret-free error
         _log.warning("MCP test for %r failed: %s", name, type(exc).__name__)
-        return {"ok": False, "tools": [], "error": _short_error(exc)}
+        return {"ok": False, "tools": [], "error": _short_error(exc), **_reach(name)}
+
+
+def _reach(name: str) -> dict[str, Any]:
+    """Whether a run started right now would receive this server's tools, and if not, why not.
+
+    A live connect proves the server works. It does not prove the *agent* can reach it, and the gap
+    between those two facts was measured: a server was registered, Test answered "ok, 4 tools" and
+    listed all four, and the next run made twenty-two tool calls over nineteen minutes without one
+    of them being from the server — because ``mcp_autoload`` is off by default. Nothing on the
+    screen said so. "It works" and "you can use it" looked identical, and only one was true.
+
+    Three states, and each has a different remedy:
+
+    * autoload off — nothing reaches any run. Turn it on; no relaunch needed, because the pool is
+      built lazily on the first turn that asks for it.
+    * autoload on, pool not built yet — the next run builds it and picks this server up.
+    * autoload on, pool already built without this name — this server was added after the servers
+      were connected, and the pool is deliberately never rebuilt in a process (see
+      :mod:`chimera.integrations.mcp_pool`). It needs a relaunch.
+
+    The reason is an ENUM, not a sentence. The app is translated into ten languages, and a screen
+    that prints an English string from the server is a screen where one line is in the wrong
+    language — the same rule the orchestration frames already follow for ``fell_back.reason``.
+
+    Reads the pool WITHOUT building it, so asking the question never has the side effect of
+    answering it — clicking Test must not spawn a subprocess per configured server.
+    """
+    from chimera.config import get_settings
+    from chimera.integrations.mcp_pool import pool_state
+
+    try:
+        estado = pool_state(get_settings())
+    except Exception as exc:  # noqa: BLE001 -- a status read must never fail a test
+        _log.debug("MCP reach unknown: %s", type(exc).__name__)
+        return {"reaches_agent": None, "reaches_agent_reason": None}
+
+    if not estado.autoload:
+        return {"reaches_agent": False, "reaches_agent_reason": "autoload_off"}
+    if estado.connected is None or name in estado.connected:
+        return {"reaches_agent": True, "reaches_agent_reason": None}
+    return {"reaches_agent": False, "reaches_agent_reason": "added_after_connect"}
 
 
 def _short_error(exc: Exception) -> str:

--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -54,6 +54,10 @@ class AttemptReceipt(BaseModel):
 
     index: int = 0
     verified: bool = False
+    #: Digest of the tree at the moment this verdict was given, or "" when nothing captured it.
+    #: Kept so ``delivered_matches_verified`` on the run can be recomputed later by a reader, rather
+    #: than only believed — the whole point of the field is that a claim be checkable.
+    verified_fingerprint: str = ""
     reverted: bool = False
     success: bool = False
     verify_output: str = ""  # the concrete verifier output (test/assert), truncated in the builder
@@ -122,6 +126,19 @@ class RunReceipt(BaseModel):
     was the only way to supply one."""
     answer: str = ""  # the final answer, truncated in the builder
 
+    delivered_matches_verified: bool | None = None
+    """Is the tree on disk still the one the winning attempt's verdict was about?
+
+    ``verified`` is a statement about an instant; this row is read as a statement about the
+    delivery, and those came apart in a measured run — the receipt said ``verified: True`` with
+    ``Ran 20 tests ... OK`` stored beside it, and the delivered tree failed all twenty on every one
+    of twenty executions, because a line present in the stored diff was missing from the file.
+
+    ``None`` means not checkable (no successful attempt, no workspace guard, or a row written before
+    the check existed) and is deliberately not ``True``: "we did not look" and "we looked and it
+    matched" are different claims, and defaulting to the stronger one would stamp it on every old
+    row in the file."""
+
     stopped_reason: str = ""
     """Why the loop stopped: ``final`` | ``max_steps`` | ``tool_loop`` | ``budget`` | ``spend`` |
     ``cancelled``.
@@ -183,6 +200,7 @@ def build_receipt(
     verify_source: str = "user",
     profile_source: str = "user",
     workspace: str = "",
+    delivered_matches_verified: bool | None = None,
 ) -> RunReceipt:
     """Map an ``AutonomousResult`` (and its attempts) into a receipt, truncating the bounded fields."""
     attempts = [
@@ -218,6 +236,7 @@ def build_receipt(
             completion_tokens=int(getattr(a, "completion_tokens", 0) or 0),
             model=str(getattr(a, "model", "") or ""),
             discarded_at=str(getattr(a, "discarded_at", "") or ""),
+            verified_fingerprint=str(getattr(a, "verified_fingerprint", "") or ""),
         )
         for a in result.attempts
     ]
@@ -238,6 +257,7 @@ def build_receipt(
         profile=profile,
         workspace=workspace,
         usd=total_usd(attempts),
+        delivered_matches_verified=delivered_matches_verified,
     )
 
 

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -1313,6 +1313,17 @@ class RunReceiptOut(BaseModel):
     narrowed to one project and a Runs list that happens to contain one project look identical, and
     the reader is the one who has to tell them apart."""
 
+    delivered_matches_verified: bool | None = None
+    """Is the tree on disk still the one the winning attempt's verdict was about?
+
+    On the wire because ``success`` is read as a statement about the delivery while it is a statement
+    about an instant, and the two came apart in a measured run: the row said verified with the
+    verifier's own ``Ran 20 tests ... OK`` beside it, and the delivered files failed all twenty.
+
+    ``null`` means nothing looked — no successful attempt, no workspace guard, or a receipt written
+    before the check existed — and is deliberately not ``true``, so the screen does not stamp the
+    stronger claim on every row already in the file."""
+
 
 class CancelOut(BaseModel):
     ok: bool  # True when the run_id was known and its stop flag was set; False for a finished/unknown id
@@ -1613,6 +1624,16 @@ class McpTestOut(BaseModel):
     ok: bool  # True ONLY after a real stdio connect + tool enumeration — the sole "connected" signal
     tools: list[McpToolOut]  # the tools the server exposed on a successful connect; [] otherwise
     error: str | None  # a short, secret-free failure message when ok is False; null on success
+    # "It works" and "the agent can use it" are different facts, and only reporting the first is how
+    # a server that tested green sat unreachable through a nineteen-minute run. False means a run
+    # started now gets none of these tools; null means the answer could not be read.
+    reaches_agent: bool | None = None
+    # WHY not, as an enum the app translates: "autoload_off" (the toggle is off, so no run is given
+    # these tools) or "added_after_connect" (the servers are connected once per process and this one
+    # arrived later, so it needs a restart). The remedies differ, which is why one flag is not
+    # enough. An enum rather than a sentence because the app ships in ten languages. Null whenever
+    # `reaches_agent` is not False.
+    reaches_agent_reason: str | None = None
 
 
 class McpAddRequest(BaseModel):

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -244,6 +244,16 @@ class Attempt:
     verify_output: str = ""
     diff_summary: str = ""
     diffs: list[FileDiff] = field(default_factory=list)  # real per-file unified diffs (pre-revert)
+    #: Digest da arvore NO MOMENTO em que este veredito foi dado, ou "" quando nao houve captura.
+    #:
+    #: Existe porque `verified` descreve um instante e o recibo e lido como se descrevesse a
+    #: entrega. Medido: um run gravou `verified=True` com a saida do verificador dizendo
+    #: `Ran 20 tests ... OK`, e a arvore em disco falhava as vinte, deterministicamente — o diff
+    #: guardado no proprio recibo tinha uma linha que o arquivo entregue nao tinha. Comparar este
+    #: digest com um novo, na hora de gravar o recibo, responde "o que foi entregue ainda e o que
+    #: foi verificado?" sem exigir que se saiba QUEM escreveu depois.
+    verified_fingerprint: str = ""
+
     #: Onde o trabalho revertido foi guardado inteiro, ou "" quando nao houve reversao.
     #:
     #: `diffs` acima existe e nao serve para recuperar nada: o recibo corta cada patch em 4.000
@@ -884,6 +894,10 @@ class AutonomousAgent:
             diff_productive: bool | None = None
             diff_summary: str | None = None
             diffs: list[FileDiff] = []
+            # Per attempt, not `last_after`: that one survives the loop for `--keep-workspace`, so
+            # on a second attempt without a capture it would still hold the FIRST attempt's tree and
+            # this receipt would attest to a verdict about somebody else's files.
+            impressao_verificada = ""
             if snapshot is not None and self.guard is not None:
                 from chimera.evolution.diff_gate import diff_snapshots, unified_diffs
 
@@ -901,6 +915,11 @@ class AutonomousAgent:
                 diff_productive = pdiff.is_productive
                 diff_summary = pdiff.audit_summary()
                 diffs = unified_diffs(snapshot, after)  # real diffs, BEFORE any revert below
+                # The tree AS VERIFIED: `_verify()` ran just above, so this capture is the state the
+                # verdict is about — not a fresh read a later write could already have changed.
+                from chimera.core.checkpoint import fingerprint as _impressao
+
+                impressao_verificada = _impressao(after)
 
             # What the attempt actually did, handed to the reviewer as EVIDENCE.
             #
@@ -1080,6 +1099,9 @@ class AutonomousAgent:
             attempt.diff_summary = diff_summary or ""
             attempt.diffs = diffs
             attempt.diff_productive = diff_productive
+            # Empty when there was no guard to capture with, which reads as "not checkable" rather
+            # than as "unchanged".
+            attempt.verified_fingerprint = impressao_verificada
             attempt.side_effects = _side_effects(steplog)
             # The key that joins this outcome to the trace line the same run just wrote. Read off
             # the worker's result, like  above and for the same reason: it is the worker that
@@ -1489,6 +1511,43 @@ class AutonomousAgent:
             _log.warning("nao consegui guardar o trabalho revertido: %s", exc)
             return ""
 
+    def _delivered_matches_verified(self, result: AutonomousResult) -> bool | None:
+        """Is the tree on disk still the tree the winning attempt's verdict was about?
+
+        ``verified`` is a statement about an instant. The receipt is read as a statement about the
+        delivery, and those came apart in a measured run: the row said ``verified: True`` with the
+        verifier's own ``Ran 20 tests ... OK`` stored beside it, and the delivered tree failed all
+        twenty on every one of twenty executions. The diff the same receipt carried contained a line
+        the file on disk did not have — something wrote after the moment the verdict describes.
+
+        This does not try to name what wrote. Naming it would mean guessing, and a guess in a
+        receipt is worse than a gap. It compares two digests and reports the answer:
+
+        * ``True`` — the delivered tree is byte-for-byte the verified one;
+        * ``False`` — it is not, and ``verified`` should be read as being about a tree that no
+          longer exists;
+        * ``None`` — not checkable. No successful attempt, no guard to capture with, or a receipt
+          from before the digest existed. Distinct from ``True`` on purpose: "we did not look" and
+          "we looked and it matched" are different claims, and collapsing them would put the
+          stronger one on every old row.
+
+        Never raises. A run that finished is a run whose receipt must be written, and a status read
+        that can fail the write is a worse defect than the one it reports.
+        """
+        try:
+            vencedora = next((a for a in reversed(result.attempts) if a.success), None)
+            if vencedora is None:
+                return None
+            esperada = getattr(vencedora, "verified_fingerprint", "") or ""
+            if not esperada or self.guard is None:
+                return None
+            from chimera.core.checkpoint import fingerprint as _impressao
+
+            return _impressao(self.guard.snapshot()) == esperada
+        except Exception as exc:  # noqa: BLE001 -- never break a receipt to report on one
+            _log.debug("delivery check skipped: %s", type(exc).__name__)
+            return None
+
     def _persist_receipt(self, result: AutonomousResult, task: str) -> None:
         """Append a run receipt recording how this finished run PROVED its work (read-only evidence).
 
@@ -1506,6 +1565,9 @@ class AutonomousAgent:
 
         Reads the verify command off the verifier when it exposes one (``CommandVerifier.command``);
         ``None`` for a run with no executable verifier.
+
+        Also asks, one last time, whether the tree still IS the tree the verdict describes. See
+        :meth:`_delivered_matches_verified`.
         """
         if self.run_log is None:
             return
@@ -1522,6 +1584,7 @@ class AutonomousAgent:
                 # built without a workspace records none rather than the process cwd, which would be
                 # a guess wearing the same clothes as a fact.
                 workspace=str(self.workspace) if self.workspace else "",
+                delivered_matches_verified=self._delivered_matches_verified(result),
             )
             append_run(self.run_log, receipt)
         except Exception as exc:  # noqa: BLE001 — receipt persistence is best-effort, never fatal

--- a/chimera/core/checkpoint.py
+++ b/chimera/core/checkpoint.py
@@ -22,6 +22,7 @@ them. Leftover junk is recoverable; deleting a developer's tracked files is not.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -52,6 +53,36 @@ class FileSnapshot:
 
     files: dict[str, str] = field(default_factory=dict)
     present: set[str] = field(default_factory=set)
+
+
+def fingerprint(snap: FileSnapshot) -> str:
+    """A stable digest of everything a snapshot captured — content AND presence.
+
+    Exists so a receipt can be checked rather than believed. A run reported ``verified: True`` with
+    the verifier's own output showing ``Ran 20 tests ... OK``, and the tree it left on disk failed
+    all twenty, deterministically: the diff the receipt stored contained one line the delivered file
+    did not have. Something wrote after the moment the verdict describes.
+
+    Comparing two of these answers "is what was delivered still what was verified?" without needing
+    to know which step wrote afterwards — which is the point. A guard that requires you to have
+    already found the culprit is not a guard.
+
+    Presence is in the digest and not only content: a file that appears or disappears changes what
+    the verify command would do, and a digest over content alone would call that no change. Binary
+    and unreadable files are in ``present`` without content (see :meth:`WorkspaceGuard.snapshot`),
+    so they are covered by presence and not by their bytes — a limit worth knowing rather than
+    hiding, and it matches exactly what the snapshot could see in the first place.
+    """
+    h = hashlib.sha256()
+    for rel in sorted(snap.present):
+        h.update(rel.encode("utf-8"))
+        h.update(b"\x00")
+        conteudo = snap.files.get(rel)
+        # A file present-but-unread is distinguished from one that is present and empty. Hashing
+        # both as b"" would make replacing a text file with a binary of the same name invisible.
+        h.update(b"?" if conteudo is None else hashlib.sha256(conteudo.encode("utf-8")).digest())
+        h.update(b"\x00")
+    return h.hexdigest()
 
 
 class WorkspaceGuard:

--- a/chimera/integrations/mcp_pool.py
+++ b/chimera/integrations/mcp_pool.py
@@ -25,6 +25,7 @@ stock install behaves exactly as it did.
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import Any
 
 from chimera.config import Settings
@@ -88,6 +89,42 @@ def _build(settings: Settings) -> Any:
             # true forever.
             _log.warning("MCP: skipping server %r — %s", cfg.name, str(exc)[:300])
     return pool if pool.names() else None
+
+
+@dataclass(frozen=True)
+class PoolState:
+    """Whether a run started right now would receive the configured MCP tools.
+
+    Exists because :func:`connectors` cannot answer that question: calling it BUILDS the pool, which
+    spawns a subprocess per configured server. A screen asking "will the agent see this?" must not
+    be the thing that connects them.
+
+    ``connected`` is ``None`` when the pool has not been built yet, which is not the same as "no
+    servers": the pool is built lazily on the first turn, so a server configured while autoload is
+    on will be picked up then. Collapsing that into an empty tuple would report "the agent cannot
+    see it" about a server the agent is about to see.
+    """
+
+    autoload: bool
+    built: bool
+    connected: tuple[str, ...] | None
+
+
+def pool_state(settings: Settings) -> PoolState:
+    """Report the pool without building it. Safe to call from a read-only endpoint."""
+    with _lock:
+        nomes: tuple[str, ...] | None = None
+        if _pool is not None:
+            try:
+                nomes = tuple(_pool.names())
+            except Exception:  # noqa: BLE001 -- a broken pool must not break a status read
+                nomes = ()
+        elif _tried:
+            # Built and came back empty (no servers, or every one failed to connect). That is a real
+            # answer, and reporting it as "not built yet" would promise a later pickup that is not
+            # coming — `_tried` latches, so nothing will try again in this process.
+            nomes = ()
+        return PoolState(autoload=bool(settings.mcp_autoload), built=_tried, connected=nomes)
 
 
 def reset_for_tests() -> None:

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -74,13 +74,13 @@ CATALOG: tuple[CatalogEntry, ...] = (
     ),
     CatalogEntry(
         "openrouter/mistralai/mistral-small-3.2-24b-instruct", "weak", "Mistral",
-        0.075, 0.20, tools=True, context_k=256,
-        notes="the local-lift goldilocks model; cheap paid weak with usable tools",
+        0.075, 0.20, tools=True, context_k=131,
+        notes="the local-lift goldilocks model; cheap paid weak with usable tools. The window read\n        256k here until 2026-09-03; the provider serves 131k",
     ),
     CatalogEntry(
         "openrouter/meta-llama/llama-3.3-70b-instruct", "weak", "Meta",
-        0.71, 0.71, tools=True, context_k=131,
-        notes="the paid variant; the :free one was withdrawn on 2026-08-18. Input and output\n        cost the same here, which is unusual and is what the provider charges",
+        0.10, 0.32, tools=True, context_k=131,
+        notes="the paid variant; the :free one was withdrawn on 2026-08-18. Priced 0.71/0.71 here\n        until a live check on 2026-09-03 measured 0.10/0.32 — and the note that input and\n        output cost the same stopped being true with it",
     ),
     CatalogEntry(
         "openrouter/openai/gpt-oss-20b", "weak", "OpenAI",
@@ -90,13 +90,13 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
-        0.55, 1.65, tools=True, context_k=163,
-        notes="proven in this repo's benches; the product default",
+        0.25, 0.95, tools=True, context_k=163,
+        notes="proven in this repo's benches; the product default. Priced 0.55/1.65 here until a\n        live check on 2026-09-03 measured 0.25/0.95",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-4.6", "mid", "Zhipu (GLM)",
-        0.50, 2.00, tools=True, context_k=204,
-        notes="strong agentic mid",
+        0.55, 2.20, tools=True, context_k=204,
+        notes="strong agentic mid. Priced 0.50/2.00 here until a live check on 2026-09-03 measured\n        0.55/2.20 — this one went UP, which is the case a drift check has to be able to see:\n        anything written assuming prices only fall would have read this as still correct",
     ),
     CatalogEntry(
         "openrouter/google/gemini-2.5-flash", "mid", "Google",

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -105,4 +105,11 @@ def test_mcp_test_failure_is_short_and_secret_free(tmp_path: Any, monkeypatch: A
 def test_mcp_test_unknown_server(tmp_path: Any) -> None:
     client = _client(tmp_path)
     data = client.post("/api/mcp/ghost/test").json()
-    assert data == {"ok": False, "tools": [], "error": "no such server"}
+    # The reach fields joined this response in
+    # `test_the_server_tested_green_and_the_agent_could_not_reach_it`, because "it works" and "the
+    # agent can use it" are different facts. Asserting the three that matter here rather than the
+    # whole dict: this test is about an unknown NAME, and pinning every key makes it fail again the
+    # next time an unrelated field is added.
+    assert data["ok"] is False
+    assert data["tools"] == []
+    assert data["error"] == "no such server"

--- a/tests/test_the_example_config_agrees_with_the_code.py
+++ b/tests/test_the_example_config_agrees_with_the_code.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Any
 
 from chimera.config import Settings
 
@@ -40,14 +41,27 @@ def _ativas() -> dict[str, str]:
     return fora
 
 
+def _declarado(campo: str) -> Any:
+    """The default the CODE declares, not what this process happens to be configured with.
+
+    `Settings()` reads the environment, and under the full suite some earlier test has exported a
+    `CHIMERA_*` — so an instance answers "what is in force here", which is a different question and
+    made this test pass alone and fail in the suite. The example file is compared against what the
+    code ships, so the field default is the right reading either way.
+    """
+    campo_info = Settings.model_fields[campo]
+    if campo_info.default_factory is not None:
+        return campo_info.default_factory()
+    return campo_info.default
+
+
 def test_the_example_config_agrees_with_the_code() -> None:
-    s = Settings()
     ativas = _ativas()
     esperado = {
-        "CHIMERA_DEFAULT_MODEL": s.default_model,
-        "CHIMERA_FUSION_PANEL": ",".join(s.fusion_panel),
-        "CHIMERA_FUSION_JUDGE": s.fusion_judge,
-        "CHIMERA_FUSION_SYNTHESIZER": s.fusion_synthesizer,
+        "CHIMERA_DEFAULT_MODEL": _declarado("default_model"),
+        "CHIMERA_FUSION_PANEL": ",".join(_declarado("fusion_panel")),
+        "CHIMERA_FUSION_JUDGE": _declarado("fusion_judge"),
+        "CHIMERA_FUSION_SYNTHESIZER": _declarado("fusion_synthesizer"),
     }
     divergentes = {
         k: (ativas[k], v) for k, v in esperado.items() if k in ativas and ativas[k] != v

--- a/tests/test_the_example_config_agrees_with_the_code.py
+++ b/tests/test_the_example_config_agrees_with_the_code.py
@@ -1,0 +1,108 @@
+"""`.env.example` set a default 20x dearer than the code's, and named two withdrawn models.
+
+Its own header tells the reader to copy it to `.env`, so the assignments in it are not
+documentation — they are the configuration a new install runs on. Measured on 2026-09-03:
+
+* ``CHIMERA_DEFAULT_MODEL=openrouter/openai/gpt-5.5`` — 5.00/30.00 per million — while the code's
+  default was ``deepseek-chat-v3.1`` at 0.25/0.95. Copying the file ran every cheap task on a model
+  **20x dearer on input and 31x on output**, and nothing said so.
+* ``CHIMERA_FUSION_PANEL`` named ``claude-opus-4-8`` and ``gemini-3.1-pro``, both withdrawn from
+  OpenRouter — a copied example that fails at call time.
+* ``CHIMERA_FUSION_JUDGE`` was the panel's own first member, which is the judge grading its own
+  answer. The comment above ``_DEFAULT_JUDGE`` in ``chimera/config.py`` records that exact defect
+  being fixed once already; the example file had quietly kept a copy of it.
+
+None of it was caught by anything, because the drift gate that checks models against the live index
+reads ``Settings()`` — and ``Settings()`` never reads this file in a test process. So this holds the
+narrower, offline invariant: an ACTIVE assignment in the example must agree with the code default it
+sets. A commented-out suggestion is free to differ, which is what makes it a suggestion.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from chimera.config import Settings
+
+EXEMPLO = Path(__file__).resolve().parents[1] / ".env.example"
+
+
+def _ativas() -> dict[str, str]:
+    """Only the uncommented ``KEY=value`` lines — the ones a copy actually applies."""
+    fora = {}
+    for linha in EXEMPLO.read_text(encoding="utf-8").splitlines():
+        crua = linha.strip()
+        if not crua or crua.startswith("#") or "=" not in crua:
+            continue
+        chave, _, valor = crua.partition("=")
+        fora[chave.strip()] = valor.strip()
+    return fora
+
+
+def test_the_example_config_agrees_with_the_code() -> None:
+    s = Settings()
+    ativas = _ativas()
+    esperado = {
+        "CHIMERA_DEFAULT_MODEL": s.default_model,
+        "CHIMERA_FUSION_PANEL": ",".join(s.fusion_panel),
+        "CHIMERA_FUSION_JUDGE": s.fusion_judge,
+        "CHIMERA_FUSION_SYNTHESIZER": s.fusion_synthesizer,
+    }
+    divergentes = {
+        k: (ativas[k], v) for k, v in esperado.items() if k in ativas and ativas[k] != v
+    }
+    assert not divergentes, (
+        "the example file is copied to .env as-is, so an active assignment that disagrees with the "
+        f"code silently changes what a new install runs: {divergentes}"
+    )
+
+
+def test_the_example_does_not_make_the_judge_a_panellist() -> None:
+    """The judge grading its own answer is a defect the code fixed and the example reintroduced."""
+    ativas = _ativas()
+    painel = [m.strip() for m in ativas.get("CHIMERA_FUSION_PANEL", "").split(",") if m.strip()]
+    juiz = ativas.get("CHIMERA_FUSION_JUDGE", "")
+    if not painel or not juiz:
+        return
+    assert juiz not in painel, f"{juiz} judges the panel it sits on"
+
+    def fornecedor(slug: str) -> str:
+        partes = slug.split("/")
+        return partes[1] if len(partes) > 2 else (partes[0] if partes else "")
+
+    assert fornecedor(juiz) not in {fornecedor(m) for m in painel}, (
+        "same vendor as a panellist — the kinship rule the fusion engine enforces"
+    )
+
+
+def test_every_active_model_slug_is_shaped_like_one() -> None:
+    """Offline shape check. Whether a slug still EXISTS is the live gate's job, not this one's."""
+    ativas = _ativas()
+    slugs: list[str] = []
+    for chave, valor in ativas.items():
+        if "MODEL" in chave or "PANEL" in chave or "JUDGE" in chave or "SYNTHESIZER" in chave:
+            slugs += [m.strip() for m in valor.split(",") if m.strip()]
+    for slug in slugs:
+        assert re.fullmatch(r"[a-z0-9._-]+(/[A-Za-z0-9._:-]+){1,2}", slug), slug
+        assert ":free" not in slug, (
+            f"{slug} is a :free slug — the file's own comment says these rate-limit under load and "
+            "make fusion degrade silently, so the example must not ship one"
+        )
+
+
+def test_the_withdrawn_slugs_that_were_here_do_not_come_back() -> None:
+    """Named, not inferred: these two were in the file and are gone from OpenRouter.
+
+    Scoped to the ACTIVE assignments, not to the text. The comment above those lines names both
+    slugs on purpose — it is the record of what was wrong and why — and a check over the whole file
+    would forbid writing that history down. Which it did, on the first run of this test.
+    """
+    ativas = " ".join(_ativas().values())
+    for morto in ("claude-opus-4-8", "gemini-3.1-pro"):
+        # `gemini-3.1-pro-preview` is live and legitimate; the withdrawn one is the bare name, so
+        # match it as a whole slug rather than as a prefix of its own successor.
+        for slug in (m for v in ativas.split() for m in v.split(",")):
+            assert not slug.strip().endswith(morto), (
+                f"{morto!r} was withdrawn; an example naming it fails at call time"
+            )

--- a/tests/test_the_server_tested_green_and_the_agent_could_not_reach_it.py
+++ b/tests/test_the_server_tested_green_and_the_agent_could_not_reach_it.py
@@ -1,0 +1,230 @@
+"""Test said "ok, 4 tools" and the next run could not use one of them.
+
+Measured on a live install: a SQLite MCP server was registered, the Test button connected, answered
+``ok`` and listed all four tools by name. The run that followed made **twenty-two tool calls over
+nineteen minutes and not one of them was from that server** — because ``mcp_autoload`` is off by
+default. Nothing on the screen said so.
+
+``ok`` and "the agent can use this" are different facts, and the screen only ever reported the
+first. This adds the second, with a reason the app translates rather than an English sentence, and
+three states because the remedies differ:
+
+* autoload off — turn it on; the pool is built lazily, so no relaunch is needed;
+* autoload on, pool not built — the next run builds it and picks this server up;
+* autoload on, pool built without this name — added after the connect, and the pool is never
+  rebuilt in a process, so it needs a restart.
+
+The reach read must never BUILD the pool: asking "will the agent see this?" cannot be the thing
+that spawns a subprocess per configured server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.api import mcp_api
+from chimera.integrations import mcp_pool
+
+
+@pytest.fixture(autouse=True)
+def pool_limpo():
+    mcp_pool.reset_for_tests()
+    yield
+    mcp_pool.reset_for_tests()
+
+
+@pytest.fixture
+def casa(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A home with one configured server and a stubbed connect, so nothing spawns."""
+    mcp_api.add(tmp_path, "loja", "uvx", ["mcp-alchemy"], {"DB_URL": "sqlite:///x.db"})
+    monkeypatch.setattr(
+        mcp_api, "_live_test",
+        lambda _cfg: [{"name": "execute_query", "description": "run SQL"}],
+    )
+    return tmp_path
+
+
+class _Falso:
+    """A settings stand-in carrying only what the reach read looks at."""
+
+    def __init__(self, autoload: bool, home: Path) -> None:
+        self.mcp_autoload = autoload
+        self.home = home
+
+
+def _com_settings(monkeypatch: pytest.MonkeyPatch, autoload: bool, home: Path) -> None:
+    monkeypatch.setattr("chimera.config.get_settings", lambda: _Falso(autoload, home))
+
+
+# --------------------------------------------------------------------------------------------
+# 1. autoload off — it works and no run can use it
+
+
+def test_a_working_server_reports_that_no_run_can_reach_it(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _com_settings(monkeypatch, False, casa)
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["ok"] is True, "the server works — that part was never wrong"
+    assert out["tools"], "and its tools are listed"
+    assert out["reaches_agent"] is False, (
+        "a green test beside no reach signal is what let a server sit unused through a "
+        "nineteen-minute run"
+    )
+    assert out["reaches_agent_reason"] == "autoload_off"
+
+
+def test_the_reason_is_an_enum_and_not_an_english_sentence(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The app ships in ten languages; a server-side sentence is one line in the wrong one."""
+    _com_settings(monkeypatch, False, casa)
+
+    razao = mcp_api.test_server(casa, "loja")["reaches_agent_reason"]
+
+    assert razao == "autoload_off"
+    assert " " not in razao, "an enum, not prose"
+
+
+# --------------------------------------------------------------------------------------------
+# 2. autoload on — the three states it splits into
+
+
+def test_autoload_on_with_no_pool_yet_reaches_the_agent(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Not built yet is not the same as empty: the next turn builds it and picks this up."""
+    _com_settings(monkeypatch, True, casa)
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["reaches_agent"] is True
+    assert out["reaches_agent_reason"] is None
+
+
+def test_a_server_added_after_the_connect_says_to_restart(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _com_settings(monkeypatch, True, casa)
+    _finge_pool_com(monkeypatch, ("github",))
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["reaches_agent"] is False
+    assert out["reaches_agent_reason"] == "added_after_connect", (
+        "turning the toggle on cannot fix this one — the pool is never rebuilt in a process"
+    )
+
+
+def test_a_server_already_in_the_pool_reaches_the_agent(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _com_settings(monkeypatch, True, casa)
+    _finge_pool_com(monkeypatch, ("github", "loja"))
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["reaches_agent"] is True
+    assert out["reaches_agent_reason"] is None
+
+
+def _finge_pool_com(monkeypatch: pytest.MonkeyPatch, nomes: tuple[str, ...]) -> None:
+    """A pool that is BUILT and holds exactly ``nomes``."""
+
+    class _Pool:
+        def names(self) -> tuple[str, ...]:
+            return nomes
+
+    monkeypatch.setattr(mcp_pool, "_pool", _Pool())
+    monkeypatch.setattr(mcp_pool, "_tried", True)
+
+
+def test_a_pool_that_was_built_and_came_back_empty_is_not_reported_as_pending(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_tried` latches, so "not built yet" would promise a pickup that is never coming."""
+    _com_settings(monkeypatch, True, casa)
+    monkeypatch.setattr(mcp_pool, "_pool", None)
+    monkeypatch.setattr(mcp_pool, "_tried", True)
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["reaches_agent"] is False
+    assert out["reaches_agent_reason"] == "added_after_connect"
+
+
+# --------------------------------------------------------------------------------------------
+# 3. Asking must not be the thing that answers
+
+
+def test_reading_the_reach_never_builds_the_pool(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _com_settings(monkeypatch, True, casa)
+    construiu = []
+    monkeypatch.setattr(mcp_pool, "_build", lambda _s: construiu.append(1))
+
+    mcp_api.test_server(casa, "loja")
+
+    assert construiu == [], (
+        "a screen asking whether the agent can see a server must not spawn a subprocess per "
+        "configured server to find out"
+    )
+    assert mcp_pool._tried is False
+
+
+def test_a_failed_connect_still_reports_the_reach(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken server and an unreachable one are different problems; report both."""
+    _com_settings(monkeypatch, False, casa)
+    monkeypatch.setattr(mcp_api, "_live_test", lambda _c: (_ for _ in ()).throw(TimeoutError("slow")))
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["ok"] is False
+    assert out["error"]
+    assert out["reaches_agent"] is False
+
+
+def test_an_unknown_server_still_reports_the_reach(
+    casa: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _com_settings(monkeypatch, False, casa)
+
+    out = mcp_api.test_server(casa, "nao-existe")
+
+    assert out["ok"] is False
+    assert out["error"] == "no such server"
+    assert "reaches_agent" in out
+
+
+def test_the_reach_read_never_raises(casa: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unknown is a real third state — a status read must not turn a working test into a 500."""
+    monkeypatch.setattr(
+        "chimera.config.get_settings", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    out = mcp_api.test_server(casa, "loja")
+
+    assert out["ok"] is True
+    assert out["reaches_agent"] is None
+    assert out["reaches_agent_reason"] is None
+
+
+# --------------------------------------------------------------------------------------------
+# 4. The state read itself
+
+
+def test_pool_state_distinguishes_not_built_from_empty() -> None:
+    from chimera.integrations.mcp_pool import PoolState, pool_state
+
+    e = pool_state(_Falso(True, Path(".")))
+    assert isinstance(e, PoolState)
+    assert e.connected is None, "nothing has been built, which is not the same as nothing exists"
+    assert e.built is False
+    assert e.autoload is True

--- a/tests/test_verified_described_a_snapshot_and_was_read_as_the_delivery.py
+++ b/tests/test_verified_described_a_snapshot_and_was_read_as_the_delivery.py
@@ -1,0 +1,316 @@
+"""The receipt said ``verified: True`` and the delivered tree failed all twenty tests.
+
+Measured on a real run. A task asked for a Python module plus its unittest suite. The receipt read
+``verified: True``, ``evidence: verifier``, and carried the verifier's own output:
+
+    Ran 20 tests in 0.001s
+    OK
+
+Running the same command against the tree the run left behind: **20 failures out of 20 executions**,
+deterministic — not flaky, impossible. The diff the same receipt stored explained it. The verified
+version had a line the delivered file did not::
+
+    na versao verificada            no arquivo entregue
+      calc.pop("anterior")            calc.pop("anterior")
+      calc["anterior"] = anterior     (ausente)
+      sha256(calc)                    sha256(calc)   -> nunca bate
+
+Restoring that one line: 20/20 OK. Something wrote after the moment the verdict describes, and
+nothing in the receipt could say so, because ``verified`` is a statement about an instant while the
+row is read as a statement about the delivery.
+
+These tests do not identify what wrote. That was never established from the artifacts, and a guess
+in a receipt is worse than a gap. What they hold is that the claim is now CHECKABLE: a digest of the
+tree as verified, a digest at receipt time, and a third state for "we did not look" that is not
+allowed to read as "it matched".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from chimera.core.autonomous import Attempt, AutonomousAgent, AutonomousConfig, AutonomousResult
+from chimera.core.checkpoint import FileSnapshot, WorkspaceGuard, fingerprint
+
+
+class _Worker:
+    def run(self, *_a: object, **_k: object) -> object:  # pragma: no cover - never called here
+        raise AssertionError("these tests never run a task")
+
+
+def _agente(guard: WorkspaceGuard | None) -> AutonomousAgent:
+    a = AutonomousAgent(
+        _Worker(), config=AutonomousConfig(use_planner=False, use_manager=False)
+    )
+    a.guard = guard
+    return a
+
+
+def _resultado(*attempts: Attempt) -> AutonomousResult:
+    return AutonomousResult(
+        success=any(a.success for a in attempts), answer="", attempts=list(attempts)
+    )
+
+
+def _venceu(impressao: str) -> Attempt:
+    a = Attempt(1, "feito", True, True, False, True)
+    a.verified_fingerprint = impressao
+    return a
+
+
+# --------------------------------------------------------------------------------------------
+# 1. The digest has to notice what the verify command would notice
+
+
+def test_the_same_tree_has_the_same_digest() -> None:
+    a = FileSnapshot(files={"k.py": "x = 1"}, present={"k.py"})
+    b = FileSnapshot(files={"k.py": "x = 1"}, present={"k.py"})
+    assert fingerprint(a) == fingerprint(b)
+
+
+def test_one_changed_line_changes_the_digest() -> None:
+    """The measured case was exactly this: one line, present in one tree and not the other."""
+    antes = FileSnapshot(files={"k.py": 'calc.pop("a")\nsha(calc)'}, present={"k.py"})
+    depois = FileSnapshot(files={"k.py": 'calc.pop("a")\ncalc["a"] = a\nsha(calc)'}, present={"k.py"})
+    assert fingerprint(antes) != fingerprint(depois)
+
+
+def test_a_file_appearing_changes_the_digest() -> None:
+    """Content-only hashing would call a new file no change, and a new file changes the test run."""
+    a = FileSnapshot(files={"k.py": "x = 1"}, present={"k.py"})
+    b = FileSnapshot(files={"k.py": "x = 1"}, present={"k.py", "conftest.py"})
+    assert fingerprint(a) != fingerprint(b)
+
+
+def test_a_file_disappearing_changes_the_digest() -> None:
+    a = FileSnapshot(files={"k.py": "x = 1", "t.py": "pass"}, present={"k.py", "t.py"})
+    b = FileSnapshot(files={"k.py": "x = 1"}, present={"k.py"})
+    assert fingerprint(a) != fingerprint(b)
+
+
+def test_present_but_unread_is_not_the_same_as_present_and_empty() -> None:
+    """Binary files land in `present` with no content; hashing both as b"" hides a replacement."""
+    binario = FileSnapshot(files={}, present={"logo.png"})
+    vazio = FileSnapshot(files={"logo.png": ""}, present={"logo.png"})
+    assert fingerprint(binario) != fingerprint(vazio)
+
+
+def test_the_digest_does_not_depend_on_insertion_order() -> None:
+    a = FileSnapshot(files={"a.py": "1", "b.py": "2"}, present={"a.py", "b.py"})
+    b = FileSnapshot(files={"b.py": "2", "a.py": "1"}, present={"b.py", "a.py"})
+    assert fingerprint(a) == fingerprint(b)
+
+
+# --------------------------------------------------------------------------------------------
+# 2. The reproduction: verified, then written, then reported
+
+
+def test_a_write_after_the_verdict_is_reported(tmp_path: Path) -> None:
+    """The measured failure, in miniature."""
+    alvo = tmp_path / "kernel.py"
+    alvo.write_text('calc.pop("a")\ncalc["a"] = a\nsha(calc)\n', encoding="utf-8")
+    guard = WorkspaceGuard(tmp_path)
+    verificada = fingerprint(guard.snapshot())
+
+    # ... and then something writes. In the measured run, one line went missing.
+    alvo.write_text('calc.pop("a")\nsha(calc)\n', encoding="utf-8")
+
+    resposta = _agente(guard)._delivered_matches_verified(_resultado(_venceu(verificada)))
+
+    assert resposta is False, (
+        "this is the whole finding: verified said True about a tree that is no longer on disk"
+    )
+
+
+def test_an_untouched_tree_matches(tmp_path: Path) -> None:
+    (tmp_path / "kernel.py").write_text("x = 1\n", encoding="utf-8")
+    guard = WorkspaceGuard(tmp_path)
+    verificada = fingerprint(guard.snapshot())
+
+    resposta = _agente(guard)._delivered_matches_verified(_resultado(_venceu(verificada)))
+
+    assert resposta is True
+
+
+def test_a_new_file_after_the_verdict_is_reported(tmp_path: Path) -> None:
+    (tmp_path / "kernel.py").write_text("x = 1\n", encoding="utf-8")
+    guard = WorkspaceGuard(tmp_path)
+    verificada = fingerprint(guard.snapshot())
+
+    (tmp_path / "extra.py").write_text("import os\n", encoding="utf-8")
+
+    assert _agente(guard)._delivered_matches_verified(_resultado(_venceu(verificada))) is False
+
+
+# --------------------------------------------------------------------------------------------
+# 3. "We did not look" must not read as "it matched"
+
+
+@pytest.mark.parametrize(
+    "porque, resultado, com_guard",
+    [
+        ("nenhuma tentativa venceu", _resultado(Attempt(1, "", False, False, True, False)), True),
+        ("nenhuma tentativa", _resultado(), True),
+        ("sem digest (recibo antigo)", _resultado(_venceu("")), True),
+    ],
+)
+def test_not_checkable_is_none_and_never_true(
+    tmp_path: Path, porque: str, resultado: AutonomousResult, com_guard: bool
+) -> None:
+    guard = WorkspaceGuard(tmp_path) if com_guard else None
+    assert _agente(guard)._delivered_matches_verified(resultado) is None, porque
+
+
+def test_no_guard_means_not_checkable(tmp_path: Path) -> None:
+    assert _agente(None)._delivered_matches_verified(_resultado(_venceu("abc"))) is None
+
+
+def test_the_digest_read_is_the_WINNING_attempt_and_not_the_first(tmp_path: Path) -> None:
+    """A retried run has a losing attempt in front of the one that decided it.
+
+    Every other test here has exactly one attempt, where first, last and winner are the same object
+    — so reading `attempts[0]` instead of the successful one passes all of them. A run that failed
+    once and then succeeded is the only shape that tells them apart, and it is the ordinary shape:
+    `max_attempts` defaults to 3.
+    """
+    (tmp_path / "kernel.py").write_text("x = 1\n", encoding="utf-8")
+    guard = WorkspaceGuard(tmp_path)
+    verificada = fingerprint(guard.snapshot())
+
+    perdeu = Attempt(1, "nao deu", False, False, True, False)
+    perdeu.verified_fingerprint = "digest-de-uma-arvore-que-foi-revertida"
+    ganhou = _venceu(verificada)
+    ganhou.index = 2
+
+    resposta = _agente(guard)._delivered_matches_verified(_resultado(perdeu, ganhou))
+
+    assert resposta is True, (
+        "the reverted attempt's digest describes a tree that was deliberately thrown away; "
+        "comparing against it reports every retried run as mismatched"
+    )
+
+
+def test_the_check_never_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run that finished must get a receipt; a status read cannot be what stops one."""
+    guard = WorkspaceGuard(tmp_path)
+    monkeypatch.setattr(
+        WorkspaceGuard, "snapshot", lambda _s: (_ for _ in ()).throw(OSError("disk gone"))
+    )
+
+    assert _agente(guard)._delivered_matches_verified(_resultado(_venceu("abc"))) is None
+
+
+# --------------------------------------------------------------------------------------------
+# 4. It reaches the receipt, and the digest is kept so a reader can recompute it
+
+
+def test_the_receipt_carries_the_answer() -> None:
+    from chimera.api.runs import build_receipt
+
+    r = build_receipt(
+        _resultado(_venceu("abc")), "tarefa", "pytest", "2026-09-03T00:00:00Z",
+        delivered_matches_verified=False,
+    )
+    assert r.delivered_matches_verified is False
+
+
+def test_an_old_receipt_reads_as_unknown_not_as_matching() -> None:
+    """Defaulting to True would stamp the stronger claim on every row already in the file."""
+    from chimera.api.runs import build_receipt
+
+    r = build_receipt(_resultado(_venceu("abc")), "t", None, "2026-09-03T00:00:00Z")
+    assert r.delivered_matches_verified is None
+
+
+def test_the_attempt_digest_survives_into_the_receipt() -> None:
+    """Kept so the claim can be RECOMPUTED by a reader, which is the point of it existing."""
+    from chimera.api.runs import build_receipt
+
+    r = build_receipt(_resultado(_venceu("dedo-digital")), "t", None, "2026-09-03T00:00:00Z")
+    assert r.attempts[0].verified_fingerprint == "dedo-digital"
+
+
+# --------------------------------------------------------------------------------------------
+# 5. The wiring, which is the part every test above takes on faith
+#
+# Everything before this point PLANTS a fingerprint on the attempt by hand. That proves the
+# comparison, and proves nothing about whether a real run ever records one — the exact shape of the
+# guard that was written, committed and never called. This runs the loop.
+
+
+def _agente_real(ws: Path, log: Path, escreve: str = "# feito\n") -> AutonomousAgent:
+    class _Escreve:
+        def run(self, _task: str) -> object:
+            from chimera.core.agent import AgentResult
+
+            (ws / "done.py").write_text(escreve, encoding="utf-8")
+            return AgentResult(answer="pronto", steps=1, stopped_reason="final")
+
+    return AutonomousAgent(
+        _Escreve(),
+        guard=WorkspaceGuard(ws),
+        workspace=ws,
+        run_log=log,
+        config=AutonomousConfig(max_attempts=1, use_planner=False, use_manager=False),
+    )
+
+
+def test_a_real_run_records_a_fingerprint_without_anybody_planting_one(tmp_path: Path) -> None:
+    ws = tmp_path / "ws"
+    ws.mkdir()
+
+    resultado = _agente_real(ws, tmp_path / "runs.jsonl").run("escreva done.py")
+
+    assert resultado.success, resultado.answer
+    vencedora = next(a for a in resultado.attempts if a.success)
+    assert vencedora.verified_fingerprint, (
+        "the field exists, the comparison works, and nothing on the run path ever filled it in — "
+        "which is a guard written and never called"
+    )
+    assert len(vencedora.verified_fingerprint) == 64, "a sha256 hexdigest"
+
+
+def test_a_real_run_writes_the_answer_into_its_receipt(tmp_path: Path) -> None:
+    import json
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    log = tmp_path / "runs.jsonl"
+
+    _agente_real(ws, log).run("escreva done.py")
+
+    linhas = [json.loads(x) for x in log.read_text(encoding="utf-8").splitlines() if x.strip()]
+    assert linhas, "the run wrote no receipt at all"
+    assert linhas[-1]["delivered_matches_verified"] is True, (
+        "nothing touched the tree after the verdict, so the delivered tree IS the verified one"
+    )
+
+
+def test_a_real_run_reports_false_when_the_tree_moves_under_it(tmp_path: Path) -> None:
+    """The measured failure, driven through the real loop rather than a hand-built result."""
+    import json
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    log = tmp_path / "runs.jsonl"
+    agente = _agente_real(ws, log)
+
+    # Stand in for whatever wrote after the verdict in the measured run. Wrapping the receipt call
+    # is the only place a test can be sure it lands AFTER the digest was taken and BEFORE the row
+    # is written — which is precisely the window the finding is about.
+    original = agente._persist_receipt
+
+    def escreve_depois(result: object, task: str) -> None:
+        (ws / "done.py").write_text("# alguem escreveu depois\n", encoding="utf-8")
+        original(result, task)  # type: ignore[arg-type]
+
+    agente._persist_receipt = escreve_depois  # type: ignore[method-assign]
+    agente.run("escreva done.py")
+
+    linhas = [json.loads(x) for x in log.read_text(encoding="utf-8").splitlines() if x.strip()]
+    assert linhas[-1]["success"] is True, "the run still succeeded — that verdict was true when given"
+    assert linhas[-1]["delivered_matches_verified"] is False, (
+        "and the row now says the delivered tree is not the one that verdict was about"
+    )


### PR DESCRIPTION
Found by *using* the app — a deep test of 0.49.2 that built three real projects. Each of these is a
surface stating something true beside something it had no way to know, in a shape where the reader
cannot tell which is which.

## The Test button proved the server and said nothing about the agent

A SQLite MCP server was registered on a live install. Test connected, answered `ok`, and listed all
four tools by name. The run that followed made **twenty-two tool calls over nineteen minutes and
not one was from that server** — `mcp_autoload` is off by default. Nothing on the screen said so.

`reaches_agent` answers the question the person clicking Test is actually asking, with three states
because the remedies differ: autoload off (turn it on — the pool builds lazily, no relaunch),
autoload on with no pool yet (the next run picks it up), autoload on with a pool that predates this
server (connected once per process, so it needs a restart).

Two deliberate non-choices: the green block stays green, because the server *does* work and the
caveat belongs beside that rather than replacing it; and `pool_state` reads without connecting,
because a screen asking whether the agent can see a server must not be the thing that spawns a
subprocess per configured server.

## "Verified" described an instant and was read as the delivery

A run reported `verified: True` with the verifier's own `Ran 20 tests ... OK` stored beside it. The
same command against the tree it left behind: **20 failures out of 20 executions**, deterministic.
The diff the receipt itself carried explained it — the verified version had a line the delivered
file did not:

```
na versao verificada            no arquivo entregue
  calc.pop("anterior")            calc.pop("anterior")
  calc["anterior"] = anterior     (ausente)
  sha256(calc)                    sha256(calc)   -> nunca bate
```

Restoring that one line: 20/20 OK.

This does not try to name what wrote afterwards — that was never established from the artifacts, and
a guess in a receipt is worse than a gap. It makes the claim **checkable**: a digest of the tree as
verified, another at receipt time, and `delivered_matches_verified`. `null` means nothing looked and
is deliberately not `true`, so the stronger claim is not stamped on every row already in the file.

## The example config set a 20x dearer default and two withdrawn slugs

`.env.example` tells the reader to copy it to `.env`, so its assignments are not documentation —
they are what a new install runs on. Measured against the live index and the code's own defaults:

| line | said | code default | effect |
|---|---|---|---|
| `CHIMERA_DEFAULT_MODEL` | `openai/gpt-5.5` (5.00/30.00) | `deepseek-chat-v3.1` (0.25/0.95) | **20x input, 31x output** |
| `CHIMERA_FUSION_PANEL` | `claude-opus-4-8`, `gemini-3.1-pro` | — | both withdrawn: fails at call time |
| `CHIMERA_FUSION_JUDGE` | the panel's own first member | — | the judge grading its own answer |

That last one is the exact defect the comment above `_DEFAULT_JUDGE` records being fixed once
already; the example file had quietly kept a copy. Nothing caught any of it because the live drift
gate reads `Settings()`, and `Settings()` never reads this file in a test process.

Four catalogue prices were also stale — verified against the live index, not assumed:

```
llama-3.3-70b-instruct   0.71 / 0.71   ->  0.10 / 0.32
deepseek-chat-v3.1       0.55 / 1.65   ->  0.25 / 0.95
z-ai/glm-4.6             0.50 / 2.00   ->  0.55 / 2.20    (went UP)
mistral-small-3.2        window 256k   ->  131k
```

**This changes no product default.** Which model the app should prefer is a decision with real
risk — a measured example from the same test: `deepseek-v4-pro` described an HTML file instead of
writing it and burned US$ 1.50 delivering nothing, while cheaper models delivered. Only what was
factually wrong is corrected here.

## How to test

```bash
python -m pytest tests/test_the_server_tested_green_and_the_agent_could_not_reach_it.py tests/test_verified_described_a_snapshot_and_was_read_as_the_delivery.py tests/test_the_example_config_agrees_with_the_code.py tests/test_mcp_api.py -q
```

Each fix was **sabotaged individually** and a test failed in every case. One sabotage passed on the
first pass — replacing "the winning attempt" with "the first attempt" — because every test had a
single attempt, where first and winner are the same object. That was the test failing to
discriminate, not the sabotage: a two-attempt case was added and it now catches it.

Full suites: **5008 Python pass**, 4 fail (the same four already failing on this machine before the
change); **1025 frontend pass**; typecheck clean; OpenAPI + generated TS regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
