### PR TITLE
fix(models): the defaults were a generation behind, and one could vanish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ CHIMERA_DEEPSEEK_KEYS=
 # default's 0.25/0.95, so copying the example silently ran every cheap task on a model 20x
 # dearer on input and 31x on output. `test_the_example_config_agrees_with_the_code` keeps the
 # two from parting again.
-CHIMERA_DEFAULT_MODEL=openrouter/deepseek/deepseek-chat-v3.1
+CHIMERA_DEFAULT_MODEL=openrouter/deepseek/deepseek-v4-flash-0731
 
 # Custom endpoint for self-hosted / OpenAI-compatible servers (Ollama, vLLM, ...).
 # e.g. CHIMERA_API_BASE=http://127.0.0.1:11434  with CHIMERA_DEFAULT_MODEL=ollama/llama3
@@ -169,8 +169,8 @@ CHIMERA_AUTO_FUSE=off
 # member, which is the judge grading its own answer. That is the exact defect the comment
 # above `_DEFAULT_JUDGE` in chimera/config.py records having been fixed once already; the
 # example file had quietly kept a copy of it.
-CHIMERA_FUSION_PANEL=openrouter/anthropic/claude-opus-5,openrouter/openai/gpt-5.5,openrouter/google/gemini-3.1-pro-preview
-CHIMERA_FUSION_JUDGE=openrouter/deepseek/deepseek-r1
+CHIMERA_FUSION_PANEL=openrouter/anthropic/claude-opus-5,openrouter/openai/gpt-5.5,openrouter/google/gemini-3.8-flash
+CHIMERA_FUSION_JUDGE=openrouter/deepseek/deepseek-v4-flash-0731
 CHIMERA_FUSION_SYNTHESIZER=openrouter/anthropic/claude-opus-5
 
 # Selective fusion (ON by default). Probe the first CHIMERA_FUSION_PROBE_K panel models;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **The shipped model defaults were a generation behind, and one of them could be withdrawn without
+  notice.** Surveyed against the live OpenRouter index on 2026-09-03 and changed on the measurements
+  below. Nothing is removed from the catalogue — what changes is which entry is the DEFAULT.
+
+  | role | was | is | why |
+  |---|---|---|---|
+  | `default_model`, mid rung | `deepseek-chat-v3.1` 0.25/0.95 | `deepseek-v4-flash-0731` 0.065/0.18 | 3.8x cheaper in, 5.3x out, 8x the window, same vendor |
+  | top rung (`balanced`, `auto`) | `deepseek-r1` 0.70/2.50 | `z-ai/glm-5.3` 1.40/4.40 | R1 carried a **64k** window into a tier that asks for 100k |
+  | `fusion_judge` | `deepseek-r1` | `deepseek-v4-flash-0731` | same window problem, and it judges what the panel wrote |
+  | fusion panel, Google seat | `gemini-3.1-pro-preview` | `gemini-3.8-flash` | a `-preview` in a default; also cheaper AND the better index |
+
+  R1 is the clearest case and it was in two roles. Third-party agentic index **3.1** — the lowest of
+  any candidate examined, tied with a 20B model in the *weak* tier — and on a trivial write-a-file
+  probe it took **209s** against 29s for the then-default and 51s for the model that replaced it.
+
+  **The probe that was supposed to decide this did not decide it, and that is worth stating.** The
+  write-a-file smoke test exists because a model in an earlier session described an HTML file instead
+  of writing it and burned US$ 1.50 delivering nothing. Run across eight candidates, **8 of 8 wrote
+  the file** — so it rules out catastrophic tool-calling failure and separates nothing. One candidate
+  appeared to fail and turned out to be a transient: retried three times, it wrote in 4.6-9.5s, the
+  fastest of the set. The swap therefore rests on price, context window, a third-party index and
+  latency — all measured, none of them a claim about output quality, which was not measured.
+
+  `glm-5.3-flash` is the striking number and is deliberately **not** the default: 0.075/0.25 with an
+  agentic index of 58.2, within a point of `claude-opus-5` at 66x the input price — and 257s on the
+  same one-file probe, against 72s for the slug that took the role. It is in the catalogue with that
+  written beside it.
+
+  The weak tier does not move. `mistral-small-3.2` is the fastest thing measured here and the only
+  one with validation inside this repo.
+
 ### Fixed
 
 - **The skill install error blamed a limit that was not the one that bit.** Installing from the

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -37,14 +37,29 @@ if TYPE_CHECKING:
 _DEFAULT_PANEL = [
     "openrouter/anthropic/claude-opus-5",
     "openrouter/openai/gpt-5.5",
-    "openrouter/google/gemini-3.1-pro-preview",
+    # Was `gemini-3.1-pro-preview`. A `-preview` slug in a DEFAULT is a default that can be
+    # withdrawn without notice, and there is no stable Gemini 3.x "pro" to move to — only the flash
+    # line ships non-preview. Measured on the live index 2026-09-03: 2.000/12.000 -> 0.750/3.750 per
+    # million, and the third-party agentic index goes 23 -> 50. Cheaper AND the better number, which
+    # is unusual enough to say out loud.
+    "openrouter/google/gemini-3.8-flash",
 ]
 # The judge must not be a panelist. It shipped as `_DEFAULT_PANEL[0]` — the same slug, verbatim —
 # which made the default fusion self-evaluating in the one place this project claims to have an
 # independent signal rather than a self-report. Nothing guarded it; `validate_fusion_roles` below
 # does now. DeepSeek-R1 is a fourth vendor (the panel is Anthropic/OpenAI/Google) and is reasoning-
 # tuned, which is what judging asks for.
