### PR TITLE
bench(rag): the semantic half earns its place, and it is the fusion that earns it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   minutes to reach the same refusal."* So the durable ask travels only with somewhere to send it.
 
 
+## [Unreleased]
+
+### Changed
+
+- **`chimera find` has a semantic half, and it earns its place by a rule fixed before the run.**
+  `bench/rag/baseline.json` has held `keyword_recall: 0.4925` with `vector_recall: null` since
+  2026-08-13. `bench/rag/` was the only one of sixteen benches with no pre-registration; it has one
+  now, written before an embedder was called, and the run against it says **ADOPT**.
+
+  | arm | recall@10 |
+  |---|---:|
+  | keyword (FTS5 + BM25) | 0.4425 |
+  | vector (cosine, diagnostic) | **0.4100** |
+  | hybrid (reciprocal rank fusion) | **0.5050** |
+
+  Paired over the same 400 probes: **+6.25 pp**, 95% CI [+3.2, +8.3], McNemar exact p = 1.7e-04.
+  Against the rule as written — delta ≥ +5 pp, p < 0.01, hybrid not below keyword — all three hold.
+
+  **The finding that was not obvious: semantic retrieval on its own is WORSE than keyword here.**
+  Every point of the win is the fusion. Naming `vector` as the arm under test — the intuitive
+  choice, since the embedder is the thing being added — would have read this run as a refutation and
+  abandoned the path. The two rankings are wrong about different probes, and RRF is what turns that
+  into recall neither has alone.
+
+  What the fusion costs is in the table too: 34 probes gained, **9 lost** — probes keyword found
+  alone that the hybrid pushed out of the top ten.
+
+  Measured with `openrouter/openai/text-embedding-3-small` at 1536 dimensions, and the embedder and
+  width are recorded **inside** the result. Vector spaces do not convert, so this does not choose the
+  shipped default; a local embedder needs its own run, and now has a measured reason to get one.
+
+### Fixed
+
+- **The RAG bench could not answer a paired question.** `RagReport` carried three totals and nothing
+  per probe, so the pairs a McNemar test needs were computed and discarded inside the loop that
+  computed them. Per-probe hit/miss is now recorded for all three arms and feeds
+  `chimera/eval/paired.py` directly.
+- **`embed_missing` was called without `embedder=`**, leaving `ChunkStore._align_embedder` inert in
+  exactly the run that first writes vectors. That guard zeroes every vector when the model identity
+  or width changes; without it a mixed-dimension index reports healthy and returns nothing, because
+  `_cosine` gives 0.0 on a mismatch and the `score > 0` filter then drops everything.
+- **Query embeddings were one call per probe**, inside the loop — 400 round-trips for the same money
+  as two batches. A provider returning a short batch now voids the semantic arms rather than pairing
+  each query with the next one's vector.
+- **The published baseline was stale, and says so.** The same harness measures 0.4750 on the
+  2026-08-14 tree (2,838 chunks) and 0.4425 today (3,459). `chimera/` is 29% larger than it was and
+  recall@10 falls as the haystack grows. The old figure was right about an older corpus; the record
+  now carries the chunk count beside every recall number, and names what it supersedes.
+
 ## [0.49.3] - 2026-09-03
 
 ### Changed

