### PR TITLE
feat(context): a summariser for the compaction that has never fired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **A rule-form summariser for the span a compaction drops** — `chimera/core/summarise.py`, behind
+  `AgentConfig.summarise_compaction`, **off**. `compact()` has taken a `summarise` callable since it
+  was written and no production caller ever passed one, so every compaction leaves the structural
+  note. The note is a deliberate choice with its own defence — *"the agent can re-read a file; it
+  cannot un-believe a fabricated summary"* — so this is built beside it, not instead of it: the
+  summary travels **with** the note, asks for standing instructions rather than a narration, forbids
+  inference, and degrades to the note on every failure path.
+
 ### Changed
 
 - **Parallel tool calls: measured, and not built.** `chimera/core/agent.py` runs a turn's tool calls
@@ -187,6 +197,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
   `bench/parallel_tools/RESULTS.md` has the per-model table and what the census could not show;
   `scripts/count_tool_batches.py` reproduces it from your own traces.
+
+- **Compaction has never fired. Measured: 0 in 137 runs**, peak context a median of 6,826 tokens.
+  The pre-registered arms in `bench/compaction/` were written, and then not run, because they would
+  have compared two ways of doing something production does not do.
+
+  Two reasons, both in the code: the CLI's `context_budget` defaults to `None`, so `chimera solve`
+  has no compaction at all; and the Code screen sends 0.6 — of the model's **advertised** window,
+  which for the shipped default is 1,310,000 tokens. It therefore compacts at 786,000, against a
+  largest-ever-observed 64,067.
+
+  **The finding is the shape of the trigger.** When windows were 8k and 128k, "0.6 of the window" and
+  "as much as the model can still use well" were roughly the same number. Advertised windows have
+  grown an order of magnitude; the useful window has not. The next measurement is at what context
+  length this model starts getting the task wrong — a trigger set from that is about the model, one
+  set from the advertised maximum is about the marketing.
+
 
 ## [0.49.3] - 2026-09-03
 

