### PR TITLE
bench(models): per-model edit-format tailoring has nothing to tailor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   set from the advertised maximum is about the marketing.
 
 
+## [Unreleased]
+
+### Changed
+
+- **Per-model edit-format tailoring: measured, and there is nothing to tailor.** The claim that would
+  justify it — an OpenAI-family model is cheaper with patches, a Claude-family one with whole blocks
+  — was put to 66 runs over `bench/edit_tools`'s pytest-verified task set, with the format **forced**
+  by denylist rather than suggested in a prompt.
+
+  | family | n | W − P (completion tokens) | 95% CI |
+  |---|---:|---:|---|
+  | `deepseek-v4-flash-0731` | 10 | −239 (−10.3%) | [−1,032, +448] **includes zero** |
+  | `glm-5.3-flash` | 9 | +256 (+12.2%) | [−355, +729] **includes zero** |
+  | `gemini-3.8-flash` | 0 | — | no usable pair |
+
+  The two medians point in **opposite directions**, which is exactly what the tailoring story
+  predicts — and the first draft of the results said so. It was wrong: the per-task deltas run from
+  −2,092 to +3,184, and neither interval excludes zero. There is no effect for a direction to
+  describe. `bench/edit_format_by_model/` records the near-miss reading and why it was dropped.
+
+  Larger than the effect under test, and found on the way: `glm-5.3-flash` cost **17× the money and
+  2.5× the wall clock** of `deepseek-v4-flash-0731` for the same tasks at the same pass rate. Both
+  are "flash"-tier by name.
+
 ## [0.49.3] - 2026-09-03
 
 ### Changed

--- a/bench/edit_format_by_model/PREREGISTRATION.md
+++ b/bench/edit_format_by_model/PREREGISTRATION.md
@@ -1,0 +1,161 @@
+# Does the cheaper edit format differ by model family? — pre-registration
+
+**Written before any arm ran. No outcome was seen first.**
+
+The claim under test is the one that would justify per-model tailoring at all: that a harness should
+give an OpenAI-family model patches and a Claude-family model whole blocks, because each is cheaper
+in its own family. Chimera does neither — one system prompt, one tool schema, one edit format for
+every model, with a single vendor branch anywhere in the codebase (an Anthropic `cache_control`
+header). Before building the machinery to tailor, this measures whether there is anything to exploit.
+
+Today's parallel-tools census is what makes the question worth asking rather than assuming: it
+measured a **23-point spread between model families** in how often they put two tool calls in one
+turn — `gemini-3.8-flash` and `deepseek-chat-v3.1` never did it across 414 steps, while
+`deepseek-v4-flash-0731` did it 23.3% of the time. Families demonstrably differ in how they drive a
+tool-calling API. Whether that difference reaches *cost of an edit* is what this run answers.
+
+---
+
+## Two facts from this repository that shape the design
+
+**Pass/fail is saturated and cannot be the outcome.** `bench/edit_tools/RESULTS.md`, on this same
+task set: *"22 usable pairs out of 22 attempted; every run in both arms passed its verifier."* An
+outcome at ceiling in both arms discriminates nothing, and choosing it would produce a run that
+looks careful and measures noise.
+
+**The prior from this repo is that edit-surface changes move calls, not money.** The same bench found
+`edit_batch` cut edit calls by a median of 2.0 with a CI excluding zero, and moved completion tokens
+by −33 with a CI of [−85.5, +70.0] — not significant. So the honest expectation going in is that
+format changes cost counts rather than tokens, and the primary outcome is set to **the thing that is
+actually paid for**.
+
+## Arms — forced, not suggested
+
+| arm | tool surface | the agent must |
+|---|---|---|
+| **P — patch** | `write_file` denied | edit in place with `edit_file` / `apply_patch` |
+| **W — whole** | `edit_file`, `apply_patch` denied | rewrite whole files with `write_file` |
+
+Forced via `CHIMERA_TOOL_DENYLIST` rather than nudged in the prompt, because a nudge measures how
+obedient a model is and this is meant to measure which format is cheaper *for it*. Reading tools
+(`read_file`, `list_dir`, `grep`, `glob`) and `run_shell` are identical in both arms.
+
+## Models
+
+Three families, one cheap model each, all three present in the census that motivated this:
+
+- `openrouter/deepseek/deepseek-v4-flash-0731` — DeepSeek (and the shipped default)
+- `openrouter/z-ai/glm-5.3-flash` — Z-AI
+- `openrouter/google/gemini-3.8-flash` — Google
+
+## Tasks
+
+The 11 tasks `bench/edit_tools/run_ab.py` uses — its 12 minus `import_module_moved`, which that
+bench's own pre-registration excluded because the control arm failed it 3/3. The exclusion is
+inherited rather than re-decided, so it cannot be a choice made after seeing anything here.
+
+11 tasks × 2 arms × 3 models = 66 runs.
+
+## Primary outcome and decision rule, fixed now
+
+**Completion tokens to a passing verifier**, per (task, arm, model). Verdict is the existing
+`_verdict` — our pytest, on a test restored from pristine, so an agent that edits the test into
+passing scores nothing.
+
+The question is an **interaction**, not a main effect. A format that is cheaper for every model is a
+better default, not a reason to tailor.
+
+- **BUILD per-model tailoring** if the sign of (W − P) **differs between at least two families**,
+  *and* each of those two within-family medians differs by **≥ 20%** of that family's median tokens.
+- **REJECT** if the same arm is cheaper in all three families, whatever the margin: that is a
+  finding about the default, not about tailoring.
+- **REJECT** if the differences are inside ±20%: a branch per family is a maintenance liability that
+  ages with every model release, and a small effect does not pay for it.
+
+Secondary, reported and never used to decide: pass rate (expected at ceiling — if it is not, that
+changes what the token figures mean and is reported before them), edit calls, tool calls, wall clock.
+
+## Gates before the aggregate is believed
+
+- **Pass rate is read first.** A cell where an arm fails is a cell whose token figure is the cost of
+  failing, not the cost of the format.
+- **Both arms are checked for the tool they were denied.** An arm that still called the denied tool
+  did not run the condition it is labelled with, and the pair is void.
+- **A run that used zero edit tools of any kind** did not do the task the way the arm describes, and
+  is inspected rather than counted.
+
+## What this cannot show
+
+- **One model per family, one size tier.** All three are "flash"-class. A frontier model in the same
+  family may behave differently, and nothing here transfers to it.
+- **Small fixtures.** `tasks.py` says it itself: *"a rename across four toy modules is not a rename
+  across django."* Whole-file rewriting is cheapest exactly when files are small, which biases arm W
+  upward relative to a real repository. Stated rather than corrected — correcting it means a much
+  larger corpus.
+- **One repeat per cell.** This is a screening run: it can find a large sign flip between families
+  and cannot resolve a subtle one. If it finds nothing, "no effect this size" is the claim, not "no
+  effect".
+- **Nothing about prompt or schema tailoring.** Only the edit format is manipulated. A family
+  difference in how a system prompt should be worded is a separate question with a separate ruler.
+
+## Cost
+
+66 `chimera solve` runs on flash-tier models. Estimated under two dollars, and reported as measured
+rather than estimated once the run is done.
+
+## Result
+
+`bench/edit_format_by_model/RESULTS.md`.
+
+---
+
+## Amendment: one gate was measuring the wrong thing
+
+Made while the grid was still running, and recorded with what had already been seen.
+
+The gate *"both arms are checked for the tool they were denied"* voided a pair when the denied tool
+appeared in the run's `tool_names`. That list records what the model **asked for**, not what ran:
+`agent.py` appends the name at line 729 and calls `_run_tool` at line 733, and a denied tool is
+absent from the registry, so `_run_tool` returns `"error: unknown tool"` and nothing executes.
+
+So a denied name in that list is the manipulation **working** — the model reaching for the format it
+was refused — and voiding those pairs would discard exactly the runs where the condition bit
+hardest. The gate now voids on two things only: the verifier failed, or the arm never used the tool
+it was supposed to.
+
+**What had been seen when this was found.** A dry run of `analyse.py` over the first 15 of 66 rows
+printed one family's figure: `deepseek-v4-flash-0731`, 4 usable pairs, W cheaper by 9.0% — below the
+20% margin, so "reject" on that partial slice. That is stated because the alternative is asking a
+reader to trust that a correction made mid-run was not steered by a number.
+
+The correction rests on a fact about the instrument that is checkable in the source and has nothing
+to do with any outcome. The **decision rule is unchanged**. And `analyse.py` now prints the verdict
+under *both* gates, so whether the correction moved the answer is visible rather than asserted.
+
+---
+
+## Amendment: a timed-out run was scoring as a free success
+
+Found at row 29 of 66, while the grid was still running.
+
+Two rows carried `completion_tokens = 0` with `usd = 0.0000` and `tool_calls = 0`. Both had
+`exit = 124` — killed at the 900-second timeout, so no receipt was ever written. And one of them,
+`glm-5.3-flash / P / signature_swap_args`, was scored **`passed = True`**: `_verdict` runs pytest
+over whatever the process had already written to the workspace, and by then the edits were done.
+
+A run whose price was never recorded cannot appear in a table of prices, and a timeout entering the
+median as a zero-cost success would drag the arm that timed out downward — the exact opposite of the
+truth about it. So a third void is added: **`exit == 124` or zero recorded tokens**, whatever the
+verdict says.
+
+Voided on the measurement rather than on the verdict, and by pair as the others are.
+
+**What this costs, stated rather than discovered later.** Voiding timeouts removes the tasks an arm
+could not finish inside fifteen minutes, which are the hardest ones — so the surviving comparison is
+between tasks both arms completed, and it understates any difference that shows up only under
+pressure. Two of the first 29 rows, about 7%.
+
+**What had been seen when this was found.** Three individual rows from the progress line
+(`glm-5.3-flash W signature_swap_args 6968 tokens`, `P signature_return_shape 3781`, and the two
+zeroes above). No aggregate has been computed since the previous amendment, and the decision rule is
+again unchanged.

