### PR TITLE
chore(deps): lift the litellm ceiling, and put a floor where the guard now belongs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,13 @@ name = "chimera-agent"
 version = "0.49.2"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
-# Upper bound tracks the litellm ceiling below (<1.92, which requires Python <3.14). Without it a
-# 3.14 user reads ">=3.11", installs, and hits an opaque resolution failure instead of a clear
-# "requires a Python before 3.14". Lift both together when litellm ships Windows/macOS wheels again.
+# The bound stays, and its REASON changed. It used to track the litellm ceiling below (<1.92, which
+# required Python <3.14); that ceiling has been lifted, and 1.96.2+ requires <3.15. What holds the
+# bound now is narrower and checkable: the test matrix in `.github/workflows/ci.yml` runs 3.11, 3.12
+# and 3.13. Declaring support for a version nothing runs would be a claim with no measurement behind
+# it, which is the one kind of promise this project does not make.
+#
+# Lift it by ADDING 3.14 to that matrix and watching it pass — not by widening this line.
 requires-python = ">=3.11,<3.14"
 license = { text = "Apache-2.0" }
 authors = [{ name = "The Chimera Agent Authors", email = "chimeraagent01@gmail.com" }]
@@ -31,12 +35,22 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    # Ceiling, not preference: 1.92 moved litellm to a compiled Rust core and publishes wheels ONLY
-    # for manylinux (x86_64/aarch64) — no Windows, no macOS. On those platforms pip falls back to the
-    # sdist, which needs a Rust toolchain + maturin and fails on a normal machine. 1.91.4 is the last
-    # release with a pure-Python `py3-none-any` wheel, so it installs everywhere. Lift this the moment
-    # upstream ships Windows/macOS wheels again.
-    "litellm>=1.40,<1.92",
+    # Upstream shipped the wheels again, so the ceiling that existed for them is gone — and the FLOOR
+    # is what replaces it. Checked against PyPI on 2026-09-03, release by release:
+    #
+    #     1.92.0  1.92.1        manylinux only        <- the reason the old ceiling existed
+    #     1.93.0                manylinux only
+    #     1.93.1  1.94.0  1.94.1  1.95.0    Windows, no macOS
+    #     1.96.2 and every release after     Windows AND macOS AND manylinux AND musllinux
+    #
+    # So `<1.99`, which is what the bot proposed, is not safe: the range still admits 1.93.0, where a
+    # macOS or Windows user falls back to the sdist and needs a Rust toolchain to install. The floor
+    # has to sit at the first release of the CONTINUOUS run that covers both — 1.96.2 — and it is the
+    # continuity that matters, not the newest version, because a resolver is free to pick any member
+    # of the range.
+    #
+    # The ceiling is now an ordinary major bound rather than a platform workaround.
+    "litellm>=1.96.2,<2",
     "pydantic>=2.7",
     "pydantic-settings>=2.3",
     "typer>=0.12",

