### PR TITLE
bench(loop): what a parallel tool call would buy, and why it is not built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   recall@10 falls as the haystack grows. The old figure was right about an older corpus; the record
   now carries the chunk count beside every recall number, and names what it supersedes.
 
+## [Unreleased]
+
+### Changed
+
+- **Parallel tool calls: measured, and not built.** `chimera/core/agent.py` runs a turn's tool calls
+  in a plain `for`. Making that concurrent needs a read-only marking on `Tool` that does not exist,
+  thread-safety on a `TaintLedger` that has none, and a change to what the loop-breaker *is* — its
+  `break` currently stops the rest of a batch from running, and in a concurrent batch they have
+  already run by the time a verdict exists.
+
+  One number decides whether that is worth doing, and nobody had it. `StepRecord.tools` is exactly
+  the batch and `traces.jsonl` already held it, so the census cost nothing: **137 runs, 868
+  tool-calling steps, complete rather than sampled.**
+
+  | | |
+  |---|---:|
+  | median step (model call + its tools) | **5,578 ms** |
+  | total saved by parallelising every safe batch, across all 137 runs | **589 ms** |
+  | per run | **4.3 ms** — 0.08% of one step |
+
+  Parallelising every safe tool call in a run saves less than one hundredth of a single model call.
+  The waits in an agent loop are seconds of inference; tool calls are milliseconds of local
+  filesystem — `read_file` 0.3 ms, `list_dir` 1.0 ms, against 0.13 ms to dispatch a thread.
+
+  **And the aggregate would have been the wrong number.** 6.9% of steps carry two or more calls, but
+  that is a mixture over models that behave in opposite ways: `gemini-3.8-flash` and
+  `deepseek-chat-v3.1` never batch at all across 414 steps, while the shipped default
+  `deepseek-v4-flash-0731` batches 23.3% of the time. Two models with zero account for half the
+  corpus. Any measurement of loop behaviour averaged over models is averaging over that.
+
+  `bench/parallel_tools/RESULTS.md` has the per-model table and what the census could not show;
+  `scripts/count_tool_batches.py` reproduces it from your own traces.
+
 ## [0.49.3] - 2026-09-03
 
 ### Changed

--- a/bench/parallel_tools/RESULTS.md
+++ b/bench/parallel_tools/RESULTS.md
@@ -1,0 +1,100 @@
+# What parallel tool calls would buy: 4.3 ms per run
+
+**Verdict: do not build it.** Measured 2026-09-04 over 137 real runs already on disk, at a cost of
+nothing.
+
+`chimera/core/agent.py` executes a turn's `tool_calls` in a plain `for`, one after another. Making
+that concurrent is a genuine piece of work — a read-only marking on `Tool` that does not exist today,
+thread-safety on a `TaintLedger` that has none, and a change to what the loop-breaker *is*: today its
+`break` stops the remaining calls in a batch from running, and in a concurrent batch they have
+already run by the time a verdict exists, so a circuit breaker becomes a report.
+
+Before any of that, one number decides whether the front exists. Nobody had measured it, and
+`tests/test_three_zero_cost_defects.py` records that every stub in the suite declares one call per
+step — a hint that the shape was assumed rather than observed.
+
+## The measurement
+
+`StepRecord.tools` is exactly the batch, and `traces.jsonl` already held it for every run this
+install has made. No new runs, no tokens spent. A **complete** census of the available traces rather
+than a sample: a sampled census of co-occurrence undercounts by construction, and this one was 137
+records and a second of CPU.
+
+## The answer, and why the aggregate is the wrong number
+
+Across all traces, 6.9% of tool-calling steps carried two or more calls. That figure is a mixture
+over models that behave in opposite ways, and reporting it alone would be a claim about none of them:
+
+| model | steps with tools | multi-call | ceiling on waits removed |
+|---|---:|---:|---:|
+| `gemini-3.8-flash` | 226 | **0.0%** | 0% |
+| `deepseek-chat-v3.1` | 188 | **0.0%** | 0% |
+| `deepseek-v4-pro` | 148 | 6.8% | 0.6% |
+| `glm-5.3-flash` | 111 | 22.5% | 4.2% |
+| **`deepseek-v4-flash-0731`** (the shipped default) | 60 | **23.3%** | **10.8%** |
+| `glm-5.3` | 57 | 1.8% | 1.7% |
+| `grok-4.6` | 16 | 31.2% | 18.2% |
+| `kimi-k3` | 8 | 37.5% | 25.0% |
+
+Two models with zero multi-call steps account for half the corpus and drag the average to a third of
+what the default model does. "Ceiling" is the share of tool waits that would disappear if a batch of
+N safe calls took the time of one — an upper bound that ignores dispatch and assumes equal-length
+calls.
+
+## Where the front dies: what those waits are worth
+
+Only batches made **entirely** of read-only tools can be parallelised safely — a mixed batch races a
+write and disarms the loop-breaker — and the batches that qualify are these:
+
+```
+7x  list_dir, read_file        5x  grep, grep
+3x  glob, read_file            2x  list_dir, list_dir
+```
+
+Measured on this machine, on this repository:
+
+| tool | median |
+|---|---:|
+| `read_file` | **0.3 ms** |
+| `list_dir` | **1.0 ms** |
+| `glob` | 23.7 ms |
+| `grep` | 69.8 ms |
+| dispatching one thread | 0.13 ms |
+
+The most common safe batch, `list_dir + read_file`, costs 1.3 ms sequentially. Running it on two
+threads saves 0.3 ms and spends 0.13 ms getting there.
+
+Against the thing an agent loop actually waits for:
+
+| | |
+|---|---:|
+| median step (model call + its tools) | **5,578 ms** |
+| total saving across all 137 runs, every safe batch parallelised | **589 ms** |
+| per run | **4.3 ms** |
+| as a share of one median step | **0.08%** |
+
+**Parallelising every safe tool call in a run saves less than one hundredth of a single model
+call.** The waits in this loop are seconds of inference; the tool calls are milliseconds of local
+filesystem. That is structural, not a property of this corpus.
+
+## What this census could not show
+
+- **137 runs from one install.** The task mix is what this machine happened to do, weighted towards
+  short probes. A long exploratory task over a large tree would batch more reads.
+- **The model list is the one that was used.** A model absent here — Claude, GPT — may batch far more
+  aggressively; `kimi-k3` reaches 37.5% on eight steps, which is a hint rather than a rate.
+- **`grep` at 69.8 ms is this repository on this disk.** A monorepo an order of magnitude larger
+  moves that number, and `grep, grep` is the second most common safe batch.
+
+None of those close the gap. For 4.3 ms per run to become interesting against a 5,578 ms step, the
+saving would have to grow by roughly three orders of magnitude — which no plausible shift in model
+mix or corpus size produces, because the ceiling is bounded by tool latency and tool latency is
+milliseconds.
+
+## What to do instead
+
+Nothing, here. The finding worth carrying out of this is the one about the aggregate: `deepseek-v4-
+flash-0731` and `gemini-3.8-flash` differ by 23 percentage points in how they use a tool-calling
+API, and any measurement of loop behaviour that averages over models is averaging over that.
+
+Reproduce with `python scripts/count_tool_batches.py`.