--- a/bench/edit_format_by_model/RESULTS.md
+++ b/bench/edit_format_by_model/RESULTS.md
@@ -1,0 +1,96 @@
+# Per-model edit-format tailoring: nothing to tailor
+
+Run 2026-09-04 against the rule fixed in [`PREREGISTRATION.md`](PREREGISTRATION.md) and its two
+amendments. 66 runs, **US$ 2.63** measured (pre-registered as "estimated under two dollars").
+
+## Verdict: REJECT
+
+| family | n pairs | P (patch) | W (whole) | W − P | % | 95% CI |
+|---|---:|---:|---:|---:|---:|---|
+| `deepseek-v4-flash-0731` | 10 | 2,351 | 2,296 | **−239** | −10.3% | [−1,032, +448] **includes zero** |
+| `glm-5.3-flash` | 9 | 2,109 | 2,069 | **+256** | +12.2% | [−355, +729] **includes zero** |
+| `gemini-3.8-flash` | **0** | — | — | — | — | no usable pair |
+
+Completion tokens to a passing verifier, paired per task, bootstrapped over the per-task deltas.
+
+**Neither family shows an effect distinguishable from zero.** The pre-registered rule would already
+have rejected on the 20% margin; the intervals say something stronger, which is that there is no
+effect for a margin to fall short of.
+
+## The reading this run nearly got, and why it would have been wrong
+
+The two medians point in **opposite directions** — DeepSeek is cheaper rewriting whole files, Z-AI is
+cheaper patching — at 10.3% and 12.2%. That is exactly the shape a per-model tailoring story
+predicts, and the draft of this file said so: *"the direction flips, which is what the story
+predicts; the magnitude does not pay for the machinery."*
+
+It was wrong. The per-task deltas are these:
+
+```
+deepseek   -2092  -1230  -1032  -621  -387  -91  +114  +263  +988  +3184
+glm-flash   -465   -355   -263  -157  +256  +287  +337  +729  +4236
+```
+
+A median of −239 out of a spread that runs from −2,092 to +3,184 is not a direction. The bootstrap
+interval was added for exactly this and is recorded as an addition rather than folded in silently:
+it strengthens a reject and could not have turned one into an adopt.
+
+## The third family contributed nothing, and the run cannot say why
+
+`gemini-3.8-flash`: 22 runs, **0 usable pairs**.
+
+- **11 never ran.** OpenRouter rate-limited them — `usd = 0`, `tool_calls = 0`, and a tail asking for
+  a BYO key to accumulate limits.
+- **11 ran and failed**, at a median of 24 tool calls and US$ 0.87 total, passing 2 of 11 — against
+  19 of 19 for the two families that produced data.
+
+That looks like a capability gap between "flash"-tier models, and this run **cannot claim it**: the
+tails of the failing runs carry LiteLLM provider-error banners, so some of those failures may be the
+same rate limiting arriving mid-run rather than the model losing the task. Separating them needs a
+key without that limit, and the two explanations are not separable from what was collected.
+
+## What was thrown away, and why
+
+14 of 33 pairs voided:
+
+| reason | rule |
+|---|---|
+| the verifier failed | a failing run's tokens are the cost of failing, not the cost of the format |
+| no cost recorded (`exit 124`, or zero tokens) | a run whose price was never recorded cannot be in a table of prices |
+| the arm never used its own tool | it did not run the condition its label claims |
+
+**Asking for the denied tool is not a void**, and that was one of the two amendments: `tool_names` is
+appended before the tool runs, and a denied tool is absent from the registry, so the name in that
+list is the model reaching for a refused format — the manipulation working, not leaking. Two rows.
+
+Voiding timeouts removes the tasks an arm could not finish in fifteen minutes, which are the hardest,
+so the surviving comparison is between tasks both arms completed. Any difference that only appears
+under pressure is understated here.
+
+## The side finding, which is larger than the one under test
+
+| family | usd for 9–10 tasks, per arm | median seconds |
+|---|---:|---:|
+| `deepseek-v4-flash-0731` | **0.035** | 31 |
+| `glm-5.3-flash` | **0.611** | 76 |
+
+Same tasks, same verifier, same pass rate — **17× the money and 2.5× the wall clock**. Both are
+"flash"-tier by name. Nothing in this bench was designed to measure that and it is reported as an
+observation rather than a result, but it is a far larger lever on cost than any edit-format choice
+measured here.
+
+## What this cannot show
+
+- **Two families, not three**, one flash-tier model each, one repeat per cell. A screening run: it
+  can find a large sign flip and cannot resolve a subtle one. The claim is "no effect **this size**",
+  not "no effect".
+- **Small fixtures.** `tasks.py` says it: *"a rename across four toy modules is not a rename across
+  django."* Whole-file rewriting is cheapest exactly when files are small, so arm W is flattered here
+  relative to a real repository — and it still did not win.
+- **Only the edit format.** Nothing here is about tailoring a prompt or a tool schema per family. The
+  parallel-tools census found a 23-point spread between families in tool-call batching, so families
+  *do* differ; this says the difference does not reach the cost of an edit.
+- **The two amendments were made mid-run**, both on facts about the instrument, both recorded in the
+  pre-registration with what had been seen at the time, and neither touched the decision rule.
+
+Reproduce with `python bench/edit_format_by_model/run.py` then `analyse.py`.