-_DEFAULT_JUDGE = "openrouter/deepseek/deepseek-r1"
+#
+# Moved off R1 on 2026-09-03, on three measurements rather than a preference. Its context window is
+# 64k — the tier it serves asks for 100k, so the judge could not read what the panel produced on a
+# long turn. Its third-party agentic index is 3.1, the lowest of any candidate examined, tied with a
+# 20B model in the weak tier. And on a trivial write-a-file probe it took 209s against 29s for the
+# then-default and 51s for the top model that replaced it.
+#
+# The replacement keeps DeepSeek as the judge's vendor, so the independence argument above is
+# unchanged: the panel is Anthropic/OpenAI/Google and the judge is neither a panelist nor a
+# vendor-mate of one.
+_DEFAULT_JUDGE = "openrouter/deepseek/deepseek-v4-flash-0731"
 # Spelled out rather than reusing `_DEFAULT_JUDGE`, which is what it did before. Changing the judge
 # would otherwise have moved the synthesiser too, silently — the synthesiser's job is composition,
 # not evaluation, so it is a separate decision and stays where it was.
@@ -172,7 +187,7 @@ class Settings(BaseSettings):
     # wizard SHOWS that suggestion without writing it when the user leaves it alone, so a mismatch
     # puts one slug on screen and runs another.
     default_model: str = Field(
-        default="openrouter/deepseek/deepseek-chat-v3.1", validation_alias="CHIMERA_DEFAULT_MODEL"
+        default="openrouter/deepseek/deepseek-v4-flash-0731", validation_alias="CHIMERA_DEFAULT_MODEL"
     )
 
     # --- Model tiers (M16): weak -> mid -> top, vendor-agnostic. Any LiteLLM/OpenRouter

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -89,6 +89,16 @@ CATALOG: tuple[CatalogEntry, ...] = (
     ),
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
+        "openrouter/deepseek/deepseek-v4-flash-0731", "mid", "DeepSeek",
+        0.065, 0.18, tools=True, context_k=1310,
+        notes="the product default and the fusion judge since 2026-09-03. Same vendor as the chat-v3.1 it replaced, at 0.065/0.18 against 0.25/0.95 (3.8x cheaper in, 5.3x out) with eight times the window. Wrote a file on the first ask in a live probe, in 72s",
+    ),
+    CatalogEntry(
+        "openrouter/z-ai/glm-5.3-flash", "mid", "Zhipu (GLM)",
+        0.075, 0.25, tools=True, context_k=1310,
+        notes="the best price-to-index here by a distance: 0.075/0.25 with a third-party agentic index of 58.2, within a point of claude-opus-5 at 66x the input price. NOT the default, and the reason is measured: on the same one-file probe it took 257s against 72s for the slug above. Reach for it when the window or the index matters more than latency",
+    ),
+    CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
         0.25, 0.95, tools=True, context_k=163,
         notes="proven in this repo's benches; the product default. Priced 0.55/1.65 here until a\n        live check on 2026-09-03 measured 0.25/0.95",