--- a/bench/compaction/PREREGISTRATION.md
+++ b/bench/compaction/PREREGISTRATION.md
@@ -1,0 +1,140 @@
+# Does a summarised compaction keep what a note drops? — pre-registration
+
+**Written before either arm ran. No outcome was seen first.**
+
+`compact()` has accepted a `summarise` callable since it was written. No production caller has ever
+passed one, so every compaction in the product replaces the dropped span with `_structural_note`:
+
+> 21 earlier messages were removed to free context. Tools used in that span: write_file. Re-read any
+> file you need rather than relying on memory of it.
+
+That is a deliberate choice with its own defence, in the note's docstring: *"claiming to preserve
+content we never read would be worse than saying plainly that N exchanges happened. The agent can
+re-read a file; it cannot un-believe a fabricated summary."* This bench does not overturn that by
+conviction. It measures it.
+
+---
+
+## What is lost, and the trap in measuring it
+
+`RunState` restores the task, the plan and the open file; the system message survives verbatim. So a
+constraint written in the *task* is already preserved, in both arms, and a probe that puts one there
+**cannot exhibit the effect** — both arms pass and the run measures nothing. Verified before
+designing anything: with `RunState.task` set to the convention it survives compaction; with it unset
+it does not.
+
+The production case is the second one. On the Code screen a fresh `Agent` is built per request, so
+`run_state.task` holds *this* turn's message — a convention established in turn one of a
+conversation lives only in the history being compacted, with nothing to restore it.
+
+That is what the two papers `context_budget.py` already cites describe: compactors retain 17% of
+injected session constraints (arXiv 2608.11242), and rule-form items survive far better than facts
+(arXiv 2608.11392). The summariser under test is built on the second of those — it is asked for
+standing instructions in imperative form, explicitly not for a narration of what happened.
+
+## Arms
+
+| arm | what replaces the dropped span |
+|---|---|
+| **A — note** (control) | `_structural_note`: how many messages went, which tools ran |
+| **B — note + rules** (treatment) | the same note, **plus** the standing instructions of that span |
+
+B contains A. That is deliberate and it constrains what a negative can mean: B cannot lose by
+dropping information, only by **misleading** — a fabricated or garbled rule the agent then follows.
+That is precisely the risk the note's docstring names, so it is the risk this design leaves exposed
+rather than engineered away.
+
+## The probe
+
+A multi-turn conversation, on one workspace:
+
+1. **Turn 1** establishes a convention in plain words and asks for a first small file.
+2. **Turns 2–5** ask for more small files — enough traffic to force a compaction.
+3. **Final turn** asks for one more file, without restating the convention.
+
+Outcome: **does the final file honour the convention?** Checked mechanically against the file on
+disk, never by reading the model's prose about what it did.
+
+Conventions are chosen to be checkable without judgement (a required first line, a required suffix,
+a forbidden construct) and varied across conversations so a model cannot luck into one.
+
+`context_budget` is set low enough that a compaction fires within the conversation. That is the same
+mechanism production uses, triggered sooner; a run in which no compaction fired is **void** and
+reported as such rather than counted as a pass.
+
+## Decision rule, fixed now
+
+Primary outcome: the paired difference in "final file honours the convention", A against B, over the
+same conversations, tested with McNemar via `chimera/eval/paired.py`.
+
+- **ADOPT** if the paired delta is **≥ +15 percentage points** *and* **p < 0.05**.
+- **REJECT** otherwise.
+- **REJECT AND REPORT LOUDLY** if B < A. The summariser costs a model call per compaction; being
+  *worse* than a free structural note would be the outcome the current design was chosen to avoid,
+  and it would be a finding rather than a failed run.
+
+Fifteen points rather than five: this intervention is not free. It adds one model call per
+compaction, on the agent's own backend, and it replaces an honest count with something the agent
+will believe. A small gain does not pay for that.
+
+n = 30 paired conversations. A pilot of 6 runs first, and only to confirm the apparatus — that a
+compaction fires and that the convention lands in the dropped span. **The pilot's outcomes are not
+read**; if they were, the rule above would be a rule chosen after seeing data.
+
+## Gates before the aggregate is believed
+
+- **Compaction fired** in both arms of a pair, or the pair is void.
+- **Three summaries read with human eyes**, against the span they compress. A fabricated rule is the
+  failure this design is most exposed to and it will not show up in an aggregate.
+- **A convention that the control also honours is not evidence.** If A passes at ceiling, the probe
+  is too easy and the run cannot discriminate; that is a finding about the probe, reported as one.
+
+## What is also measured, because the gain is not the whole story
+
+- **Cost**: extra model calls, extra tokens, and added wall-clock per compaction.
+- **Fabrication**: how often the summary states a rule that was never said. Counted by hand over a
+  sample, and reported even at zero.
+- **The other direction**: conversations where A honoured the convention and B did not, listed
+  individually rather than netted away.
+
+## What this cannot show
+
+- **One model.** Today's parallel-tools census measured a 23-point spread between model families in
+  how they use a tool-calling API; nothing here transfers across families without measuring there.
+- **Synthetic conventions.** A stated rule about a first line is not a real user's mid-run
+  correction, and it is the easy end of what compaction destroys.
+- **A forced-low context budget.** Compaction fires earlier than production, so the dropped span is
+  shorter and easier to summarise than a real one. This biases *towards* the treatment, and the
+  bias is stated rather than corrected — correcting it would cost a very long run per pair.
+- **Nothing about long-horizon drift.** One compaction per conversation. The failure that shows up
+  after five is a different question.
+
+## Result
+
+`bench/compaction/RESULTS.md`, with the per-pair outcomes and the fabrication count.
+
+---
+
+## Amendment: the arms were not run
+
+Written after calibrating the apparatus and **before** reading any outcome. The pilot mode prints
+whether a compaction fired and what replaced the span; it does not print whether the convention
+survived, and that column does not exist in it.
+
+Calibration found that with `context_budget` at 0.04 no compaction fired in a six-turn
+conversation — and 0.04 is already **fifteen times lower** than the 0.6 the Code screen sends.
+The reason is the shape of the trigger: it is a fraction of the model's *advertised* window, and
+the shipped default advertises **1,310,000 tokens**. So the Code screen compacts at 786,000, the
+calibration ran at 41,920, and a six-turn conversation reaches 4,200. Compacting at all on this
+model needs a fraction around **0.0025** — a factor of 240 below what production sends.
+
+That prompted the question one layer up, which `traces.jsonl` answers for free: **zero compactions in
+137 runs.** The behaviour these arms compare is not one production reaches.
+
+Running them anyway would measure a configuration no surface uses, which is the failure this document
+already named in its own terms — *"a probe that puts the constraint in the task cannot exhibit the
+effect"* — wearing a different coat. `bench/fusion_paired` declined a 900-cell run on the same
+grounds after its pilot showed the corpus saturated.
+
+The rule above stands unchanged for whoever has a reason to run it. `bench/compaction/run.py` is the
+harness; `RESULTS.md` records the census and the measurement it asks for instead.

