### PR TITLE
fix(governance): the refusal never named the taint, or the way out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   globs, and when a declared pattern looks absolute names that pattern and what to write instead. A
   path resolving outside the workspace and one hitting `ALWAYS_DENIED` get their own messages,
   because those have different remedies and pointing at the region would send the reader nowhere.
+- **A run that read data over MCP could not write a file, and nothing said why.** Measured: four
+  runs of the same task, **US$ 5.11, not one file written.** The identical task reading the same
+  catalogue with the built-in tools instead delivered on the first pass, in 236 seconds, for
+  **US$ 0.37**.
+
+  The mechanism is correct at every step. MCP output is untrusted content, so reading it taints the
+  run; a tainted write needs human approval; and on an HTTP surface `approver_for("ask")` finds no
+  terminal and degrades to deny — because whoever is looking at the console did not make the request
+  and cannot consent for whoever did.
+
+  What was wrong is that the refusal said *"the tool did NOT run and nobody approved it"*. That
+  sentence is true when a person was asked and declined, true when the owner configured deny, and
+  true when **no approver could exist at all** — three situations with three different fixes, and
+  the only thing it suggests is retrying. Retrying is the one thing that cannot work in the third
+  case: the answer is structurally identical every time, so a three-attempt budget buys three
+  identical refusals and a bill.
+
+  Each case now gets its own sentence. The unattended one says nobody *could* be asked, says why the
+  console cannot consent, says retrying will be refused identically, and names both ways out — the
+  pause-for-approval switch that parks the run for a verdict (quoted as it is labelled on the
+  screen), and keeping untrusted content out of the run in the first place. A configured deny says
+  so and does **not** offer the pause switch, which cannot release it. A human who declined keeps
+  the plain sentence, because they may well approve the next one.
+
 - **The MCP Test button proved the server and said nothing about the agent.** A SQLite server was
   registered, Test connected, answered *ok* and listed all four of its tools by name. The run that
   followed made **twenty-two tool calls over nineteen minutes and not one of them was from that

--- a/chimera/governance/governed_tool.py
+++ b/chimera/governance/governed_tool.py
@@ -194,10 +194,22 @@ class GovernedTool(Tool):
         approve: ApproveFn | None = None,
         context: ContextFn | None = None,
         ledger: ApprovalLedger | None = None,
+        no_approver: str = "",
     ) -> None:
         self.inner = inner
         self.kernel = kernel
         self.approve = approve
+        # WHY no approver can say yes here, or "" when one genuinely can. Two situations produce the
+        # same refusal and need different sentences: an approver was asked and declined, and no
+        # approver could be asked at all. Only the assembly knows which — `profile.py` is where the
+        # unattended surface turns `ask` into `deny` — so it is passed in rather than guessed.
+        #
+        # Measured, and this is what it cost: a run reading a data catalogue over MCP tainted itself,
+        # every write then needed approval, and on an HTTP surface nothing can approve. The agent was
+        # told "nobody approved it", retried, spent its whole budget, and reported the environment as
+        # broken. Four runs, US$ 5.11, nothing written. The identical task without the MCP delivered
+        # in 236 seconds for US$ 0.37. The refusal was correct every time and named none of it.
+        self.no_approver = no_approver
         # Where a BLOCK gets written down. Deliberately NOT the approver: `observe`'s approver says
         # yes to everything, so routing a BLOCK through it would either record a grant that did not
         # happen or turn `rm -rf /` into an execution. What a BLOCK needs is the ledger's `record`,
@@ -251,9 +263,34 @@ class GovernedTool(Tool):
             approved = self.approve(verdict, action) if self.approve else False
             if not approved:
                 return refusal(f"[governance: needs review — {verdict.reason}] "
-                               f"The tool did NOT run and nobody approved it. Do not "
+                               f"The tool did NOT run. {self._why_nobody_approved()} Do not "
                                f"report this as done.")
         return self.inner.run(**kwargs)
+
+    def _why_nobody_approved(self) -> str:
+        """The sentence after "the tool did NOT run" — different per reason, because the fixes are.
+
+        "Nobody approved it" is true in all three cases and actionable in none. Retrying is the only
+        thing it suggests, and retrying is the one thing that cannot work when no approver exists:
+        the answer is structurally the same every time, so a three-attempt budget buys three
+        identical refusals and a bill.
+        """
+        if self.no_approver == "unattended":
+            return (
+                "Nobody could be asked: this request arrived over the API, where the only terminal "
+                "belongs to somebody who did not make it and cannot consent for whoever did. "
+                "Retrying will be refused identically. To let this through, start the run with "
+                "pause-on-taint — in the app, 'pause for my approval if the run reads untrusted "
+                "content' — which parks it for a verdict instead of refusing it. Or keep untrusted "
+                "content out of the run: reading data through an MCP server taints it, and the same "
+                "read done with the built-in tools does not."
+            )
+        if self.no_approver == "owner_denies":
+            return (
+                "Nobody was asked: this deployment sets approvals to deny, so a review is a refusal "
+                "by configuration. Retrying will be refused identically."
+            )
+        return "Nobody approved it."
 
     def _context(self) -> str:
         """The current task, or ``""``. Never raises: a broken provider must not block a tool.
@@ -277,6 +314,7 @@ def govern_registry(
     approve: ApproveFn | None = None,
     context: ContextFn | None = None,
     ledger: ApprovalLedger | None = None,
+    no_approver: str = "",
 ) -> ToolRegistry:
     """Return a new registry with every tool wrapped in a :class:`GovernedTool`.
 