--- a/bench/rag/PREREGISTRATION.md
+++ b/bench/rag/PREREGISTRATION.md
@@ -1,0 +1,159 @@
+# The semantic half of `chimera find` — pre-registration
+
+**Written before any embedder was called. No number in this document was seen first.**
+
+`bench/rag/baseline.json` has held `keyword_recall: 0.4925` with `vector_recall: null` and
+`hybrid_recall: null` since 2026-08-13, and its own note pre-registers the baseline:
+
+> Baseline taken BEFORE any embedder was wired, so the semantic number cannot be chosen after seeing
+> what would look good. `headroom` is the ceiling: the most a semantic layer could add.
+
+That fixed the *baseline*. It did not fix a *decision rule*, and this bench is the only one of the
+sixteen in `bench/` without a pre-registration file. This is that file.
+
+---
+
+## What is being decided
+
+Whether `chimera/rag/` should retrieve semantically at all — not which embedder it should use.
+
+`ChunkStore.search_vector` and `reciprocal_rank_fusion` are written and unit-tested. The only thing
+missing is an `EmbedFn`, and `LLMGateway.embed` already has the exact signature `ChunkStore` expects.
+So the cost of finding out is a few cents of embedding, and the cost of *not* finding out is that a
+whole retrieval path stays half-built on the assumption that it would help.
+
+**Adopting a default embedder is a separate decision and this run cannot make it.** See "what this
+arm cannot show" below.
+
+## Arms
+
+| arm | what it is | role |
+|---|---|---|
+| `keyword` | FTS5 + BM25, `search_keyword` | the baseline, already measured at 0.4925 |
+| `vector` | cosine over embeddings, `search_vector` | **diagnostic only** — never adopted alone |
+| `hybrid` | reciprocal rank fusion of the two | **the arm under test**, because it is what would ship |
+
+Hybrid rather than vector is the comparison that decides, and the reason is not preference: RRF is
+already written, fusing is what the module exists to do, and a vector arm that wins alone while the
+fusion loses would be a result about the fusion, not about semantics.
+
+## Decision rule, fixed now
+
+Primary outcome: **recall@10 of `hybrid` minus recall@10 of `keyword`**, paired over the same probes,
+tested with McNemar via `chimera/eval/paired.py`.
+
+- **ADOPT** if the paired delta is **≥ +5.0 percentage points** *and* **p < 0.01**.
+- **REJECT** otherwise — including the case where the delta is positive but small, which is a real
+  outcome and not a reason to go looking for a different cut.
+- **REJECT AND REPORT LOUDLY** if `hybrid < keyword`. Fusing two rankings can be worse than either;
+  it is the retrieval version of an intervention that acts during the process rather than at the
+  end, and this project has measured that shape hurting before. A negative here is a finding, not a
+  failed run.
+
+Five points is chosen against the apparatus rather than against taste: with 400 probes, a paired
+difference of 5 pp is comfortably inside what McNemar can resolve at this discordance, and it is
+large enough that a per-embedder swing would not flip the sign of the verdict.
+
+`vector` is reported and never used to decide.
+
+## What is fixed before the run
+
+Three things about the harness, all of which would otherwise contaminate the number:
+
+1. **`embed_missing` is called with `embedder=`.** `ChunkStore._align_embedder` zeroes every vector
+   when the model identity or dimension changes, and it is inert when the name is not supplied — so
+   the guard against a mixed-dimension index would be off in exactly the run that introduces
+   vectors. `store.py` documents the failure it prevents: `_cosine` returns `0.0` on a dimension
+   mismatch and the `score > 0` filter then drops everything, so the index reports healthy and
+   returns nothing.
+2. **Per-probe outcomes are recorded, not just counts.** The rule above needs paired hit/miss per
+   probe; `RagReport` carried totals only, so McNemar was not computable from what the bench
+   returned.
+3. **Query embeddings are batched.** 400 single-item calls is the same money and several minutes of
+   avoidable latency.
+
+## Sanity checks that gate reading the number at all
+
+Run before the aggregate is believed, in this order:
+
+- `embedded > 0`. An embedder that produced no vectors did not fail quietly — the report says so and
+  the run is void.
+- **Three probe results read with human eyes**, query and top-3 idents. A vector arm near zero is
+  the apparatus, not the phenomenon; this project has spent two weeks on that lesson once already.
+- ~~Keyword recall reproduces **0.4925 ± 0.01** on the same corpus.~~ **Amended before the run —
+  see below.**
+
+## What this arm cannot show
+
+Recorded because a refutation, or a confirmation, is only about what the instrument could exhibit.
+
+- **The number is per-embedder and is not portable.** `store.py` says why in its own words: there is
+  no conversion from one model's vector space to another's. A run with `text-embedding-3-small`
+  measures that model. A local model will give a different number and possibly a different verdict,
+  and this run cannot stand in for it.
+- **It cannot choose the shipped default.** `text-embedding-3-small` costs per call, and an index
+  over a repository re-embeds every chunk whose line span moved. For an open-source tool people run
+  on their own machine, a paid default is a recurring drip. If this arm clears the bar, the local
+  arm becomes worth the install — and that is the run that decides the default.
+- **The probes are one kind of question.** They are first docstring lines with the symbol's own name
+  tokens and stopwords removed — "describe this in prose". A developer searching for a remembered
+  identifier, or pasting an error message, is asking something else, and this bench says nothing
+  about those.
+- **Absolute recall is understated for both arms.** Docstrings are stripped from the index to keep
+  the question out of the corpus, so the semantic arm is matching prose against code with the prose
+  removed. Production would index the docstrings. The paired delta is the number that survives this;
+  the absolute figures are floors.
+- **One corpus, one language.** `chimera/` is Python. Nothing here transfers to a TypeScript
+  codebase without measuring it there.
+- **It says nothing about whether the agent should have this as a tool.** `chimera find` is CLI-only,
+  and whether a retrieval tool beats the `grep`/`glob` the agent already has is a different question
+  with a different measurement.
+
+## Cost
+
+~2,700 chunks and 400 queries against `text-embedding-3-small`. Under two cents. Recorded here so
+that "it was cheap" is a fact rather than a recollection.
+
+## Result
+
+Written to `bench/rag/RESULTS.md` and `bench/rag/baseline.json`, with the embedder name and vector
+dimension **inside** the record rather than in a footnote.
+
+---
+
+## Amendment, made before the paid arm ran and after the control check failed
+
+The control check above did not pass, and the amendment is recorded rather than the check quietly
+dropped. Measured, with the harness in this branch:
+
+| corpus | chunks | keyword recall@10 |
+|---|---:|---:|
+| 2026-08-13, as published in `baseline.json` | 2,691 | 0.4925 |
+| 2026-08-14, checked out into a worktree and re-run with **this** code | 2,838 | 0.4750 |
+| today | 3,459 | 0.4425 |
+
+Two explanations fit "the control does not reproduce": the harness changed the measurement, or the
+corpus changed. They separate, and separating them cost nothing — the same code against the tree the
+baseline was taken from lands in the baseline's neighbourhood, and recall falls monotonically as the
+corpus grows. The corpus is `chimera/` itself, which is 29% larger than it was three weeks ago;
+recall@10 over a bigger haystack is a harder question, and the effect is roughly proportional to the
+growth across both steps.
+
+So the number was not wrong when it was written. It is **stale**, which is a different thing, and
+`baseline.json` is refreshed for today's corpus as part of this run.
+
+**Why this is an amendment and not a moved goalpost.** Nothing about the hypothesis has been seen.
+No embedder has been called; `vector_recall` and `hybrid_recall` are still null at the moment this
+paragraph is written. What was seen is that a *sanity check* referenced a figure taken from a
+different corpus — a fact about the check, not about the effect under test. The distinction that
+matters is that the primary comparison is **paired within a single run**: hybrid against keyword,
+over the same 400 probes, in the same index, at the same moment. It never depended on matching a
+three-week-old absolute number.
+
+The check is therefore restated, and it is a stronger one:
+
+- **The keyword arm and the hybrid arm come from the same run over the same probes.** A comparison
+  assembled from two runs is not paired, whatever the arms are called.
+- **The harness reproduces itself on a fixed corpus**, which the table above demonstrates.
+- The absolute figures are reported **with the corpus size beside them**, because this exercise has
+  just shown that a recall figure without its corpus is not a number anyone can check.