--- a/tests/test_the_litellm_floor_is_real.py
+++ b/tests/test_the_litellm_floor_is_real.py
@@ -1,0 +1,108 @@
+"""The litellm pin has a FLOOR now, and nothing was holding it.
+
+The ceiling used to be the guard: `litellm<1.92`, because 1.92 moved to a compiled Rust core and
+published wheels only for manylinux — a Windows or macOS user fell back to the sdist and needed a
+Rust toolchain to install. That ceiling has a dedicated comment explaining itself, and the comment
+says to lift it the moment upstream ships the wheels again.
+
+Upstream did. Checked against PyPI on 2026-09-03, release by release::
+
+    1.92.0  1.92.1                            manylinux only
+    1.93.0                                    manylinux only
+    1.93.1  1.94.0  1.94.1  1.95.0            Windows, no macOS
+    1.96.2 and every release after            Windows AND macOS AND manylinux AND musllinux
+
+So the guard moved from the ceiling to the FLOOR, and the floor is the part with no test behind it.
+`>=1.40,<1.99` — which is what the bot proposed — is green on Linux CI and still admits 1.93.0,
+where a macOS install breaks exactly the way the old comment describes. A range is only a promise
+about its worst member.
+
+`mcp` has had this shape of test since its own ceiling was set (`test_mcp_dependency_is_real`). This
+is the same guard for the same class of mistake, on the dependency that is harder to notice because
+CI runs on the one platform the bad versions support.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+RAIZ = Path(__file__).resolve().parents[1]
+
+#: The first release of the CONTINUOUS run that ships Windows AND macOS wheels. Continuity is the
+#: property that matters, not recency: a resolver may pick any member of the range, so one broken
+#: version below the floor is enough to break an install.
+PISO = (1, 96, 2)
+
+
+def _spec_litellm() -> str:
+    dados = tomllib.loads((RAIZ / "pyproject.toml").read_text(encoding="utf-8"))
+    deps = dados["project"]["dependencies"]
+    achados = [d for d in deps if d.replace(" ", "").startswith("litellm")]
+    assert achados, "litellm is no longer a declared dependency"
+    return achados[0]
+
+
+def _versao(texto: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in re.findall(r"\d+", texto)[:3])
+
+
+def test_the_pin_has_a_floor_at_all() -> None:
+    spec = _spec_litellm()
+    assert re.search(r">=\s*\d", spec), f"{spec!r} has no lower bound, so any version resolves"
+
+
+def test_the_floor_excludes_every_release_without_windows_and_macos_wheels() -> None:
+    spec = _spec_litellm()
+    m = re.search(r">=\s*([\d.]+)", spec)
+    assert m, spec
+    declarado = _versao(m.group(1))
+    assert declarado >= PISO, (
+        f"{spec!r} admits litellm {'.'.join(map(str, declarado))}, below {'.'.join(map(str, PISO))}. "
+        "Releases under that floor ship manylinux-only or Windows-only wheels, so a macOS or "
+        "Windows install falls back to the sdist and needs a Rust toolchain. CI runs on Linux, "
+        "where every one of them installs fine — this test is the only thing that sees it."
+    )
+
+
+def test_the_ceiling_is_now_an_ordinary_major_bound() -> None:
+    """The platform workaround is gone; what remains should be a plain major bound, and be one."""
+    spec = _spec_litellm()
+    m = re.search(r"<\s*([\d.]+)", spec)
+    assert m, f"{spec!r} has no upper bound"
+    assert _versao(m.group(1))[0] >= 2, (
+        f"{spec!r} still caps inside 1.x. The reason for that cap — manylinux-only wheels — no "
+        "longer holds from 1.96.2 on, so a 1.x cap now excludes working releases for a reason that "
+        "expired. If a NEW reason appears, write it above the pin rather than leaving this one."
+    )
+
+
+def test_the_comment_records_why_the_floor_is_where_it_is() -> None:
+    """A number with no reason beside it is a number the next person will 'tidy up'."""
+    texto = (RAIZ / "pyproject.toml").read_text(encoding="utf-8")
+    trecho = texto[max(0, texto.find('"litellm') - 1600):texto.find('"litellm')]
+    assert "1.96.2" in trecho, "the floor is not explained where it is set"
+    assert "macOS" in trecho or "macos" in trecho, "the platform the floor protects is not named"
+
+
+def test_the_python_bound_no_longer_claims_litellm_as_its_reason() -> None:
+    """It used to track the litellm ceiling. That ceiling is gone, so the stated reason had to move.
+
+    The bound itself stays — the test matrix runs 3.11 to 3.13 — but a bound whose written reason
+    has expired is the shape that survives long after anyone can check it.
+    """
+    texto = (RAIZ / "pyproject.toml").read_text(encoding="utf-8")
+    i = texto.find("requires-python")
+    contexto = texto[max(0, i - 1200):i]
+    # Not "the old reason is unmentioned" — the first draft of this test asserted that, and it
+    # failed on a comment that mentions the old ceiling in the PAST tense, which is precisely the
+    # right thing to write. What must be true is narrower: the expired reason is marked as expired,
+    # and the reason that holds today is named.
+    assert "1.92" not in contexto or "lifted" in contexto or "used to" in contexto, (
+        "the Python bound cites the litellm ceiling without saying it has been lifted, so a reader "
+        "cannot tell a live reason from a dead one"
+    )
+    assert "ci.yml" in contexto or "matrix" in contexto, (
+        "the bound needs to say what actually holds it now — the tested versions"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -355,9 +355,9 @@ name = "boto3"
 version = "1.43.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore", marker = "python_full_version >= '3.12'" },
-    { name = "jmespath", marker = "python_full_version >= '3.12'" },
-    { name = "s3transfer", marker = "python_full_version >= '3.12'" },
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/2c/e7f668f2d022b5c7dca881c7a9530aa7200445566c06f0f23daf4bf78084/boto3-1.43.50.tar.gz", hash = "sha256:a6865b9cd1d15511f6aad89cef964105acecff2160a3e29ae53c10d9821416af", size = 112731, upload-time = "2026-07-16T19:33:15.719Z" }
 wheels = [
@@ -369,9 +369,9 @@ name = "botocore"
 version = "1.43.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath", marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.12'" },
-    { name = "urllib3", marker = "python_full_version >= '3.12'" },
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/3b/0a640eb595fb86e853c06301982393e60cbaba634cb0fc70bbdc119e1140/botocore-1.43.50.tar.gz", hash = "sha256:7b07c423c44b1ab3815af103f11fa28ea317e28dda1335718a02ecde371a25e9", size = 15709326, upload-time = "2026-07-16T19:33:05.282Z" }
 wheels = [
@@ -615,7 +615,7 @@ requires-dist = [
     { name = "faster-whisper", marker = "extra == 'stt'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "keyring", marker = "extra == 'secrets'", specifier = ">=25" },
-    { name = "litellm", specifier = ">=1.40,<1.92" },
+    { name = "litellm", specifier = ">=1.96.2,<2" },
     { name = "markitdown", extras = ["docx", "pptx", "xlsx", "pdf"], marker = "extra == 'documents'", specifier = ">=0.1" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.7" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0,<2" },
@@ -1991,10 +1991,11 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.91.4"
+version = "1.99.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "boto3" },
     { name = "click" },
     { name = "fastuuid" },
     { name = "httpx" },
@@ -2003,13 +2004,20 @@ dependencies = [
     { name = "jsonschema" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/2a/a544cfdf8957accd303a99923f55c9fadc3a919d4ed6feca45e73001cade/litellm-1.91.4.tar.gz", hash = "sha256:b810d4c9e63e46908f4eeb14dde76b9811ca7101bec6290eb2522abd273c076d", size = 14875903, upload-time = "2026-07-19T02:45:39.187Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1a/76b5f28ba9e07fa0cb807bbdefdf318c554f60623bff699e7b601d0d7b3a/litellm-1.99.0.tar.gz", hash = "sha256:594bf4b6ff6b79c6aa3c3b78c0e939d4afd12687e076ba3fb608d38a5aa7f9c6", size = 16786386, upload-time = "2026-09-01T00:43:07.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/8c/da17d91fc56532b36a27109447016d67e4618afc4447e8c4023240e920f5/litellm-1.91.4-py3-none-any.whl", hash = "sha256:d2c4bb42e99a01c8c01182a1c4aae534bcbfd7329f6ff8c634eab1e38ca58126", size = 16673648, upload-time = "2026-07-19T02:45:36.38Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ef/4ef1afe95d3a7c52d63b5f2bb32ec5264a4cea198a7dddb8ceff9633f2da/litellm-1.99.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a43e8716da8beed04480e91b4233ff2f1ab1fedd84cad332dbc526b54a9229ca", size = 23350560, upload-time = "2026-09-01T00:42:41.449Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/f329cf74fc1f929a93210b16523bbcebd679694090df741bb8bee726a473/litellm-1.99.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e2b383070656fdbec4bc44602edaaed2a21e99ceee4ea0a4650c8cb381e67b59", size = 22999186, upload-time = "2026-09-01T00:42:44.978Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4f/0e73fc3f0740249b676d0714bd58c4141f1fc733b88a85b6001f9f2e5e62/litellm-1.99.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e461b7ce53af990e5287cf7ae30d82c956b56dcce886f63ef39a76e678f82a3b", size = 23145753, upload-time = "2026-09-01T00:42:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c4/8e92a6277e28096784616cfda16b2cd839c7bdaabce692ae950e2f0cf72e/litellm-1.99.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1c45097e426fed2ae7fbd38b5404c3addeb203d0e1148c0a59848aabd5fe83c6", size = 23518654, upload-time = "2026-09-01T00:42:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/aa/11c9bd6297e4a9001426ff825bc8bb119d3a9a3de4e5ee9fed22997e6e28/litellm-1.99.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e42f94731665b68e263481efd79f7629e9b97eed7e10c57dc37a890eca058227", size = 23218889, upload-time = "2026-09-01T00:42:54.99Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/1fc21c6fb21897867d9c753d651b24903e63955dadffeb2a73517f35003a/litellm-1.99.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:71109c323164b4b6776ff259876523e6e883a465aa1413dd51a1bda8e92efc5f", size = 23617457, upload-time = "2026-09-01T00:42:59.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4f/df449e0cfa1f40025e91f3a47b03109e16de44d43149e97fbcbd1ae8c5e2/litellm-1.99.0-cp310-abi3-win_amd64.whl", hash = "sha256:5617804e838499bce8fecb41ad9bc984b7977361e557666fed0fef0c4623ce62", size = 23432066, upload-time = "2026-09-01T00:43:03.177Z" },
 ]
 
 [[package]]
@@ -3947,7 +3955,7 @@ name = "s3transfer"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore", marker = "python_full_version >= '3.12'" },
+    { name = "botocore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
 wheels = [


### PR DESCRIPTION
Supersedes #29, which proposed `>=1.40,<1.99` — a range that is green on Linux CI and still breaks macOS installs. See below.

## The ceiling did its job and is now expired

It existed for one written reason: litellm 1.92 moved to a compiled Rust core and published wheels **only for manylinux**, so a Windows or macOS user fell back to the sdist and needed a Rust toolchain. The comment said to lift it the moment upstream shipped the wheels again.

Upstream did. Checked against PyPI on 2026-09-03, release by release:

| versions | wheels |
|---|---|
| 1.92.0, 1.92.1, 1.93.0 | manylinux only |
| 1.93.1, 1.94.0, 1.94.1, 1.95.0 | Windows, **no macOS** |
| **1.96.2 and every release after** | Windows AND macOS AND manylinux AND musllinux |

## Why the bot's range is not safe

`>=1.40,<1.99` still admits **1.93.0**. A resolver is free to pick any member of a range, and a range is a promise about its *worst* member — so the guard has to move from the ceiling to the **floor**, at the first release of the continuous run covering both platforms: **1.96.2**.

The nasty part is that this is invisible to CI: every version below the floor works fine on Linux, which is the only platform CI runs.

## What holds it now

`tests/test_the_litellm_floor_is_real.py` — the shape `test_mcp_dependency_is_real` already uses for the other pinned SDK. **Nothing was holding this pin**, which is why the bot could propose lowering it and the build would have agreed.

Four sabotages, 4 of 4 caught, including the bot's own proposed range and a floor one release too low.

## The Python bound stays, and its reason changed

It used to track the litellm ceiling (1.91.4 required `<3.14`); 1.96.2+ requires `<3.15`. What holds `<3.14` now is narrower and checkable: `ci.yml` runs 3.11, 3.12 and 3.13, and declaring support for a version nothing runs would be a claim with no measurement behind it. **Lift it by adding 3.14 to that matrix and watching it pass**, not by widening the line — and a test now fails if the bound goes back to citing a reason that expired.

## Measured

Resolved to litellm **1.99.0**. Full suite: **5066 pass, 4 fail** — the same four already failing on this machine beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)