### PR TITLE
feat(agent): the task list the agent keeps, and the measurement that decides its default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **The agent keeps a task list, and it is on the screen.** `RunState.tasks` has existed since
+  compaction was written, with a docstring saying what it is for and a renderer that puts it back
+  after a compaction. Nothing ever wrote to it, and the loop that would have been the obvious writer
+  says in as many words why it must not: it counts attempts, not steps, so it has no completion to
+  report, and filling the field from the plan would be *"a lie in the field whose entire purpose is
+  to be believed"*.
+
+  That was right. The missing piece was a truthful source, and there is one: the agent. A new
+  `todo_write` tool records the list, `RunState.tasks` mirrors it so a compaction restores it with
+  its status intact, and a `todo` frame carries it live to the Code screen and the run panel.
+
+  **What it reports is a claim, and every surface says so.** Every other structured frame in this
+  vocabulary reports something observed — `edit` is a diff read off disk before and after the write,
+  `result` is a verifier's exit code. A row of ticks looks like a third member of that family and is
+  not one. The frame carries `claimed`, and the panel writes it out: *"1 of 3 done — what the agent
+  says about its own progress, not a verdict."*
+
+  Two rules are enforced rather than suggested: at most one item may be in progress (a list with six
+  answers nothing), and items that leave the list are named back to the agent (a quietly dropped
+  requirement renders identically to one that never existed).
+
+  **Adoption was measured before this defaulted to anything**, because a tool the model never calls
+  is schema in every prompt and no behaviour. Same task, same models, one sentence of difference:
+
+  | | `deepseek-v4-flash-0731` | `z-ai/glm-5.3` |
+  |---|---|---|
+  | schema only | 0 calls | 0 calls |
+  | schema + one prompt line | 0 calls, in 4 runs | 4 calls, correct progression |
+
+  So the prompt line is not optional, and it is only added when the session actually granted the
+  tool. And the part worth saying plainly: **the model this project currently ships as its default
+  does not use this tool**, in four runs where it was told to. On that model the feature costs 896
+  characters per step and delivers nothing. It ships on anyway — its failure mode is "unused" rather
+  than "worse", and there is no bench control arm for it to destroy — with the number written into
+  `chimera/config.py` so the decision can be reopened with a measurement instead of an opinion.
+
+  Registered in `default_registry` like every other tool, which is what puts it under the session
+  allowlist: a registry an operator scoped to two tools does not quietly gain a third. Bound per
+  thread, so the several workers a crew runs off one shared registry keep separate lists.
+
+### Fixed
+
+- `CodeSession.send` forwarded a new callback to any agent whose `run` declared `**kwargs`, on the
+  reasoning — written in a comment — that an implementation predating the parameter had to keep
+  working. A catch-all usually forwards to something narrower, so the comment described a safety the
+  code did not provide: six API turns died before their first tool call. The signature is now read
+  for the parameter by name.
+
 ## [0.49.3] - 2026-09-03
 
 ### Changed