--- a/bench/rag/RESULTS.md
+++ b/bench/rag/RESULTS.md
@@ -1,0 +1,104 @@
+# The semantic half of `chimera find` — results
+
+Run 2026-09-04 against the rule fixed in [`PREREGISTRATION.md`](PREREGISTRATION.md), including its
+amendment. Embedder: **`openrouter/openai/text-embedding-3-small`, 1536 dimensions**. Corpus:
+`chimera/` at `85b30ff`, **3,459 chunks**, 400 probes, recall@10.
+
+## Verdict: ADOPT
+
+| arm | recall@10 |
+|---|---:|
+| `keyword` — FTS5 + BM25 | 0.4425 |
+| `vector` — cosine, diagnostic only | **0.4100** |
+| `hybrid` — reciprocal rank fusion | **0.5050** |
+
+Paired over the same 400 probes, `hybrid` against `keyword`:
+
+```
+both hit         a = 168
+keyword only     b =   9
+hybrid only      c =  34
+both miss        d = 189
+                     ----
+discordant            43
+
+paired delta   +6.25 pp     95% CI [+3.2, +8.3]
+McNemar exact  p = 1.7e-04
+```
+
+Against the rule as it was written: delta ≥ +5.0 pp ✓ · p < 0.01 ✓ · hybrid not below keyword ✓.
+
+## The finding that was not obvious, and is the reason the arms were fixed in advance
+
+**Semantic retrieval on its own is WORSE than keyword here — 0.4100 against 0.4425.** Every point of
+the win comes from the fusion, not from the embeddings.
+
+Had the pre-registration named `vector` as the arm under test — the intuitive choice, since the
+embedder is the thing being added — this run would have read as a refutation and the retrieval path
+would have been abandoned. Had it been left unfixed, the same numbers would have supported either
+story depending on which was written afterwards. The two rankings are wrong about *different*
+probes, and RRF is what converts that into recall neither has alone.
+
+## What the fusion costs, measured rather than assumed
+
+`b = 9`. Nine probes that keyword found alone, the hybrid lost. Fusing is not free: a strong keyword
+hit can be pushed out of the top ten by vector results that are individually plausible and
+collectively wrong. The net is +34/−9, and the −9 is in the table because a gain reported without
+its loss is a gain reported by somebody who did not look.
+
+## The corpus moved, and the published baseline was stale
+
+`baseline.json` held `keyword_recall: 0.4925` from 2026-08-13. The same harness, today, measures
+0.4425 — and the reason is not the harness:
+
+| corpus | chunks | keyword recall@10 |
+|---|---:|---:|
+| 2026-08-13, as published | 2,691 | 0.4925 |
+| 2026-08-14, in a worktree, re-run with **this** code | 2,838 | 0.4750 |
+| today | 3,459 | 0.4425 |
+
+`chimera/` is 29% larger than it was three weeks ago, and recall@10 falls as the haystack grows,
+roughly in proportion across both steps. The old number was right about an older corpus. It is
+refreshed here, with the chunk count beside it — a recall figure without its corpus size is not a
+number anyone can check, which is the whole lesson of this table.
+
+## Three harness defects fixed before the run
+
+Each would have contaminated the result rather than failing loudly:
+
+1. **`embed_missing` was called without `embedder=`**, so `_align_embedder` — the guard that zeroes
+   every vector when the model identity or width changes — was inert in exactly the run that
+   introduces vectors. `store.py` describes the failure it prevents: `_cosine` returns 0.0 on a
+   dimension mismatch and the `score > 0` filter then drops everything, so the index reports healthy
+   and returns nothing.
+2. **`RagReport` carried totals only.** The decision rule is paired, and a paired test needs the
+   pairs. Per-probe hit/miss is now recorded for all three arms and feeds `chimera/eval/paired.py`
+   directly.
+3. **Query embeddings were one call per probe**, inside the loop — 400 round-trips for the same
+   money.
+
+## Cost
+
+62 embedding calls, 3,859 texts (3,459 chunks + 400 queries). Roughly **two cents** at
+`text-embedding-3-small` pricing — an estimate from the text volume, not a figure read off an
+invoice, and labelled as such.
+
+## What this does not decide
+
+Restated from the pre-registration because a result travels further than the document that framed it:
+
+- **It does not choose the shipped embedder.** The number is per-embedder and vector spaces do not
+  convert. A local model (`ollama/nomic-embed-text`) would give a different figure and possibly a
+  different verdict. For an open-source tool people run on their own machine, a paid default is a
+  recurring drip — so the local arm is the one that should decide `settings.embed_model` for the
+  index, and it is now worth the install for a measured reason.
+- **It does not say the agent should have this as a tool.** `chimera find` is CLI-only and the agent
+  cannot reach it. Whether retrieval beats the `grep`/`glob` the agent already has is a different
+  question needing a different measurement.
+- **The probes are one kind of question**: a docstring's first line with the symbol's own name tokens
+  and stopwords removed. Probe 200 of this run reads *"Who words person who runs"*, which is what
+  that transformation does to some docstrings — all three arms miss it, and no retriever should be
+  blamed. A developer pasting an error message or half-remembering an identifier is asking something
+  this bench does not model.
+- **Absolute recall is a floor for both arms.** Docstrings are stripped from the index to keep the
+  question out of the corpus; production would index them. The paired delta is what survives that.