--- a/bench/compaction/RESULTS.md
+++ b/bench/compaction/RESULTS.md
@@ -1,0 +1,92 @@
+# The arms were not run, because compaction has never fired
+
+Measured 2026-09-04. **Zero compactions in 137 real runs.**
+
+[`PREREGISTRATION.md`](PREREGISTRATION.md) fixed a paired rule for a question one layer down: does a
+rule-form summary preserve standing instructions better than the structural note? The apparatus
+calibration answered a question one layer *up* first, and the answer makes the arms a measurement of
+a path production does not take.
+
+## What the census says
+
+`traces.jsonl` records `compactions` per run and `compacted` per step. Over every run this install
+has traced:
+
+| | |
+|---|---:|
+| runs | 137 |
+| runs with **≥1 compaction** | **0** |
+| steps marked compacted | **0** |
+| peak context, median | 6,826 tokens |
+| peak context, maximum | 64,067 tokens |
+
+## Why it never fires
+
+Two independent reasons, and both are in the code rather than in the corpus:
+
+1. **On the CLI, compaction is off.** `context_budget` defaults to `None`, and `Agent` builds no
+   `ContextBudget` without one. `chimera solve` therefore has no compaction at all unless the
+   operator passes `--context-budget`.
+2. **On the Code screen it is on, and unreachable.** `Conversation.tsx` sends `context_budget: 0.6`,
+   and the trigger is that fraction of the model's *advertised* window. Measured for the shipped
+   default:
+
+   ```
+   deepseek-v4-flash-0731   window 1,310,000   0.6 -> compacts at 786,000 tokens
+   ```
+
+   The largest context any traced run reached is 64,067 — a factor of twelve short.
+
+## The finding this leaves, and the measurement it asks for
+
+**A fraction of the advertised window is the wrong shape for the trigger**, and it has been quietly
+getting wronger. When windows were 8k and 128k, "0.6 of the window" and "as much as the model can
+still use well" were roughly the same number. Advertised windows have since grown by an order of
+magnitude; the *useful* window has not moved with them.
+
+The survey in `~/.claude/refs/harness-engineering.md` puts it plainly, from four independent sources:
+degradation within a single pass begins **before** the window fills, and a model advertising over
+200k can degrade from around 50k. This corpus's maximum, 64,067 tokens, is already past that mark —
+and nothing compacted, because the trigger is looking at 786,000.
+
+That is a claim from literature, not from this repository, and it is the next thing to measure rather
+than a reason to change the trigger now. The measurement is: **at what context length does this model
+start getting the task wrong?** A trigger set from that number is a trigger about the model; a
+trigger set from the vendor's advertised maximum is a trigger about the marketing.
+
+## The summariser ships, off
+
+`chimera/core/summarise.py` is written and tested — a rule-form summariser built on the split the two
+papers `context_budget` already cites: compactors retain 17% of injected session constraints
+(arXiv 2608.11242), and rule-form items survive far better than facts (arXiv 2608.11392). It asks for
+standing instructions and forbids inference; on any failure it degrades to the structural note, and
+it carries that note *alongside* the summary rather than instead of it.
+
+`AgentConfig.summarise_compaction` is **False**. Turning it on would add a model call per compaction
+to a path nothing takes — a cost with no effect to weigh against it. `bench/compaction/run.py` runs
+the pre-registered arms when someone has a reason to.
+
+## Why the arms were not run, and why that is not a moved goalpost
+
+Nothing about the hypothesis was seen. The pilot in `run.py --pilot` prints whether a compaction
+fired and what replaced the span, and **deliberately not** whether the convention survived; the
+outcome column does not exist in that mode. What was learned is that the apparatus needs a
+`context_budget` around **0.0025** to compact at all on this model — a configuration no surface uses
+— and at that point the run would measure a synthetic setting rather than the product.
+
+The pre-registration already named this shape of problem in its own terms: *"a probe that puts the
+constraint in the task cannot exhibit the effect — both arms pass and the run measures nothing."*
+Running under a budget three hundred times lower than production is the same failure wearing a
+different coat.
+
+`bench/fusion_paired` declined a 900-cell run on the same grounds after its pilot showed the corpus
+saturated. This is that precedent, applied.
+
+## What this census could not show
+
+- **137 runs from one install**, weighted towards short probes and short conversations. A person
+  working a full day in one Code conversation would reach further — though twelve times further is a
+  great deal of conversation.
+- **Only runs with a trace.** A run started without `trace_path` writes nothing here.
+- **It says nothing about whether a summary would help**, only that nothing currently reaches the
+  place where it would.