@@ -287,6 +325,9 @@ def govern_registry(
     governed = ToolRegistry()
     for tool in registry.tools():
         governed.register(
-            GovernedTool(tool, kernel, approve=approve, context=context, ledger=ledger)
+            GovernedTool(
+                tool, kernel, approve=approve, context=context, ledger=ledger,
+                no_approver=no_approver,
+            )
         )
     return governed

--- a/chimera/governance/profile.py
+++ b/chimera/governance/profile.py
@@ -146,12 +146,19 @@ def govern_step(
     # module's docstring reached neither list. `GovernedTool` now writes them to `refused` — the
     # `ledger=` below is what lets it — and the price of enforcement is `granted` (would start
     # refusing) plus `refused` (already refusing, in every mode).
+    # Why no approver can say yes, for the refusal to name. "" means one genuinely can, so a
+    # decline is a decline; the two values below are the cases where retrying cannot change the
+    # answer, and the refusal has to say so instead of inviting a retry that costs money.
+    no_approver = ""
     if resolved == "observe":
         approver_name = "allow"
         approve = allow_everything(approvals)
     else:
         wanted = settings.approval_mode
+        if wanted == "deny":
+            no_approver = "owner_denies"
         if not attended and wanted == "ask":
+            no_approver = "unattended"
             # `deny` is what `approver_for` picks for itself once it finds no terminal; this reaches
             # the same fail-closed answer one step earlier, before a tty that belongs to somebody
             # else can be mistaken for the requester.
@@ -164,6 +171,7 @@ def govern_step(
         TrustKernel(audit=audit, audit_allows=audit_allows),
         approve=approve,
         ledger=approvals,
+        no_approver=no_approver,
     )
     # One line per assembly, and the only place the deployment's mode is written where a reader can
     # find it. Two holes close here.

--- a/tests/test_the_refusal_never_named_the_taint_or_the_way_out.py
+++ b/tests/test_the_refusal_never_named_the_taint_or_the_way_out.py
@@ -1,0 +1,238 @@
+"""Four runs, US$ 5.11, nothing written — and no message named the cause or the cure.
+
+Measured on a live install. A task asked for a shop front built from a real SQLite catalogue, read
+through an MCP server. MCP output is untrusted content — correctly — so reading it tainted the run.
+A tainted write needs human approval, and on an HTTP surface there is nobody who can give it:
+
+    approver_for("ask") prompts on the server's stdin, and degrades to deny only when
+    that stdin is not a terminal ... an unattended caller passes attended=False and the
+    prompt is never built.
+                                            -- chimera/governance/profile.py
+
+That decision is right. Whoever is looking at the console did not make the request and cannot
+consent for whoever did. What was wrong is that the refusal said only *"nobody approved it"*, which
+is true in three different situations and actionable in none of them. The agent read it, retried,
+spent its whole three-attempt budget on an answer that was structurally identical every time, and
+reported the environment as broken.
+
+The paired measurement that closed the diagnosis — same task, same model, same folder, same
+write-region, changing only how the catalogue was read:
+
+    through the MCP server    3 attempts, nothing written, 4 times over    US$ 5.11
+    through code_interpreter  delivered on the first pass, 236 s          US$ 0.37
+
+And the way out already existed on the same screen: *"pause for my approval if the run reads
+untrusted content"*, which parks the run for a verdict instead of refusing it. It was simply never
+mentioned at the moment it would have helped.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.governance import governed_tool
+from chimera.governance.governed_tool import GovernedTool, govern_registry
+from chimera.governance.policy import Decision
+from chimera.tools.base import Tool
+from chimera.tools.registry import ToolRegistry
+
+
+class _Escreve(Tool):
+    name = "write_file"
+    description = "escreve um arquivo"
+    parameters: dict = {}
+
+    def run(self, **_kwargs: object) -> str:
+        return "wrote it"
+
+
+class _Kernel:
+    """A kernel that always asks for review — the state a tainted run puts every write into."""
+
+    def __init__(self, reason: str = "the run read untrusted content") -> None:
+        self.reason = reason
+
+    def evaluate(self, action: str, **_kwargs: object) -> object:
+        from chimera.governance.policy import Verdict
+
+        return Verdict(decision=Decision.REVIEW, reason=self.reason)
+
+
+class _Audit:
+    """The audit log the assembly writes its one line to. Records nothing here."""
+
+    def record(self, *_a: object, **_k: object) -> None:
+        return None
+
+    def append(self, *_a: object, **_k: object) -> None:
+        return None
+
+
+def _recusa(no_approver: str) -> str:
+    tool = GovernedTool(_Escreve(), _Kernel(), approve=None, no_approver=no_approver)
+    return tool.run(path="index.html", content="<html>")
+
+
+# --------------------------------------------------------------------------------------------
+# 1. The measured case: an API run, nobody who can approve
+
+
+def test_the_refusal_says_nobody_COULD_be_asked_not_that_nobody_did() -> None:
+    saida = _recusa("unattended")
+    assert "Nobody could be asked" in saida
+    assert "over the API" in saida, "name the surface — the reader cannot see which one they are on"
+
+
+def test_it_says_retrying_cannot_help() -> None:
+    """Retrying is the only thing the old sentence suggested, and the one thing that cannot work."""
+    assert "Retrying will be refused identically" in _recusa("unattended")
+
+
+def test_it_names_the_switch_that_exists_on_the_same_screen() -> None:
+    saida = _recusa("unattended")
+    assert "pause-on-taint" in saida
+    assert "pause for my approval if the run reads untrusted content" in saida, (
+        "quote the control as it is labelled, or the reader has to guess which switch is meant"
+    )
+
+
+def test_it_names_the_other_way_out_too() -> None:
+    """A user who does not want to pause has a second option, and it is the cheaper one."""
+    saida = _recusa("unattended")
+    assert "MCP" in saida
+    assert "built-in tools" in saida
+
+
+def test_it_explains_why_the_console_cannot_consent() -> None:
+    """Without this the rule reads as an arbitrary restriction rather than as the point."""
+    saida = _recusa("unattended")
+    assert "did not make it" in saida and "cannot consent" in saida
+
+
+# --------------------------------------------------------------------------------------------
+# 2. The other two cases keep their own sentences, because the fixes differ
+
+
+def test_an_owner_who_set_deny_is_told_that_and_not_the_taint_story() -> None:
+    saida = _recusa("owner_denies")
+    assert "sets approvals to deny" in saida
+    assert "pause-on-taint" not in saida, (
+        "the pause switch cannot release a refusal the owner configured; offering it sends the "
+        "reader to a control that will not help"
+    )
+
+
+def test_a_real_decline_keeps_the_plain_sentence() -> None:
+    """Somebody was asked and said no. Nothing here needs explaining away."""
+    saida = _recusa("")
+    assert "Nobody approved it." in saida
+    assert "Retrying will be refused identically" not in saida, (
+        "a human who declined once may approve the next one — telling them otherwise is false"
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# 3. What must not change
+
+
+def test_the_tool_still_does_not_run() -> None:
+    assert "wrote it" not in _recusa("unattended")
+
+
+@pytest.mark.parametrize("causa", ["unattended", "owner_denies", ""])
+def test_every_refusal_still_forbids_reporting_it_as_done(causa: str) -> None:
+    assert "Do not report this as done" in _recusa(causa)
+
+
+@pytest.mark.parametrize("causa", ["unattended", "owner_denies", ""])
+def test_every_refusal_still_carries_the_kernel_reason(causa: str) -> None:
+    tool = GovernedTool(
+        _Escreve(), _Kernel("the run read untrusted content"), approve=None, no_approver=causa
+    )
+    assert "the run read untrusted content" in tool.run(path="x", content="y")
+
+
+def test_an_approved_review_still_runs() -> None:
+    tool = GovernedTool(
+        _Escreve(), _Kernel(), approve=lambda _v, _a: True, no_approver="unattended"
+    )
+    assert tool.run(path="x", content="y") == "wrote it"
+
+
+# --------------------------------------------------------------------------------------------
+# 4. The wiring: the reason has to reach every wrapped tool, and be chosen by the one place
+#    that knows
+
+
+def test_govern_registry_passes_the_reason_to_every_tool() -> None:
+    reg = ToolRegistry()
+    reg.register(_Escreve())
+
+    governed = govern_registry(reg, _Kernel(), no_approver="unattended")
+
+    saida = next(iter(governed.tools())).run(path="x", content="y")
+    assert "Nobody could be asked" in saida, (
+        "a reason that reaches the wrapper and not the tools is a field nobody ever reads"
+    )
+
+
+def test_an_unattended_ask_becomes_the_unattended_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`profile.py` is the only place that knows the surface is unattended."""
+    from chimera.governance import profile
+
+    capturado: dict[str, str] = {}
+    # Patched where it is DEFINED, not on `profile`: the import is inside the function, so a name
+    # bound on the module object is never the one the call resolves.
+    monkeypatch.setattr(
+        governed_tool, "govern_registry",
+        lambda reg, kernel, **kw: capturado.update(no_approver=kw.get("no_approver", "")) or reg,
+    )
+
+    class _S:
+        governance_mode = "enforce"
+        approval_mode = "ask"
+
+    profile.govern_step(ToolRegistry(), settings=_S(), audit=_Audit(), surface="api:test", attended=False)
+
+    assert capturado["no_approver"] == "unattended"
+
+
+def test_an_attended_ask_leaves_the_reason_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Somebody IS there — a decline is a decline, and must not be explained away."""
+    from chimera.governance import profile
+
+    capturado: dict[str, str] = {}
+    # Patched where it is DEFINED, not on `profile`: the import is inside the function, so a name
+    # bound on the module object is never the one the call resolves.
+    monkeypatch.setattr(
+        governed_tool, "govern_registry",
+        lambda reg, kernel, **kw: capturado.update(no_approver=kw.get("no_approver", "")) or reg,
+    )
+
+    class _S:
+        governance_mode = "enforce"
+        approval_mode = "ask"
+
+    profile.govern_step(ToolRegistry(), settings=_S(), audit=_Audit(), surface="cli", attended=True)
+
+    assert capturado["no_approver"] == ""
+
+
+def test_a_configured_deny_is_reported_as_the_owners_choice(monkeypatch: pytest.MonkeyPatch) -> None:
+    from chimera.governance import profile
+
+    capturado: dict[str, str] = {}
+    # Patched where it is DEFINED, not on `profile`: the import is inside the function, so a name
+    # bound on the module object is never the one the call resolves.
+    monkeypatch.setattr(
+        governed_tool, "govern_registry",
+        lambda reg, kernel, **kw: capturado.update(no_approver=kw.get("no_approver", "")) or reg,
+    )
+
+    class _S:
+        governance_mode = "enforce"
+        approval_mode = "deny"
+
+    profile.govern_step(ToolRegistry(), settings=_S(), audit=_Audit(), surface="cli", attended=True)
+
+    assert capturado["no_approver"] == "owner_denies"


### PR DESCRIPTION
> Reopens the work from #322, which GitHub auto-closed when its base branch (#321) was merged and
> deleted. Same commit, rebased onto `main`.

## The measurement

Four runs of the same task on a live install. **US$ 5.11, not one file written.** The identical
task, same model, same folder, same write-region — changing only how the catalogue was read:

| reading the catalogue | outcome | cost |
|---|---|---|
| through the MCP server | 3 attempts, nothing written, four times over | **US$ 5.11** |
| through `code_interpreter` | delivered on the first pass, 236 s | **US$ 0.37** |

## Every step of the mechanism is right

MCP output is untrusted content, so reading it taints the run. A tainted write needs human
approval. And on an HTTP surface `approver_for("ask")` finds no terminal and degrades to deny —
because whoever is looking at the console did not make the request and cannot consent for whoever
did. None of that changes here.

## What was wrong is the sentence

> The tool did NOT run and nobody approved it.

True when a person was asked and declined. True when the owner configured deny. True when **no
approver could exist at all**. Three situations, three different fixes — and the only action it
suggests is retrying, which is precisely the one thing that cannot work in the third case, where
the answer is structurally identical every time. A three-attempt budget buys three identical
refusals and a bill.

`no_approver` now travels from the assembly, which is the only place that knows: `profile.py` is
where an unattended surface turns `ask` into `deny`.

- **unattended** — says nobody *could* be asked, says why the console cannot consent, says retrying
  will be refused identically, and names both ways out: the pause-for-approval switch that parks the
  run for a verdict (quoted as it is labelled on screen), and keeping untrusted content out of the
  run, since the same read through the built-in tools does not taint.
- **owner_denies** — says so, and deliberately does **not** offer the pause switch, which cannot
  release it. Sending the reader to a control that will not help is the defect being fixed, not a
  smaller version of it.
- **neither** — keeps the plain sentence. A human who declined once may approve the next one, and
  telling them retrying is futile would be false.

The decision is untouched: the tool still does not run, the kernel's reason still travels, and every
refusal still forbids reporting it as done. Tests hold all three.

## How to test

```bash
python -m pytest tests/test_the_refusal_never_named_the_taint_or_the_way_out.py -q
```

19 tests. Nine sabotages, **9 of 9 caught**, suite green before and after the matrix — including the
two that matter most for a message change: dropping the pause-on-taint remedy, and giving the
owner-denies case a story it cannot act on.

Full suite on this change: **5032 pass, 4 fail** — the same four already failing on this machine
beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