--- a/bench/rag/baseline.json
+++ b/bench/rag/baseline.json
@@ -1,15 +1,38 @@
 {
   "probes": 400,
-  "chunks": 2691,
+  "chunks": 3459,
   "k": 10,
-  "keyword_recall": 0.4925,
-  "vector_recall": null,
-  "hybrid_recall": null,
-  "headroom": 0.5075,
+  "embedder": "openrouter/openai/text-embedding-3-small",
+  "dimensions": 1536,
+  "keyword_recall": 0.4425,
+  "vector_recall": 0.41,
+  "hybrid_recall": 0.505,
+  "headroom": 0.5575,
+  "paired_hybrid_vs_keyword": {
+    "a_both": 168,
+    "b_keyword_only": 9,
+    "c_hybrid_only": 34,
+    "d_both_fail": 189,
+    "delta_pp": 6.25,
+    "ci95_pp": [
+      3.2,
+      8.3
+    ],
+    "mcnemar_exact_p": 0.00017
+  },
   "notes": [
-    "no embedder supplied \u2014 the ceiling below is what one could add at most"
+    "vector ALONE loses to keyword (0.4100 vs 0.4425) \u2014 the whole gain is the fusion",
+    "the fusion also costs 9 probes keyword found alone; the net is +34/-9",
+    "recall is per-corpus: chimera/ grew 2691 -> 3459 chunks since the 2026-08-13 baseline, and the same harness measures 0.4750 on the 2026-08-14 tree",
+    "recall is per-embedder: vector spaces do not convert, so a local model needs its own run"
   ],
-  "corpus": "chimera/ (this repository)",
-  "date": "2026-08-13",
-  "preregistered": "Baseline taken BEFORE any embedder was wired, so the semantic number cannot be chosen after seeing what would look good. headroom is the ceiling: the most a semantic layer could add."
+  "corpus": "chimera/ (this repository) at 85b30ff",
+  "date": "2026-09-04",
+  "preregistered": "bench/rag/PREREGISTRATION.md \u2014 arms, decision rule and gates fixed before any embedder was called; the control-check amendment is recorded there.",
+  "supersedes": {
+    "date": "2026-08-13",
+    "chunks": 2691,
+    "keyword_recall": 0.4925,
+    "why": "same harness, larger corpus \u2014 not a correction, a different corpus"
+  }
 }