@@ -115,6 +125,11 @@ CATALOG: tuple[CatalogEntry, ...] = (
     ),
     # --- top: orchestrator/judge class. Decompose, adjudicate, synthesize. ---
     CatalogEntry(
+        "openrouter/z-ai/glm-5.3", "top", "Zhipu (GLM)",
+        1.40, 4.40, tools=True, context_k=1310,
+        notes="the top rung of `balanced` and `auto` since 2026-09-03, and the reason is the slug below rather than this one: R1 carried a 64k window into a tier that asks for 100k. This has 1310k, a third-party agentic index of 59.1 against R1's 3.1, and wrote a file in 51s against R1's 209s. It costs twice as much per token and buys a working top tier",
+    ),
+    CatalogEntry(
         "openrouter/deepseek/deepseek-r1", "top", "DeepSeek",
         0.70, 2.50, tools=True, context_k=64,
         notes="economic reasoner; the default economic orchestrator. Note the SMALL window",
@@ -128,6 +143,11 @@ CATALOG: tuple[CatalogEntry, ...] = (
         "openrouter/openai/gpt-5.5", "top", "OpenAI",
         5.00, 30.00, tools=True, context_k=1050,
         notes="frontier; this repo's default_model until 2026-08-18, and the reason it changed",
+    ),
+    CatalogEntry(
+        "openrouter/google/gemini-3.8-flash", "top", "Google",
+        0.75, 3.75, tools=True, context_k=1048,
+        notes="the Google seat on the default fusion panel since 2026-09-03, replacing the -preview slug below there. A -preview in a DEFAULT is a default that can be withdrawn without notice, and there is no stable Gemini 3.x pro to move to: only the flash line ships non-preview. Cheaper (0.75/3.75 against 2.00/12.00) AND the better third-party agentic index (50 against 23)",
     ),
     CatalogEntry(
         "openrouter/google/gemini-3.1-pro-preview", "top", "Google",
@@ -188,7 +208,7 @@ PROVIDERS: tuple[ProviderInfo, ...] = (
     ProviderInfo(
         "OPENROUTER_API_KEY",
         "OpenRouter",
-        "openrouter/deepseek/deepseek-chat-v3.1",
+        "openrouter/deepseek/deepseek-v4-flash-0731",
         "https://openrouter.ai/keys",
     ),
     # gpt-5.6-sol, via its documented alias; same $5/$30 as the 5.5 it replaces.
@@ -276,24 +296,24 @@ class TierLadder:
 _PRESETS: dict[CostMode, TierLadder] = {
     "cheap": TierLadder(
         weak="openrouter/mistralai/mistral-small-3.2-24b-instruct",
-        mid="openrouter/deepseek/deepseek-chat-v3.1",
-        top="openrouter/deepseek/deepseek-chat-v3.1",  # never pay reasoner rates
+        mid="openrouter/deepseek/deepseek-v4-flash-0731",
+        top="openrouter/deepseek/deepseek-v4-flash-0731",  # never pay reasoner rates
         entry="weak",
     ),
     "balanced": TierLadder(
         weak="openrouter/mistralai/mistral-small-3.2-24b-instruct",
-        mid="openrouter/deepseek/deepseek-chat-v3.1",
-        top="openrouter/deepseek/deepseek-r1",
+        mid="openrouter/deepseek/deepseek-v4-flash-0731",
+        top="openrouter/z-ai/glm-5.3",
         entry="weak",
     ),
     "auto": TierLadder(
         weak="openrouter/mistralai/mistral-small-3.2-24b-instruct",
-        mid="openrouter/deepseek/deepseek-chat-v3.1",
-        top="openrouter/deepseek/deepseek-r1",
+        mid="openrouter/deepseek/deepseek-v4-flash-0731",
+        top="openrouter/z-ai/glm-5.3",
         entry="mid",
     ),
     "premium": TierLadder(
-        weak="openrouter/deepseek/deepseek-chat-v3.1",
+        weak="openrouter/deepseek/deepseek-v4-flash-0731",
         mid="openrouter/openai/gpt-5.5",
         top="openrouter/anthropic/claude-opus-5",
         entry="mid",

--- a/tests/test_a_default_cannot_be_a_model_that_may_vanish.py
+++ b/tests/test_a_default_cannot_be_a_model_that_may_vanish.py
@@ -1,0 +1,109 @@
+"""A `-preview` slug shipped as a default, and nothing was watching.
+
+Found by surveying the live index on 2026-09-03: `_DEFAULT_PANEL` carried
+`openrouter/google/gemini-3.1-pro-preview`. A preview is a model its vendor may withdraw without
+notice, and a default is the one setting a user never chose — so the failure lands on somebody who
+never opted into the risk, as a call that stops working for a reason nothing on their screen
+explains.
+
+The same family covers two more shapes the survey turned up in the catalogue:
+
+* `~vendor/model-latest` aliases, thirteen of them, which do not vanish — they silently become a
+  different model. For a default that is worse, because nothing fails and the behaviour changes.
+* `:free` slugs, which this repo has already been bitten by twice: the catalogue's own notes record
+  `llama-3.3-70b-instruct:free` and `gpt-oss-20b:free` being withdrawn a fortnight apart.
+
+None of that is a reason to keep them out of the CATALOGUE. A user who picks a preview on purpose
+has made a choice and can unmake it. What this holds is narrower: the settings nobody chose.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.config import Settings
+from chimera.providers.catalog import PROVIDERS, _PRESETS
+
+#: Substrings that mark a slug as one a vendor may withdraw or repoint under you.
+FRAGIL = ("preview", "-beta", "-exp", ":free", "-latest")
+
+
+def _declarado(campo: str):
+    """The default the CODE ships, not what this process is configured with."""
+    info = Settings.model_fields[campo]
+    return info.default_factory() if info.default_factory is not None else info.default
+
+
+def _fragilidades(slug: str) -> list[str]:
+    if not slug:
+        return []
+    achados = [f for f in FRAGIL if f in slug]
+    if slug.startswith("~"):
+        achados.append("~alias")
+    return achados
+
+
+def _todos_os_padroes() -> dict[str, str]:
+    """Every slug a user gets without choosing it, keyed by where it comes from."""
+    tudo: dict[str, str] = {
+        "default_model": _declarado("default_model"),
+        "fusion_judge": _declarado("fusion_judge"),
+        "fusion_synthesizer": _declarado("fusion_synthesizer"),
+    }
+    for i, m in enumerate(_declarado("fusion_panel")):
+        tudo[f"fusion_panel[{i}]"] = m
+    for i, m in enumerate(_declarado("transfer_panel")):
+        tudo[f"transfer_panel[{i}]"] = m
+    for modo, escada in _PRESETS.items():
+        for papel in ("weak", "mid", "top"):
+            tudo[f"_PRESETS[{modo}].{papel}"] = getattr(escada, papel)
+    for p in PROVIDERS:
+        tudo[f"PROVIDERS[{p.label}].default_model"] = p.default_model
+    return tudo
+
+
+def test_no_default_is_a_model_that_may_be_withdrawn_or_repointed() -> None:
+    culpados = {
+        onde: (slug, _fragilidades(slug))
+        for onde, slug in _todos_os_padroes().items()
+        if _fragilidades(slug)
+    }
+    assert not culpados, (
+        "a default is the setting a user never chose, so a slug the vendor may withdraw or repoint "
+        f"puts the failure on somebody who did not opt into it: {culpados}"
+    )
+
+
+@pytest.mark.parametrize("onde,slug", sorted(_todos_os_padroes().items()))
+def test_every_default_is_a_real_slug_shape(onde: str, slug: str) -> None:
+    """Cheap shape check — a default that is empty or half-written fails at call time, not here."""
+    assert slug, f"{onde} is empty"
+    assert "/" in slug, f"{onde} = {slug!r} is not a provider-qualified slug"
+    assert not slug.strip() != slug, f"{onde} = {slug!r} has surrounding whitespace"
+
+
+def test_the_check_would_actually_have_caught_the_one_that_shipped() -> None:
+    """The guard is only worth having if it fires on the case that produced it.
+
+    `gemini-3.1-pro-preview` sat in `_DEFAULT_PANEL` through several releases. Asserting the rule
+    against today's clean state proves nothing about whether the rule can see a violation.
+    """
+    assert _fragilidades("openrouter/google/gemini-3.1-pro-preview") == ["preview"]
+    assert _fragilidades("~google/gemini-flash-latest") == ["-latest", "~alias"]
+    assert _fragilidades("openrouter/qwen/qwen3-coder:free") == [":free"]
+    assert _fragilidades("openrouter/deepseek/deepseek-v4-flash-0731") == []
+
+
+def test_the_judge_is_not_a_panelist_nor_a_vendor_mate_of_one() -> None:
+    """Restated here because the judge MOVED, and the rule it has to keep is easy to lose in a swap.
+
+    `test_fusion_role_independence` owns this property; this asserts it about the shipped values
+    after the change, so a future swap that quietly breaks independence fails in the file that
+    changed it too.
+    """
+    juiz = _declarado("fusion_judge")
+    painel = _declarado("fusion_panel")
+    assert juiz not in painel, "the judge would be grading its own answer"
+    vendor = juiz.split("/")[1] if juiz.count("/") >= 2 else juiz.split("/")[0]
+    parentes = [m for m in painel if m.split("/")[1] == vendor]
+    assert not parentes, f"the judge shares a vendor with {parentes}, so they are not two votes"

--- a/tests/test_a_default_cannot_be_a_model_that_may_vanish.py
+++ b/tests/test_a_default_cannot_be_a_model_that_may_vanish.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import pytest
 
 from chimera.config import Settings
-from chimera.providers.catalog import PROVIDERS, _PRESETS
+from chimera.providers.catalog import _PRESETS, PROVIDERS
 
 #: Substrings that mark a slug as one a vendor may withdraw or repoint under you.
 FRAGIL = ("preview", "-beta", "-exp", ":free", "-latest")
@@ -79,7 +79,7 @@ def test_every_default_is_a_real_slug_shape(onde: str, slug: str) -> None:
     """Cheap shape check — a default that is empty or half-written fails at call time, not here."""
     assert slug, f"{onde} is empty"
     assert "/" in slug, f"{onde} = {slug!r} is not a provider-qualified slug"
-    assert not slug.strip() != slug, f"{onde} = {slug!r} has surrounding whitespace"
+    assert slug.strip() == slug, f"{onde} = {slug!r} has surrounding whitespace"
 
 
 def test_the_check_would_actually_have_caught_the_one_that_shipped() -> None:


### PR DESCRIPTION
Surveyed against the live OpenRouter index on 2026-09-03. **Nothing is removed from the catalogue** — what changes is which entry is the *default*, which is the setting a user never chose.

| role | was | is | why |
|---|---|---|---|
| `default_model`, mid rung | `deepseek-chat-v3.1` 0.25/0.95 | `deepseek-v4-flash-0731` 0.065/0.18 | 3.8× cheaper in, 5.3× out, 8× the window, same vendor |
| top rung (`balanced`, `auto`) | `deepseek-r1` 0.70/2.50 | `z-ai/glm-5.3` 1.40/4.40 | R1 carried a **64k** window into a tier that asks for 100k |
| `fusion_judge` | `deepseek-r1` | `deepseek-v4-flash-0731` | same window problem, on the role that reads what the panel wrote |
| fusion panel, Google seat | `gemini-3.1-pro-preview` | `gemini-3.8-flash` | a `-preview` in a default; also cheaper **and** the better index |

## R1 was in two roles and fails on every axis measured

Context **64k** in a tier that asks for 100k. Third-party agentic index **3.1** — the lowest of any candidate examined, tied with a 20B model in the *weak* tier. And **209s** on a trivial write-a-file probe, against 29s for the then-default and 51s for the model that replaced it.

## The probe meant to decide this did not decide it

The write-a-file smoke test exists because a model in an earlier session **described** an HTML file instead of writing it, burning US$ 1.50 and delivering nothing. Run across eight candidates:

```
8 of 8 wrote the file
```

So it rules out catastrophic tool-calling failure and separates nothing else. One candidate appeared to fail; retried three times it wrote in 4.6–9.5s — the fastest of the set — so that was a transient, and it keeps its role.

**The swap therefore rests on price, context window, a third-party index and latency.** All measured. Output quality was not measured and is not claimed.

## The number that is deliberately not the default

`glm-5.3-flash`: 0.075/0.25 with an agentic index of **58.2**, within a point of `claude-opus-5` at **66× less** on input. And **257s** on the same one-file probe against 72s for the slug that took the role. It is in the catalogue with exactly that written beside it, so somebody who wants the window or the index can reach for it on purpose.

The weak tier does not move: `mistral-small-3.2` is the fastest thing measured here and the only one with validation inside this repo.

## What now holds the rule

`tests/test_a_default_cannot_be_a_model_that_may_vanish.py` — the `-preview` slug sat in `_DEFAULT_PANEL` through several releases with nothing watching. It covers `-preview`, `:free`, `-beta`, `-exp` and `~vendor/…-latest` aliases (which do not vanish — they silently become a different model, which for a default is worse) across every default: `default_model`, judge, synthesizer, both panels, all four cost ladders, every provider default.

Five sabotages, **5 of 5 caught**, including one asserting the guard fires on the exact slug that shipped — a rule asserted only against a clean state proves nothing about whether it can see a violation.

Full suite: **5113 pass, 4 fail** — the same four already failing on this machine beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)