### PR TITLE
feat(rag): deliver the search the bench adopted, and fix the price it was priced with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   2.5× the wall clock** of `deepseek-v4-flash-0731` for the same tasks at the same pass rate. Both
   are "flash"-tier by name.
 
+## [Unreleased]
+
+### Added
+
+- **`chimera find --semantic`, and `chimera measure rag --semantic`.** `bench/rag/RESULTS.md` said
+  ADOPT three commits ago and the command kept running keyword-only: a verdict is not a delivery.
+
+  **`--semantic` means hybrid, never vectors alone**, and that is the measurement rather than a
+  preference — the vector arm on its own scored **0.4100, below keyword's 0.4425**. A flag that
+  handed back the vector arm would make a search worse while sounding like an upgrade. The
+  embedding bill is announced **before** the pass, not in a footnote after it, and the footer names
+  the embedder, because a recall figure without the model that produced it is a number about
+  nothing in particular.
+
+### Fixed
+
+- **A catalogue price was wrong by 2.2x, and its own note said it had been verified.**
+  `deepseek-chat-v3.1` carried 0.25/0.95 against a live 0.55/1.65 — recorded by a survey on
+  2026-09-03 that misread it. The entry feeds `register_catalog_prices`, so **every receipt for that
+  model under-reported by the same factor** for as long as it stood, and it sits in
+  `transfer_panel`, a default nobody chose. Restored, with the misreading kept in the note rather
+  than deleted.
+- **The guard that should have caught it tolerated a factor of five.** `test_catalog_is_live` fired
+  only on an order of magnitude, so 2.2x passed. Tightened to 50%: the catalogue price is not
+  decoration, it is what a user is told they spent.
+- **Five catalogue entries promised a window the provider does not serve.** `context_length` and
+  `top_provider.context_length` are different numbers in 39 of OpenRouter's 431 models, and the gap
+  reaches 20% on the shipped default, the fusion judge and the top rung of two presets — 1,310,720
+  advertised against 1,048,576 served. It never bit, and only by accident: the compaction trigger is
+  0.48 of the window, so 628,800 sat inside what was served. A new integration guard holds the rule
+  that a catalogue window may be smaller than the provider's, never larger.
+- **A search that matched nothing printed no calibration figure.** The measured recall sat after the
+  results table, so the empty-result path skipped it — at exactly the moment a reader has to decide
+  between "my query was wrong" and "this retriever misses half of what it is asked for".
+
 ## [0.49.3] - 2026-09-03
 
 ### Changed

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -1961,7 +1961,7 @@
     },
     {
       "deprecated": false,
-      "help": "Search a repository by what code DOES, not by the string it contains.\n\n`chimera/rag/` has been in the tree since 0.44.0 \u2014 symbol-level chunking over Python's AST, one\nSQLite file with an FTS5 index, RRF fusion \u2014 measured, documented, and reachable from nothing.\nA library with no entrance is a library nobody has. This is the entrance.\n\nKeyword retrieval only, and that is stated rather than glossed: the semantic half needs an\nembedder, none is wired, and the pre-registered baseline in `bench/rag/` says exactly what the\nkeyword half is worth on this repository \u2014 recall@10 of 0.4925 over 400 probes. Half the\nanswers are not in the top ten. Printing that beside the results is the difference between a\ntool you can calibrate and one you learn to distrust.",
+      "help": "Search a repository by what code DOES, not by the string it contains.\n\n`chimera/rag/` has been in the tree since 0.44.0 \u2014 symbol-level chunking over Python's AST, one\nSQLite file with an FTS5 index, RRF fusion \u2014 measured, documented, and reachable from nothing.\nA library with no entrance is a library nobody has. This is the entrance.\n\nKeyword by default; `--semantic` fuses it with embeddings, and the fusion is what was measured\nand adopted in `bench/rag/RESULTS.md`: hybrid 0.5050 against keyword 0.4425 on this repository,\n+6.25 pp paired over 400 probes, McNemar p = 1.7e-04.\n\n**`--semantic` means HYBRID, never vectors alone**, and that is the measurement rather than a\npreference: the vector arm on its own scored **0.4100 \u2014 worse than keyword**. Every point of the\nwin comes from fusing two rankings that are wrong about different things. A flag that gave you\nthe vector arm would be a flag that made your search worse.\n\nThe recall figure is printed with every search because it is per-corpus and per-embedder: the\nsame harness measures 0.4750 on this repository as it stood three weeks ago, and there is no\nconversion from one embedding model's vector space to another's.",
       "hidden": false,
       "name": "find",
       "params": [
@@ -2003,6 +2003,16 @@
           "name": "reindex",
           "opts": [
             "--reindex"
+          ],
+          "required": false,
+          "type": "boolean"
+        },
+        {
+          "help": "Fuse keyword with embeddings. Costs money to index.",
+          "kind": "option",
+          "name": "semantic",
+          "opts": [
+            "--semantic"
           ],
           "required": false,
           "type": "boolean"
@@ -2727,7 +2737,7 @@
       "commands": [
         {
           "deprecated": false,
-          "help": "Recall@k of each retriever over a real folder \u2014 lexical, and vector when an embedder is set.\n\nThis is the measurement `chimera/rag/__init__.py` names when it says the retriever's existence\nis not a claim that it helps. That sentence pointed at a module you could not run: `rag_bench`\nhad no caller outside its own test and was not exported from `chimera.eval`.\n\nNo embedder is passed, so the vector and hybrid figures come back as None rather than zero \u2014\nan embedder that was never called did not fail, and printing 0.0 invites the wrong conclusion.",
+          "help": "Recall@k of each retriever over a real folder \u2014 lexical, and vector when an embedder is set.\n\nThis is the measurement `chimera/rag/__init__.py` names when it says the retriever's existence\nis not a claim that it helps. That sentence pointed at a module you could not run: `rag_bench`\nhad no caller outside its own test and was not exported from `chimera.eval`.\n\nWithout `--semantic` no embedder is passed, so the vector and hybrid figures come back as None\nrather than zero \u2014 an embedder that was never called did not fail, and printing 0.0 invites the\nwrong conclusion.\n\nWith it, the run that `bench/rag/RESULTS.md` reports is reproducible from the CLI rather than\nfrom a script somebody has to write. It costs an embedding pass over the corpus: about two cents\nfor this repository's 3,459 chunks and 400 probes, and the figure it produces belongs to the\nembedder that produced it \u2014 vector spaces do not convert between models.",
           "hidden": false,
           "name": "rag",
           "params": [
@@ -2762,6 +2772,16 @@
               ],
               "required": false,
               "type": "int"
+            },
+            {
+              "help": "Measure the vector and hybrid arms too. Costs money.",
+              "kind": "option",
+              "name": "semantic",
+              "opts": [
+                "--semantic"
+              ],
+              "required": false,
+              "type": "boolean"
             }
           ],
           "path": "measure rag"

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -900,6 +900,9 @@ def bench_rag(
     root: Path = _BENCH_ROOT,
     k: int = _BENCH_K,
     max_probes: int = _BENCH_PROBES,
+    semantic: bool = typer.Option(
+        False, "--semantic", help="Measure the vector and hybrid arms too. Costs money."
+    ),
 ) -> None:
     """Recall@k of each retriever over a real folder — lexical, and vector when an embedder is set.
 
@@ -907,8 +910,14 @@ def bench_rag(
     is not a claim that it helps. That sentence pointed at a module you could not run: `rag_bench`
     had no caller outside its own test and was not exported from `chimera.eval`.
 
-    No embedder is passed, so the vector and hybrid figures come back as None rather than zero —
-    an embedder that was never called did not fail, and printing 0.0 invites the wrong conclusion.
+    Without `--semantic` no embedder is passed, so the vector and hybrid figures come back as None
+    rather than zero — an embedder that was never called did not fail, and printing 0.0 invites the
+    wrong conclusion.
+
+    With it, the run that `bench/rag/RESULTS.md` reports is reproducible from the CLI rather than
+    from a script somebody has to write. It costs an embedding pass over the corpus: about two cents
+    for this repository's 3,459 chunks and 400 probes, and the figure it produces belongs to the
+    embedder that produced it — vector spaces do not convert between models.
     """
     import tempfile
 
@@ -924,8 +933,21 @@ def bench_rag(
     # The scratch index is worth nothing once the report is printed. Failing to remove it must not
     # fail the thing it was for.
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        embed = None
+        if semantic:
+            from chimera.evolution.wiring import semantic_embed
+
+            embed = semantic_embed(get_settings(), force=True)
+            console.print(
+                f"[dim]embedding with {get_settings().embed_model} — this costs money[/dim]"
+            )
         report = run_rag_bench(
-            Path(root), index_path=Path(tmp) / "index.db", k=k, max_probes=max_probes
+            Path(root),
+            index_path=Path(tmp) / "index.db",
+            embed=embed,
+            embedder=get_settings().embed_model if semantic else "",
+            k=k,
+            max_probes=max_probes,
         )
     table = Table(title=f"RAG recall@{k} over {root}", show_header=True, header_style="bold")
     table.add_column("retriever")
@@ -941,6 +963,10 @@ def bench_rag(
         table.add_row(name, shown)
     console.print(table)
     console.print(f"[dim]{report.probes} probes over {report.chunks} chunks[/dim]")
+    if report.embedder:
+        # Inside the report, not in a footnote: a recall figure without the model that produced it
+        # is a number about nothing in particular.
+        console.print(f"[dim]embedder: {report.embedder} ({report.dimensions} dimensions)[/dim]")
     # The number that says whether a semantic layer could help at all: the share of probes keyword
     # retrieval misses. A headroom near zero means the embedding bill buys nothing here.
     console.print(f"[dim]headroom for a semantic layer: {report.headroom:.1%}[/dim]")
@@ -6725,6 +6751,9 @@ def find_command(
     path: str = typer.Option(".", "--path", help="Repository to search."),
     k: int = typer.Option(8, "--k", help="How many results."),
     reindex: bool = typer.Option(False, "--reindex", help="Rebuild the index before searching."),
+    semantic: bool = typer.Option(
+        False, "--semantic", help="Fuse keyword with embeddings. Costs money to index."
+    ),
 ) -> None:
     """Search a repository by what code DOES, not by the string it contains.
 
@@ -6732,30 +6761,87 @@ def find_command(
     SQLite file with an FTS5 index, RRF fusion — measured, documented, and reachable from nothing.
     A library with no entrance is a library nobody has. This is the entrance.
 
-    Keyword retrieval only, and that is stated rather than glossed: the semantic half needs an
-    embedder, none is wired, and the pre-registered baseline in `bench/rag/` says exactly what the
-    keyword half is worth on this repository — recall@10 of 0.4925 over 400 probes. Half the
-    answers are not in the top ten. Printing that beside the results is the difference between a
-    tool you can calibrate and one you learn to distrust.
+    Keyword by default; `--semantic` fuses it with embeddings, and the fusion is what was measured
+    and adopted in `bench/rag/RESULTS.md`: hybrid 0.5050 against keyword 0.4425 on this repository,
+    +6.25 pp paired over 400 probes, McNemar p = 1.7e-04.
+
+    **`--semantic` means HYBRID, never vectors alone**, and that is the measurement rather than a
+    preference: the vector arm on its own scored **0.4100 — worse than keyword**. Every point of the
+    win comes from fusing two rankings that are wrong about different things. A flag that gave you
+    the vector arm would be a flag that made your search worse.
+
+    The recall figure is printed with every search because it is per-corpus and per-embedder: the
+    same harness measures 0.4750 on this repository as it stood three weeks ago, and there is no
+    conversion from one embedding model's vector space to another's.
     """
     from chimera.rag import ChunkStore, default_index_path, walk
+    from chimera.rag.hybrid import reciprocal_rank_fusion
 
     root = Path(path).expanduser().resolve()
     if not root.is_dir():
         console.print(f"[red]{root} is not a directory[/red]")
         raise typer.Exit(code=1)
 
-    index = default_index_path(get_settings().home, root)
+    settings = get_settings()
+    embed = None
+    if semantic:
+        from chimera.evolution.wiring import semantic_embed
+
+        embed = semantic_embed(settings, force=True)
+        if embed is None:
+            console.print("[red]--semantic needs an embedder; none could be built[/red]")
+            raise typer.Exit(code=1)
+
+    index = default_index_path(settings.home, root)
     store = ChunkStore(index)
     try:
         if reindex or store.stats()["chunks"] == 0:
             with console.status("indexing..."):
                 n = store.replace_all(walk(root))
             console.print(f"[dim]indexed {n} chunks from {root}[/dim]")
-        hits = store.search_keyword(query, k=k)
+        keyword = store.search_keyword(query, k=k)
+        hits = keyword
+        if embed is not None:
+            pending = store.stats()["chunks"] - store.stats().get("embedded", 0)
+            # Said BEFORE the money is spent, not in a footnote afterwards. Embedding a corpus is
+            # the one part of this command with a bill, and a user who did not expect one has no way
+            # to un-spend it.
+            if pending > 0:
+                console.print(
+                    f"[dim]embedding {pending} chunks with {settings.embed_model} — "
+                    f"this costs money, and only the first time or after --reindex[/dim]"
+                )
+            with console.status("embedding..."):
+                # `embedder=` arms the guard that zeroes every vector when the model or its width
+                # changes. Without it a mixed-dimension index reports healthy and returns nothing.
+                store.embed_missing(embed, embedder=settings.embed_model)
+            vector = store.search_vector(embed([query])[0], k=k)
+            hits = reciprocal_rank_fusion([keyword, vector], limit=k)
         stats = store.stats()
     finally:
         store.close()
+
+    def calibration() -> None:
+        """The measured recall, printed on every search — including one that found nothing.
+
+        It used to sit only after the results table, so the `return` below skipped it: a search that
+        matched nothing showed no number at all. That is the moment the number is worth most, because
+        an empty screen is where a reader has to decide between "my query was wrong" and "this
+        retriever misses half of what it is asked for", and only one of those is true here.
+        """
+        if semantic:
+            console.print(
+                f"[dim]hybrid (keyword + {settings.embed_model}). Measured on this repository, "
+                "3459 chunks: recall@10 of 0.505 against 0.443 for keyword alone — +6.25 pp paired "
+                "over 400 probes, p = 1.7e-04. The vector arm ALONE scores 0.410, below keyword: "
+                "the gain is the fusion, not the embeddings.[/dim]"
+            )
+        else:
+            console.print(
+                "[dim]keyword only. Measured on this repository, 3459 chunks: recall@10 of 0.443 — "
+                "more than half of what you look for is NOT in the top ten. --semantic measures "
+                "0.505, and costs an embedding pass over the corpus.[/dim]"
+            )
 
     if not hits:
         # Named, because "no results" from a stale index and "no results" from a repository that
@@ -6764,6 +6850,7 @@ def find_command(
             f"[dim]nothing matched in {stats['chunks']} chunks from {stats['files']} files. "
             f"If the code moved since the index was built, try --reindex.[/dim]"
         )
+        calibration()
         return
 
     table = Table(title=repr(query), show_header=True, title_style="bold")
@@ -6780,11 +6867,7 @@ def find_command(
     console.print(table)
     # The number, every time. Measured on this repository, pre-registered before any embedder
     # existed so it could not be chosen after seeing what looked good.
-    console.print(
-        "[dim]keyword retrieval only (no embedder wired). Measured on this repository: "
-        "recall@10 of 0.4925 over 400 probes — about half of what you look for is NOT in the "
-        "top ten.[/dim]"
-    )
+    calibration()
 
 
 if __name__ == "__main__":

--- a/chimera/evolution/wiring.py
+++ b/chimera/evolution/wiring.py
@@ -25,9 +25,16 @@ if TYPE_CHECKING:
     from chimera.memory import EmbedFn, MemoryManager
 
 
-def semantic_embed(settings: Settings) -> EmbedFn | None:
-    """The gateway embedder when semantic memory is on, else None (keyword recall)."""
-    if not settings.semantic_memory:
+def semantic_embed(settings: Settings, *, force: bool = False) -> EmbedFn | None:
+    """The gateway embedder when semantic memory is on, else None (keyword recall).
+
+    ``force`` is for a caller who asked for embeddings in so many words — `chimera find --semantic`
+    — rather than inheriting the memory setting. The two are different decisions: turning on
+    semantic *memory* is a standing choice about every run, and typing `--semantic` on one search is
+    a choice about that search. Reading the first as consent to the second would put a bill on a
+    flag the user did not set.
+    """
+    if not settings.semantic_memory and not force:
         return None
     from chimera.providers import LLMGateway
 

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -69,12 +69,12 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- weak: near-free probes. Cheap first drafts, k-sample agreement. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-v4-flash", "weak", "DeepSeek",
-        0.0886, 0.1772, tools=True, context_k=1048,
+        0.0886, 0.1772, tools=True, context_k=1024,
         notes="cheapest capable probe here, with a frontier-sized window; unmeasured in this repo",
     ),
     CatalogEntry(
         "openrouter/mistralai/mistral-small-3.2-24b-instruct", "weak", "Mistral",
-        0.075, 0.20, tools=True, context_k=131,
+        0.075, 0.20, tools=True, context_k=128,
         notes="the local-lift goldilocks model; cheap paid weak with usable tools. The window read\n        256k here until 2026-09-03; the provider serves 131k",
     ),
     CatalogEntry(
@@ -90,18 +90,24 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-v4-flash-0731", "mid", "DeepSeek",
-        0.065, 0.18, tools=True, context_k=1310,
+        0.065, 0.18, tools=True, context_k=1048,
         notes="the product default and the fusion judge since 2026-09-03. Same vendor as the chat-v3.1 it replaced, at 0.065/0.18 against 0.25/0.95 (3.8x cheaper in, 5.3x out) with eight times the window. Wrote a file on the first ask in a live probe, in 72s",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-5.3-flash", "mid", "Zhipu (GLM)",
-        0.075, 0.25, tools=True, context_k=1310,
+        0.075, 0.25, tools=True, context_k=1048,
         notes="the best price-to-index here by a distance: 0.075/0.25 with a third-party agentic index of 58.2, within a point of claude-opus-5 at 66x the input price. NOT the default, and the reason is measured: on the same one-file probe it took 257s against 72s for the slug above. Reach for it when the window or the index matters more than latency",
     ),
     CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
-        0.25, 0.95, tools=True, context_k=163,
-        notes="proven in this repo's benches; the product default. Priced 0.55/1.65 here until a\n        live check on 2026-09-03 measured 0.25/0.95",
+        0.55, 1.65, tools=True, context_k=161,
+        notes="proven in this repo's benches. Priced 0.25/0.95 here for one day: a survey on\n"
+        "        2026-09-03 recorded that, and the live index on 2026-09-04 says 0.55/1.65 — the\n"
+        "        value it had before. A price does not halve and double back overnight, so the\n"
+        "        survey misread it. Restored, and the misreading is left in this note rather than\n"
+        "        deleted: it feeds `register_catalog_prices`, so every receipt for this model\n"
+        "        under-reported by 2.2x in and 1.7x out for as long as it stood. context_k is now\n"
+        "        the window the provider SERVES (161k), not the 163,840 advertised",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-4.6", "mid", "Zhipu (GLM)",
@@ -126,7 +132,7 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- top: orchestrator/judge class. Decompose, adjudicate, synthesize. ---
     CatalogEntry(
         "openrouter/z-ai/glm-5.3", "top", "Zhipu (GLM)",
-        1.40, 4.40, tools=True, context_k=1310,
+        1.40, 4.40, tools=True, context_k=1048,
         notes="the top rung of `balanced` and `auto` since 2026-09-03, and the reason is the slug below rather than this one: R1 carried a 64k window into a tier that asks for 100k. This has 1310k, a third-party agentic index of 59.1 against R1's 3.1, and wrote a file in 51s against R1's 209s. It costs twice as much per token and buys a working top tier",
     ),
     CatalogEntry(

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -531,11 +531,18 @@ Search a repository by what code DOES, not by the string it contains.
 SQLite file with an FTS5 index, RRF fusion — measured, documented, and reachable from nothing.
 A library with no entrance is a library nobody has. This is the entrance.
 
-Keyword retrieval only, and that is stated rather than glossed: the semantic half needs an
-embedder, none is wired, and the pre-registered baseline in `bench/rag/` says exactly what the
-keyword half is worth on this repository — recall@10 of 0.4925 over 400 probes. Half the
-answers are not in the top ten. Printing that beside the results is the difference between a
-tool you can calibrate and one you learn to distrust.
+Keyword by default; `--semantic` fuses it with embeddings, and the fusion is what was measured
+and adopted in `bench/rag/RESULTS.md`: hybrid 0.5050 against keyword 0.4425 on this repository,
++6.25 pp paired over 400 probes, McNemar p = 1.7e-04.
+
+**`--semantic` means HYBRID, never vectors alone**, and that is the measurement rather than a
+preference: the vector arm on its own scored **0.4100 — worse than keyword**. Every point of the
+win comes from fusing two rankings that are wrong about different things. A flag that gave you
+the vector arm would be a flag that made your search worse.
+
+The recall figure is printed with every search because it is per-corpus and per-embedder: the
+same harness measures 0.4750 on this repository as it stood three weeks ago, and there is no
+conversion from one embedding model's vector space to another's.
 
 ```bash
 chimera find QUERY
@@ -550,6 +557,7 @@ chimera find QUERY
 | `--path` | Repository to search. | `'.'` |
 | `--k` | How many results. | `8` |
 | `--reindex` | Rebuild the index before searching. |  |
+| `--semantic` | Fuse keyword with embeddings. Costs money to index. |  |
 
 ## fuse
 

--- a/tests/test_catalog_is_live.py
+++ b/tests/test_catalog_is_live.py
@@ -101,9 +101,18 @@ def test_the_transfer_panel_still_exists(live_slugs: set[str]) -> None:
 
 
 def test_the_catalogue_prices_are_not_wildly_stale(live_slugs: set[str]) -> None:
-    """Prices are documented as approximate, so this is deliberately loose: it fires on an ORDER of
-    magnitude, not on a percent. The catalogue said $0.14/$0.28 for a model that had moved to
-    $0.25/$0.95 — tolerable. It would also have said it after a 10x move, which is not.
+    """The catalogue price is not decoration: `register_catalog_prices` seeds the receipt table
+    with it, so an error here is an error in what a user is told they spent.
+
+    This used to allow a factor of five either way, on the reasoning that prices are documented as
+    approximate. Measured against that: on 2026-09-04 the catalogue carried 0.25/0.95 for
+    `deepseek-chat-v3.1` while the live index said 0.55/1.65 — **2.2x low, and this test passed**,
+    because 2.2 is inside 5. Every fusion receipt for that model under-reported by the same factor
+    for as long as it stood, and the entry's own note asserted the wrong figure had been verified.
+
+    Tightened to 50%. A price that has genuinely moved by half is worth a line in the catalogue
+    anyway, and this file is `-m integration`, so a real market move reddens a run somebody chose
+    rather than the build.
     """
     from chimera.providers.catalog import CATALOG
 
@@ -117,6 +126,56 @@ def test_the_catalogue_prices_are_not_wildly_stale(live_slugs: set[str]) -> None
         # knowing and cannot be expressed as a ratio.
         if (entry.input_per_m == 0) != (current.input_per_m == 0):
             wrong.append(f"{entry.slug}: {entry.input_per_m} vs {current.input_per_m} (free tier changed)")
-        elif entry.input_per_m > 0 and not (0.2 <= current.input_per_m / entry.input_per_m <= 5):
+        elif entry.input_per_m > 0 and not (0.67 <= current.input_per_m / entry.input_per_m <= 1.5):
             wrong.append(f"{entry.slug}: catalogue {entry.input_per_m}, live {current.input_per_m}")
-    assert not wrong, f"catalogue prices are off by an order of magnitude: {wrong}"
+    assert not wrong, f"catalogue prices are off by more than half: {wrong}"
+
+
+def _served_windows() -> dict[str, int]:
+    """`top_provider.context_length` per slug, fetched raw.
+
+    `openrouter_models()` keeps only the ADVERTISED `context_length`, so asking it this question
+    would return None for every entry and the test would pass by having nothing to check — a guard
+    that cannot fire. The raw index is read here instead rather than widening the production
+    listing for one integration test.
+    """
+    import json
+    import urllib.request
+
+    req = urllib.request.Request(
+        "https://openrouter.ai/api/v1/models", headers={"User-Agent": "chimera-tests"}
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:
+        data = json.loads(response.read())["data"]
+    served: dict[str, int] = {}
+    for entry in data:
+        window = (entry.get("top_provider") or {}).get("context_length")
+        if isinstance(window, int) and window > 0:
+            served[f"openrouter/{entry['id']}"] = window
+    return served
+
+
+def test_no_catalogue_window_promises_more_than_the_provider_serves(live_slugs: set[str]) -> None:
+    """`context_length` and `top_provider.context_length` are different numbers, and the second wins.
+
+    Measured on 2026-09-04: 39 of the 431 models in the live index advertise a window their provider
+    does not serve, and the gap reaches **20%** on exactly the three slugs this project uses as its
+    mid default, its fusion judge and the top rung of two presets — 1,310,720 advertised against
+    1,048,576 served.
+
+    It did not bite, and only by accident: the compaction trigger is `0.6 x 0.8 = 0.48` of the
+    window, so 628,800 sat well inside what was actually served. Raise that fraction and the margin
+    is gone. `context_k` now carries the served figure for those three, and this holds the rule: a
+    catalogue window may be smaller than the provider's, never larger.
+    """
+    from chimera.providers.catalog import CATALOG
+
+    served = _served_windows()
+    if not served:
+        pytest.skip("the index did not report a served window for anything")
+    over = [
+        f"{entry.slug}: catalogue {entry.context_k}k, served {served[entry.slug]}"
+        for entry in CATALOG
+        if entry.slug in served and entry.context_k * 1000 > served[entry.slug]
+    ]
+    assert not over, f"a catalogue window promises more than the provider serves: {over}"

--- a/tests/test_the_search_that_was_adopted_and_not_delivered.py
+++ b/tests/test_the_search_that_was_adopted_and_not_delivered.py
@@ -1,0 +1,182 @@
+"""`bench/rag` said ADOPT, and `chimera find` kept running keyword-only.
+
+The measurement in `bench/rag/RESULTS.md` is unambiguous: hybrid 0.5050 against keyword 0.4425 on
+this repository, +6.25 pp paired over 400 probes, McNemar p = 1.7e-04. What it did not do is reach a
+user — the command had no way to ask for the semantic half, and `chimera measure rag` had no way to
+pass an embedder, so the run that produced the verdict could only be reproduced by writing a script.
+
+Two things this file holds, and the second is the one that would be easy to lose:
+
+* `--semantic` means **hybrid**, never vectors alone. The vector arm on its own scored **0.4100 —
+  below keyword**. Every point of the win comes from fusing two rankings that are wrong about
+  different things, so a flag that handed a user the vector arm would be a flag that made their
+  search worse while sounding like an upgrade.
+* The embedding bill is announced **before** it is incurred. Indexing is the one part of this command
+  that costs money, and a user who did not expect one cannot un-spend it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from chimera.cli.main import app
+from chimera.config import Settings
+
+runner = CliRunner()
+
+
+def flat(output: str) -> str:
+    """Rich wraps to the terminal width, so a phrase can arrive split across two lines.
+
+    Asserting on the raw output makes the test a function of the runner's column count, which is
+    a property of the harness rather than of the command.
+    """
+    return re.sub(r"\s+", " ", output)
+
+SOURCE = '''
+def parse_plan(text: str) -> list[str]:
+    """Turn a numbered plan into the steps it names."""
+    return text.splitlines()
+
+
+def budget_left(spent: float, cap: float) -> float:
+    """How much of the ceiling has not been spent yet."""
+    return cap - spent
+'''
+
+VOCAB = ["plan", "steps", "budget", "ceiling", "spent", "numbered", "turn"]
+
+
+def _embed(texts: list[str]) -> list[list[float]]:
+    return [[float(t.lower().count(w)) for w in VOCAB] for t in texts]
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "core.py").write_text(SOURCE, encoding="utf-8")
+    return tmp_path
+
+
+# --- the flag exists and is off by default ---------------------------------------------------------
+
+
+def test_without_the_flag_no_embedder_is_built(tmp_path: Path, monkeypatch: Any) -> None:
+    """The default path must not acquire a bill. Nothing calls an embedder unless asked."""
+    called: list[int] = []
+    monkeypatch.setattr(
+        "chimera.evolution.wiring.semantic_embed",
+        lambda *a, **k: called.append(1) or _embed,
+        raising=True,
+    )
+    monkeypatch.setattr("chimera.config.get_settings", lambda: Settings(CHIMERA_HOME=str(tmp_path)))
+
+    result = runner.invoke(app, ["find", "how a plan becomes steps", "--path", str(_repo(tmp_path))])
+
+    assert result.exit_code == 0, result.output
+    assert called == [], "an embedder was built for a search that did not ask for one"
+    assert "keyword only" in flat(result.output)
+
+
+def test_the_keyword_footer_names_what_it_costs_to_do_better(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr("chimera.config.get_settings", lambda: Settings(CHIMERA_HOME=str(tmp_path)))
+
+    result = runner.invoke(app, ["find", "budget ceiling", "--path", str(_repo(tmp_path))])
+
+    assert "0.443" in flat(result.output), "the measured keyword recall travels with every search"
+    assert "--semantic" in flat(result.output)
+
+
+# --- the semantic arm ------------------------------------------------------------------------------
+
+
+def test_semantic_fuses_and_never_returns_the_vector_arm_alone(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """The measurement's own conclusion, held in code: vector ALONE scored below keyword."""
+    fused: list[str] = []
+    real_fusion = None
+    from chimera.rag import hybrid
+
+    real_fusion = hybrid.reciprocal_rank_fusion
+
+    def spy(rankings: Any, limit: int = 10) -> Any:
+        fused.append("called")
+        return real_fusion(rankings, limit=limit)
+
+    monkeypatch.setattr("chimera.rag.hybrid.reciprocal_rank_fusion", spy, raising=True)
+    monkeypatch.setattr("chimera.evolution.wiring.semantic_embed", lambda *a, **k: _embed)
+    monkeypatch.setattr("chimera.config.get_settings", lambda: Settings(CHIMERA_HOME=str(tmp_path)))
+
+    result = runner.invoke(
+        app, ["find", "how a plan becomes steps", "--path", str(_repo(tmp_path)), "--semantic"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert fused, "the semantic arm did not fuse — it would be handing back the losing retriever"
+
+
+def test_the_bill_is_announced_before_it_is_incurred(tmp_path: Path, monkeypatch: Any) -> None:
+    """Order matters: a warning printed after the embedding pass warns nobody."""
+    order: list[str] = []
+
+    def embed(texts: list[str]) -> list[list[float]]:
+        order.append("embedded")
+        return _embed(texts)
+
+    monkeypatch.setattr("chimera.evolution.wiring.semantic_embed", lambda *a, **k: embed)
+    monkeypatch.setattr("chimera.config.get_settings", lambda: Settings(CHIMERA_HOME=str(tmp_path)))
+
+    result = runner.invoke(app, ["find", "budget", "--path", str(_repo(tmp_path)), "--semantic"])
+
+    assert "costs money" in flat(result.output)
+    assert order, "nothing was embedded, so this proves nothing about the ordering"
+    # The line is printed by the same command before the pass; asserting both appear is what a
+    # captured-output test can honestly claim.
+    seen = flat(result.output)
+    assert seen.index("costs money") < seen.index("recall@10")
+
+
+def test_the_semantic_footer_names_the_embedder(tmp_path: Path, monkeypatch: Any) -> None:
+    """A recall figure without the model that produced it is a number about nothing in particular —
+    vector spaces do not convert between models."""
+    monkeypatch.setattr("chimera.evolution.wiring.semantic_embed", lambda *a, **k: _embed)
+    settings = Settings(CHIMERA_HOME=str(tmp_path))
+    monkeypatch.setattr("chimera.config.get_settings", lambda: settings)
+
+    result = runner.invoke(app, ["find", "budget", "--path", str(_repo(tmp_path)), "--semantic"])
+
+    assert settings.embed_model in flat(result.output)
+    assert "0.410" in flat(result.output), "the losing vector arm is stated, not hidden"
+
+
+def test_an_embedder_that_cannot_be_built_refuses_rather_than_falling_back(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """Falling back to keyword under a `--semantic` flag would answer a question nobody asked."""
+    monkeypatch.setattr("chimera.evolution.wiring.semantic_embed", lambda *a, **k: None)
+    monkeypatch.setattr("chimera.config.get_settings", lambda: Settings(CHIMERA_HOME=str(tmp_path)))
+
+    result = runner.invoke(app, ["find", "budget", "--path", str(_repo(tmp_path)), "--semantic"])
+
+    assert result.exit_code == 1
+    assert "needs an embedder" in flat(result.output)
+
+
+# --- the seam that made it possible ------------------------------------------------------------------
+
+
+def test_asking_in_so_many_words_is_not_the_same_as_the_standing_setting() -> None:
+    """`--semantic` on one search and `CHIMERA_SEMANTIC_MEMORY=1` are different decisions.
+
+    Reading the standing setting as consent to a one-off bill, or refusing the one-off because the
+    standing setting is off, would each be answering a question the user did not ask.
+    """
+    from chimera.evolution.wiring import semantic_embed
+
+    off = Settings(CHIMERA_HOME="x")
+    assert semantic_embed(off) is None
+    assert semantic_embed(off, force=True) is not None


### PR DESCRIPTION
Two things, joined because auditing one found the other.

## The search the bench adopted, delivered

`bench/rag/RESULTS.md` said **ADOPT** three commits ago — hybrid 0.5050 against keyword 0.4425, +6.25 pp paired over 400 probes, McNemar p = 1.7e-04 — and `chimera find` kept running keyword-only. A verdict is not a delivery.

`--semantic` now fuses, and three properties of it are the measurement rather than a preference:

- **It means HYBRID, never vectors alone.** The vector arm on its own scored **0.4100, below keyword's 0.4425**. Every point of the win comes from fusing two rankings wrong about different things, so a flag that handed back the vector arm would make a search *worse* while sounding like an upgrade. There is a test whose whole job is to fail if the fusion is ever skipped.
- **The bill is announced before it is incurred.** Indexing is the one part of this command that costs money, and a user who did not expect one cannot un-spend it.
- **The footer names the embedder.** A recall figure without the model that produced it is a number about nothing in particular — `store.py` already says vector spaces do not convert.

`chimera measure rag --semantic` follows, so the run that produced the verdict is reproducible from the CLI instead of from a script somebody has to write.

## A price that was wrong by 2.2×, with a note saying it had been verified

Auditing the catalogue against OpenRouter's live index of **431 models** found an error I introduced yesterday: `deepseek-chat-v3.1` catalogued at **0.25/0.95** against a live **0.55/1.65**. The entry's own note said *"Priced 0.55/1.65 here until a live check on 2026-09-03 measured 0.25/0.95"* — the check misread it.

A price does not halve and double back overnight. What makes it worth more than a typo:

- it feeds `register_catalog_prices`, so **every receipt for that model under-reported by 2.2× in and 1.7× out** for as long as it stood;
- it sits in `transfer_panel` — a default nobody chose;
- **the guard that should have caught it allowed a factor of five.** 2.2 is inside 5, so the test passed. Tightened to 50%, with the reasoning written down: a catalogue price is not decoration, it is what a user is told they spent.

The misreading is kept in the entry's note rather than deleted.

## Five windows promised more than the provider serves

`context_length` and `top_provider.context_length` are different numbers in **39 of the 431**, and the gap reaches **20%** on exactly the slugs this project uses as its mid default, its fusion judge and the top rung of two presets — 1,310,720 advertised against 1,048,576 served.

It never bit, and only by accident: the compaction trigger is `0.6 × 0.8 = 0.48` of the window, so 628,800 sat well inside what was actually served. Raise the fraction and the margin is gone.

A new integration guard holds the rule — a catalogue window may be smaller than the provider's, never larger — and it was **shown to fail on the old values before being trusted**. It found two entries beyond the three already known.

## And a small one the tests found

A search that matched nothing printed **no calibration figure**: the measured recall sat after the results table, so the empty-result path returned before it. That is the moment the number is worth most, because an empty screen is where a reader decides between "my query was wrong" and "this retriever misses half of what it is asked for", and only one of those is true.

## The audit's other answer, for the record

**Every one of OpenRouter's 431 models is usable.** There is no gate anywhere: `config.py` has no slug validator, `gateway.py` never mentions the catalogue, and `_resolve_model` is `return model or default`. The 19-entry catalogue is a suggestion list and a price seed. The desktop picker lists the live index, not the 19.

One caveat found and not fixed here: a user with **only** an Anthropic key sees an **empty** picker, because the listing fetches the remote index only when `openrouter` is among the configured providers and all 19 catalogue entries are `openrouter/`-prefixed.

## Verification

7 new tests for the search path; the window guard proven against the pre-fix values; full suite green apart from 4 pre-existing environment failures. CLI snapshot regenerated for the two new flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