--- a/apps/desktop/src/components/Code.todo.test.tsx
+++ b/apps/desktop/src/components/Code.todo.test.tsx
@@ -1,0 +1,83 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Code } from "@/components/Code";
+import { getFsTree, getGitStatus, getPostureFacts, getRuns, streamCodeTurn } from "@/lib/api";
+import { emptyTree, gitStatus, postureFacts, scriptTurn } from "@/test/code-api-mock";
+import { renderWithProviders } from "@/test/utils";
+
+vi.mock("@/lib/api", async () => (await import("@/test/code-api-mock")).makeCodeApiMock());
+
+/**
+ * The agent's own task list, streamed as it records one.
+ *
+ * The assertion that matters here is not that the list renders — it is that the screen says whose
+ * claim it is. Everything else structured on this surface reports something that was checked: the
+ * diff is read off disk before and after the write, the verification badge is a command's exit
+ * code. A row of ticks looks like a third member of that family and is not one; nothing verified
+ * it. So the caption is tested as hard as the content, and the last test here is the one that
+ * fails if somebody later "tidies it away" as noise.
+ */
+async function turnWithTodos(todos: { task: string; status: string }[][]) {
+  const user = userEvent.setup();
+  vi.mocked(streamCodeTurn).mockImplementation(scriptTurn({ todos }));
+  renderWithProviders(<Code />);
+  await user.type(screen.getByPlaceholderText(/^Ask about this code/), "do the work{Enter}");
+  return user;
+}
+
+const THREE = [
+  { task: "read the schema", status: "done" },
+  { task: "write the catalogue", status: "doing" },
+  { task: "check the format", status: "pending" },
+];
+
+describe("Code — the task list the agent keeps", () => {
+  beforeEach(() => {
+    vi.mocked(getFsTree).mockResolvedValue(emptyTree());
+    vi.mocked(getGitStatus).mockResolvedValue(gitStatus());
+    vi.mocked(getRuns).mockResolvedValue([]);
+    vi.mocked(getPostureFacts).mockResolvedValue(postureFacts());
+  });
+
+  it("renders every item with its status", async () => {
+    await turnWithTodos([THREE]);
+
+    expect(await screen.findByText("read the schema")).toBeInTheDocument();
+    expect(screen.getByText("write the catalogue")).toBeInTheDocument();
+    expect(screen.getByText("check the format")).toBeInTheDocument();
+    expect(screen.getByText("doing")).toBeInTheDocument();
+  });
+
+  it("replaces the list rather than merging two snapshots into one", async () => {
+    // Each frame carries the WHOLE list. Appending would show a list that never existed — here,
+    // "write the catalogue" twice, once in each status.
+    await turnWithTodos([
+      THREE,
+      [
+        { task: "read the schema", status: "done" },
+        { task: "write the catalogue", status: "done" },
+      ],
+    ]);
+
+    expect(await screen.findByText("read the schema")).toBeInTheDocument();
+    expect(screen.getAllByText("write the catalogue")).toHaveLength(1);
+    expect(screen.queryByText("check the format")).not.toBeInTheDocument();
+  });
+
+  it("shows nothing at all when the agent recorded no list", async () => {
+    await turnWithTodos([]);
+
+    expect(await screen.findByText("done")).toBeInTheDocument(); // the turn finished
+    expect(screen.queryByLabelText("Task list")).not.toBeInTheDocument();
+  });
+
+  it("says the progress is the agent's own account and not a verdict", async () => {
+    await turnWithTodos([THREE]);
+
+    // The whole point of the component. If this assertion is ever deleted, the screen has started
+    // reporting a model's claim in the same voice it uses for a verifier's exit code.
+    expect(await screen.findByText(/not a verdict/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 of 3 done/i)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/components/code/Conversation.tsx
+++ b/apps/desktop/src/components/code/Conversation.tsx
@@ -47,6 +47,7 @@ import {
 } from "@/components/code/Attachments";
 import { BatchProposal } from "@/components/code/BatchProposal";
 import { DiffView } from "@/components/code/DiffView";
+import { TodoPanel, type TodoEntry } from "@/components/code/TodoPanel";
 import {
   EMPTY_CAST,
   FusionCast,
@@ -108,6 +109,10 @@ interface Exchange {
   answer: string;
   tools: CodeToolEvent[];
   edits: { path: string; patch: string }[];
+  /** The agent's own task list for this turn — its claim about its progress, not a verdict.
+   *  Replaced wholesale on every frame, because the frame carries the whole list: merging
+   *  would build a list out of two snapshots and show one that never existed. */
+  todos: TodoEntry[];
   done: CodeTurnDone | null;
   failed?: boolean;
   /** What the server actually said when the turn failed. A wrong API key, a rate limit, a model
@@ -557,6 +562,11 @@ export function Conversation({
             ...e,
             done: (e.done ?? null) as Exchange["done"],
             verified: (e.verified ?? undefined) as Exchange["verified"],
+            // Empty on a replay, for the reason `CodeExchangeOut` already gives about `edits`: the
+            // list was streamed and never entered the message list, so a reopened conversation can
+            // show the tool call that recorded it but not the list itself. An absent list reads as
+            // "none was kept", which is true, rather than as a claim about the work.
+            todos: [],
           })),
         );
         setReplayed(true);
@@ -740,7 +750,7 @@ export function Conversation({
     setBusy(true);
     setExchanges((prev) => [
       ...prev,
-      { you: message, answer: "", tools: [], edits: [], done: null },
+      { you: message, answer: "", tools: [], edits: [], todos: [], done: null },
     ]);
     let touchedFiles = false;
     // Whether THIS turn's verifier failed. It decides what happens to a queued follow-up, and it
@@ -827,6 +837,10 @@ export function Conversation({
         onEdit: (path, patch) => {
           touchedFiles = true;
           patchLast((e) => ({ ...e, edits: [...e.edits, { path, patch }] }));
+        },
+        onTodo: (items) => {
+          // Replaced, not appended. Unlike `edits`, each frame is the complete list.
+          patchLast((e) => ({ ...e, todos: items }));
         },
         onVerified: (v) => {
           verifyFailed = v.state === "failed";
@@ -1065,6 +1079,7 @@ export function Conversation({
                   ))}
                 </div>
               ) : null}
+              <TodoPanel items={e.todos} />
               {e.edits.map((edit, j) => (
                 <div key={j} className="space-y-1">
                   <button

--- a/apps/desktop/src/components/code/TodoPanel.tsx
+++ b/apps/desktop/src/components/code/TodoPanel.tsx
@@ -1,0 +1,65 @@
+import { useT } from "@/lib/i18n";
+
+/** One line of the agent's own task list. */
+export interface TodoEntry {
+  task: string;
+  status: string;
+}
+
+/**
+ * The run's task list, as the agent declared it.
+ *
+ * The caption is the component. Every other structured thing this screen renders reports something
+ * that was checked: `DiffView` shows a diff read off disk before and after the write, and the
+ * verification badge shows a command's exit code. A row of ticks looks like more of the same, and
+ * it is not — it is the model's own account of its progress, which nothing verified. So the panel
+ * says whose claim it is, once, in words, above the list. Without that line this is a progress bar
+ * that reports its own success.
+ *
+ * No colour carries meaning here on its own: the status word is written out beside every item, so
+ * the list reads the same to someone who cannot distinguish the tints.
+ */
+export function TodoPanel({ items }: { items: TodoEntry[] }) {
+  const t = useT();
+  if (!items.length) return null;
+  const done = items.filter((i) => i.status === "done").length;
+  // Written out rather than composed as `code.todo.status.${status}`. The dead-key gate reads the
+  // source for literal key strings, so an interpolated key is a key it cannot see — and the three
+  // it could not see would be reported as unused and deleted by the next person tidying up.
+  const label = (status: string) =>
+    status === "done"
+      ? t("code.todo.status.done")
+      : status === "doing"
+        ? t("code.todo.status.doing")
+        : t("code.todo.status.pending");
+  return (
+    <section
+      className="space-y-1 rounded-md border border-border p-2"
+      aria-label={t("code.todo.title")}
+    >
+      <p className="text-xs text-muted-foreground">
+        {t("code.todo.claimed", { done: String(done), total: String(items.length) })}
+      </p>
+      <ul className="space-y-0.5">
+        {items.map((item, i) => (
+          <li key={i} className="flex gap-2 text-xs">
+            <span
+              className={
+                item.status === "done"
+                  ? "text-ok-foreground"
+                  : item.status === "doing"
+                    ? "text-accent-ink"
+                    : "text-muted-foreground"
+              }
+            >
+              {label(item.status)}
+            </span>
+            <span className={item.status === "done" ? "text-muted-foreground" : undefined}>
+              {item.task}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/desktop/src/components/run/RunLauncher.tsx
+++ b/apps/desktop/src/components/run/RunLauncher.tsx
@@ -495,5 +495,13 @@ export function liveLine(e: RunEvent, t: TFunc): string | null {
   if (e.kind === "attempt") return `${t("runs.attempt")} ${e.index} — ${t("runs.verifying")}`;
   if (e.kind === "result")
     return `${t("runs.attempt")} ${e.index}: ${e.success ? t("runs.passed") : t("runs.failed")}`;
+  // The one line here that is a CLAIM rather than an observation, which is why it reuses the
+  // wording the panel uses instead of inventing a shorter one: a bare "3/5 done" on a live
+  // feed of verified events reads as a fifth verified event.
+  if (e.kind === "todo" && e.items)
+    return t("code.todo.claimed", {
+      done: String(e.items.filter((i) => i.status === "done").length),
+      total: String(e.items.length),
+    });
   return null; // `final` is covered by onDone
 }

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -845,6 +845,12 @@ export interface RunEvent {
   // fabricated — read from the file on disk before/after the write-tool call).
   path?: string;
   patch?: string;
+  // `kind === "todo"`: the run's task list, whole, as the AGENT declared it. `claimed` is what
+  // separates it from every other frame here — `edit` is a diff read off disk and `result` is a
+  // verifier's exit code, while this is the model's account of its own progress and nothing
+  // checked it. A renderer that drops the distinction draws a row of ticks that reads as verified.
+  items?: { task: string; status: string }[];
+  claimed?: boolean;
 }
 
 /** The terminal `done` payload of a run. */
@@ -1134,6 +1140,7 @@ export interface CodeTurnHandlers {
   onToken?: (text: string) => void;
   onTool?: (e: CodeToolEvent) => void;
   onEdit?: (path: string, patch: string) => void;
+  onTodo?: (items: { task: string; status: string }[]) => void;
   onVerified?: (v: CodeVerified) => void;
   onDone?: (d: CodeTurnDone) => void;
   onError?: (msg: string) => void;
@@ -1315,6 +1322,8 @@ function applyCodeTurnFrame(
   else if (event === "token") h.onToken?.(payload.text as string);
   else if (event === "tool") h.onTool?.(payload as unknown as CodeToolEvent);
   else if (event === "edit") h.onEdit?.(payload.path as string, payload.patch as string);
+  else if (event === "todo")
+    h.onTodo?.((payload.items ?? []) as { task: string; status: string }[]);
   else if (event === "verified") h.onVerified?.(payload as unknown as CodeVerified);
   else if (event === "done") h.onDone?.(payload as unknown as CodeTurnDone);
   else if (event === "error") h.onError?.(payload.message as string);

--- a/apps/desktop/src/lib/i18n.tsx
+++ b/apps/desktop/src/lib/i18n.tsx
@@ -83,6 +83,8 @@ const en: Dict = {
     "Replace an exact substring in a workspace file (surgical edit — prefer this over write_file for changing an existing file). 'old' must match exactly and, unless replace_all is true, appear exactly once; a missing or ambiguous match is refused.",
   "tools.desc.apply_patch":
     "Apply multiple search/replace hunks to one workspace file, atomically. The patch is a sequence of '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE' blocks; each SEARCH must match exactly once. If any hunk fails to anchor, the file is left unchanged.",
+  "tools.desc.todo_write":
+    "Record your task list for this run, replacing whatever you recorded before. Send every item each time, including the finished ones. At most one item may be 'doing'. Use this for work with several steps so progress survives a context compaction and the person watching can see where you are.",
   "tools.desc.list_dir": "List entries of a directory in the workspace.",
   "tools.desc.grep":
     "Search file contents by regular expression. Returns 'relpath:lineno: line' matches. Optionally restrict to a subdirectory and to files matching a glob (e.g. '*.py').",
@@ -903,6 +905,12 @@ const en: Dict = {
   "code.roles.panel": "panel",
   "code.roles.unproven":
     "Routing each role to a different model is NOT yet measured. See bench/role_routing — until that runs, this is a choice about cost and models, not a claim that it works better.",
+  "code.todo.title": "Task list",
+  "code.todo.claimed":
+    "{done} of {total} done — what the agent says about its own progress, not a verdict.",
+  "code.todo.status.done": "done",
+  "code.todo.status.doing": "doing",
+  "code.todo.status.pending": "to do",
   "code.worth.title": "Was it worth it?",
   "code.worth.profile": "profile",
   "code.worth.runs": "runs",
@@ -1366,6 +1374,8 @@ const pt: Dict = {
     "Substitui uma substring exata em um arquivo do workspace (edição cirúrgica — prefira isto a write_file para alterar um arquivo existente). 'old' precisa corresponder exatamente e, a menos que replace_all seja true, aparecer exatamente uma vez; correspondência ausente ou ambígua é recusada.",
   "tools.desc.apply_patch":
     "Aplica vários trechos de busca/substituição a um único arquivo do workspace, de forma atômica. O patch é uma sequência de blocos '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'; cada SEARCH precisa corresponder exatamente uma vez. Se algum trecho não ancorar, o arquivo fica inalterado.",
+  "tools.desc.todo_write":
+    "Registre sua lista de tarefas desta execução, substituindo o que você registrou antes. Envie todos os itens sempre, inclusive os concluídos. No máximo um item pode estar em 'doing'. Use isto em trabalhos de várias etapas, para que o progresso sobreviva a uma compactação de contexto e quem estiver acompanhando veja onde você está.",
   "tools.desc.list_dir": "Lista as entradas de um diretório no workspace.",
   "tools.desc.grep":
     "Busca no conteúdo dos arquivos por expressão regular. Devolve correspondências no formato 'relpath:lineno: line'. Opcionalmente restringe a um subdiretório e a arquivos que casem com um glob (ex.: '*.py').",
@@ -2194,6 +2204,12 @@ const pt: Dict = {
   "code.roles.panel": "painel",
   "code.roles.unproven":
     "Rotear cada papel para um modelo diferente AINDA não foi medido. Veja bench/role_routing — até isso rodar, esta é uma escolha de custo e de modelos, não uma alegação de que funciona melhor.",
+  "code.todo.title": "Lista de tarefas",
+  "code.todo.claimed":
+    "{done} de {total} concluídas — o que o agente diz do próprio progresso, não um veredito.",
+  "code.todo.status.done": "feito",
+  "code.todo.status.doing": "fazendo",
+  "code.todo.status.pending": "a fazer",
   "code.worth.title": "Valeu a pena?",
   "code.worth.profile": "perfil",
   "code.worth.runs": "execuções",
@@ -2698,6 +2714,8 @@ const es: Dict = {
     "Reemplaza una subcadena exacta en un archivo del workspace (edición quirúrgica — prefiere esto a write_file para cambiar un archivo existente). 'old' debe coincidir exactamente y, salvo que replace_all sea true, aparecer exactamente una vez; una coincidencia ausente o ambigua se rechaza.",
   "tools.desc.apply_patch":
     "Aplica varios bloques de búsqueda/reemplazo a un solo archivo del workspace, de forma atómica. El patch es una secuencia de bloques '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'; cada SEARCH debe coincidir exactamente una vez. Si algún bloque no ancla, el archivo queda sin cambios.",
+  "tools.desc.todo_write":
+    "Registra tu lista de tareas de esta ejecución, reemplazando lo que registraste antes. Envía todos los elementos cada vez, incluidos los terminados. Como máximo un elemento puede estar en 'doing'. Úsalo en trabajos de varios pasos, para que el progreso sobreviva a una compactación de contexto y quien mire vea dónde estás.",
   "tools.desc.list_dir": "Lista las entradas de un directorio del workspace.",
   "tools.desc.grep":
     "Busca en el contenido de los archivos por expresión regular. Devuelve coincidencias con el formato 'relpath:lineno: line'. Opcionalmente se restringe a un subdirectorio y a archivos que coincidan con un glob (p. ej. '*.py').",
@@ -3496,6 +3514,12 @@ const es: Dict = {
   "code.roles.panel": "panel",
   "code.roles.unproven":
     "Enrutar cada rol a un modelo distinto AÚN no está medido. Ver bench/role_routing — hasta que se ejecute, esto es una elección de coste y de modelos, no una afirmación de que funcione mejor.",
+  "code.todo.title": "Lista de tareas",
+  "code.todo.claimed":
+    "{done} de {total} completadas — lo que el agente dice de su propio avance, no un veredicto.",
+  "code.todo.status.done": "hecho",
+  "code.todo.status.doing": "haciendo",
+  "code.todo.status.pending": "por hacer",
   "code.worth.title": "¿Valió la pena?",
   "code.worth.profile": "perfil",
   "code.worth.runs": "ejecuciones",
@@ -4004,6 +4028,8 @@ const fr: Dict = {
     "Remplace une sous-chaîne exacte dans un fichier du workspace (édition chirurgicale — préférez ceci à write_file pour modifier un fichier existant). 'old' doit correspondre exactement et, sauf si replace_all vaut true, apparaître exactement une fois ; une correspondance absente ou ambiguë est refusée.",
   "tools.desc.apply_patch":
     "Applique plusieurs hunks search/replace à un seul fichier du workspace, de façon atomique. Le patch est une suite de blocs '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE' ; chaque SEARCH doit correspondre exactement une fois. Si un hunk ne s'ancre pas, le fichier reste inchangé.",
+  "tools.desc.todo_write":
+    "Enregistrez votre liste de tâches pour cette exécution, en remplaçant ce que vous aviez enregistré. Envoyez tous les éléments à chaque fois, y compris ceux qui sont terminés. Au plus un élément peut être en « doing ». À utiliser pour un travail en plusieurs étapes, afin que la progression survive à une compaction du contexte et que la personne qui regarde voie où vous en êtes.",
   "tools.desc.list_dir": "Liste les entrées d'un répertoire du workspace.",
   "tools.desc.grep":
     "Cherche dans le contenu des fichiers par expression régulière. Renvoie les correspondances au format 'relpath:lineno: line'. Peut se restreindre à un sous-répertoire et aux fichiers correspondant à un glob (par ex. '*.py').",
@@ -4811,6 +4837,12 @@ const fr: Dict = {
   "code.roles.panel": "panel",
   "code.roles.unproven":
     "Router chaque rôle vers un modèle différent n'est PAS encore mesuré. Voir bench/role_routing — tant que ce n'est pas exécuté, c'est un choix de coût et de modèles, pas une affirmation que cela marche mieux.",
+  "code.todo.title": "Liste de tâches",
+  "code.todo.claimed":
+    "{done} sur {total} terminées — ce que l'agent dit de sa propre progression, pas un verdict.",
+  "code.todo.status.done": "fait",
+  "code.todo.status.doing": "en cours",
+  "code.todo.status.pending": "à faire",
   "code.worth.title": "Est-ce que ça valait le coup ?",
   "code.worth.profile": "profil",
   "code.worth.runs": "exécutions",
@@ -5319,6 +5351,8 @@ const de: Dict = {
     "Ersetzt einen exakten Teilstring in einer Datei im Workspace (chirurgische Änderung — nimm dafür lieber das hier als write_file, wenn du eine bestehende Datei änderst). 'old' muss exakt passen und, sofern replace_all nicht true ist, genau einmal vorkommen; eine fehlende oder mehrdeutige Fundstelle wird abgelehnt.",
   "tools.desc.apply_patch":
     "Wendet mehrere search/replace-Hunks atomar auf eine einzelne Datei im Workspace an. Der Patch ist eine Folge von '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'-Blöcken; jedes SEARCH muss genau einmal passen. Verankert sich ein Hunk nicht, bleibt die Datei unverändert.",
+  "tools.desc.todo_write":
+    "Halten Sie Ihre Aufgabenliste für diesen Lauf fest und ersetzen Sie damit die vorherige. Senden Sie jedes Mal alle Einträge, auch die erledigten. Höchstens ein Eintrag darf auf 'doing' stehen. Nutzen Sie das bei mehrstufiger Arbeit, damit der Fortschritt eine Kontextverdichtung übersteht und wer zusieht erkennt, wo Sie stehen.",
   "tools.desc.list_dir":
     "Listet die Einträge eines Verzeichnisses im Workspace auf.",
   "tools.desc.grep":
@@ -6125,6 +6159,12 @@ const de: Dict = {
   "code.roles.panel": "Panel",
   "code.roles.unproven":
     "Jede Rolle auf ein eigenes Modell zu routen ist NOCH NICHT gemessen. Siehe bench/role_routing — bis das läuft, ist das eine Entscheidung über Kosten und Modelle, keine Behauptung, dass es besser funktioniert.",
+  "code.todo.title": "Aufgabenliste",
+  "code.todo.claimed":
+    "{done} von {total} erledigt — was der Agent über seinen eigenen Fortschritt sagt, kein Urteil.",
+  "code.todo.status.done": "erledigt",
+  "code.todo.status.doing": "läuft",
+  "code.todo.status.pending": "offen",
   "code.worth.title": "Hat es sich gelohnt?",
   "code.worth.profile": "Profil",
   "code.worth.runs": "Läufe",
@@ -6627,6 +6667,8 @@ const zh: Dict = {
     "替换工作区文件中的一段精确子串（精准编辑——要改动已有文件，优先用它而不是 write_file）。'old' 必须完全匹配；除非 replace_all 为 true，否则只能出现一次。匹配不到或有歧义时会被拒绝。",
   "tools.desc.apply_patch":
     "对工作区里的一个文件原子地应用多个搜索/替换块。补丁是一串 '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE' 块；每个 SEARCH 必须恰好匹配一次。只要有一个块定位失败，文件就原样不动。",
+  "tools.desc.todo_write":
+    "记录本次运行的任务清单，覆盖你此前记录的内容。每次都发送全部条目，包括已完成的。最多只能有一个条目处于 'doing'。用于多步骤的工作，让进度在上下文压缩后仍然保留，观看的人也能看到你进行到哪一步。",
   "tools.desc.list_dir": "列出工作区中某个目录的条目。",
   "tools.desc.grep":
     "用正则表达式搜索文件内容。返回 'relpath:lineno: line' 形式的匹配。可选择只搜某个子目录，以及只搜匹配某个 glob 的文件（例如 '*.py'）。",
@@ -7372,6 +7414,12 @@ const zh: Dict = {
   "code.roles.panel": "面板",
   "code.roles.unproven":
     "把每个角色路由到不同模型这件事尚未被测量。见 bench/role_routing——在那跑完之前，这只是关于成本和模型的选择，不是它更好用的主张。",
+  "code.todo.title": "任务清单",
+  "code.todo.claimed":
+    "{total} 项中已完成 {done} 项 — 这是智能体对自身进度的说法，不是核验结论。",
+  "code.todo.status.done": "已完成",
+  "code.todo.status.doing": "进行中",
+  "code.todo.status.pending": "待办",
   "code.worth.title": "值得吗？",
   "code.worth.profile": "配置",
   "code.worth.runs": "运行",
@@ -7872,6 +7920,8 @@ const ja: Dict = {
     "ワークスペースのファイル内で、完全一致する部分文字列を置き換えます（外科的な編集 — 既存ファイルを変更するなら write_file よりこちらを使ってください）。'old' は完全に一致し、replace_all が true でない限りちょうど 1 回だけ現れる必要があります。見つからない場合や複数該当する場合は拒否されます。",
   "tools.desc.apply_patch":
     "ワークスペースの 1 つのファイルに、複数の検索／置換ハンクをアトミックに適用します。パッチは '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE' ブロックの並びで、各 SEARCH はちょうど 1 回だけ一致する必要があります。どれか 1 つでも位置を特定できなければ、ファイルは変更されません。",
+  "tools.desc.todo_write":
+    "この実行のタスクリストを記録し、以前に記録した内容を置き換えます。完了したものも含め、毎回すべての項目を送ってください。'doing' にできる項目は最大 1 件です。複数の手順がある作業で使うと、コンテキストの圧縮後も進捗が残り、見ている人が現在地を把握できます。",
   "tools.desc.list_dir": "ワークスペース内のディレクトリの項目を一覧します。",
   "tools.desc.grep":
     "正規表現でファイルの内容を検索します。一致は 'relpath:lineno: line' の形で返します。サブディレクトリに限定したり、glob に一致するファイル（例: '*.py'）に限定したりもできます。",
@@ -8662,6 +8712,12 @@ const ja: Dict = {
   "code.roles.panel": "パネル",
   "code.roles.unproven":
     "役割ごとに別のモデルへ振り分けることは、まだ測定されていません。bench/role_routing を参照してください — それが走るまで、これはコストとモデルの選択であって、より良く動くという主張ではありません。",
+  "code.todo.title": "タスクリスト",
+  "code.todo.claimed":
+    "{total} 件中 {done} 件完了 — エージェント自身の申告であり、検証結果ではありません。",
+  "code.todo.status.done": "完了",
+  "code.todo.status.doing": "作業中",
+  "code.todo.status.pending": "未着手",
   "code.worth.title": "割に合った？",
   "code.worth.profile": "プロファイル",
   "code.worth.runs": "実行",
@@ -9127,6 +9183,8 @@ const it: Dict = {
     "Sostituisce una sottostringa esatta in un file del workspace (modifica chirurgica — preferiscilo a write_file per cambiare un file esistente). 'old' deve corrispondere esattamente e, a meno che replace_all sia true, comparire esattamente una volta; una corrispondenza mancante o ambigua viene rifiutata.",
   "tools.desc.apply_patch":
     "Applica più blocchi di ricerca/sostituzione a un solo file del workspace, in modo atomico. La patch è una sequenza di blocchi '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'; ogni SEARCH deve corrispondere esattamente una volta. Se un blocco non si ancora, il file resta invariato.",
+  "tools.desc.todo_write":
+    "Registra il tuo elenco di attività per questa esecuzione, sostituendo quello registrato prima. Invia ogni volta tutti gli elementi, compresi quelli conclusi. Al massimo un elemento può essere in 'doing'. Usalo per lavori in più passaggi, così l'avanzamento sopravvive a una compattazione del contesto e chi guarda vede a che punto sei.",
   "tools.desc.list_dir": "Elenca le voci di una directory nel workspace.",
   "tools.desc.grep":
     "Cerca nel contenuto dei file con un'espressione regolare. Restituisce le corrispondenze nel formato 'relpath:lineno: line'. Facoltativamente si limita a una sottodirectory e ai file che corrispondono a un glob (es.: '*.py').",
@@ -9968,6 +10026,12 @@ const it: Dict = {
   "code.roles.panel": "panel",
   "code.roles.unproven":
     "Instradare ogni ruolo su un modello diverso NON è ancora misurato. Vedi bench/role_routing — finché non viene eseguito, questa è una scelta di costo e di modelli, non un'affermazione che funzioni meglio.",
+  "code.todo.title": "Elenco delle attività",
+  "code.todo.claimed":
+    "{done} di {total} completate — ciò che l'agente dice del proprio avanzamento, non un verdetto.",
+  "code.todo.status.done": "fatto",
+  "code.todo.status.doing": "in corso",
+  "code.todo.status.pending": "da fare",
   "code.worth.title": "Ne è valsa la pena?",
   "code.worth.profile": "profilo",
   "code.worth.runs": "esecuzioni",
@@ -10435,6 +10499,8 @@ const pl: Dict = {
     "Zamienia dokładny podciąg w pliku w workspace (chirurgiczna edycja — do zmiany istniejącego pliku wybierz to zamiast write_file). 'old' musi pasować dokładnie i — o ile replace_all nie jest true — wystąpić dokładnie raz; brak dopasowania albo dopasowanie niejednoznaczne kończy się odmową.",
   "tools.desc.apply_patch":
     "Nakłada wiele fragmentów search/replace na jeden plik w workspace, atomowo. Patch to ciąg bloków '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'; każdy SEARCH musi pasować dokładnie raz. Jeśli którykolwiek fragment się nie zakotwiczy, plik zostaje bez zmian.",
+  "tools.desc.todo_write":
+    "Zapisz swoją listę zadań dla tego przebiegu, zastępując to, co zapisałeś wcześniej. Za każdym razem wysyłaj wszystkie pozycje, także ukończone. Najwyżej jedna pozycja może mieć status 'doing'. Używaj tego przy pracy wieloetapowej, aby postęp przetrwał kompaktowanie kontekstu, a osoba obserwująca widziała, gdzie jesteś.",
   "tools.desc.list_dir": "Wypisuje wpisy katalogu w workspace.",
   "tools.desc.grep":
     "Przeszukuje zawartość plików wyrażeniem regularnym. Zwraca dopasowania w postaci 'relpath:lineno: line'. Opcjonalnie ogranicza się do podkatalogu i do plików pasujących do glob (np. '*.py').",
@@ -11269,6 +11335,12 @@ const pl: Dict = {
   "code.roles.panel": "panel",
   "code.roles.unproven":
     "Kierowanie każdej roli do innego modelu NIE zostało jeszcze zmierzone. Zobacz bench/role_routing — dopóki to nie zostanie uruchomione, jest to wybór kosztu i modeli, a nie twierdzenie, że działa lepiej.",
+  "code.todo.title": "Lista zadań",
+  "code.todo.claimed":
+    "{done} z {total} ukończonych — to, co agent mówi o własnym postępie, a nie werdykt.",
+  "code.todo.status.done": "gotowe",
+  "code.todo.status.doing": "w toku",
+  "code.todo.status.pending": "do zrobienia",
   "code.worth.title": "Czy było warto?",
   "code.worth.profile": "profil",
   "code.worth.runs": "uruchomienia",
@@ -11736,6 +11808,8 @@ const ru: Dict = {
     "Заменяет точную подстроку в файле рабочей папки (точечная правка — для изменения существующего файла берите это, а не write_file). 'old' должен совпадать буквально и, если replace_all не true, встречаться ровно один раз; если совпадения нет или их несколько, правка отклоняется.",
   "tools.desc.apply_patch":
     "Применяет несколько блоков поиска/замены к одному файлу рабочей папки, атомарно. Патч — это последовательность блоков '<<<<<<< SEARCH / ======= / >>>>>>> REPLACE'; каждый SEARCH должен совпасть ровно один раз. Если хотя бы один блок не находит своё место, файл остаётся нетронутым.",
+  "tools.desc.todo_write":
+    "Запишите список задач для этого запуска, заменив то, что записали раньше. Каждый раз отправляйте все пункты, включая завершённые. Не более одного пункта может быть в состоянии 'doing'. Используйте это для работы из нескольких шагов, чтобы прогресс пережил уплотнение контекста и наблюдающий видел, где вы находитесь.",
   "tools.desc.list_dir": "Перечисляет содержимое каталога в рабочей папке.",
   "tools.desc.grep":
     "Ищет по содержимому файлов регулярным выражением. Возвращает совпадения в виде 'relpath:lineno: line'. Можно ограничить поиск подкаталогом и файлами, подходящими под glob (например, '*.py').",
@@ -12576,6 +12650,12 @@ const ru: Dict = {
   "code.roles.panel": "панель",
   "code.roles.unproven":
     "Направление каждой роли к своей модели ПОКА не измерено. Смотрите bench/role_routing — пока это не запущено, перед вами выбор про стоимость и модели, а не утверждение, что так лучше.",
+  "code.todo.title": "Список задач",
+  "code.todo.claimed":
+    "{done} из {total} выполнено — это слова самого агента о своём прогрессе, а не проверенный результат.",
+  "code.todo.status.done": "готово",
+  "code.todo.status.doing": "в работе",
+  "code.todo.status.pending": "к выполнению",
   "code.worth.title": "Стоило ли оно того?",
   "code.worth.profile": "профиль",
   "code.worth.runs": "запуски",

--- a/apps/desktop/src/test/code-api-mock.ts
+++ b/apps/desktop/src/test/code-api-mock.ts
@@ -243,6 +243,7 @@ export function scriptTurn(
     verified?: CodeVerified;
     done?: Partial<CodeTurnDone>;
     error?: boolean;
+    todos?: { task: string; status: string }[][];
   } = {},
 ) {
   return async (_req: unknown, h: CodeTurnHandlers) => {
@@ -250,6 +251,8 @@ export function scriptTurn(
     for (const token of script.tokens ?? []) h.onToken?.(token);
     for (const tool of script.tools ?? []) h.onTool?.(tool);
     for (const edit of script.edits ?? []) h.onEdit?.(edit.path, edit.patch);
+    // Each frame is the WHOLE list, so a script sends snapshots, not additions.
+    for (const todo of script.todos ?? []) h.onTodo?.(todo);
     if (script.error) {
       h.onError?.("boom");
       return;

--- a/chimera/api/code_api.py
+++ b/chimera/api/code_api.py
@@ -1131,6 +1131,20 @@ def register_code_api(
             edited.append(path)
             emit("edit", {"path": path, "patch": patch})
 
+        def on_todo(items: list[dict[str, str]]) -> None:
+            """The agent's own task list, whole, each time it records one.
+
+            `claimed` travels with it and is not decoration. Every other structured frame this
+            surface sends reports something that was observed — `edit` carries a diff read off
+            disk, `verified` carries a command's exit code — and a row of ticks is exactly the
+            shape a reader has been taught to trust. This one is what the model said about
+            itself, so the frame says so and the screen has to repeat it.
+
+            Sent whole rather than as a delta: `seq` gives this surface replay, but a consumer
+            that renders a partial list would show a list that never existed.
+            """
+            emit("todo", {"items": items, "claimed": True})
+
         def work() -> None:
             try:
                 # Taken BEFORE the turn, so a turn that edits can be judged and undone like a run.
@@ -1280,6 +1294,7 @@ def register_code_api(
                         on_token=on_token if (req.stream and not fused) else None,
                         on_tool=on_tool,
                         on_edit=on_edit,
+                        on_todo=on_todo,
                         images=images or None,
                     )
                     if fused:

--- a/chimera/config.py
+++ b/chimera/config.py
@@ -338,6 +338,20 @@ class Settings(BaseSettings):
     # report a LOSS, which below a handful of tools it truthfully is.
     defer_tools: bool = Field(default=False, validation_alias="CHIMERA_DEFER_TOOLS")
 
+    # --- The task list the agent keeps for itself (chimera/tools/todo.py).
+    # On, and the reasoning differs from the two flags above it, so it is written down rather than
+    # assumed. `defer_tools` and `edit_batch` are interventions with a quality claim: each has a
+    # measurable arm, so each waits for its measurement. This one makes no quality claim. It records
+    # what the agent says about its own progress, so the list survives a compaction (`RunState.tasks`
+    # was built for exactly this and never received anything) and a person watching a long run can
+    # see where it is. There is no arm that could refute it — it is either called or it is not.
+    #
+    # The price is stated instead: 657 characters of schema in every prompt of every step, which
+    # `chimera.tools.todo.schema_cost_chars` recomputes rather than trusting this comment. What to
+    # watch is adoption: a tool the model never calls is 657 characters of nothing, and that is the
+    # number that would turn this default off.
+    todo_list: bool = Field(default=True, validation_alias="CHIMERA_TODO_LIST")
+
     # --- Auto-fuse error-sensitive turns in solve/crew without an explicit --fuse.
     # Off by default (fusion costs 2-3x); when on, the cost-aware router still keeps
     # cheap/tool turns single-model and only fuses deep or error-sensitive ones. ---

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -113,6 +113,32 @@ def _default_compact_schemas() -> bool:
     return get_settings().compact_schemas
 
 
+#: The sentence that turns the task-list schema into a task list. See `Agent.run` for the
+#: measurement that decides it is not optional.
+TODO_PROMPT = (
+    "When a task has several steps, record them with todo_write before you start and update the "
+    "list as each one finishes. It is your own account of your progress, so keep it true: mark a "
+    "step done when it is done, not when you intend to do it."
+)
+
+
+def _find_tool(tools: ToolRegistry, name: str) -> Any:
+    """The registered tool under ``name``, unwrapped, or None when the session does not grant it.
+
+    Unwrapped because governance and the taint ledger each return a *new* registry of wrappers
+    around the original tools, so what the loop holds by then is a `GovernedTool` around a
+    `LedgeredTool` around the thing with the method. Absent is the ordinary case, not an error: a
+    session allowlist that did not name this tool is an operator decision, and the loop's answer to
+    it is to run without.
+    """
+    if name not in tools:
+        return None
+    found: Any = tools.get(name)
+    while not hasattr(found, "bind") and getattr(found, "inner", None) is not None:
+        found = found.inner
+    return found if hasattr(found, "bind") else None
+
+
 @dataclass
 class AgentConfig:
     """Tunable behaviour for an :class:`Agent` run."""
@@ -310,6 +336,7 @@ class Agent:
         #: What a compaction must restore. A caller that knows the open file, the plan or the task
         #: list assigns it here; left empty, compaction still keeps the recent tail.
         self.run_state = RunState()
+
         # The skill library surfaced as context. Defaults to the built-in registry (lazy, shared),
         # so every construction site picks up skills without changes; pass an explicit one to override.
         self.skills = skills
@@ -402,6 +429,7 @@ class Agent:
         on_token: Callable[[str], None] | None = None,
         on_tool: Callable[[ToolActivity], None] | None = None,
         on_edit: Callable[[str, str], None] | None = None,
+        on_todo: Callable[[list[dict[str, str]]], None] | None = None,
         history: list[MessageLike] | None = None,
         images: list[str] | None = None,
         should_stop: Callable[[], bool] | None = None,
@@ -424,7 +452,24 @@ class Agent:
         ``should_stop`` is polled once per step and ends the run with ``stopped_reason="cancelled"``,
         keeping everything done so far. A model call already in flight cannot be interrupted, so a
         step boundary is as fine as cancellation gets — but it is far finer than an attempt
-        boundary, which is where the only cancel check used to live."""
+        boundary, which is where the only cancel check used to live.
+
+        ``on_todo`` fires with the whole task list each time the agent records one. What it carries
+        is the agent's own claim about its progress — unlike ``on_edit``, which reports a diff read
+        off disk — so a consumer that renders it owes the reader that distinction."""
+        # Attached per call rather than at construction: the sink belongs to this invocation, and a
+        # second turn with no sink must not keep announcing into the first turn's queue.
+        # Bound here rather than at construction, and per call: the sink belongs to THIS
+        # invocation (a second turn with no sink must not keep announcing into the first turn's
+        # queue), and the binding is thread-local, so it has to happen on the thread that will run.
+        todo = _find_tool(self.tools, "todo_write")
+        if todo is not None:
+            todo.bind(
+                self.run_state,
+                (lambda items: on_todo([{"task": i.task, "status": i.status} for i in items]))
+                if on_todo is not None
+                else None,
+            )
         system_prompt = self.config.system_prompt
         skill_block = self._skill_context(task)
         if skill_block:
@@ -449,6 +494,18 @@ class Agent:
         # silently.
         if self.config.instructions:
             system_prompt = f"{system_prompt}\n\n{self.config.instructions}"
+        # Last of all, and only when the session actually granted the tool: a sentence telling a
+        # model to use something it was not given is a sentence that invites a call to nothing.
+        #
+        # It is here because the schema alone does not work, and that is measured rather than
+        # assumed. Same task, same models, one sentence of difference: bare, `todo_write` was called
+        # 0 times by either of two models; nudged, glm-5.3 called it 4 times with a correct
+        # progression. deepseek-v4-flash called it 0 times in 4 nudged runs, so on that model this
+        # buys nothing — which is a fact about the shipped default, recorded in `chimera/config.py`
+        # rather than left for a user to discover. Without this line the tool is 657 characters of
+        # schema and no behaviour at all.
+        if todo is not None:
+            system_prompt = f"{system_prompt}\n\n{TODO_PROMPT}"
         # Remembered here so a compaction can put it back. The task arrives as the last user message
         # and, after enough turns, falls out of the tail that compaction keeps — leaving the agent
         # executing a plan whose purpose was deleted. Set at the loop rather than by each caller

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -41,6 +41,7 @@ from chimera.core.events import edit as _ev_edit
 from chimera.core.events import final as _ev_final
 from chimera.core.events import result as _ev_result
 from chimera.core.events import status as _ev_status
+from chimera.core.events import todo as _ev_todo
 from chimera.core.events import tool as _ev_tool
 from chimera.core.ledger import ProgressLedger, TaskLedger
 from chimera.core.planner import Plan, Planner
@@ -525,6 +526,19 @@ class AutonomousAgent:
             )
         )
 
+    def _emit_todo(self, items: list[dict[str, str]]) -> None:
+        """Forward the worker's own task list as a ``todo`` event through the sink.
+
+        The one frame in this vocabulary that reports a *claim* rather than an observation, which
+        the event carries as ``claimed`` so no consumer has to infer it. Worth the distinction:
+        ``result`` frames come from a verifier's exit code and ``edit`` frames from a diff read off
+        disk, so a reader who learned to trust those would have no reason to read this one
+        differently — and a row of ticks is exactly the shape that gets trusted.
+        """
+        if self.on_event is None:
+            return
+        self._emit(_ev_todo(items))
+
     def _run_worker(
         self, worker: Worker, prompt: str, *, spend: SpendBudget | None = None
     ) -> AgentResult:
@@ -559,6 +573,8 @@ class AutonomousAgent:
                 kwargs["on_edit"] = self._emit_edit
             if "on_tool" in accepted:
                 kwargs["on_tool"] = self._emit_tool
+            if "on_todo" in accepted:
+                kwargs["on_todo"] = self._emit_todo
         if not kwargs:
             return worker.run(prompt)
         try:

--- a/chimera/core/code_session.py
+++ b/chimera/core/code_session.py
@@ -24,6 +24,7 @@ safe, because that is where every turn starts.
 
 from __future__ import annotations
 
+import inspect
 import json
 import uuid
 from collections.abc import Callable
@@ -154,6 +155,7 @@ class CodeSession:
         on_token: Callable[[str], None] | None = None,
         on_tool: Callable[[ToolActivity], None] | None = None,
         on_edit: Callable[[str, str], None] | None = None,
+        on_todo: Callable[[list[dict[str, str]]], None] | None = None,
         images: list[str] | None = None,
     ) -> AgentResult:
         """Run one turn with the previous turns as history, and absorb the result.
@@ -166,7 +168,19 @@ class CodeSession:
         # open-source framework, so an implementation written before images existed is a reasonable
         # thing to find in the wild — and passing `images=None` to it would break it for the sake of
         # sending nothing.
+        # `on_todo` joins `images` in the conditional block for the reason written above it, and
+        # it is the newer of the two: `SupportsCodeRun` is published, so an implementation that
+        # predates the task list must not be handed a keyword it never declared.
+        #
+        # The signature is READ rather than assumed, which the same seam in `AutonomousAgent.
+        # _run_worker` already does for `on_edit`/`on_tool`. Writing the rule as a comment and
+        # forwarding unconditionally is how the first draft of this looked: the prose said an
+        # older implementation was safe, and every stub agent in the suite raised TypeError on
+        # the first turn. The `**kwargs`-only case is covered too, by asking whether the
+        # parameter is named — a callable that swallows anything accepts it either way.
         extra: dict[str, Any] = {"images": images} if images else {}
+        if on_todo is not None and _accepts(self.agent.run, "on_todo"):
+            extra["on_todo"] = on_todo
         result = self.agent.run(
             task,
             on_token=on_token,
@@ -235,6 +249,27 @@ class CodeSession:
             return
         self.receipts.append(receipt)
         del self.receipts[:-MAX_RECEIPTS]
+
+
+def _accepts(run: Any, name: str) -> bool:
+    """Whether ``run`` DECLARES a keyword called ``name``. A ``**kwargs`` catch-all does not count.
+
+    Counting the catch-all is the tempting reading and it is wrong, because a callable that swallows
+    every keyword usually forwards them to something that does not. Measured: `_EditingAgent` in the
+    API suite is `run(self, task, **kw)` calling `super().run(task, **kw)`, and the parent names four
+    callbacks and not this one — so "it accepts anything" meant "it raises TypeError one frame
+    deeper", and six turns died before their first tool call.
+
+    The alternative is what `AutonomousAgent._run_worker` does: forward, catch TypeError, retry
+    plain. That is right there, where the retry costs one more model call. Here the turn may already
+    have written files and paid for tool calls before the TypeError, so a blind second attempt would
+    do that work twice. A named parameter is explicit support; anything else runs without the frames.
+    """
+    try:
+        params = inspect.signature(run).parameters
+    except (TypeError, ValueError):  # unintrospectable callable (C impl / odd wrapper)
+        return False
+    return name in params
 
 
 class CodeSessionStore:

--- a/chimera/core/events.py
+++ b/chimera/core/events.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-EventKind = Literal["status", "attempt", "result", "final", "token", "edit", "tool"]
+EventKind = Literal["status", "attempt", "result", "final", "token", "edit", "tool", "todo"]
 
 # A sink for events. Kept as a plain callable so any consumer (print, a queue, an SSE writer)
 # plugs in without a shared base class.
@@ -110,6 +110,28 @@ def tool(name: str, arguments: dict[str, Any], ok: bool, observation: str = "") 
             "ok": ok,
             "observation": _clip_observation(observation or "", TOOL_OBSERVATION_CHARS),
         },
+    )
+
+
+def todo(items: list[dict[str, str]]) -> AgentEvent:
+    """The run's task list, as the agent just declared it.
+
+    ``claimed`` is in the payload and is not decoration. Every other structured event in this
+    vocabulary reports something the harness observed: ``edit`` carries a diff read off disk before
+    and after, ``result`` carries a verifier's exit code. This one carries what the model said about
+    its own progress, which nothing checked — and a row of ticks renders identically whether it was
+    earned or asserted. A consumer that drops the flag is free to; a consumer that never had it
+    would have no way to know it needed one.
+
+    Sent whole rather than as a delta, mirroring the tool: a UI that missed one frame would
+    otherwise render a list that never existed, and there is no sequence number here to notice with.
+    """
+    counts = {status: sum(1 for i in items if i.get("status") == status) for status in
+              ("pending", "doing", "done")}
+    return AgentEvent(
+        "todo",
+        f"task list: {counts['done']}/{len(items)} done",
+        {"items": list(items), "claimed": True, **counts},
     )
 
 

--- a/chimera/governance/governed_tool.py
+++ b/chimera/governance/governed_tool.py
@@ -75,6 +75,14 @@ _DOCUMENT_ARGS = frozenset(
         # walking in would print them. The tool name stays as the identifier, so the audit line
         # still says WHAT was called; only the payload becomes a character count.
         "arguments",
+        # todo_write: the whole task list. A body rather than an identifier, on both counts the
+        # list is read for. The identity of the call is "recorded a task list"; the text is prose
+        # the model wrote, of no fixed length, and a step reading "delete the old keys from
+        # config/secrets.env" would be judged by shell rules for words that describe an intention
+        # rather than issue a command. It is NOT nested: the keys inside are ours (`task`,
+        # `status`), but neither is a secret-shaped name, so walking in would print the same
+        # prose the elision exists to keep out of a log the app serves over HTTP.
+        "items",
     }
 )
 

--- a/chimera/tools/builtin.py
+++ b/chimera/tools/builtin.py
@@ -111,6 +111,14 @@ def default_registry(
     # says it earns its place — not before.
     if settings.edit_batch:
         registry.register(EditBatchTool(workspace, write_region=write_region))
+    # In the default registry, not bolted on by the loop afterwards, and that is the whole point:
+    # a session the operator scoped to two tools must not quietly gain a third. Here it passes
+    # through `restrict_registry` and the governance wrappers like everything else. It carries no
+    # state of its own — `Agent.run` binds this thread's run state before the first step.
+    if settings.todo_list:
+        from chimera.tools.todo import TodoWriteTool
+
+        registry.register(TodoWriteTool())
     registry.register(ListDirTool(workspace))
     registry.register(GrepTool(workspace, trust_workspace=trust_workspace))
     registry.register(GlobTool(workspace))

--- a/chimera/tools/todo.py
+++ b/chimera/tools/todo.py
@@ -1,0 +1,246 @@
+"""The task list the agent keeps for itself — declared by the agent, never inferred by the harness.
+
+``RunState.tasks`` has existed since compaction was written, carrying a docstring that says exactly
+what it is for: *"Task list with status, so finished work is not redone. Status is the point: a bare
+copy of the plan's steps asserts that none are done, which is a claim, not a blank."*
+
+Nothing ever wrote to it. ``AutonomousAgent._seed_run_state`` says why, in as many words: that loop
+counts attempts, not steps, so it has no completion to report, and filling the field from the plan
+would be *"a lie in the field whose entire purpose is to be believed"*.
+
+Both of those are right, and this module does not overturn either. The field was empty because no
+truthful source of completion existed — and there is exactly one source that can be truthful about
+what an agent has finished, which is the agent. This tool is that source. What it records is a
+**claim**, and every surface that renders it has to say so; a list of ticks that reads as verified
+progress would be a new instance of the defect this repository has just spent a release fixing six
+of, where a screen states something true beside something it has no way to know.
+
+Two rules are enforced rather than suggested, because both are cheap and both are what makes the
+list worth reading:
+
+* **At most one item in progress.** A list with six items "doing" answers no question. This is the
+  only field that tells a reader — or the agent after a compaction — where the work actually is.
+* **Dropped items are named.** An agent that quietly deletes a requirement from its own list looks
+  identical, in the rendered output, to one that never had it. The observation names what left, so
+  the omission has to be deliberate rather than silent.
+
+Cost, stated because this repository's convention is that a tool schema earns its place: this adds
+one schema to every prompt of every step for the whole run, the same charge that keeps ``edit_batch``
+off by default (``bench/edit_tools``) and that ``chimera/tools/defer.py`` measured at 86% of the
+schema budget for the 18 tools nobody calls. :func:`schema_cost_chars` reports the number so a
+future measurement can put it against whatever the list is worth, instead of arguing about it.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from chimera.tools.base import Tool
+
+#: The three states. Deliberately three: "blocked" invites an agent to park work it should be
+#: reporting as a failure, and a fourth word buys nothing a sentence in the task text cannot say.
+STATUSES = ("pending", "doing", "done")
+
+
+@dataclass(frozen=True)
+class TodoItem:
+    """One line of the list: what it is, and where it stands."""
+
+    task: str
+    status: str
+
+    def render(self) -> str:
+        """The form that goes into the prompt on restore — status first, so it scans."""
+        return f"[{self.status}] {self.task}"
+
+
+def render(items: list[TodoItem]) -> list[str]:
+    """The list as ``RunState.tasks`` holds it: plain strings, one per item.
+
+    ``RunState.tasks`` is ``list[str]`` and ``RunState.as_message`` already renders it. Keeping the
+    structure here and the strings there means the restore path needs no change at all — the field
+    that was designed for this receives exactly what its docstring describes.
+    """
+    return [item.render() for item in items]
+
+
+class TodoWriteTool(Tool):
+    """Record the run's task list. Replaces the whole list; the agent owns it.
+
+    Whole-list replacement rather than per-item patching is the smaller contract: a patch API needs
+    stable ids, an agent that loses track of an id writes a duplicate, and the failure is invisible.
+    Sending the list back every time costs a few tokens and cannot desynchronise.
+    """
+
+    name = "todo_write"
+    description = (
+        "Record your task list for this run, replacing whatever you recorded before. "
+        "Send every item each time, including the finished ones. At most one item may be 'doing'. "
+        "Use this for work with several steps so progress survives a context compaction and the "
+        "person watching can see where you are."
+    )
+    parameters = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "description": "The complete list, in order.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "task": {"type": "string", "description": "What is to be done."},
+                        "status": {"type": "string", "enum": list(STATUSES)},
+                    },
+                    "required": ["task", "status"],
+                },
+            }
+        },
+        "required": ["items"],
+    }
+
+    def __init__(
+        self,
+        state: Any = None,
+        *,
+        on_change: Callable[[list[TodoItem]], None] | None = None,
+    ) -> None:
+        """One instance lives in the registry; what it writes to is chosen per thread.
+
+        This tool is registered like every other, which is what makes the session allowlist and the
+        governance kernel govern it — a registry the operator scoped down to two tools must not
+        quietly gain a third, however harmless the third one is. But a registry is routinely SHARED:
+        a crew runs several workers off one, concurrently, in separate threads, and a single
+        instance holding a single ``state`` would merge their lists into one and report entries no
+        worker in that run created.
+
+        Thread-local binding is what reconciles those. `Agent.run` binds its own run state at the
+        top of the call, so each concurrently running agent writes to its own list, and a sequential
+        second run rebinds rather than inheriting. Constructed with an explicit ``state`` — as tests
+        and library callers do — it binds that one immediately for the calling thread.
+        """
+        self._local = threading.local()
+        #: The structured list per thread lives beside the state it mirrors, for the same reason.
+        if state is not None:
+            self.bind(state, on_change)
+
+    def bind(self, state: Any, on_change: Callable[[list[TodoItem]], None] | None = None) -> None:
+        """Point this thread's writes at ``state``, announcing through ``on_change``."""
+        self._local.state = state
+        self._local.on_change = on_change
+        self._local.items = []
+
+    @property
+    def state(self) -> Any:
+        """This thread's carrier, defaulting to a private one so an unbound call still records."""
+        found = getattr(self._local, "state", None)
+        if found is None:
+            from chimera.core.context_budget import RunState
+
+            found = RunState()
+            self.bind(found)
+        return found
+
+    @property
+    def on_change(self) -> Callable[[list[TodoItem]], None] | None:
+        return getattr(self._local, "on_change", None)
+
+    @property
+    def items(self) -> list[TodoItem]:
+        self.state  # noqa: B018 - ensures this thread is bound before reading its list
+        return list(getattr(self._local, "items", []))
+
+    def run(self, **kwargs: Any) -> str:
+        raw = kwargs.get("items")
+        # Some backends hand an array-valued argument back as its JSON text. Parsing it here costs
+        # one branch and turns a whole class of provider-shaped failure into a working call.
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return "error: 'items' must be a list of {task, status} objects"
+        if not isinstance(raw, list):
+            return "error: 'items' must be a list of {task, status} objects"
+
+        parsed: list[TodoItem] = []
+        for entry in raw:
+            if not isinstance(entry, dict):
+                return "error: every item must be an object with 'task' and 'status'"
+            task = str(entry.get("task") or "").strip()
+            status = str(entry.get("status") or "").strip().lower()
+            if not task:
+                return "error: an item has an empty 'task'"
+            if status not in STATUSES:
+                return f"error: status must be one of {', '.join(STATUSES)} (got {status!r})"
+            parsed.append(TodoItem(task=task, status=status))
+
+        doing = [item.task for item in parsed if item.status == "doing"]
+        if len(doing) > 1:
+            # Refused rather than normalised. Silently demoting the extras would leave the agent
+            # believing a list it does not have, which is the failure this whole module exists to
+            # avoid — and the message is enough for it to send a corrected list on the next step.
+            return (
+                "error: at most one item may be 'doing' at a time, and "
+                f"{len(doing)} were sent ({'; '.join(doing)}). "
+                "Mark the one you are working on now and leave the rest 'pending'."
+            )
+
+        dropped = [item.task for item in self.items if item.task not in {p.task for p in parsed}]
+        state = self.state
+        self._local.items = parsed
+        # Assigned, not mutated in place: a caller holding the old list keeps a coherent snapshot
+        # rather than watching it change under them mid-render.
+        state.tasks = render(parsed)
+        if self.on_change is not None:
+            # Suppressed, and the breadth is the point: the list is already committed by the
+            # time this runs, so a renderer that falls over must not undo a record the agent
+            # has been told it made. A narrower catch would let one broken consumer decide
+            # what the run believes about its own progress.
+            with contextlib.suppress(Exception):
+                self.on_change(list(parsed))
+
+        return self._observation(parsed, dropped)
+
+    @staticmethod
+    def _observation(items: list[TodoItem], dropped: list[str]) -> str:
+        """What the model reads back — its own list, plus anything that left it.
+
+        Echoing the list is not decoration: it is the only way the agent can tell a call that landed
+        from one the provider mangled, and it is what a later step reads when deciding what is next.
+        """
+        counts = {status: sum(1 for i in items if i.status == status) for status in STATUSES}
+        head = (
+            f"Task list recorded — {counts['done']} done, "
+            f"{counts['doing']} in progress, {counts['pending']} pending."
+        )
+        body = "\n".join(item.render() for item in items) or "(the list is empty)"
+        note = (
+            "\n\nNo longer in the list, and therefore no longer reported as work you are doing:\n"
+            + "\n".join(f"- {task}" for task in dropped)
+            if dropped
+            else ""
+        )
+        return f"{head}\n{body}{note}"
+
+
+def schema_cost_chars() -> int:
+    """Characters this tool's schema adds to every prompt of every step, for the whole run.
+
+    Reported rather than assumed, because the repository's standing rule for a new tool is that it
+    earns its schema. ``bench/edit_tools`` is the precedent that kept a measured-but-marginal tool
+    off by default; this number is what a comparable measurement for the task list would weigh.
+    """
+    return len(
+        json.dumps(
+            {
+                "name": TodoWriteTool.name,
+                "description": TodoWriteTool.description,
+                "parameters": TodoWriteTool.parameters,
+            },
+            separators=(",", ":"),
+        )
+    )

--- a/tests/test_the_task_list_was_a_field_nothing_ever_wrote_to.py
+++ b/tests/test_the_task_list_was_a_field_nothing_ever_wrote_to.py
@@ -1,0 +1,407 @@
+"""``RunState.tasks`` shipped with a docstring, a renderer, and no writer.
+
+The field has existed since compaction was written. ``RunState.as_message`` renders it. Its comment
+says what it is for — *"Task list with status, so finished work is not redone"* — and
+``AutonomousAgent._seed_run_state`` says, in as many words, why that loop must not fill it: it
+counts attempts, not steps, so it has no completion to report and inventing one would be *"a lie in
+the field whose entire purpose is to be believed"*.
+
+Both were right. What was missing is the only source that can truthfully say a step is finished,
+which is the agent. These tests hold the tool that lets it say so, and the three properties that
+make the answer worth having: the list reaches the field the restore path already reads, one run's
+list cannot be written by another run's agent, and what the tool reports is labelled a claim
+everywhere it travels.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from chimera.core import Agent, AgentConfig
+from chimera.core.context_budget import RunState
+from chimera.core.events import todo as todo_event
+from chimera.providers import CompletionResult, ToolCall
+from chimera.tools import ToolRegistry
+from chimera.tools.builtin import EchoTool
+from chimera.tools.todo import STATUSES, TodoItem, TodoWriteTool, render, schema_cost_chars
+
+
+def _tool(**kw: Any) -> TodoWriteTool:
+    return TodoWriteTool(RunState(), **kw)
+
+
+def _three() -> list[dict[str, str]]:
+    return [
+        {"task": "read the schema", "status": "done"},
+        {"task": "write the catalogue", "status": "doing"},
+        {"task": "check the format", "status": "pending"},
+    ]
+
+
+# --- what the tool records -----------------------------------------------------------------------
+
+
+def test_the_list_lands_in_the_field_the_restore_path_reads() -> None:
+    """The whole point. `as_message` already renders `tasks`; nothing ever put anything there."""
+    state = RunState()
+    TodoWriteTool(state).run(items=_three())
+    assert state.tasks == [
+        "[done] read the schema",
+        "[doing] write the catalogue",
+        "[pending] check the format",
+    ]
+
+
+def test_a_compaction_restores_the_list_with_its_status() -> None:
+    """Status is the reason the field exists: bare steps assert that none are done."""
+    state = RunState()
+    state.task = "build the catalogue"
+    TodoWriteTool(state).run(items=_three())
+    message = state.as_message()
+    assert message is not None
+    content = message["content"]
+    assert "[done] read the schema" in content
+    assert "[doing] write the catalogue" in content
+    assert "[pending] check the format" in content
+
+
+def test_the_observation_echoes_the_list_back() -> None:
+    """The agent's only way to tell a call that landed from one the provider mangled."""
+    out = _tool().run(items=_three())
+    assert "1 done, 1 in progress, 1 pending" in out
+    assert "[doing] write the catalogue" in out
+
+
+def test_the_counts_in_the_observation_are_the_real_ones() -> None:
+    out = _tool().run(items=[{"task": f"t{i}", "status": "done"} for i in range(4)])
+    assert "4 done, 0 in progress, 0 pending" in out
+
+
+def test_an_empty_list_is_recorded_rather_than_refused() -> None:
+    """Clearing the list is a legitimate thing to say, and it must not read as an error."""
+    tool = _tool()
+    tool.run(items=_three())
+    out = tool.run(items=[])
+    assert not out.startswith("error:")
+    assert tool.state.tasks == []
+
+
+# --- the two rules that are enforced ---------------------------------------------------------------
+
+
+def test_two_items_in_progress_is_refused() -> None:
+    out = _tool().run(items=[{"task": "a", "status": "doing"}, {"task": "b", "status": "doing"}])
+    assert out.startswith("error:")
+    assert "a; b" in out, "the refusal has to name which ones, or the agent guesses"
+
+
+def test_a_refused_call_leaves_the_previous_list_standing() -> None:
+    """Refusing and half-applying are different. Half-applying is the failure mode this avoids."""
+    tool = _tool()
+    tool.run(items=_three())
+    before = list(tool.state.tasks)
+    tool.run(items=[{"task": "a", "status": "doing"}, {"task": "b", "status": "doing"}])
+    assert tool.state.tasks == before
+
+
+def test_one_item_in_progress_is_fine() -> None:
+    assert not _tool().run(items=_three()).startswith("error:")
+
+
+def test_items_that_left_the_list_are_named() -> None:
+    """An agent that quietly drops a requirement renders identically to one that never had it."""
+    tool = _tool()
+    tool.run(items=_three())
+    out = tool.run(items=[{"task": "read the schema", "status": "done"}])
+    assert "No longer in the list" in out
+    assert "write the catalogue" in out and "check the format" in out
+
+
+def test_nothing_is_reported_as_dropped_when_nothing_dropped() -> None:
+    tool = _tool()
+    tool.run(items=_three())
+    out = tool.run(items=_three())
+    assert "No longer in the list" not in out
+
+
+# --- input the model actually sends ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "items,fragment",
+    [
+        ("not a list", "must be a list"),
+        (42, "must be a list"),
+        ([{"task": "", "status": "done"}], "empty 'task'"),
+        ([{"task": "a", "status": "finished"}], "status must be one of"),
+        (["a string"], "must be an object"),
+    ],
+)
+def test_malformed_input_is_refused_with_a_reason(items: Any, fragment: str) -> None:
+    out = _tool().run(items=items)
+    assert out.startswith("error:") and fragment in out
+
+
+def test_a_json_string_of_items_is_parsed() -> None:
+    """Some backends hand an array-valued argument back as its JSON text."""
+    tool = _tool()
+    assert not tool.run(items=json.dumps(_three())).startswith("error:")
+    assert len(tool.state.tasks) == 3
+
+
+def test_status_is_case_insensitive() -> None:
+    tool = _tool()
+    assert not tool.run(items=[{"task": "a", "status": "DONE"}]).startswith("error:")
+    assert tool.state.tasks == ["[done] a"]
+
+
+def test_every_declared_status_is_accepted() -> None:
+    for status in STATUSES:
+        assert not _tool().run(items=[{"task": "a", "status": status}]).startswith("error:")
+
+
+# --- the sink ---------------------------------------------------------------------------------------
+
+
+def test_the_sink_receives_the_structured_list() -> None:
+    seen: list[list[TodoItem]] = []
+    _tool(on_change=seen.append).run(items=_three())
+    assert [i.status for i in seen[0]] == ["done", "doing", "pending"]
+
+
+def test_a_raising_sink_does_not_lose_a_recorded_list() -> None:
+    """The list is already committed by then; a broken renderer must not undo it."""
+
+    def explode(_items: list[TodoItem]) -> None:
+        raise RuntimeError("the UI fell over")
+
+    tool = _tool(on_change=explode)
+    assert not tool.run(items=_three()).startswith("error:")
+    assert len(tool.state.tasks) == 3
+
+
+def test_a_refused_call_does_not_reach_the_sink() -> None:
+    seen: list[Any] = []
+    _tool(on_change=seen.append).run(items=[{"task": "a", "status": "x"}])
+    assert seen == []
+
+
+# --- the event ---------------------------------------------------------------------------------------
+
+
+def test_the_event_says_the_list_is_claimed_not_verified() -> None:
+    """Every other structured frame reports an observation. This one reports what the model said."""
+    event = todo_event(_three())
+    assert event.kind == "todo"
+    assert event.data["claimed"] is True
+
+
+def test_the_event_carries_the_whole_list_and_the_counts() -> None:
+    event = todo_event(_three())
+    assert len(event.data["items"]) == 3
+    assert (event.data["done"], event.data["doing"], event.data["pending"]) == (1, 1, 1)
+    assert "1/3 done" in event.text
+
+
+def test_the_event_copies_the_list_it_was_given() -> None:
+    """Sent whole, so a consumer holding a frame must not watch it change under them."""
+    items = _three()
+    event = todo_event(items)
+    items.clear()
+    assert len(event.data["items"]) == 3
+
+
+# --- wiring into the loop -------------------------------------------------------------------------
+
+
+class ScriptedBackend:
+    def __init__(self, responses: list[CompletionResult]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def complete(self, messages: list[Any], *, tools: Any = None, **kwargs: Any) -> CompletionResult:
+        self.calls.append({"tools": tools, "messages": list(messages)})
+        if self._responses:
+            return self._responses.pop(0)
+        return CompletionResult(content="final answer", model="fake")
+
+
+def _registry(*, todo: bool = True) -> ToolRegistry:
+    """A registry shaped like the one the session hands the loop.
+
+    `todo=False` stands for the case that matters: an operator who scoped the session to a tool set
+    that does not name this one. `restrict_registry` produces exactly that, and the loop must run
+    without rather than adding what it was not granted.
+    """
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    if todo:
+        registry.register(TodoWriteTool())
+    return registry
+
+
+def _calling_backend() -> ScriptedBackend:
+    return ScriptedBackend(
+        [
+            CompletionResult(
+                content="",
+                model="fake",
+                tool_calls=[ToolCall(id="1", name="todo_write", arguments={"items": _three()})],
+            )
+        ]
+    )
+
+
+def test_the_real_default_registry_carries_it(tmp_path: Any) -> None:
+    """The registry the surfaces actually build — not the hand-rolled one the rest of this file uses.
+
+    Added because the sabotage matrix found nothing to fail when the registration in
+    `builtin.default_registry` was removed: every other test here constructs its own registry, so
+    the setting could have become a no-op and the suite would have stayed green.
+    """
+    from chimera.tools.builtin import default_registry
+
+    assert "todo_write" in default_registry(tmp_path).names()
+
+
+def test_the_default_registry_carries_it_so_the_allowlist_can_take_it_away() -> None:
+    """Registered like every other tool, which is what puts it under the session's scoping."""
+    from chimera.governance.allowlist import restrict_registry
+
+    assert "todo_write" in _registry().names()
+    scoped = restrict_registry(_registry(), allow=["echo"])
+    assert "todo_write" not in scoped.names()
+
+
+def test_a_session_that_was_not_granted_the_tool_runs_without_it() -> None:
+    """Absent is an operator decision, not an error — and nothing must be bolted back on."""
+    backend = ScriptedBackend([])
+    agent = Agent(backend, _registry(todo=False), AgentConfig())
+    agent.run("hello", on_todo=lambda _items: pytest.fail("nothing should announce"))
+    names = [t["function"]["name"] for t in (backend.calls[0]["tools"] or [])]
+    assert names == ["echo"]
+
+
+def test_the_binding_reaches_through_the_governance_wrappers() -> None:
+    """By the time the loop holds the registry, the tool is behind one or two wrappers."""
+
+    class Wrapper:
+        def __init__(self, inner: Any) -> None:
+            self.inner = inner
+            self.name = inner.name
+            self.description = inner.description
+            self.parameters = inner.parameters
+
+        def run(self, **kwargs: Any) -> str:
+            return self.inner.run(**kwargs)
+
+        def to_openai_schema(self) -> dict[str, Any]:
+            return self.inner.to_openai_schema()
+
+    wrapped = ToolRegistry()
+    wrapped.register(EchoTool())
+    wrapped.register(Wrapper(Wrapper(TodoWriteTool())))  # type: ignore[arg-type]
+    agent = Agent(_calling_backend(), wrapped, AgentConfig())
+    agent.run("do the work")
+    assert len(agent.run_state.tasks) == 3
+
+
+def test_two_agents_on_one_registry_keep_separate_lists() -> None:
+    """A crew runs several workers off ONE registry, concurrently, in separate threads."""
+    import threading
+
+    shared = _registry()
+    first = Agent(_calling_backend(), shared, AgentConfig())
+    second = Agent(_calling_backend(), shared, AgentConfig())
+    barrier = threading.Barrier(2)
+
+    def go(agent: Agent, label: str) -> None:
+        barrier.wait()
+        agent.run(label)
+
+    threads = [
+        threading.Thread(target=go, args=(first, "one")),
+        threading.Thread(target=go, args=(second, "two")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert len(first.run_state.tasks) == 3
+    assert len(second.run_state.tasks) == 3
+
+
+def test_a_recorded_list_reaches_the_run_state_through_a_real_loop() -> None:
+    agent = Agent(_calling_backend(), _registry(), AgentConfig())
+    agent.run("do the work")
+    assert agent.run_state.tasks[1] == "[doing] write the catalogue"
+
+
+def test_the_sink_passed_to_run_receives_the_list() -> None:
+    seen: list[list[dict[str, str]]] = []
+    agent = Agent(_calling_backend(), _registry(), AgentConfig())
+    agent.run("do the work", on_todo=seen.append)
+    assert seen == [_three()]
+
+
+def test_a_later_turn_without_a_sink_stops_announcing_into_the_old_one() -> None:
+    """A queue belonging to turn 1 must not receive turn 2's frames.
+
+    The regression this catches is binding only when a sink was passed: the tool then keeps the
+    previous turn's `on_change`, and turn 2 announces into a queue whose reader has gone.
+    """
+    seen: list[Any] = []
+    agent = Agent(_calling_backend(), _registry(), AgentConfig())
+    agent.run("first", on_todo=seen.append)
+    agent.backend = _calling_backend()  # type: ignore[assignment]
+    agent.run("second")
+    assert len(seen) == 1
+
+
+# --- the price ---------------------------------------------------------------------------------------
+
+
+def test_the_schema_cost_is_a_real_measurement() -> None:
+    """Stated rather than assumed: this repo keeps `edit_batch` off over exactly this charge."""
+    cost = schema_cost_chars()
+    assert cost == len(
+        json.dumps(
+            {
+                "name": TodoWriteTool.name,
+                "description": TodoWriteTool.description,
+                "parameters": TodoWriteTool.parameters,
+            },
+            separators=(",", ":"),
+        )
+    )
+    assert 300 < cost < 1200, f"the schema moved to {cost} chars — reprice it, do not widen this"
+
+
+def test_render_is_the_single_source_of_the_string_form() -> None:
+    """`RunState.tasks` and the observation must not drift into two spellings of one list."""
+    items = [TodoItem("a", "done"), TodoItem("b", "pending")]
+    assert render(items) == ["[done] a", "[pending] b"]
+
+
+# --- the sentence that makes the schema work ---------------------------------------------------
+
+
+def test_the_prompt_mentions_the_tool_when_the_session_has_it() -> None:
+    """Measured, not assumed: bare, two models called it zero times. One sentence changed that."""
+    from chimera.core.agent import TODO_PROMPT
+
+    backend = ScriptedBackend([])
+    Agent(backend, _registry(), AgentConfig()).run("hello")
+    assert TODO_PROMPT in backend.calls[0]["messages"][0]["content"]
+
+
+def test_the_prompt_says_nothing_about_a_tool_the_session_withheld() -> None:
+    """A sentence naming a tool the model was not given is an invitation to call nothing."""
+    from chimera.core.agent import TODO_PROMPT
+
+    backend = ScriptedBackend([])
+    Agent(backend, _registry(todo=False), AgentConfig()).run("hello")
+    assert TODO_PROMPT not in backend.calls[0]["messages"][0]["content"]


### PR DESCRIPTION
`RunState.tasks` has existed since compaction was written. It has a docstring saying what it is for — *"Task list with status, so finished work is not redone"* — and `RunState.as_message` renders it back after a compaction. **Nothing has ever written to it.**

The loop that would have been the obvious writer says why it must not be one, in `_seed_run_state`: it counts attempts, not steps, so it has no completion to report, and filling the field from the plan would be *"a lie in the field whose entire purpose is to be believed"*.

That was right. What was missing is a truthful source of completion, and there is exactly one — the agent says so. This is that source.

## What it does

`todo_write` records the run's list, replacing it whole. `RunState.tasks` mirrors it as strings, so the restore path that was built for this receives exactly what its docstring describes:

```
[context restored after compaction — the conversation above was summarised]

Tasks:
- [done] read the schema
- [doing] write the catalogue
- [pending] check the format
```

A `todo` frame carries it live to the Code screen and to the run panel.

## What it reports is a claim, and every surface says so

Every other structured frame in this vocabulary reports something **observed**: `edit` is a unified diff read off disk before and after the write; `result` is a verifier's exit code. A row of ticks looks like a third member of that family and is not one — nothing checked it.

So the frame carries `claimed`, and the panel writes it out: *"1 of 3 done — what the agent says about its own progress, not a verdict."* There is a test whose only job is to fail if that sentence is ever tidied away.

Two rules are enforced rather than suggested:

- **At most one item in progress.** A list with six answers no question, and this is the only field that says where the work actually is.
- **Dropped items are named back to the agent.** A quietly deleted requirement renders identically to one that never existed.

## Adoption was measured before choosing a default

A tool the model never calls is schema in every prompt and no behaviour. The `edit_batch` precedent in this repo is explicit that a schema earns its place. Same task, same models, one sentence of difference:

| | `deepseek-v4-flash-0731` | `z-ai/glm-5.3` |
|---|---|---|
| schema only | **0 calls** | **0 calls** |
| schema + one prompt line | **0 calls**, in 4 runs | **4 calls**, correct progression |

Two things follow, and the second is uncomfortable:

1. **The prompt line is not optional** — without it the tool is 657 characters of schema and no behaviour. It is added only when the session actually granted the tool, because a sentence naming a tool the model was not given is an invitation to call nothing.
2. **The model this project ships as its default does not use this tool**, in four runs where it was told to. On that model the feature costs 896 characters per step and delivers nothing.

It ships **on** anyway: its failure mode is "unused" rather than "worse", and unlike `edit_batch` there is no bench control arm for it to destroy. The number is written into `chimera/config.py` so the decision can be reopened with a measurement instead of an opinion.

## Where it is registered, and why that matters

In `default_registry`, like every other tool — which is what puts it under `restrict_registry`. A session an operator scoped to two tools must not quietly gain a third, however harmless the third one is.

That creates the opposite problem: a registry is routinely **shared**, and a crew runs several workers off one, concurrently. So the binding is thread-local — `Agent.run` binds its own run state on the thread that will run — and two agents on one registry keep separate lists. There is a test that runs them on a barrier to prove it.

## Also fixed

`CodeSession.send` forwarded a new callback to any agent whose `run` declared `**kwargs`, on the reasoning — written in a comment — that an implementation predating the parameter had to keep working. A catch-all usually forwards to something narrower, so the comment described a safety the code did not provide: six API turns died before their first tool call. The signature is now read for the parameter by name.

## Verification

- `tests/test_the_task_list_was_a_field_nothing_ever_wrote_to.py` — 36 tests.
- **Sabotage matrix: 14/14.** Each guard reverted on its own, the edit confirmed on disk, and a test required to fail. Two escaped the first pass and both were informative: one was a badly written sabotage, the other found a real gap — nothing tested that the *real* `default_registry` carries the tool, so the setting could have become a no-op with the suite still green. A test was added and the sabotage then caught it.
- Full Python suite green apart from 4 pre-existing environment failures (a space in the repo path breaks a shell command on Windows) — verified against a clean tree.
- Frontend: 144 files / 1029 tests, `tsc --noEmit` and `vite build` clean. The build caught an `Exchange` construction site the tests could not, because vitest does not typecheck.
- i18n: 5 keys plus the tool description across all ten dictionaries, anchored on each language's own block rather than by position (`it`/`pl` and `zh`/`ja` are defined in a different order than `LANGS` lists them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)