--- a/bench/compaction/run.py
+++ b/bench/compaction/run.py
@@ -1,0 +1,199 @@
+"""Run the compaction bench described in `PREREGISTRATION.md`.
+
+    python bench/compaction/run.py --pilot     # apparatus only: does a compaction fire?
+    python bench/compaction/run.py             # the paired run
+
+The conversation is shaped like the Code screen, because that is where the failure lives: a fresh
+`Agent` per turn with the previous transcript as history, so `run_state.task` holds THIS turn's
+message and a convention from turn one has nothing restoring it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+from chimera.config import get_settings  # noqa: E402
+from chimera.core import Agent, AgentConfig  # noqa: E402
+from chimera.providers.gateway import LLMGateway  # noqa: E402
+from chimera.tools.builtin import default_registry  # noqa: E402
+
+MODEL = "openrouter/deepseek/deepseek-v4-flash-0731"
+BUDGET = 0.04
+MARKER = "[earlier conversation, compacted]"
+
+
+@dataclass
+class Convention:
+    """A rule stated once, in words, and checkable on a file without judgement."""
+
+    name: str
+    said: str
+    check: object  # (str) -> bool
+
+
+CONVENTIONS = [
+    Convention(
+        "copyright-first-line",
+        "In this project every Python file must begin with the exact line '# (c) Bruno 2026'.",
+        lambda text: text.lstrip().startswith("# (c) Bruno 2026"),
+    ),
+    Convention(
+        "author-constant",
+        "In this project every Python module must define a module-level constant AUTOR = \"Bruno\".",
+        lambda text: re.search(r'^AUTOR\s*=\s*"Bruno"', text, re.M) is not None,
+    ),
+    Convention(
+        "end-marker",
+        "In this project every Python file must end with the exact line '# fim'.",
+        lambda text: text.rstrip().endswith("# fim"),
+    ),
+    Convention(
+        "function-prefix",
+        "In this project every function name must start with 'bee_'.",
+        lambda text: bool(re.findall(r"^def\s+(\w+)", text, re.M))
+        and all(n.startswith("bee_") for n in re.findall(r"^def\s+(\w+)", text, re.M)),
+    ),
+    Convention(
+        "no-print",
+        "In this project the print() builtin is banned; return values instead of printing them.",
+        lambda text: "print(" not in text,
+    ),
+    Convention(
+        "future-import",
+        "In this project every Python file must have 'from __future__ import annotations' as its "
+        "first import.",
+        lambda text: "from __future__ import annotations" in text,
+    ),
+]
+
+THEMES = [
+    ("shapes", ["area.py", "perimeter.py", "volume.py"], "geometry helpers"),
+    ("strings", ["slug.py", "titlecase.py", "trim.py"], "string helpers"),
+    ("money", ["vat.py", "discount.py", "rounding.py"], "money helpers"),
+    ("time", ["weekday.py", "elapsed.py", "parse_date.py"], "date helpers"),
+    ("lists", ["chunk.py", "dedupe.py", "flatten.py"], "list helpers"),
+]
+
+FINAL_FILE = "final.py"
+
+
+@dataclass
+class Pair:
+    convention: Convention
+    theme: tuple[str, list[str], str]
+
+    def turns(self) -> list[str]:
+        _, files, what = self.theme
+        first = (
+            f"{self.convention.said} With that in mind, create {files[0]} with one small function "
+            f"for {what}."
+        )
+        middle = [f"Now create {name} with one more small function for {what}." for name in files[1:]]
+        last = f"Now create {FINAL_FILE} with one more small function for {what}."
+        return [first, *middle, last]
+
+
+@dataclass
+class Outcome:
+    pair_id: str
+    arm: str
+    compacted: bool = False
+    honoured: bool = False
+    file_written: bool = False
+    usd: float = 0.0
+    seconds: float = 0.0
+    turns: int = 0
+    summaries: list[str] = field(default_factory=list)
+
+
+def run_conversation(pair: Pair, arm: str) -> Outcome:
+    workspace = Path(tempfile.mkdtemp(prefix="compact-bench-"))
+    out = Outcome(pair_id=f"{pair.convention.name}/{pair.theme[0]}", arm=arm)
+    settings = get_settings()
+    gateway = LLMGateway(settings)
+    history: list[object] = []
+    started = time.time()
+    try:
+        for task in pair.turns():
+            # A fresh Agent per turn, as the Code screen builds one per request. That is what makes
+            # `run_state.task` this turn's message rather than the conversation's opening.
+            agent = Agent(
+                gateway,
+                default_registry(workspace),
+                AgentConfig(
+                    model=MODEL,
+                    context_budget=BUDGET,
+                    max_steps=6,
+                    max_usd=0.06,
+                    summarise_compaction=(arm == "rules"),
+                ),
+            )
+            result = agent.run(task, history=list(history))  # type: ignore[arg-type]
+            out.turns += 1
+            out.usd += result.usd or 0.0
+            history = [
+                m for m in result.transcript
+                if not (isinstance(m, dict) and m.get("role") == "system")
+            ]
+            for message in history:
+                content = str(message.get("content") or "") if isinstance(message, dict) else ""
+                if MARKER in content:
+                    out.compacted = True
+                    if content not in out.summaries:
+                        out.summaries.append(content)
+        final = workspace / FINAL_FILE
+        out.file_written = final.is_file()
+        if out.file_written:
+            out.honoured = bool(pair.convention.check(final.read_text(encoding="utf-8")))
+    finally:
+        out.seconds = time.time() - started
+        shutil.rmtree(workspace, ignore_errors=True)
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pilot", action="store_true", help="apparatus only; outcomes not printed")
+    parser.add_argument("--out", default="bench/compaction/outcomes.json")
+    args = parser.parse_args()
+
+    pairs = [Pair(c, t) for c in CONVENTIONS for t in THEMES]
+    if args.pilot:
+        # Six, one per convention, control arm only. Prints whether a compaction fired and what the
+        # note replaced the span with — and DELIBERATELY not whether the convention survived. Reading
+        # that here would make the decision rule a rule chosen after seeing data.
+        print("PILOT — apparatus only. Outcomes are not read.\n")
+        for pair in pairs[:: len(THEMES)]:
+            out = run_conversation(pair, "note")
+            print(f"  {out.pair_id:34} compactou={out.compacted}  turnos={out.turns}  "
+                  f"arquivo={out.file_written}  usd={out.usd:.4f}  {out.seconds:.0f}s")
+            if out.summaries:
+                print(f"     vao: {out.summaries[0][:150]}")
+        return 0
+
+    results: list[Outcome] = []
+    for index, pair in enumerate(pairs, 1):
+        for arm in ("note", "rules"):
+            out = run_conversation(pair, arm)
+            results.append(out)
+            print(f"  [{index:2}/{len(pairs)}] {arm:5} {out.pair_id:34} "
+                  f"compactou={out.compacted} honrou={out.honoured} usd={out.usd:.4f}")
+    Path(args.out).write_text(
+        json.dumps([vars(r) for r in results], indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"\n  gravado em {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -167,6 +167,11 @@ class AgentConfig:
     # the prompt, compacting once the prompt crosses `trigger` of it. Off by default because
     # compaction discards messages, and a caller that has not asked for that should not get it.
     context_budget: float | None = None
+    # Replace the dropped span with a model-written summary of what still BINDS, instead of the
+    # structural note. Off pending `bench/compaction`, and the reason is the note's own docstring:
+    # a summary is believed in a way a note is not, so a bad one is worse than an honest count.
+    # Costs one model call per compaction, on the agent's own backend.
+    summarise_compaction: bool = False
     # Dollar ceiling for the whole run. None (the default) keeps the historical behaviour: no cap,
     # and therefore no new way for a run to stop. Set it and the loop refuses the next model call
     # once the spend reaches it — checked BEFORE the call, so the money is never spent to discover
@@ -336,6 +341,13 @@ class Agent:
         #: What a compaction must restore. A caller that knows the open file, the plan or the task
         #: list assigns it here; left empty, compaction still keeps the recent tail.
         self.run_state = RunState()
+        # Built once rather than per compaction, and None unless asked for: `compact()` treats
+        # None as "use the structural note", which is the behaviour every caller has today.
+        self._summarise = None
+        if self.config.summarise_compaction:
+            from chimera.core.summarise import rule_summariser
+
+            self._summarise = rule_summariser(backend, self.config.model)
 
         # The skill library surfaced as context. Defaults to the built-in registry (lazy, shared),
         # so every construction site picks up skills without changes; pass an explicit one to override.
@@ -651,7 +663,10 @@ class Agent:
                 and self._budget.should_compact(result.prompt_tokens)
             ):
                 messages, compacted = compact(
-                    messages, keep_recent=self.config.keep_recent, state=self.run_state
+                    messages,
+                    keep_recent=self.config.keep_recent,
+                    state=self.run_state,
+                    summarise=self._summarise,
                 )
                 if compacted:
                     record.compacted = True

--- a/chimera/core/summarise.py
+++ b/chimera/core/summarise.py
@@ -1,0 +1,119 @@
+"""A summariser for the span a compaction drops — written as rules, not as narration.
+
+`compact()` takes a `summarise` callable and no production caller has ever passed one, so every
+compaction in the product replaces the dropped span with `_structural_note`: *"21 earlier messages
+were removed. Tools used in that span: write_file."* That note is a deliberate choice and its own
+docstring defends it — *"the agent can re-read a file; it cannot un-believe a fabricated summary"* —
+which is why this module exists beside it rather than instead of it, and why it is measured before
+it is switched on.
+
+**What is actually lost.** `RunState` restores the task, the plan and the open file, and the system
+message survives verbatim. What compaction drops with nothing to restore it is everything a *person*
+said after the first message: a convention established in turn one of a conversation, a correction,
+a "not that directory". On the Code screen that is the common case — a fresh `Agent` is built per
+request, so `run_state.task` holds THIS turn's message and turn one's convention lives only in the
+history being compacted.
+
+**Why rule-form.** The two papers `context_budget` cites split exactly here: compactors retain 17% of
+injected session constraints (arXiv 2608.11242), and rule-form items survive a compaction far better
+than facts (arXiv 2608.11392). So this does not ask for a summary of what happened — the structural
+note already says what happened, cheaper and without a model. It asks for the standing instructions
+and decisions, which are the part with no other route back into the prompt.
+
+**What it must never do** is invent. A summary is believed in a way a note is not, so the prompt
+forbids inference and the fallback on any failure is the structural note rather than silence: a
+compaction that could not summarise must still compact.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from chimera.telemetry import get_logger
+
+_log = get_logger("core.summarise")
+
+#: Cap on what is sent to the summariser. The dropped span can be most of a context window, and
+#: paying full price to compress it would make the compaction cost as much as the overflow it
+#: prevents. Head and tail both, for the reason `events._clip_observation` gives: the beginning
+#: carries what was established and the end carries where the work had got to.
+MAX_INPUT_CHARS = 12_000
+
+SYSTEM = (
+    "You compress the earlier part of a conversation that is being dropped to free context. "
+    "Write ONLY the standing instructions, constraints, decisions and corrections that a "
+    "collaborator would need in order to keep working consistently — in imperative form, one per "
+    "line, shortest wording that keeps the meaning. "
+    "Do NOT narrate what happened, do not summarise file contents, and do not list tool calls: "
+    "those are recoverable by re-reading and are reported separately. "
+    "Write nothing that was not actually said. If the span contains no standing instruction at all, "
+    "reply with the single word NONE."
+)
+
+
+def _flatten(messages: list[Any]) -> str:
+    """The dropped span as plain text, clipped at both ends."""
+    lines: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "?")
+        content = str(message.get("content") or "").strip()
+        # Tool results are the bulk of a span and the least worth summarising: they are the thing
+        # the agent can get back by asking again. The name is kept so a rule that depends on one
+        # ("we agreed to use the second file grep found") is still legible.
+        if role == "tool":
+            content = content[:200]
+        if content:
+            lines.append(f"{role}: {content}")
+    text = "\n".join(lines)
+    if len(text) <= MAX_INPUT_CHARS:
+        return text
+    head = MAX_INPUT_CHARS // 2
+    return f"{text[:head]}\n…\n{text[-(MAX_INPUT_CHARS - head):]}"
+
+
+def rule_summariser(
+    backend: Any,
+    model: str | None = None,
+    *,
+    fallback: Callable[[list[Any]], str] | None = None,
+) -> Callable[[list[Any]], str]:
+    """Build the `summarise` callable `compact()` accepts.
+
+    ``fallback`` is what is used when the model returns nothing usable, and defaults to the
+    structural note. That is not defensive decoration: the alternative is a compaction that silently
+    replaces a span with an empty string, which is the one outcome strictly worse than either arm.
+    """
+    from chimera.core.context_budget import _structural_note
+
+    to_note = fallback or _structural_note
+
+    def summarise(older: list[Any]) -> str:
+        body = _flatten(older)
+        if not body.strip():
+            return to_note(older)
+        try:
+            from chimera.providers.gateway import Message
+
+            answer = backend.complete(
+                [Message(role="system", content=SYSTEM), Message(role="user", content=body)],
+                model=model,
+                temperature=0.0,
+            ).content
+        except Exception as exc:  # noqa: BLE001 — a compaction must not fail on a summariser
+            _log.warning("compaction summariser failed, using the structural note: %s", exc)
+            return to_note(older)
+
+        rules = (answer or "").strip()
+        if not rules or rules.upper().startswith("NONE"):
+            # Nothing standing was said, which is a real answer and a common one. The note is then
+            # both cheaper and more informative than an empty summary.
+            return to_note(older)
+        # The note goes WITH it, never instead of it. They answer different questions — the note
+        # says how much was dropped and which tools ran, the summary says what still binds — and an
+        # agent that reads only the second has no idea how much it is missing.
+        return f"{to_note(older)}\n\nStanding from that span:\n{rules}"
+
+    return summarise