--- a/scripts/count_tool_batches.py
+++ b/scripts/count_tool_batches.py
@@ -1,0 +1,106 @@
+"""How often does a model ask for more than one tool in a turn, and what would parallelising buy?
+
+The census behind `bench/parallel_tools/RESULTS.md`. It reads traces this install has already
+written — `StepRecord.tools` is exactly the batch — so it costs nothing and needs no new runs.
+
+Complete rather than sampled, and that is not fastidiousness: a measurement of co-occurrence needs
+BOTH members of a pair inside the sample, so a fraction `f` of the corpus undercounts by roughly `f`
+and prints a reassuring number. Here the whole file is a second of CPU.
+
+    python scripts/count_tool_batches.py [path/to/traces.jsonl]
+
+Reported per model, never as one average. Two of the models in the corpus that produced the results
+file never batched at all while the shipped default batched 23% of the time; an aggregate over those
+is a statement about neither.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+#: Tools a concurrent batch could safely hold: nothing written, no command run, no money spent
+#: outside the loop's accounting, no live session touched, and nothing that moves the taint ledger.
+#: Absent means unsafe, which is the right default for a list a new tool joins without asking.
+#:
+#: Median milliseconds measured on the repository this ships in — the numbers are what turn a count
+#: of batches into a saving, and a batch of two 0.3 ms reads is not a saving.
+SAFE_MS = {
+    "read_file": 0.3,
+    "list_dir": 1.0,
+    "grep": 69.8,
+    "glob": 23.7,
+    "read_document": 5.0,
+    "echo": 0.1,
+    "tool_list": 0.1,
+    "tool_describe": 0.1,
+    "todo_write": 0.1,
+}
+
+
+def default_trace() -> Path:
+    from chimera.config import get_settings
+
+    return Path(get_settings().home) / "traces.jsonl"
+
+
+def main(argv: list[str]) -> int:
+    path = Path(argv[1]) if len(argv) > 1 else default_trace()
+    if not path.is_file():
+        print(f"no traces at {path} — a run writes them when `trace_path` is set")
+        return 1
+
+    runs = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    per_model: dict[str, Counter[int]] = defaultdict(Counter)
+    saved_ms: dict[str, float] = defaultdict(float)
+    shapes: Counter[tuple[str, ...]] = Counter()
+    step_ms: list[float] = []
+
+    for run in runs:
+        for step in run.get("steps") or []:
+            if step.get("elapsed_ms"):
+                step_ms.append(float(step["elapsed_ms"]))
+            names = [str(t.get("name") or "") for t in (step.get("tools") or [])]
+            if not names:
+                continue
+            model = str(step.get("model") or "?")
+            per_model[model][len(names)] += 1
+            if len(names) >= 2:
+                shapes[tuple(sorted(names))] += 1
+                if all(n in SAFE_MS for n in names):
+                    # In parallel only the slowest of the batch is waited on.
+                    costs = sorted((SAFE_MS[n] for n in names), reverse=True)
+                    saved_ms[model] += sum(costs[1:])
+
+    total = sum(sum(c.values()) for c in per_model.values())
+    print(f"{len(runs)} runs · {total} steps that called a tool\n")
+    print(f"{'model':44} {'steps':>6} {'multi':>6} {'multi %':>8} {'saved ms':>9}")
+    for model, counts in sorted(per_model.items(), key=lambda kv: -sum(kv[1].values())):
+        steps = sum(counts.values())
+        multi = sum(v for k, v in counts.items() if k >= 2)
+        print(
+            f"{model.replace('openrouter/', '')[:44]:44} {steps:6} {multi:6} "
+            f"{multi / steps * 100:7.1f}% {saved_ms[model]:9.1f}"
+        )
+
+    print("\nbatches of two or more, by shape:")
+    for names, n in shapes.most_common(10):
+        mark = "safe " if all(x in SAFE_MS for x in names) else "mixed"
+        print(f"  {n:4}x [{mark}] {', '.join(names)}")
+
+    saved = sum(saved_ms.values())
+    print(f"\ntotal saved by parallelising every safe batch: {saved:.0f} ms over {len(runs)} runs")
+    print(f"per run: {saved / len(runs) if runs else 0:.1f} ms")
+    if step_ms:
+        median = statistics.median(step_ms)
+        share = saved / len(runs) / median * 100 if runs else 0
+        print(f"median step (model call + its tools): {median:.0f} ms")
+        print(f"the saving, as a share of ONE median step: {share:.2f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
`chimera/core/agent.py` executes a turn's `tool_calls` in a plain `for`, one after another. Making that concurrent is a real piece of work: a read-only marking on `Tool` that does not exist today, thread-safety on a `TaintLedger` that has none, and a change to what the loop-breaker **is** — its `break` currently stops the remaining calls in a batch from running, and in a concurrent batch they have already run by the time a verdict exists, so a circuit breaker becomes a report.

Before any of that, one number decides whether the front exists at all. Nobody had measured it, and `tests/test_three_zero_cost_defects.py` records that every stub in the suite declares one call per step — a hint the shape was assumed rather than observed.

It cost nothing to get: `StepRecord.tools` is exactly the batch, and `traces.jsonl` already held it for 137 runs. **Complete rather than sampled** — a census of co-occurrence needs both members of a pair inside the sample, so a fraction `f` undercounts by roughly `f` and prints a reassuring number.

## Verdict: do not build it

| | |
|---|---:|
| median step (model call + its tools) | **5,578 ms** |
| total saved by parallelising every safe batch, across all 137 runs | **589 ms** |
| per run | **4.3 ms** |
| as a share of one median step | **0.08%** |

Parallelising every safe tool call in a run saves less than one hundredth of a single model call.

The reason is structural, not a property of this corpus: an agent loop waits on **inference**, in seconds, and on **tool calls**, in milliseconds. Measured here — `read_file` 0.3 ms, `list_dir` 1.0 ms, `glob` 23.7 ms, `grep` 69.8 ms, against **0.13 ms to dispatch a thread**. The most common safe batch is `list_dir + read_file` at 1.3 ms sequential; running it on two threads saves 0.3 ms and spends 0.13 ms getting there.

## The aggregate would have been the wrong number

6.9% of tool-calling steps carry two or more calls. That figure is a mixture over models that behave in opposite ways, and I nearly reported it as the verdict:

| model | steps | multi-call | ceiling on waits removed |
|---|---:|---:|---:|
| `gemini-3.8-flash` | 226 | **0.0%** | 0% |
| `deepseek-chat-v3.1` | 188 | **0.0%** | 0% |
| `deepseek-v4-pro` | 148 | 6.8% | 0.6% |
| `glm-5.3-flash` | 111 | 22.5% | 4.2% |
| **`deepseek-v4-flash-0731`** (shipped default) | 60 | **23.3%** | **10.8%** |
| `grok-4.6` | 16 | 31.2% | 18.2% |

Two models with zero multi-call steps account for half the corpus and drag the average to a third of what the default model does. The front dies on tool *latency*, not on batch frequency — but any measurement of loop behaviour averaged over models is averaging over a 23-point spread, and that is the finding worth carrying forward.

## What the census could not show

Recorded because a negative is only about what the instrument could exhibit:

- **137 runs from one install**, weighted towards short probes. A long exploratory task over a large tree would batch more reads.
- **The model list is the one that was used.** Claude and GPT are absent; `kimi-k3` reaches 37.5% on eight steps, which is a hint rather than a rate.
- **`grep` at 69.8 ms is this repository on this disk.** A much larger monorepo moves it, and `grep, grep` is the second most common safe batch.

None close the gap: for 4.3 ms per run to matter against a 5,578 ms step, the saving would have to grow by three orders of magnitude, and it is bounded by tool latency.

## Contents

- `bench/parallel_tools/RESULTS.md` — the full table and the limits.
- `scripts/count_tool_batches.py` — reproduces it from your own `traces.jsonl`, per model, never as one average.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)