--- a/chimera/eval/rag_bench.py
+++ b/chimera/eval/rag_bench.py
@@ -34,7 +34,7 @@ from pathlib import Path
 
 from chimera.rag.chunks import Chunk, walk
 from chimera.rag.hybrid import reciprocal_rank_fusion
-from chimera.rag.store import ChunkStore, EmbedFn
+from chimera.rag.store import EMBED_BATCH, ChunkStore, EmbedFn
 
 #: Words too common to make a query about anything.
 _STOP = frozenset((
@@ -147,6 +147,17 @@ class RagReport:
     headroom: float = 0.0
     k: int = 10
     notes: list[str] = field(default_factory=list)
+    #: Which model produced the vectors, and how wide they are. Inside the record rather than in
+    #: a footnote: there is no conversion from one model's vector space to another's, so a recall
+    #: figure without the embedder that produced it is a number about nothing in particular.
+    embedder: str = ""
+    dimensions: int = 0
+    #: Hit/miss per probe, aligned across the three lists. Totals cannot be tested against each
+    #: other — the arms answer the SAME probes, so the comparison that carries signal is paired,
+    #: and a paired test needs the pairs. `chimera/eval/paired.py` consumes these directly.
+    keyword_hit: list[bool] = field(default_factory=list)
+    vector_hit: list[bool] = field(default_factory=list)
+    hybrid_hit: list[bool] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, object]:
         return {
@@ -157,6 +168,8 @@ class RagReport:
             "vector_recall": None if self.vector_recall is None else round(self.vector_recall, 4),
             "hybrid_recall": None if self.hybrid_recall is None else round(self.hybrid_recall, 4),
             "headroom": round(self.headroom, 4),
+            "embedder": self.embedder,
+            "dimensions": self.dimensions,
             "notes": list(self.notes),
         }
 
@@ -248,6 +261,7 @@ def run_rag_bench(
     *,
     index_path: Path,
     embed: EmbedFn | None = None,
+    embedder: str = "",
     k: int = 10,
     max_probes: int = 400,
 ) -> RagReport:
@@ -271,30 +285,46 @@ def run_rag_bench(
 
     embedded = 0
     if embed is not None:
-        embedded = store.embed_missing(embed)
+        # `embedder=` arms `_align_embedder`, which zeroes every vector when the model identity or
+        # width changes. Without it the guard is inert in exactly the run that introduces vectors,
+        # and a mixed-dimension index reports healthy while returning nothing: `_cosine` gives 0.0
+        # on a mismatch and the `score > 0` filter then drops the lot.
+        embedded = store.embed_missing(embed, embedder=embedder)
+        report.embedder = embedder
         if embedded == 0:
             report.notes.append("the embedder produced no vectors; semantic figures are unavailable")
 
-    keyword_hits = vector_hits = hybrid_hits = 0
-    for probe in probes:
+    # One batched pass rather than one call per probe inside the loop. Same money, and it is the
+    # difference between a run measured in seconds and one measured in minutes.
+    query_vectors: list[list[float]] = []
+    if embedded and embed is not None:
+        for start in range(0, len(probes), EMBED_BATCH):
+            batch = [p.query for p in probes[start : start + EMBED_BATCH]]
+            query_vectors.extend(embed(batch))
+        if len(query_vectors) != len(probes):
+            report.notes.append(
+                f"the embedder returned {len(query_vectors)} vectors for {len(probes)} queries; "
+                "semantic figures are unavailable"
+            )
+            embedded = 0
+        elif query_vectors:
+            report.dimensions = len(query_vectors[0])
+
+    for index, probe in enumerate(probes):
         keyword = store.search_keyword(probe.query, k=k)
-        if any(h.chunk.ident == probe.target for h in keyword):
-            keyword_hits += 1
+        report.keyword_hit.append(any(h.chunk.ident == probe.target for h in keyword))
         if embedded:
-            query_vector = embed([probe.query])[0] if embed else []
-            vector = store.search_vector(query_vector, k=k)
-            if any(h.chunk.ident == probe.target for h in vector):
-                vector_hits += 1
+            vector = store.search_vector(query_vectors[index], k=k)
+            report.vector_hit.append(any(h.chunk.ident == probe.target for h in vector))
             fused = reciprocal_rank_fusion([keyword, vector], limit=k)
-            if any(h.chunk.ident == probe.target for h in fused):
-                hybrid_hits += 1
+            report.hybrid_hit.append(any(h.chunk.ident == probe.target for h in fused))
 
     total = len(probes)
-    report.keyword_recall = keyword_hits / total
+    report.keyword_recall = sum(report.keyword_hit) / total
     report.headroom = 1.0 - report.keyword_recall
     if embedded:
-        report.vector_recall = vector_hits / total
-        report.hybrid_recall = hybrid_hits / total
+        report.vector_recall = sum(report.vector_hit) / total
+        report.hybrid_recall = sum(report.hybrid_hit) / total
     else:
         report.notes.append("no embedder supplied — the ceiling below is what one could add at most")
     store.close()

--- a/tests/test_the_bench_that_could_not_be_tested_pairwise.py
+++ b/tests/test_the_bench_that_could_not_be_tested_pairwise.py
@@ -1,0 +1,166 @@
+"""Three things the RAG bench could not do, found while pre-registering a run against it.
+
+`bench/rag/PREREGISTRATION.md` fixed a paired decision rule — hybrid against keyword, McNemar, over
+the same probes — and then the harness turned out not to be able to answer it. `RagReport` carried
+three totals and nothing per probe, so the pairs the test needs were computed and thrown away inside
+the loop that computed them.
+
+The other two are quieter. `embed_missing` was called without `embedder=`, which leaves
+`ChunkStore._align_embedder` inert: the guard that zeroes every vector when the model identity or
+width changes was off in exactly the run that introduces vectors, and `store.py` describes what that
+costs — `_cosine` returns 0.0 on a dimension mismatch, the `score > 0` filter drops the lot, and the
+index reports healthy while returning nothing. And the query side embedded one probe per call,
+inside the loop, for the same money as one batch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from chimera.eval.paired import compare_paired
+from chimera.eval.rag_bench import run_rag_bench
+
+SOURCE = '''
+def verify(command: str) -> bool:
+    """Run the project's own check and say whether it passed."""
+    return True
+
+
+def budget(tokens: int) -> int:
+    """How many tokens a run is permitted to consume before compaction."""
+    return tokens
+
+
+def rank(items: list[str]) -> list[str]:
+    """Order results so the most relevant one is read first."""
+    return items
+'''
+
+VOCAB = ["command", "tokens", "run", "compaction", "permitted", "consume", "count", "order"]
+
+
+def _corpus(tmp_path: Path) -> Path:
+    (tmp_path / "core").mkdir(exist_ok=True)
+    (tmp_path / "core" / "verify.py").write_text(SOURCE, encoding="utf-8")
+    return tmp_path
+
+
+def _embed(texts: list[str]) -> list[list[float]]:
+    return [[float(t.lower().count(w)) for w in VOCAB] for t in texts]
+
+
+# --- the pairs the decision rule needs ------------------------------------------------------------
+
+
+def test_every_arm_reports_a_result_per_probe(tmp_path: Path) -> None:
+    """Totals cannot be tested against each other; the arms answer the SAME probes."""
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=_embed)
+
+    assert len(report.keyword_hit) == report.probes
+    assert len(report.vector_hit) == report.probes
+    assert len(report.hybrid_hit) == report.probes
+
+
+def test_the_per_probe_lists_agree_with_the_totals(tmp_path: Path) -> None:
+    """Two ways of counting the same thing, which is what makes either believable."""
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=_embed)
+
+    assert report.keyword_recall == sum(report.keyword_hit) / report.probes
+    assert report.vector_recall == sum(report.vector_hit) / report.probes
+    assert report.hybrid_recall == sum(report.hybrid_hit) / report.probes
+
+
+def test_the_lists_feed_the_projects_own_paired_test(tmp_path: Path) -> None:
+    """The rule is McNemar via `chimera/eval/paired.py`, which takes two aligned pass/fail lists."""
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=_embed)
+
+    result = compare_paired(report.keyword_hit, report.hybrid_hit)
+
+    assert result.n == report.probes
+    assert result.baseline_rate == report.keyword_recall
+    assert result.treatment_rate == report.hybrid_recall
+
+
+def test_without_an_embedder_only_the_keyword_arm_has_pairs(tmp_path: Path) -> None:
+    """Absent, not a list of False. A probe the vector arm never answered did not miss it."""
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3")
+
+    assert len(report.keyword_hit) == report.probes
+    assert report.vector_hit == []
+    assert report.hybrid_hit == []
+
+
+# --- the signature guard --------------------------------------------------------------------------
+
+
+def test_the_embedder_name_reaches_the_store(tmp_path: Path, monkeypatch: Any) -> None:
+    """`_align_embedder` is inert without it, in the one run that first writes vectors."""
+    from chimera.rag.store import ChunkStore
+
+    seen: dict[str, Any] = {}
+    real = ChunkStore.embed_missing
+
+    def spy(self: Any, embed: Any, *args: Any, **kwargs: Any) -> int:
+        seen.update(kwargs)
+        return real(self, embed, *args, **kwargs)
+
+    monkeypatch.setattr(ChunkStore, "embed_missing", spy, raising=True)
+    run_rag_bench(
+        _corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=_embed, embedder="fake/model-x"
+    )
+
+    assert seen.get("embedder") == "fake/model-x"
+
+
+def test_the_embedder_and_width_land_in_the_report(tmp_path: Path) -> None:
+    """A recall figure without the model that produced it is a number about nothing in particular."""
+    report = run_rag_bench(
+        _corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=_embed, embedder="fake/model-x"
+    )
+
+    assert report.embedder == "fake/model-x"
+    assert report.dimensions == len(VOCAB)
+    assert report.as_dict()["embedder"] == "fake/model-x"
+
+
+# --- batching -------------------------------------------------------------------------------------
+
+
+def test_the_queries_are_embedded_in_batches(tmp_path: Path) -> None:
+    """One call per probe is the same money and several minutes of avoidable latency."""
+    calls: list[int] = []
+
+    def counting(texts: list[str]) -> list[list[float]]:
+        calls.append(len(texts))
+        return _embed(texts)
+
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=counting)
+
+    # One batch for the corpus, one for the queries — never one per probe.
+    assert len(calls) < report.probes
+    assert max(calls) > 1
+
+
+def test_a_short_batch_voids_the_semantic_arms_rather_than_misaligning_them(
+    tmp_path: Path,
+) -> None:
+    """A provider that returns fewer vectors than it was given must not shift every later probe.
+
+    Silently zipping a short list against the probes would pair each query with the NEXT one's
+    vector — a run that completes, reports a plausible recall, and is measuring nothing.
+    """
+    state = {"first": True}
+
+    def short(texts: list[str]) -> list[list[float]]:
+        vectors = _embed(texts)
+        if state["first"]:
+            state["first"] = False
+            return vectors
+        return vectors[:-1]  # the query batch comes back one short
+
+    report = run_rag_bench(_corpus(tmp_path), index_path=tmp_path / "i.sqlite3", embed=short)
+
+    assert report.vector_recall is None
+    assert report.hybrid_recall is None
+    assert any("vectors for" in note for note in report.notes)


### PR DESCRIPTION
`bench/rag/baseline.json` has held `keyword_recall: 0.4925` with `vector_recall: null` and `hybrid_recall: null` since 2026-08-13. Its own note pre-registers the *baseline* — *"taken BEFORE any embedder was wired, so the semantic number cannot be chosen after seeing what would look good"* — but not a **decision rule**, and this was the only one of sixteen benches in `bench/` without a pre-registration file.

This writes the rule first, then runs against it.

## Verdict: ADOPT

| arm | recall@10 |
|---|---:|
| `keyword` — FTS5 + BM25 | 0.4425 |
| `vector` — cosine, diagnostic only | **0.4100** |
| `hybrid` — reciprocal rank fusion | **0.5050** |

```
both hit      a = 168      paired delta   +6.25 pp
keyword only  b =   9      95% CI         [+3.2, +8.3]
hybrid only   c =  34      McNemar exact  p = 1.7e-04
both miss     d = 189
```

Rule as written: delta ≥ +5.0 pp ✓ · p < 0.01 ✓ · hybrid not below keyword ✓.

## The finding that fixing the arms in advance bought

**Semantic retrieval on its own is worse than keyword here — 0.4100 against 0.4425.** Every point of the win comes from the fusion.

Had the pre-registration named `vector` as the arm under test — the intuitive choice, since the embedder is the thing being added — this run would have read as a refutation and the retrieval path would have been abandoned. Had it been left unfixed, the same numbers would have supported either story depending on which was written afterwards.

## What the fusion costs

`b = 9`. Nine probes keyword found alone that the hybrid lost — a strong keyword hit pushed out of the top ten by vector results that are individually plausible and collectively wrong. Net +34/−9, and the −9 is in the record because a gain reported without its loss is a gain reported by somebody who did not look.

## Three harness defects, fixed before the run

Each would have contaminated the number rather than failing loudly:

1. **`RagReport` carried totals only.** The rule is paired, and a paired test needs the pairs — which were computed and thrown away inside the loop that computed them. Per-probe hit/miss now feeds `chimera/eval/paired.py` directly.
2. **`embed_missing` was called without `embedder=`**, so `ChunkStore._align_embedder` was inert in exactly the run that first writes vectors. `store.py` describes the failure it prevents: `_cosine` returns 0.0 on a dimension mismatch and the `score > 0` filter drops everything, so the index reports healthy and returns nothing.
3. **Query embeddings were one call per probe**, inside the loop. A short batch now voids the semantic arms rather than pairing each query with the next one's vector.

## The control check failed, and the amendment is recorded rather than the check dropped

The pre-registration required keyword recall to reproduce 0.4925 ± 0.01. It measured 0.4425. Two explanations fit — the harness changed the measurement, or the corpus did — and separating them cost nothing:

| corpus | chunks | keyword recall@10 |
|---|---:|---:|
| 2026-08-13, as published | 2,691 | 0.4925 |
| 2026-08-14, in a worktree, re-run with **this** code | 2,838 | 0.4750 |
| today | 3,459 | 0.4425 |

`chimera/` is 29% larger than three weeks ago and recall@10 falls as the haystack grows, roughly in proportion across both steps. The old number was right about an older corpus; it is **stale**, not wrong.

**Why that is an amendment and not a moved goalpost:** nothing about the hypothesis had been seen — no embedder had been called and both semantic fields were still null when the paragraph was written. What was seen is that a *sanity check* referenced a figure from a different corpus. The primary comparison is paired **within a single run**, so it never depended on matching a three-week-old absolute number.

## What this does not decide

- **Not the shipped embedder.** Measured with `text-embedding-3-small` at 1536 dimensions; vector spaces do not convert. A local model needs its own run — and for an open-source tool people run on their own machine, a paid default is a recurring drip, so the local arm is the one that should set `settings.embed_model` for the index. It now has a measured reason to be installed.
- **Not whether the agent should have this as a tool.** `chimera find` is CLI-only and the agent cannot reach it. Whether retrieval beats the `grep`/`glob` it already has is a different question.
- **The probes are one kind of question.** Probe 200 of this run reads *"Who words person who runs"* — what stopword-stripping does to some docstrings. All three arms miss it and no retriever should be blamed.

## Cost and verification

62 embedding calls, 3,859 texts. Roughly two cents, stated as an estimate from text volume rather than read off an invoice.

- 8 new tests; **sabotage matrix 6/6** — each harness fix reverted alone, the edit confirmed on disk, a test required to fail.
- Full suite green apart from 4 pre-existing environment failures (a space in the repo path breaks a shell command on Windows), verified against a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)