--- a/tests/test_the_summariser_for_a_compaction_that_never_fires.py
+++ b/tests/test_the_summariser_for_a_compaction_that_never_fires.py
@@ -1,0 +1,165 @@
+"""A summariser for the span a compaction drops — and the census that says it has never run.
+
+`compact()` has taken a `summarise` callable since it was written and no production caller has ever
+passed one. This is that callable, built on the split the two papers `context_budget` cites already
+describe: compactors retain 17% of injected session constraints, and rule-form items survive far
+better than facts. So it asks for standing instructions, not for a narration — the structural note
+already says what happened, cheaper and without a model.
+
+It ships **off**, and not only because the paired arms in `bench/compaction/PREREGISTRATION.md` were
+not run. Measured over the 137 runs this install has traced: **zero compactions**, peak context a
+median 6,826 tokens against a trigger of 786,000. The behaviour under test is not reachable, and a
+default that turns on a model call for a path nothing takes is a cost with no effect to weigh it
+against.
+
+What is tested here is therefore the contract, not the benefit: the thing degrades to the note on
+every failure, it never returns an empty span, and it carries the note alongside the summary rather
+than instead of it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chimera.core.context_budget import _structural_note, compact
+from chimera.core.summarise import MAX_INPUT_CHARS, SYSTEM, rule_summariser
+
+
+class _Backend:
+    """A scripted `complete`, or an explosion. Nothing here needs a model."""
+
+    def __init__(self, answer: str = "Always start a file with '# (c) Bruno'.", boom: bool = False):
+        self.answer = answer
+        self.boom = boom
+        self.calls: list[list[Any]] = []
+
+    def complete(self, messages: list[Any], **kwargs: Any) -> Any:
+        self.calls.append(list(messages))
+        if self.boom:
+            raise RuntimeError("the provider fell over")
+
+        class _R:
+            content = self.answer
+
+        return _R()
+
+
+SPAN: list[Any] = [
+    {"role": "user", "content": "Every file in this project starts with '# (c) Bruno'."},
+    {"role": "assistant", "content": "", "tool_calls": [
+        {"id": "1", "function": {"name": "write_file", "arguments": "{}"}}]},
+    {"role": "tool", "tool_call_id": "1", "content": "wrote a.py"},
+    {"role": "user", "content": "now do the next one"},
+]
+
+
+# --- what it produces -------------------------------------------------------------------------
+
+
+def test_the_note_travels_with_the_summary_never_instead_of_it() -> None:
+    """They answer different questions: how much went, and what still binds."""
+    out = rule_summariser(_Backend())(SPAN)
+
+    assert "earlier messages were removed" in out, "the count is what says how much is missing"
+    assert "# (c) Bruno" in out
+
+
+def test_the_rules_are_labelled_as_coming_from_the_dropped_span() -> None:
+    out = rule_summariser(_Backend())(SPAN)
+    assert "Standing from that span:" in out
+
+
+def test_tool_results_are_clipped_before_they_are_sent() -> None:
+    """A span is mostly tool output, and tool output is the part the agent can just ask for again."""
+    backend = _Backend()
+    span = [*SPAN, {"role": "tool", "tool_call_id": "2", "content": "x" * 5_000}]
+    rule_summariser(backend)(span)
+
+    sent = str(backend.calls[0][1].content)
+    assert "x" * 200 in sent
+    assert "x" * 400 not in sent
+
+
+def test_a_very_long_span_is_clipped_at_both_ends() -> None:
+    """Head and tail: the beginning carries what was established, the end where the work had got to."""
+    backend = _Backend()
+    span = [{"role": "user", "content": "FIRST"}]
+    span += [{"role": "user", "content": "filler " * 400} for _ in range(20)]
+    span += [{"role": "user", "content": "LAST"}]
+    rule_summariser(backend)(span)
+
+    sent = str(backend.calls[0][1].content)
+    assert len(sent) <= MAX_INPUT_CHARS + 8
+    assert "FIRST" in sent and "LAST" in sent
+
+
+def test_the_prompt_forbids_inventing() -> None:
+    """The risk this whole design is exposed to, held in the one place that can prevent it."""
+    assert "not actually said" in SYSTEM
+    assert "NONE" in SYSTEM
+
+
+# --- every way it can fail --------------------------------------------------------------------
+
+
+def test_a_backend_that_raises_degrades_to_the_note() -> None:
+    """A compaction must still compact. The alternative is a run that dies to free memory."""
+    out = rule_summariser(_Backend(boom=True))(SPAN)
+    assert out == _structural_note(SPAN)
+
+
+def test_an_empty_answer_degrades_to_the_note() -> None:
+    assert rule_summariser(_Backend(answer="   "))(SPAN) == _structural_note(SPAN)
+
+
+def test_the_word_none_degrades_to_the_note() -> None:
+    """"Nothing standing was said" is a real answer, and a common one."""
+    assert rule_summariser(_Backend(answer="NONE"))(SPAN) == _structural_note(SPAN)
+
+
+def test_a_span_with_no_text_never_reaches_the_model() -> None:
+    backend = _Backend()
+    out = rule_summariser(backend)([{"role": "tool", "tool_call_id": "1", "content": ""}])
+    assert backend.calls == [], "an empty span is not worth a model call"
+    assert "earlier messages were removed" in out
+
+
+def test_it_never_returns_an_empty_span() -> None:
+    """The one outcome strictly worse than either arm: a span replaced by nothing at all."""
+    for backend in (_Backend(), _Backend(boom=True), _Backend(answer=""), _Backend(answer="NONE")):
+        assert rule_summariser(backend)(SPAN).strip()
+
+
+# --- through the real compaction ----------------------------------------------------------------
+
+
+def test_compact_uses_the_summariser_when_one_is_given() -> None:
+    messages: list[Any] = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": f"turn {i}"} for i in range(12)]
+
+    out, changed = compact(messages, keep_recent=4, summarise=rule_summariser(_Backend()))
+
+    assert changed
+    assert "# (c) Bruno" in str(out[1]["content"])
+
+
+def test_compact_without_one_is_byte_identical_to_before() -> None:
+    """The default path is untouched: `summarise=None` is what every caller passes today."""
+    messages: list[Any] = [{"role": "system", "content": "sys"}]
+    messages += [{"role": "user", "content": f"turn {i}"} for i in range(12)]
+
+    with_none, _ = compact(messages, keep_recent=4, summarise=None)
+    plain, _ = compact(messages, keep_recent=4)
+
+    assert with_none == plain
+
+
+def test_the_agent_builds_no_summariser_unless_asked(monkeypatch: Any) -> None:
+    from chimera.core import Agent, AgentConfig
+    from chimera.tools import ToolRegistry
+
+    assert Agent(_Backend(), ToolRegistry(), AgentConfig())._summarise is None
+    assert (
+        Agent(_Backend(), ToolRegistry(), AgentConfig(summarise_compaction=True))._summarise
+        is not None
+    )


### PR DESCRIPTION
`compact()` has accepted a `summarise` callable since it was written. **No production caller has ever passed one**, so every compaction in the product replaces the dropped span with the structural note:

> 21 earlier messages were removed to free context. Tools used in that span: write_file.

That is a deliberate choice with its own defence, in the note's docstring — *"the agent can re-read a file; it cannot un-believe a fabricated summary."* This does not overturn it by conviction. It was going to measure it.

## What happened instead: compaction has never fired

The apparatus calibration answered a question one layer up, for free, from traces already on disk:

| | |
|---|---:|
| runs traced | 137 |
| runs with at least one compaction | **0** |
| steps marked compacted | **0** |
| peak context, median | 6,826 tokens |
| peak context, maximum | 64,067 tokens |

Two causes, both in the code rather than the corpus:

1. **The CLI has no compaction.** `context_budget` defaults to `None`, so `chimera solve` never builds a `ContextBudget` unless the operator passes `--context-budget`.
2. **The Code screen's is unreachable.** It sends `0.6` — of the model's **advertised** window. The shipped default advertises **1,310,000 tokens**, so it compacts at **786,000**, twelve times past anything ever observed.

## The finding: a fraction of an advertised window is the wrong shape for a trigger

When windows were 8k and 128k, "0.6 of the window" and "as much as the model can still use well" were roughly the same number. Advertised windows have grown an order of magnitude; the useful window has not moved with them.

The next measurement is **at what context length this model starts getting the task wrong**. A trigger set from that number is about the model; a trigger set from the vendor's advertised maximum is about the marketing. That degradation begins before a window fills is a claim from literature, not from this repository — which is why it is named as the next measurement rather than shipped as a threshold change.

## Why the arms were not run, and why that is not a moved goalpost

Nothing about the hypothesis was seen. `run.py --pilot` prints whether a compaction fired and what replaced the span, and **deliberately not** whether the convention survived — that column does not exist in pilot mode.

What was learned is that compacting at all on this model needs `context_budget` around **0.0025**, a factor of **240 below what production sends**. Running there measures a synthetic configuration, which is the failure the pre-registration already named in its own terms: *"a probe that puts the constraint in the task cannot exhibit the effect — both arms pass and the run measures nothing."*

`bench/fusion_paired` declined a 900-cell run on the same grounds after its pilot showed the corpus saturated. The rule stands unchanged in the document for whoever has a reason to run it, and `bench/compaction/run.py` is the harness.

## The summariser, which ships off

Built on the split the two papers `context_budget` already cites: compactors retain 17% of injected session constraints, and rule-form items survive a compaction far better than facts.

- Asks for **standing instructions in imperative form** — not a narration; the note already says what happened, cheaper and without a model.
- **Carries the note with it**, never instead of it: they answer different questions, and an agent reading only the summary has no idea how much it is missing.
- **Forbids inference** in the prompt, and returns the note on every failure path — a raising backend, an empty answer, `NONE`, or a span with no text (which never reaches the model at all).
- **Never returns an empty span**, the one outcome strictly worse than either arm.

`AgentConfig.summarise_compaction` is `False`. Turning it on adds a model call per compaction to a path nothing takes.

## Verification

- 13 new tests; **sabotage matrix 8/8** — each guard reverted alone, the edit confirmed on disk, a test required to fail.
- Three entries came back "trecho ausente" on the first pass, and that was the harness rather than the code: a shell heredoc had eaten the backslashes in an f-string, so the replacement never matched the source. Re-run through a file, all three were caught. Recorded because "the sabotage did not apply" and "the guard is not needed" look identical in a summary line.
- `compact(summarise=None)` is byte-identical to `compact()` — the default path is untouched.
- Full suite green apart from 4 pre-existing environment failures (a space in the repo path breaks a shell command on Windows), verified against a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