--- a/bench/edit_format_by_model/analyse.py
+++ b/bench/edit_format_by_model/analyse.py
@@ -1,0 +1,172 @@
+"""Read `rows.json` and answer the question `PREREGISTRATION.md` fixed, in the order it fixed it.
+
+    python bench/edit_format_by_model/analyse.py
+
+The gates come first and the aggregate second, because a cell where an arm failed carries the cost of
+failing rather than the cost of the format, and a cell where the denied tool was used did not run the
+condition its label claims.
+
+The question is an INTERACTION. A format cheaper for every model is a better default, not a reason
+to tailor — so the verdict reads the SIGN of the within-family difference across families, never a
+pooled median that would average the two answers into neither.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+HERE = Path(__file__).resolve().parent
+MARGIN = 0.20  # the pre-registered floor: 20% of the family's own median
+
+
+def main() -> int:
+    rows = json.loads((HERE / "rows.json").read_text(encoding="utf-8"))
+    print(f"  {len(rows)} linhas\n")
+
+    # --- gates, before any aggregate -------------------------------------------------------------
+    failed = [r for r in rows if not r["passed"]]
+    # NOT a void. `tool_names` is appended BEFORE the tool runs (`agent.py:729`, against `_run_tool`
+    # at :733), and a denied tool is absent from the registry, so `_run_tool` returns
+    # "error: unknown tool" and nothing executes. A denied name in this list is therefore the model
+    # ASKING and being refused — the condition working, plus the model discovering it. Voiding those
+    # pairs would discard the runs where the manipulation bit hardest.
+    asked_denied = [r for r in rows if r["used_denied"]]
+    idle = [r for r in rows if not r["used_expected"]]
+    # A run killed at the timeout wrote no receipt, so its cost is recorded as zero — and `_verdict`
+    # still runs pytest over whatever the process had already written, so a timeout can score
+    # `passed=True` at zero tokens. That is a free success in a comparison whose entire outcome is
+    # cost. Voided on the measurement, not on the verdict: a run whose price was never recorded
+    # cannot be in a table of prices.
+    unmeasured = [r for r in rows if r["exit"] == 124 or r["completion_tokens"] == 0]
+    print("  === portoes ===")
+    print(f"    reprovou o verificador : {len(failed)}")
+    for r in failed[:8]:
+        print(f"       {r['model'].split('/')[-1][:24]:24} {r['arm']} {r['task']}")
+    print(f"    sem custo registrado   : {len(unmeasured)}   (timeout / recibo ausente)")
+    for r in unmeasured[:8]:
+        print(f"       {r['model'].split('/')[-1][:24]:24} {r['arm']} {r['task']} "
+              f"exit={r['exit']} passou={r['passed']}")
+    print(f"    nao usou o esperado    : {len(idle)}   (o braco nao rodou a sua condicao)")
+    print(f"    pediu o que foi negado : {len(asked_denied)}   (recusado; informativo, nao anula)")
+
+    void = {(r["model"], r["arm"], r["task"]) for r in (*failed, *unmeasured, *idle)}
+    # Void by PAIR: a comparison needs both arms of the same task on the same model.
+    void_pairs = {(m, t) for (m, _a, t) in void}
+    usable = [r for r in rows if (r["model"], r["task"]) not in void_pairs]
+    print(f"\n    pares descartados: {len(void_pairs)}   linhas usaveis: {len(usable)}")
+
+    # --- the interaction --------------------------------------------------------------------------
+    by: dict[str, dict[str, dict[str, int]]] = defaultdict(lambda: defaultdict(dict))
+    for r in usable:
+        by[r["model"]][r["task"]][r["arm"]] = r["completion_tokens"]
+
+    print("\n  === tokens de saida, por familia (mediana sobre tarefas pareadas) ===")
+    print(f"  {'modelo':30} {'n':>3} {'P (patch)':>10} {'W (inteiro)':>12} {'W-P':>8} {'% da mediana':>13}")
+    verdicts: dict[str, float] = {}
+    spans: dict[str, tuple[float, float]] = {}
+    random.seed(7)  # the interval must be the same number every time it is quoted
+    for model, tasks in by.items():
+        pairs = [(v["P"], v["W"]) for v in tasks.values() if "P" in v and "W" in v]
+        if not pairs:
+            continue
+        p_med = statistics.median(p for p, _ in pairs)
+        w_med = statistics.median(w for _, w in pairs)
+        # The per-task difference, then its median — not the difference of medians. The tasks are the
+        # paired unit, and differencing the summaries throws the pairing away.
+        deltas = [w - p for p, w in pairs]
+        delta = statistics.median(deltas)
+        base = statistics.median([*(p for p, _ in pairs), *(w for _, w in pairs)])
+        share = delta / base if base else 0.0
+        verdicts[model] = share
+        # A median alone cannot say whether it differs from zero, and with one repeat per cell that
+        # is the question. Bootstrapped over the paired per-task deltas — added because the medians
+        # came out at 10-12% with opposite signs, which reads as a near-miss until the interval is
+        # printed beside it. It makes a reject stronger; it could not have turned one into an adopt.
+        boots = sorted(
+            statistics.median(random.choices(deltas, k=len(deltas))) for _ in range(4000)
+        )
+        lo, hi = boots[100], boots[3900]
+        spans[model] = (lo, hi)
+        print(
+            f"  {model.split('/')[-1][:30]:30} {len(pairs):3} {p_med:10.0f} {w_med:12.0f} "
+            f"{delta:+8.0f} {share * 100:+12.1f}%   IC95 [{lo:+.0f}, {hi:+.0f}]"
+            f"{'' if lo * hi > 0 else '  INCLUI ZERO'}"
+        )
+
+    print("\n  === o veredito, pela regra fixada antes ===")
+    big = {m: s for m, s in verdicts.items() if abs(s) >= MARGIN}
+    signs = {m: (1 if s > 0 else -1) for m, s in big.items()}
+    disagree = len(set(signs.values())) > 1
+    print(f"    familias com |diferenca| >= {MARGIN:.0%}: {len(big)} de {len(verdicts)}")
+    for m, s in verdicts.items():
+        cheaper = "P (patch)" if s > 0 else "W (inteiro)"
+        forte = "sim" if abs(s) >= MARGIN else "nao"
+        print(f"       {m.split('/')[-1][:30]:30} mais barato: {cheaper:12} margem>=20%: {forte}")
+    crosses = [m for m, (lo, hi) in spans.items() if lo * hi <= 0]
+    if crosses:
+        print(f"    familias cujo IC95 inclui zero: {len(crosses)} de {len(spans)}")
+        print("       nao ha efeito mensuravel para uma inversao de sinal descrever")
+        print("\n    >>> REJEITAR: o efeito nao se distingue de zero em nenhuma familia.")
+    elif disagree and len(big) >= 2:
+        print("\n    >>> CONSTRUIR: o sinal diverge entre familias, com margem em pelo menos duas.")
+    elif len(set(1 if s > 0 else -1 for s in verdicts.values())) == 1:
+        print("\n    >>> REJEITAR: o mesmo formato e' mais barato em todas as familias.")
+        print("        Isso e' um achado sobre o PADRAO, nao sobre ajuste por modelo.")
+    else:
+        print("\n    >>> REJEITAR: as diferencas nao alcancam a margem de 20% em duas familias.")
+
+    # --- secondary, reported and never used to decide ------------------------------------------------
+    print("\n  === secundario (reportado, nunca decide) ===")
+    for model, tasks in by.items():
+        pairs = [(v["P"], v["W"]) for v in tasks.values() if "P" in v and "W" in v]
+        if not pairs:
+            continue
+        rs = [r for r in usable if r["model"] == model]
+        for arm in ("P", "W"):
+            a = [r for r in rs if r["arm"] == arm]
+            if not a:
+                continue
+            print(
+                f"    {model.split('/')[-1][:26]:26} {arm}  "
+                f"passou {sum(r['passed'] for r in a)}/{len(a)}  "
+                f"edits mediana {statistics.median(r['edit_calls'] for r in a):.0f}  "
+                f"usd {sum(r['usd'] for r in a):.4f}  "
+                f"seg mediana {statistics.median(r['seconds'] for r in a):.0f}"
+            )
+    print(f"\n    custo total da grade: usd {sum(r['usd'] for r in rows):.4f}")
+
+    # The verdict the ORIGINAL gate would have produced, printed beside the corrected one.
+    #
+    # The gate was corrected on a fact about the instrument — `tool_names` records requests, not
+    # executions — which is verifiable in `agent.py` and independent of any outcome. But the
+    # correction was made AFTER a partial figure had been printed by a dry run of this script, and
+    # that is recorded rather than smoothed over. Showing both is what lets a reader decide whether
+    # the correction moved the answer, instead of taking my word that it could not have.
+    strict_void = {(r["model"], r["task"]) for r in (*failed, *asked_denied, *idle, *unmeasured)}
+    strict = [r for r in rows if (r["model"], r["task"]) not in strict_void]
+    print("\n  === sob a guarda ORIGINAL (que anulava tambem quem PEDIU o negado) ===")
+    sby: dict[str, dict[str, dict[str, int]]] = defaultdict(lambda: defaultdict(dict))
+    for r in strict:
+        sby[r["model"]][r["task"]][r["arm"]] = r["completion_tokens"]
+    for model, tasks in sby.items():
+        pairs = [(v["P"], v["W"]) for v in tasks.values() if "P" in v and "W" in v]
+        short = model.split("/")[-1][:30]
+        if not pairs:
+            print(f"    {short:30} sem pares usaveis")
+            continue
+        delta = statistics.median([w - p for p, w in pairs])
+        base = statistics.median([*(p for p, _ in pairs), *(w for _, w in pairs)])
+        pct = delta / base * 100 if base else 0.0
+        print(f"    {short:30} n={len(pairs):2}  W-P={delta:+7.0f}  {pct:+6.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/edit_format_by_model/rows.json
+++ b/bench/edit_format_by_model/rows.json
@@ -1,0 +1,1099 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "rename_helper",
+    "passed": true,
+    "completion_tokens": 2534,
+    "edit_calls": 4,
+    "tool_calls": 17,
+    "usd": 0.003547,
+    "seconds": 39.4,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch"
+    ],
+    "tail": " -m pytest tests/ -q` in an \nenvironment where execution is permitted, it should pass, since the tests \nalready expect the new name.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "rename_helper",
+    "passed": true,
+    "completion_tokens": 2147,
+    "edit_calls": 4,
+    "tool_calls": 21,
+    "usd": 0.003382,
+    "seconds": 27.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "temExit(pytest.main([\"-q\", \"tests/test_shop.py\", \"-p\", \n\"no:cacheprovider\"]))\n</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "rename_class",
+    "passed": true,
+    "completion_tokens": 3068,
+    "edit_calls": 3,
+    "tool_calls": 19,
+    "usd": 0.003497,
+    "seconds": 30.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch"
+    ],
+    "tail": "s `Conn` no longer exists on `db.core`), \nso the tests should pass as soon as they're run in an environment that permits \nexecution.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "rename_class",
+    "passed": true,
+    "completion_tokens": 4056,
+    "edit_calls": 3,
+    "tool_calls": 18,
+    "usd": 0.003613,
+    "seconds": 45.5,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "int(result.stdout)\nprint(result.stderr)\nprint('exit code:', result.returncode)</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "signature_swap_args",
+    "passed": true,
+    "completion_tokens": 4848,
+    "edit_calls": 3,
+    "tool_calls": 22,
+    "usd": 0.00418,
+    "seconds": 44.7,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "uld not be run\nhere. The assertion logic above was verified by inspection — run `pytest \ntests/` in a normal environment to confirm.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "signature_swap_args",
+    "passed": true,
+    "completion_tokens": 2756,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.003384,
+    "seconds": 34.4,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "name=\"read_file\">\n<｜DSML｜parameter name=\"path\" \nstring=\"true\">people/roster.py</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "signature_return_shape",
+    "passed": true,
+    "completion_tokens": 1567,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.003285,
+    "seconds": 28.3,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch",
+      "edit_file"
+    ],
+    "tail": "se('a = 1') == {'key': 'a', 'value': '1'}`), matching the new \nimplementation — run `python -m pytest tests/ -q` locally to confirm.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "signature_return_shape",
+    "passed": true,
+    "completion_tokens": 4751,
+    "edit_calls": 4,
+    "tool_calls": 34,
+    "usd": 0.006799,
+    "seconds": 58.2,
+    "exit": 0,
+    "used_denied": [
+      "edit_file"
+    ],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "== {'key': 'a', 'value': '1'}` ✓\n- `load(['a = 1', 'b = 2']) == {'a': '1', 'b': '2'}` ✓\n- `keys(['a = 1', 'b = 2']) == ['a', 'b']` ✓\nsuccess after 2 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "constant_move_module",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 900.9,
+    "exit": 124,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "solve timed out"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "constant_move_module",
+    "passed": true,
+    "completion_tokens": 3445,
+    "edit_calls": 5,
+    "tool_calls": 17,
+    "usd": 0.003621,
+    "seconds": 38.7,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "voke name=\"read_file\">\n<｜DSML｜parameter name=\"path\" string=\"true\">net/retry.py</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "constant_split_two",
+    "passed": true,
+    "completion_tokens": 1675,
+    "edit_calls": 3,
+    "tool_calls": 16,
+    "usd": 0.003189,
+    "seconds": 26.1,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch"
+    ],
+    "tail": "rect by inspection (verified by reading the final files), \nbut please run `python -m pytest tests/` in your normal shell to confirm.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "constant_split_two",
+    "passed": true,
+    "completion_tokens": 1584,
+    "edit_calls": 3,
+    "tool_calls": 14,
+    "usd": 0.002676,
+    "seconds": 22.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "attr(quota.rules, 'LIMIT')`, which is \nintentional).\n\nTo run the test suite once execution is available: `python -m pytest tests -q`\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "param_add_default",
+    "passed": true,
+    "completion_tokens": 2258,
+    "edit_calls": 4,
+    "tool_calls": 13,
+    "usd": 0.003388,
+    "seconds": 37.8,
+    "exit": 0,
+    "used_denied": [
+      "write_file"
+    ],
+    "used_expected": [
+      "apply_patch",
+      "edit_file"
+    ],
+    "tail": "me=\"read_file\">\n<｜DSML｜parameter name=\"path\" \nstring=\"true\">tests/test_blog.py</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "param_add_default",
+    "passed": true,
+    "completion_tokens": 1637,
+    "edit_calls": 2,
+    "tool_calls": 14,
+    "usd": 0.00305,
+    "seconds": 41.8,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "me=\"read_file\">\n<｜DSML｜parameter name=\"path\" \nstring=\"true\">tests/test_blog.py</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "param_thread_through",
+    "passed": true,
+    "completion_tokens": 2119,
+    "edit_calls": 3,
+    "tool_calls": 16,
+    "usd": 0.003415,
+    "seconds": 27.4,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "is environment, so I couldn't execute the tests — the code \nchanges themselves are in place and verified by reading the final files.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "param_thread_through",
+    "passed": true,
+    "completion_tokens": 2382,
+    "edit_calls": 4,
+    "tool_calls": 14,
+    "usd": 0.003415,
+    "seconds": 27.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": ", since the loop short-circuits on strict only \nwhen it's True. Please run `python -m pytest tests/ -q` on your machine to \nconfirm.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "string_repeated_typo",
+    "passed": true,
+    "completion_tokens": 2442,
+    "edit_calls": 3,
+    "tool_calls": 24,
+    "usd": 0.003509,
+    "seconds": 42.7,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "n your local repo — e.g.:\n\n```bash\npytest tests/\ngit add mail/ tests/\ngit commit -m \"Fix spelling of 'received' in mail package\"\n```\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "string_repeated_typo",
+    "passed": true,
+    "completion_tokens": 1410,
+    "edit_calls": 3,
+    "tool_calls": 18,
+    "usd": 0.002934,
+    "seconds": 32.0,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "ts/ -q \n2>&1; echo \"---LINT---\"; python -m pyflakes mail/ tests/ 2>&1 || \ntrue</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "string_prefix_change",
+    "passed": true,
+    "completion_tokens": 3447,
+    "edit_calls": 3,
+    "tool_calls": 22,
+    "usd": 0.003773,
+    "seconds": 31.6,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "ectation comparison) nevertheless confirms correctness — run \n`python -m pytest tests/ -q` from the repo root to see the suite pass.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "string_prefix_change",
+    "passed": true,
+    "completion_tokens": 2217,
+    "edit_calls": 3,
+    "tool_calls": 18,
+    "usd": 0.003355,
+    "seconds": 29.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "｜DSML｜invoke name=\"grep\">\n<｜DSML｜parameter name=\"pattern\" string=\"true\">[svc\\]</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "P",
+    "task": "import_relative_to_absolute",
+    "passed": true,
+    "completion_tokens": 2260,
+    "edit_calls": 2,
+    "tool_calls": 19,
+    "usd": 0.003394,
+    "seconds": 30.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch",
+      "edit_file"
+    ],
+    "tail": "ion, and \n`tests/test_api_pkg.py` asserts exactly this transformation (no `from .` and \npresence of `from api.`), so it should pass.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "arm": "W",
+    "task": "import_relative_to_absolute",
+    "passed": true,
+    "completion_tokens": 2374,
+    "edit_calls": 2,
+    "tool_calls": 17,
+    "usd": 0.00327,
+    "seconds": 56.1,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "er() == 'pong'`, `both() \n== 'pongpong'`) and the absence of `from .` in these files, so it will confirm \nthe conversion end-to-end.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "rename_helper",
+    "passed": true,
+    "completion_tokens": 2203,
+    "edit_calls": 4,
+    "tool_calls": 22,
+    "usd": 0.069154,
+    "seconds": 86.4,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch"
+    ],
+    "tail": "s://docs.litellm.ai/docs/providers\u001b[0m\n\nAll edits are in place and verified. Updating the task list to reflect the true\nfinal state:\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "rename_helper",
+    "passed": true,
+    "completion_tokens": 6439,
+    "edit_calls": 4,
+    "tool_calls": 34,
+    "usd": 0.151774,
+    "seconds": 184.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": " collection and all \nassertions should now pass, but running `python -m pytest tests/ -v` locally \nwill give the final confirmation.\nsuccess after 2 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "rename_class",
+    "passed": true,
+    "completion_tokens": 3270,
+    "edit_calls": 3,
+    "tool_calls": 21,
+    "usd": 0.071252,
+    "seconds": 104.7,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": " contents.\n\nLet me mark the final task as done based on logical verification, since the \nenvironment blocked actual shell execution.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "rename_class",
+    "passed": true,
+    "completion_tokens": 3607,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.074533,
+    "seconds": 117.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "e \nexpected, as the post-edit grep-equivalent shows zero whole-word `Conn` \noccurrences outside the test file's `hasattr` assertion.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "signature_swap_args",
+    "passed": true,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 900.8,
+    "exit": 124,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "solve timed out"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "signature_swap_args",
+    "passed": true,
+    "completion_tokens": 6968,
+    "edit_calls": 3,
+    "tool_calls": 19,
+    "usd": 0.091016,
+    "seconds": 184.3,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "t test was needed. To confirm on your side, run:\n\n```\npytest tests/test_people.py -v\n```\n\nAll four assertions should pass unchanged.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "signature_return_shape",
+    "passed": true,
+    "completion_tokens": 3781,
+    "edit_calls": 3,
+    "tool_calls": 20,
+    "usd": 0.075655,
+    "seconds": 110.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": " docstring documents the edge-case semantics, so passing tests \nare expected — but they should be confirmed with the commands above.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "signature_return_shape",
+    "passed": true,
+    "completion_tokens": 4037,
+    "edit_calls": 3,
+    "tool_calls": 22,
+    "usd": 0.074873,
+    "seconds": 116.8,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "\n\nA post-edit read of all three files confirms no tuple-unpacking callers of \n`parse` remain — every call site now uses dict access.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "constant_move_module",
+    "passed": false,
+    "completion_tokens": 23516,
+    "edit_calls": 13,
+    "tool_calls": 51,
+    "usd": 0.29478,
+    "seconds": 559.6,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch",
+      "edit_file"
+    ],
+    "tail": "roken (`report.py`, `retry.py`, and the\ntests import `net.settings`), so this line must be run before the change is \nconsidered done.\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "constant_move_module",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 1129.8,
+    "exit": 124,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "solve timed out"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "constant_split_two",
+    "passed": true,
+    "completion_tokens": 1577,
+    "edit_calls": 3,
+    "tool_calls": 11,
+    "usd": 0.063422,
+    "seconds": 62.5,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "test tests/ -v\n```\n\nThe task list was updated to reflect the four completed steps; the verification\nstep remains flagged as not run.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "constant_split_two",
+    "passed": true,
+    "completion_tokens": 1222,
+    "edit_calls": 3,
+    "tool_calls": 12,
+    "usd": 0.06142,
+    "seconds": 56.8,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": " and `LIMIT` gone\n— and the changes are a mechanical rename, so behavior is preserved. Running \n`pytest tests/` locally should pass.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "param_add_default",
+    "passed": true,
+    "completion_tokens": 3777,
+    "edit_calls": 1,
+    "tool_calls": 17,
+    "usd": 0.07311,
+    "seconds": 96.8,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "rep of all `slugify`/`sep` references above.\n\nIf you want, next session I can run the suite and append the missing edge-case \ntests.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "param_add_default",
+    "passed": true,
+    "completion_tokens": 4064,
+    "edit_calls": 1,
+    "tool_calls": 15,
+    "usd": 0.074691,
+    "seconds": 116.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": " `python -m pytest tests/ \n-v` and `python -m doctest blog/slug.py` in your environment to confirm — the \ntest file is ready for it.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "param_thread_through",
+    "passed": true,
+    "completion_tokens": 1340,
+    "edit_calls": 3,
+    "tool_calls": 8,
+    "usd": 0.062321,
+    "seconds": 51.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "param_thread_through",
+    "passed": true,
+    "completion_tokens": 2069,
+    "edit_calls": 4,
+    "tool_calls": 13,
+    "usd": 0.067544,
+    "seconds": 98.6,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "l \nexisting callers are unaffected), but please run `python -m pytest tests/ -q` \nto confirm the new tests pass in your environment.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "string_repeated_typo",
+    "passed": true,
+    "completion_tokens": 2109,
+    "edit_calls": 3,
+    "tool_calls": 18,
+    "usd": 0.067177,
+    "seconds": 43.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "file contents, the tests should pass as \nwritten; please run `pytest tests/test_mail.py` when shell access is available \nto confirm.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "string_repeated_typo",
+    "passed": true,
+    "completion_tokens": 1644,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.060986,
+    "seconds": 86.8,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "command once you have shell\naccess:\n  ```\n  git add mail/ && git commit -m \"Fix 'recieved' → 'received' typo in mail \npackage\"\n  ```\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "string_prefix_change",
+    "passed": true,
+    "completion_tokens": 1429,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.060816,
+    "seconds": 76.2,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch"
+    ],
+    "tail": "`' down'`), which now match the implementation precisely, so the tests \nwill pass when run in an environment that permits execution.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "string_prefix_change",
+    "passed": true,
+    "completion_tokens": 1166,
+    "edit_calls": 3,
+    "tool_calls": 17,
+    "usd": 0.059076,
+    "seconds": 34.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "and the edits are minimal literal swaps \nthat match the test expectations exactly, so the package is consistent with its\ntest suite.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "P",
+    "task": "import_relative_to_absolute",
+    "passed": true,
+    "completion_tokens": 2092,
+    "edit_calls": 2,
+    "tool_calls": 18,
+    "usd": 0.067562,
+    "seconds": 37.0,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "apply_patch",
+      "edit_file"
+    ],
+    "tail": "st suite (`tests/test_api_pkg.py`, which also \nasserts no `from .` remains in `v1.py`/`v2.py`) should be run to confirm at \nruntime.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "arm": "W",
+    "task": "import_relative_to_absolute",
+    "passed": true,
+    "completion_tokens": 1935,
+    "edit_calls": 2,
+    "tool_calls": 18,
+    "usd": 0.064093,
+    "seconds": 36.6,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "\nand `tests/` — no flake8/setup config), so nothing else needed updating, and no\ncommit was made since shell access was unavailable.\nsuccess after 1 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "rename_helper",
+    "passed": false,
+    "completion_tokens": 4611,
+    "edit_calls": 2,
+    "tool_calls": 24,
+    "usd": 0.08981,
+    "seconds": 95.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "rename_helper",
+    "passed": false,
+    "completion_tokens": 2320,
+    "edit_calls": 0,
+    "tool_calls": 24,
+    "usd": 0.075284,
+    "seconds": 87.6,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "rename_class",
+    "passed": false,
+    "completion_tokens": 7573,
+    "edit_calls": 1,
+    "tool_calls": 24,
+    "usd": 0.100645,
+    "seconds": 112.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "rename_class",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 26.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "signature_swap_args",
+    "passed": false,
+    "completion_tokens": 3783,
+    "edit_calls": 0,
+    "tool_calls": 24,
+    "usd": 0.083732,
+    "seconds": 94.1,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "signature_swap_args",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 40.0,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "signature_return_shape",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 58.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "signature_return_shape",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 52.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "constant_move_module",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 7.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "constant_move_module",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 62.5,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "constant_split_two",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 44.7,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "constant_split_two",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 16.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "param_add_default",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 58.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "────────────────────────────────────────────────────────────────────┘\nTimeout: litellm.Timeout: Timeout Error: OpenrouterException - The operation \nwas aborted\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "param_add_default",
+    "passed": true,
+    "completion_tokens": 1420,
+    "edit_calls": 1,
+    "tool_calls": 16,
+    "usd": 0.049077,
+    "seconds": 52.4,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "())\n```\n\nExisting callers in `blog` (`blog/post.py` and `blog/tag.py`) continue to work \nunchanged with the default separator `'-'`.\nsuccess after 2 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "param_thread_through",
+    "passed": false,
+    "completion_tokens": 3238,
+    "edit_calls": 4,
+    "tool_calls": 24,
+    "usd": 0.081918,
+    "seconds": 84.0,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "s\\brcam\\AppData\\Local\\Temp\\efm-P-_wxr2yen\\home\\disca\n                    rded\\2d7e3d46b0d6440ab3ba516b07c6939f-3.diff               \n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "param_thread_through",
+    "passed": false,
+    "completion_tokens": 3101,
+    "edit_calls": 4,
+    "tool_calls": 24,
+    "usd": 0.085069,
+    "seconds": 87.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "s\\brcam\\AppData\\Local\\Temp\\efm-W-wqb_zman\\home\\disca\n                    rded\\a419816725794de591b157b4465bbe0e-3.diff               \n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "string_repeated_typo",
+    "passed": true,
+    "completion_tokens": 1916,
+    "edit_calls": 3,
+    "tool_calls": 24,
+    "usd": 0.074437,
+    "seconds": 87.9,
+    "exit": 0,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nsuccess after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "string_repeated_typo",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 45.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "string_prefix_change",
+    "passed": false,
+    "completion_tokens": 2453,
+    "edit_calls": 2,
+    "tool_calls": 24,
+    "usd": 0.077857,
+    "seconds": 75.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "edit_file"
+    ],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "string_prefix_change",
+    "passed": false,
+    "completion_tokens": 1613,
+    "edit_calls": 2,
+    "tool_calls": 24,
+    "usd": 0.072622,
+    "seconds": 91.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [
+      "write_file"
+    ],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "P",
+    "task": "import_relative_to_absolute",
+    "passed": false,
+    "completion_tokens": 2098,
+    "edit_calls": 0,
+    "tool_calls": 24,
+    "usd": 0.079924,
+    "seconds": 77.4,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\n\u001b[1;31mProvider List: https://docs.litellm.ai/docs/providers\u001b[0m\n\n\nfailed after 3 attempt(s)\n"
+  },
+  {
+    "model": "openrouter/google/gemini-3.8-flash",
+    "arm": "W",
+    "task": "import_relative_to_absolute",
+    "passed": false,
+    "completion_tokens": 0,
+    "edit_calls": 0,
+    "tool_calls": 0,
+    "usd": 0.0,
+    "seconds": 52.3,
+    "exit": 1,
+    "used_denied": [],
+    "used_expected": [],
+    "tail": "y shortly, or add your own key to\naccumulate your rate limits: \nhttps://openrouter.ai/settings/integrations\"}]}},\"user_id\":\"user_3Dpsn3L1pvRDfx\nCoCWcNroTImrO\"}\n"
+  }
+]

--- a/bench/edit_format_by_model/run.py
+++ b/bench/edit_format_by_model/run.py
@@ -1,0 +1,121 @@
+"""Run the interaction described in `PREREGISTRATION.md`: edit format x model family.
+
+    python bench/edit_format_by_model/run.py
+
+Reuses `bench/edit_tools` wholesale — the tasks, the materialiser, the runner and the verifier. That
+is not laziness: a second copy of a verifier is a second definition of "passed", and the two drift.
+The exclusion of `import_module_moved` is inherited from that bench's pre-registration for the same
+reason, so it cannot be a choice made after seeing anything here.
+
+Arms are FORCED through the denylist rather than suggested in a prompt. A nudge measures obedience;
+denying the tool measures which format the model is cheaper in when it has no alternative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+EDIT_TOOLS_BENCH = HERE.parent / "edit_tools"
+sys.path.insert(0, str(EDIT_TOOLS_BENCH))
+
+from run_pilot import _last_receipt, _materialise, _measure, _run_solve, _verdict  # noqa: E402
+from tasks import TASKS  # noqa: E402
+
+#: Inherited from `bench/edit_tools/run_ab.py`, which dropped it because arm A failed it 3/3 and its
+#: own pre-registration discards a task the control cannot solve.
+EXCLUDED = {"import_module_moved"}
+
+ARMS = {
+    "P": {"CHIMERA_TOOL_DENYLIST": "write_file"},
+    "W": {"CHIMERA_TOOL_DENYLIST": "edit_file,apply_patch,edit_batch"},
+}
+
+MODELS = [
+    "openrouter/deepseek/deepseek-v4-flash-0731",
+    "openrouter/z-ai/glm-5.3-flash",
+    "openrouter/google/gemini-3.8-flash",
+]
+
+#: The tools each arm is supposed to have used, for the gate that checks an arm ran its condition.
+EXPECTED = {"P": {"edit_file", "apply_patch"}, "W": {"write_file"}}
+DENIED = {"P": {"write_file"}, "W": {"edit_file", "apply_patch", "edit_batch"}}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--timeout", type=int, default=900)
+    ap.add_argument("--out", default=str(HERE / "rows.json"))
+    ap.add_argument("--limit-tasks", type=int, default=0, help="smoke: first N tasks only")
+    ap.add_argument("--limit-models", type=int, default=0)
+    args = ap.parse_args()
+
+    tasks = [t for t in TASKS if t["name"] not in EXCLUDED]
+    if args.limit_tasks:
+        tasks = tasks[: args.limit_tasks]
+    models = MODELS[: args.limit_models] if args.limit_models else MODELS
+    rows: list[dict] = []
+    total = len(tasks) * len(ARMS) * len(models)
+    done = 0
+
+    for model in models:
+        for task in tasks:
+            for arm, env in ARMS.items():
+                done += 1
+                work = Path(tempfile.mkdtemp(prefix=f"efm-{arm}-"))
+                home, ws = work / "home", work / "ws"
+                ws.mkdir(parents=True)
+                _materialise(task, ws)
+                started = time.time()
+                code, tail = _run_solve(
+                    task, ws, home, args.timeout,
+                    extra_env={**env, "CHIMERA_DEFAULT_MODEL": model},
+                )
+                passed = _verdict(task, ws)
+                receipt = _last_receipt(home / "runs.jsonl")
+                edits, calls, tokens = _measure(receipt)
+                names = {
+                    n
+                    for a in (receipt.get("attempts") or [])
+                    for n in (a.get("tool_names") or [])
+                }
+                row = {
+                    "model": model,
+                    "arm": arm,
+                    "task": task["name"],
+                    "passed": bool(passed),
+                    "completion_tokens": tokens,
+                    "edit_calls": edits,
+                    "tool_calls": calls,
+                    "usd": receipt.get("usd") or 0.0,
+                    "seconds": round(time.time() - started, 1),
+                    "exit": code,
+                    # The gate: an arm that used what it was denied did not run its condition.
+                    "used_denied": sorted(names & DENIED[arm]),
+                    "used_expected": sorted(names & EXPECTED[arm]),
+                    "tail": tail[-160:],
+                }
+                rows.append(row)
+                print(
+                    f"  [{done:2}/{total}] {model.split('/')[-1][:26]:26} {arm} "
+                    f"{task['name'][:24]:24} passou={row['passed']!s:5} "
+                    f"tok={tokens:6} edits={edits:2} usd={row['usd']:.4f} {row['seconds']:.0f}s"
+                    + ("  !! usou o negado" if row["used_denied"] else "")
+                )
+                shutil.rmtree(work, ignore_errors=True)
+                Path(args.out).write_text(
+                    json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"
+                )
+
+    print(f"\n  {len(rows)} linhas em {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The claim that would justify per-model tailoring at all: an OpenAI-family model is cheaper with patches, a Claude-family one with whole blocks. Chimera does neither — one prompt, one schema, one edit format for every model. Before building the machinery, this measures whether there is anything to exploit.

66 runs over `bench/edit_tools`'s pytest-verified task set, with the format **forced** by denylist rather than suggested in a prompt: a nudge measures obedience; denying the tool measures which format the model is cheaper in when it has no alternative.

## Verdict: REJECT

| family | n pairs | W − P (completion tokens) | % | 95% CI |
|---|---:|---:|---:|---|
| `deepseek-v4-flash-0731` | 10 | −239 | −10.3% | [−1,032, +448] **includes zero** |
| `glm-5.3-flash` | 9 | +256 | +12.2% | [−355, +729] **includes zero** |
| `gemini-3.8-flash` | **0** | — | — | no usable pair |

## The reading this nearly shipped

The two medians point in **opposite directions** — DeepSeek cheaper rewriting whole files, Z-AI cheaper patching — which is exactly the shape the tailoring story predicts. The first draft of the results file said so: *"the direction flips; the magnitude does not pay for the machinery."*

It was wrong. The per-task deltas:

```
deepseek   -2092  -1230  -1032  -621  -387  -91  +114  +263  +988  +3184
glm-flash   -465   -355   -263  -157  +256  +287  +337  +729  +4236
```

A median of −239 out of that spread is not a direction. The bootstrap interval was added for exactly this and is recorded as an addition rather than folded in silently — it strengthens a reject and could not have turned one into an adopt.

## The third family contributed nothing, and the run cannot say why

`gemini-3.8-flash`: 11 of 22 runs never started (OpenRouter rate limit — zero cost, zero tool calls, a tail asking for a BYO key), and 11 ran at a median of 24 tool calls and passed 2, against 19 of 19 for the families that produced data.

That looks like a capability gap between flash-tier models and **this run cannot claim it**: the failing tails carry LiteLLM provider-error banners, so some failures may be the same rate limiting arriving mid-run. The two explanations are not separable from what was collected.

## Two amendments, both mid-run, both on the instrument

Recorded in the pre-registration with what had been seen at the time, because a gate corrected after a number is visible is exactly what destroys a pre-registration. Neither touched the decision rule.

1. **Asking for a denied tool is not a leak.** `tool_names` is appended at `agent.py:729`, before `_run_tool` at `:733`, and a denied tool is absent from the registry — so the name in that list is the model reaching for a refused format. The original gate voided those pairs, discarding the runs where the manipulation bit hardest. `analyse.py` prints the verdict under **both** gates so the correction's effect is visible rather than asserted.
2. **A timed-out run was scoring as a free success.** `exit 124` writes no receipt, so cost recorded as zero — and `_verdict` still runs pytest over what the process had already written, so one timeout scored `passed=True` at zero tokens. In a comparison whose outcome *is* cost, that drags the arm that failed to finish downward.

14 of 33 pairs voided in total. Voiding timeouts removes the hardest tasks, so any difference that only appears under pressure is understated — stated rather than discovered later.

## The side finding, larger than the one under test

| family | usd per arm, 9–10 tasks | median seconds |
|---|---:|---:|
| `deepseek-v4-flash-0731` | **0.035** | 31 |
| `glm-5.3-flash` | **0.611** | 76 |

Same tasks, same verifier, same pass rate — **17× the money, 2.5× the wall clock**. Both are "flash"-tier by name. Nothing here was designed to measure that, and it is a far larger lever on cost than any edit format measured.

## Cost

US$ 2.63 measured, against "estimated under two dollars" pre-registered. Reported as measured.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
