### PR TITLE
bench(context): no knee, because a slug is not a machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`CompletionResult.provider` — which backend served the call, not which model answered.**
+  OpenRouter routes a slug per call: three consecutive calls to
+  `openrouter/deepseek/deepseek-v4-flash-0731` came back from **`Wafer`, `Inceptron` and
+  `DigitalOcean`**. A slug names a rotating pool, so "the same model gave a different answer" and "a
+  different machine answered" are different events, and until now every record this project kept
+  made them look identical. Empty on the streaming path, where the chunks do not carry it — stated
+  on the field rather than left to be inferred from a value that is always blank on one route.
+
 - **The agent keeps a task list, and it is on the screen.** `RunState.tasks` has existed since
   compaction was written, with a docstring saying what it is for and a renderer that puts it back
   after a compaction. Nothing ever wrote to it, and the loop that would have been the obvious writer
@@ -78,35 +86,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   content the run fetched from the web. Turning a gate on is safe in every direction and belongs on
   a screen; making it permissive stays a deliberate act in a file.
 
-### Fixed
 
-- `CodeSession.send` forwarded a new callback to any agent whose `run` declared `**kwargs`, on the
-  reasoning — written in a comment — that an implementation predating the parameter had to keep
-  working. A catch-all usually forwards to something narrower, so the comment described a safety the
-  code did not provide: six API turns died before their first tool call. The signature is now read
-  for the parameter by name.
-
-- **Three unattended surfaces asked to be able to ask a person, and the parameter was dropped one
-  layer down.** `scheduler/job_runner`, `server/manager` and `kanban/lanes` all call
-  `governed_profile(..., home=settings.home)` — one of them with a comment on the line above reading
-  *"Governance on the path that runs unattended"*. `home` is what `approver_for` reads to opt into
-  asking somebody who is not at the keyboard, and the whole mechanism behind it
-  (`chimera/governance/pending.py`, a durable question answered with `chimera approve`) exists and is
-  tested.
-
-  `governed_profile` used the parameter for `AuditLog(home / "audit.jsonl")` and never handed it on
-  to `govern_step`, which is what builds the approver. So on all three surfaces every REVIEW was
-  refused with nobody asked. An operator who set `CHIMERA_APPROVAL_MODE=ask` believed they would be
-  told before anything risky; the only trace was a line in `audit.jsonl`. The parameter was named in
-  the signature, which is what made the omission read as wiring rather than as a decision.
-
-  **Forwarding it alone would have been a regression.** `ask_durably` waits fifteen minutes, and no
-  call site has ever passed a `deliver` — so the question would have been a JSON file nobody was
-  told about, which `pending.py` names itself: *"pretending otherwise would park a worker for fifteen
-  minutes to reach the same refusal."* So the durable ask travels only with somewhere to send it.
-
-
-## [Unreleased]
+- **A rule-form summariser for the span a compaction drops** — `chimera/core/summarise.py`, behind
+  `AgentConfig.summarise_compaction`, **off**. `compact()` has taken a `summarise` callable since it
+  was written and no production caller ever passed one, so every compaction leaves the structural
+  note. The note is a deliberate choice with its own defence — *"the agent can re-read a file; it
+  cannot un-believe a fabricated summary"* — so this is built beside it, not instead of it: the
+  summary travels **with** the note, asks for standing instructions rather than a narration, forbids
+  inference, and degrades to the note on every failure path.
 
 ### Changed
 
@@ -137,37 +124,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   width are recorded **inside** the result. Vector spaces do not convert, so this does not choose the
   shipped default; a local embedder needs its own run, and now has a measured reason to get one.
 
-### Fixed
-
-- **The RAG bench could not answer a paired question.** `RagReport` carried three totals and nothing
-  per probe, so the pairs a McNemar test needs were computed and discarded inside the loop that
-  computed them. Per-probe hit/miss is now recorded for all three arms and feeds
-  `chimera/eval/paired.py` directly.
-- **`embed_missing` was called without `embedder=`**, leaving `ChunkStore._align_embedder` inert in
-  exactly the run that first writes vectors. That guard zeroes every vector when the model identity
-  or width changes; without it a mixed-dimension index reports healthy and returns nothing, because
-  `_cosine` gives 0.0 on a mismatch and the `score > 0` filter then drops everything.
-- **Query embeddings were one call per probe**, inside the loop — 400 round-trips for the same money
-  as two batches. A provider returning a short batch now voids the semantic arms rather than pairing
-  each query with the next one's vector.
-- **The published baseline was stale, and says so.** The same harness measures 0.4750 on the
-  2026-08-14 tree (2,838 chunks) and 0.4425 today (3,459). `chimera/` is 29% larger than it was and
-  recall@10 falls as the haystack grows. The old figure was right about an older corpus; the record
-  now carries the chunk count beside every recall number, and names what it supersedes.
-
-## [Unreleased]
-
-### Added
-
-- **A rule-form summariser for the span a compaction drops** — `chimera/core/summarise.py`, behind
-  `AgentConfig.summarise_compaction`, **off**. `compact()` has taken a `summarise` callable since it
-  was written and no production caller ever passed one, so every compaction leaves the structural
-  note. The note is a deliberate choice with its own defence — *"the agent can re-read a file; it
-  cannot un-believe a fabricated summary"* — so this is built beside it, not instead of it: the
-  summary travels **with** the note, asks for standing instructions rather than a narration, forbids
-  inference, and degrades to the note on every failure path.
-
-### Changed
 
 - **Parallel tool calls: measured, and not built.** `chimera/core/agent.py` runs a turn's tool calls
   in a plain `for`. Making that concurrent needs a read-only marking on `Tool` that does not exist,
@@ -214,9 +170,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   set from the advertised maximum is about the marketing.
 
 
-## [Unreleased]
-
-### Changed
 
 - **Per-model edit-format tailoring: measured, and there is nothing to tailor.** The claim that would
   justify it — an OpenAI-family model is cheaper with patches, a Claude-family one with whole blocks
@@ -238,11 +191,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   2.5× the wall clock** of `deepseek-v4-flash-0731` for the same tasks at the same pass rate. Both
   are "flash"-tier by name.
 
-## [Unreleased]
-
-### Added
-
-### Changed
 
 - **`bench/context_rot` publishes no knee, because the measurement did not reproduce.**
   `bench/compaction` ended by asking at what context length the model starts getting the task wrong,
@@ -265,6 +213,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `CodeSession.send` forwarded a new callback to any agent whose `run` declared `**kwargs`, on the
+  reasoning — written in a comment — that an implementation predating the parameter had to keep
+  working. A catch-all usually forwards to something narrower, so the comment described a safety the
+  code did not provide: six API turns died before their first tool call. The signature is now read
+  for the parameter by name.
+
+- **Three unattended surfaces asked to be able to ask a person, and the parameter was dropped one
+  layer down.** `scheduler/job_runner`, `server/manager` and `kanban/lanes` all call
+  `governed_profile(..., home=settings.home)` — one of them with a comment on the line above reading
+  *"Governance on the path that runs unattended"*. `home` is what `approver_for` reads to opt into
+  asking somebody who is not at the keyboard, and the whole mechanism behind it
+  (`chimera/governance/pending.py`, a durable question answered with `chimera approve`) exists and is
+  tested.
+
+  `governed_profile` used the parameter for `AuditLog(home / "audit.jsonl")` and never handed it on
+  to `govern_step`, which is what builds the approver. So on all three surfaces every REVIEW was
+  refused with nobody asked. An operator who set `CHIMERA_APPROVAL_MODE=ask` believed they would be
+  told before anything risky; the only trace was a line in `audit.jsonl`. The parameter was named in
+  the signature, which is what made the omission read as wiring rather than as a decision.
+
+  **Forwarding it alone would have been a regression.** `ask_durably` waits fifteen minutes, and no
+  call site has ever passed a `deliver` — so the question would have been a JSON file nobody was
+  told about, which `pending.py` names itself: *"pretending otherwise would park a worker for fifteen
+  minutes to reach the same refusal."* So the durable ask travels only with somewhere to send it.
+
+
+
+- **The RAG bench could not answer a paired question.** `RagReport` carried three totals and nothing
+  per probe, so the pairs a McNemar test needs were computed and discarded inside the loop that
+  computed them. Per-probe hit/miss is now recorded for all three arms and feeds
+  `chimera/eval/paired.py` directly.
+- **`embed_missing` was called without `embedder=`**, leaving `ChunkStore._align_embedder` inert in
+  exactly the run that first writes vectors. That guard zeroes every vector when the model identity
+  or width changes; without it a mixed-dimension index reports healthy and returns nothing, because
+  `_cosine` gives 0.0 on a mismatch and the `score > 0` filter then drops everything.
+- **Query embeddings were one call per probe**, inside the loop — 400 round-trips for the same money
+  as two batches. A provider returning a short batch now voids the semantic arms rather than pairing
+  each query with the next one's vector.
+- **The published baseline was stale, and says so.** The same harness measures 0.4750 on the
+  2026-08-14 tree (2,838 chunks) and 0.4425 today (3,459). `chimera/` is 29% larger than it was and
+  recall@10 falls as the haystack grows. The old figure was right about an older corpus; the record
+  now carries the chunk count beside every recall number, and names what it supersedes.
+
+
 - **A catalogue price was wrong by 2.2x, and its own note said it had been verified.**
   `deepseek-chat-v3.1` carried 0.25/0.95 against a live 0.55/1.65 — recorded by a survey on
   2026-09-03 that misread it. The entry feeds `register_catalog_prices`, so **every receipt for that
@@ -283,7 +275,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **A search that matched nothing printed no calibration figure.** The measured recall sat after the
   results table, so the empty-result path skipped it — at exactly the moment a reader has to decide
   between "my query was wrong" and "this retriever misses half of what it is asked for".
-
 
 ## [0.49.3] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,15 +242,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **`chimera find --semantic`, and `chimera measure rag --semantic`.** `bench/rag/RESULTS.md` said
-  ADOPT three commits ago and the command kept running keyword-only: a verdict is not a delivery.
+### Changed
 
-  **`--semantic` means hybrid, never vectors alone**, and that is the measurement rather than a
-  preference — the vector arm on its own scored **0.4100, below keyword's 0.4425**. A flag that
-  handed back the vector arm would make a search worse while sounding like an upgrade. The
-  embedding bill is announced **before** the pass, not in a footnote after it, and the footer names
-  the embedder, because a recall figure without the model that produced it is a number about
-  nothing in particular.
+- **`bench/context_rot` publishes no knee, because the measurement did not reproduce.**
+  `bench/compaction` ended by asking at what context length the model starts getting the task wrong,
+  so a compaction trigger could be set from the model rather than from the vendor's advertised
+  maximum. The sweep gave a clean-looking answer — instruction-following 10/10 from 4k to 400k and
+  **7/10 at 786k**, with retrieval holding at 10/10 throughout, which is the separation the design
+  existed to make.
+
+  Replicating that point gave **2/15**. Forty calls after it gave **40/40**. Same prompt, same
+  791,951 tokens, temperature 0. Sampling, prompt length, code path and a single bad backend were
+  each ruled out; the router's per-call rotation is what remains, and it was present in every batch
+  including the one whose curve looked clean.
+
+  **A trigger set from that sweep would have been set from noise.** The consequence reaches past this
+  bench: every measurement in this repository that names a model is a measurement of a pool, and none
+  of them recorded which backend answered, because until this commit nothing could.
+
+  185 calls, 72.4M input tokens, **US$ 5.07** measured against "under two dollars" estimated — the
+  65 calls past the sweep were the investigation, and they were worth more than the sweep.
 
 ### Fixed
 
@@ -272,6 +283,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **A search that matched nothing printed no calibration figure.** The measured recall sat after the
   results table, so the empty-result path skipped it — at exactly the moment a reader has to decide
   between "my query was wrong" and "this retriever misses half of what it is asked for".
+
 
 ## [0.49.3] - 2026-09-03
 

--- a/bench/context_rot/PREREGISTRATION.md
+++ b/bench/context_rot/PREREGISTRATION.md
@@ -1,0 +1,113 @@
+# At what context length does the model stop doing what it was told? — pre-registration
+
+**Written before any measurement. No outcome was seen first.**
+
+`bench/compaction/RESULTS.md` ended by naming this as the measurement the project needs and does not
+have. The compaction trigger is a fraction of the model's **advertised** window; the shipped default
+advertises 1,310,000 tokens, so the Code screen compacts at 786,000, and nothing in 137 traced runs
+ever came within a factor of twelve of that. When windows were 8k and 128k, "0.6 of the window" and
+"as much as the model can still use well" were roughly the same number. They are not now, and this
+measures the second one.
+
+## Why the bench that already exists cannot answer it
+
+`chimera/eval/context_curve.py` measures the same phenomenon **observationally**, joining
+`runs.jsonl` to `traces.jsonl` and bucketing by peak context. Run on this install's logs it reports:
+
+```
+0–8000        47 attempts   42.6%  [29.5%, 56.7%]
+8000–32000    35 attempts   62.9%  [46.3%, 76.8%]
+32000–128000  15 attempts   — (below the pre-registered floor of 20)
+128000–∞       0 attempts   —
+not enough data: 2 buckets above the floor, need 3. No claim either way.
+```
+
+It is right to refuse, and it would be right to refuse even with ten times the data, because the
+confound is structural: **a harder task carries more context**, so success falling with length would
+be indistinguishable from length rising with difficulty. Note that in this sample success *rises*
+with context — which is that confound, not an absence of rot.
+
+Attribution needs the task held constant and only the length varied. That is what this does.
+
+## Design
+
+A **single model call**, not an agent run. The loop adds attempts, tool calls and retries, and each
+of those is a source of variance that has nothing to do with context length. Isolating the model is
+what makes the answer a fact about the model rather than about the harness around it.
+
+One prompt, assembled the same way at every length:
+
+1. **System** — the shipped default system prompt, unchanged.
+2. **The brief**, first user turn: three checkable rules for the output, plus one arbitrary fact
+   (a token) stated once and never repeated.
+3. **Padding**, N tokens of plausible prior conversation — real source files from this repository,
+   framed as earlier turns. Real text rather than repeated filler, because a repeated string is
+   compressible and a model may treat it differently from novel content.
+4. **The request**, last user turn: write one small function, and quote the fact back.
+
+## Two outcomes, measured separately
+
+They come apart, and reporting one as the other is the failure this design is built to avoid:
+
+- **RULE** — does the output obey the three rules given in the brief? Instruction-following across
+  distance.
+- **FACT** — is the arbitrary token reproduced exactly? Retrieval across distance.
+
+The literature's claim is that retrieval survives far longer than instruction-following. If that
+holds here, a run that measured only FACT would report a model working fine at a length where it has
+stopped obeying — which is precisely the mistake a needle-in-a-haystack test makes when it is used to
+justify a context budget.
+
+## Lengths
+
+**4k · 16k · 64k · 200k · 400k · 786k** prompt tokens, 10 repeats each, per model.
+
+786,000 is not a round number. It is the exact point at which the Code screen's `context_budget=0.6`
+would finally compact on the shipped default, and it is in the sweep so that the question "is the
+model already broken by the time Chimera acts?" has a direct answer rather than an extrapolated one.
+
+## Models
+
+- `openrouter/deepseek/deepseek-v4-flash-0731` — the shipped default, 1,310,000-token window
+- `openrouter/z-ai/glm-5.3-flash` — a second family, so a curve is not one vendor's artefact
+
+## What is reported, and the rule for reading it
+
+Per (model, length): RULE pass rate and FACT pass rate over 10 repeats, each with a Wilson interval.
+
+**The knee is where the RULE rate first drops below 80% of its 4k value, with the interval
+excluding that 4k value.** Reported as a length, or as "no knee below 786k" if none is found.
+
+No adopt/reject: this run produces a number, not a decision. What it feeds is a later decision about
+the shape of `context_budget`, and pre-committing that decision now — before knowing whether the
+knee is at 30k or at 600k — would be fixing an answer to a question with no data.
+
+## Gates before the numbers are believed
+
+- **The 4k point is the control.** If RULE is already below 90% at 4k, the task is too hard and the
+  curve measures the task rather than the length. Reported first.
+- **Actual prompt tokens are read from the provider's usage**, not from the padding estimate. A
+  target of 786k that arrives as 400k is a different measurement than the one this document
+  describes.
+- **Three completions at the longest length are read with human eyes.** A model that returns an
+  error string, a refusal or a truncation scores zero on both outcomes and would look like rot.
+
+## What this cannot show
+
+- **Two models, one tier.** Both are flash-class. A frontier model in either family may hold
+  instructions much further, and nothing here transfers to it.
+- **One task shape.** Three formatting rules and a token to echo. A model that loses arithmetic, or
+  loses the ability to plan, at a length where it still formats correctly would look fine here.
+- **A single call, not a conversation.** Real degradation in an agent loop compounds over turns; this
+  measures one pass. `harness-engineering.md` calls those different things — rot within a pass, and
+  drift across a trajectory — and this measures only the first.
+- **Padding is repository source.** Plausible for a coding agent and not neutral: code may hold
+  attention differently from prose, and a different padding could move the knee.
+
+## Cost
+
+Roughly 120 calls, most of them short. Estimated **under two dollars**, reported as measured.
+
+## Result
+
+`bench/context_rot/RESULTS.md`.

--- a/bench/context_rot/RESULTS.md
+++ b/bench/context_rot/RESULTS.md
@@ -1,0 +1,129 @@
+# No knee is published, because the measurement did not reproduce
+
+Run 2026-09-04 against [`PREREGISTRATION.md`](PREREGISTRATION.md). 185 model calls, 72.4M input
+tokens, **US$ 5.07** measured (pre-registered as "estimated under two dollars" — see Cost).
+
+## What the sweep said
+
+| model | 4k | 16k | 64k | 200k | 400k | **786k** |
+|---|---|---|---|---|---|---|
+| `deepseek-v4-flash-0731` RULE | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 | **7/10** |
+| `deepseek-v4-flash-0731` FACT | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 |
+| `glm-5.3-flash` RULE | 10/10 | 10/10 | 9/10 | 10/10 | 10/10 | 10/10 |
+| `glm-5.3-flash` FACT | 10/10 | 10/10 | 9/10 | 10/10 | 10/10 | 10/10 |
+
+Read on its own that is a clean result: the shipped default holds three rules perfectly to 400k and
+drops to 70% at 786k — the exact length at which `context_budget=0.6` would finally compact — while
+**retrieval stays at 100%**, which is the separation this design existed to make. A
+needle-in-a-haystack probe would have reported the model healthy at the point it stopped obeying.
+
+The three failures were all **the same rule**, and it was the **first** one stated: the header line.
+The two rules given after it survived in every case.
+
+**Do not use that table.** It did not reproduce.
+
+## The contradiction
+
+7/10 against 10/10 is Fisher p ≈ 0.10 — suggestive, not a finding. So the long point was replicated
+with twenty more samples, and everything after that was run to explain what came back:
+
+| batch | n | RULE | FACT | prompt tokens |
+|---|---:|---:|---:|---:|
+| sweep, 786k | 10 | **7/10** | 10/10 | 791,933 |
+| replication | 15 | **2/15** | **2/15** | 791,951 |
+| provider diagnostic | 24 | **24/24** | 24/24 | 791,951 |
+| path A/B — gateway | 8 | **8/8** | 8/8 | 791,951 |
+| path A/B — raw litellm | 8 | **8/8** | 8/8 | 791,951 |
+
+The same prompt, at the same length, at **temperature 0.0**, gave 70%, 13%, and then 100% across
+forty more calls. At temperature zero the variation cannot come from sampling.
+
+The replication's failures are not broken output. Read with human eyes, they are correct, complete
+median functions that ignore every rule — `def median(...)` where the brief asked for `bee_median`,
+and no header line. The model did the task and forgot the instructions.
+
+## What was ruled out
+
+- **Sampling.** Temperature 0.0 throughout.
+- **Prompt length.** 791,951 tokens in the replication and in every passing batch since. Identical.
+- **A single misbehaving backend.** The 24-call diagnostic all came from `OpenInference` and all
+  passed, so the failures are not one bad machine that the router keeps returning to. What the
+  rotation does explain is below.
+- **The code path.** Recording the provider meant calling `litellm` directly instead of
+  `gateway.complete`, which changed two things at once. An interleaved A/B — alternating call by
+  call, so a drift in load could not land on one arm — gives **8/8 and 8/8**. The paths are the same.
+
+## What explains it: a slug is not a machine
+
+Instrumenting `provider` on the gateway — the field this run found missing — answered it directly.
+**Three consecutive calls to the same slug came back from three different backends:**
+
+```
+call 0  provider='Wafer'
+call 1  provider='Inceptron'
+call 2  provider='DigitalOcean'
+```
+
+OpenRouter routes per call. `openrouter/deepseek/deepseek-v4-flash-0731` does not name a machine; it
+names a **rotating pool**, and the members of that pool do not have to agree about what happens at
+790,000 tokens — which is exactly where the disagreement appeared and nowhere else.
+
+That is not a full attribution: the two failing batches ran before the field existed, so the backend
+that served them is unrecoverable. What the rotation does establish is that **the confound is real
+and was present the whole time**, in every batch, including the sweep whose curve looked clean.
+
+## The finding, which is not the one that was sought
+
+**At ~792k tokens this model's behaviour is not a stable function of its prompt** — and the reason is
+that the prompt was never being sent to the same place twice. Not a curve with a knee: a cell that
+returns 100% in one hour and 13% in another, from a pool whose membership rotates per call.
+
+**Every measurement in this repository that names a model is a measurement of a pool.** That reaches
+further than this bench: `bench/edit_format_by_model` compared "families", `bench/rag` names an
+embedder, and the parallel-tools census reported a 23-point spread "between model families". None of
+them recorded which backend answered, because until today nothing could.
+
+That has a direct consequence for the question the bench was built to answer. `bench/compaction`
+ended by asking for the length at which the model starts getting the task wrong, so a compaction
+trigger could be set from the model instead of from the vendor's advertised maximum. **A trigger set
+from a single sweep at this length would have been set from noise** — this run measured 70% and, had
+it stopped there, would have published a knee that forty later calls contradict.
+
+The low end is not exempt. 4k–400k came back 10/10 in a single pass and **was never replicated**, so
+"no degradation below 400k" is one observation, not an established floor.
+
+## The gap this found in the product, now closed
+
+`CompletionResult` recorded which **model** answered and not which **backend served it**, so a
+receipt could not distinguish "this model behaved differently" from "a different machine answered".
+That is the question this run spent most of its money failing to settle.
+
+`provider` is now on `CompletionResult`, populated on the non-streaming path from the router's own
+response. It is **empty on the streaming path** — the chunks do not carry it — and that is stated on
+the field rather than left for a reader to infer from a value that is always blank on one route.
+
+## One thing was edited out of the record, and it is named here
+
+The stored rows carry no `answer_head` preview. The probe originally asked the model to echo a
+dash-separated code after an equals sign, and the echoed answers in the committed JSON tripped
+this repository's secret scanner — correctly, because a scanner cannot know that a string in
+that shape means nothing.
+
+The field was dropped rather than the values rewritten, and rather than an allowlist added:
+editing recorded outputs is worse than losing a debugging convenience, and weakening a security
+gate so one bench fixture can pass is a trade nobody would make on purpose. Nothing in this
+document rests on that field — the analysis never read it, and the three failing answers quoted
+above were read before it went. The marker in `run.py` is now words rather than a code.
+
+## Cost
+
+185 calls, 72,381,094 input tokens, **US$ 5.07** — against "estimated under two dollars"
+pre-registered. The estimate was for the 120-call sweep; the 65 calls that followed were the
+investigation the contradiction required, and they were worth more than the sweep. Reported as
+measured.
+
+## What would answer the question properly
+
+Repeated sampling of the same cell **across days**, not within an afternoon, with the provider
+recorded on every call from the start. The variance to characterise is between sessions, and a
+design that samples one afternoon cannot see it — which is what this run learned the expensive way.

--- a/bench/context_rot/rows.json
+++ b/bench/context_rot/rows.json
@@ -1,0 +1,1802 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 12.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 12.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 8.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 9.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 11.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 16.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 9.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 10.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 8.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4510,
+    "seconds": 9.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 31.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 10.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 9.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 8.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 9.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 11.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 9.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 8.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 9.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15735,
+    "seconds": 8.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 13.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 9.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 11.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 8.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 14.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 10.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 8.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 8.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 9.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62752,
+    "seconds": 10.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 10.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 10.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 12.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 24.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 12.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 15.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 9.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 10.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 12.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200615,
+    "seconds": 8.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 31.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 17.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 14.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 14.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 10.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 17.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 15.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 17.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 17.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403876,
+    "seconds": 18.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 33.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": false,
+    "fact": true,
+    "detail": {
+      "header": false,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 12.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 12.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 15.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": true,
+    "detail": {
+      "header": false,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 7.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 11.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 13.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 10.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": false,
+    "fact": true,
+    "detail": {
+      "header": false,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 8.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791933,
+    "seconds": 13.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 6.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 5.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 5.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 3.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 4.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 5.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 4.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 4.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 10.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 4000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4363,
+    "seconds": 15.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 4.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 9.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 3.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 4.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 6.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 8.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 5.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 6.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 7.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 16000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15020,
+    "seconds": 8.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 5.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 3.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 4.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 6.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 3.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 6.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 3.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 6.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 67171,
+    "seconds": 3.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 64000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 59730,
+    "seconds": 37.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 13.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 13.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 4.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 4.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 4.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 4.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 4.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 5.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 5.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 200000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 190232,
+    "seconds": 7.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 14.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 5.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.7,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 7.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 12.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 400000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 382187,
+    "seconds": 6.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 38.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 51.4,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 17.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 9.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 10.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 9.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 14.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 9.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 15.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/z-ai/glm-5.3-flash",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 750674,
+    "seconds": 6.4,
+    "error": ""
+  }
+]

--- a/bench/context_rot/rows_provider.json
+++ b/bench/context_rot/rows_provider.json
@@ -1,0 +1,386 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 15.2,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 9.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 11.1,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 16.1,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.2,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.4,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 12.1,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 11.0,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 12.3,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 9.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 15.3,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 18.1,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.5,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 10.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 11.3,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 13.9,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 7.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 10.3,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 10.3,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 20,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 10.8,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 21,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 13.6,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 22,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 11.7,
+    "error": "",
+    "provider": "OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 23,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 9.3,
+    "error": "",
+    "provider": "OpenInference"
+  }
+]

--- a/bench/context_rot/rows_replica.json
+++ b/bench/context_rot/rows_replica.json
@@ -1,0 +1,298 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792029,
+    "seconds": 33.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 31.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 17.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 15.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 28.3,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 15.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 17.8,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 19.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 16.0,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 10,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 16.1,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 11,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 11.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 12,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.5,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 13,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 14,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.6,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 15,
+    "rule": false,
+    "fact": false,
+    "detail": {},
+    "prompt_tokens": 0,
+    "seconds": 2115.1,
+    "error": "litellm.APIError: APIError: OpenrouterException - peer closed connection without sending complete message body (incomplete chunked read)"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 18.9,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.2,
+    "error": ""
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791951,
+    "seconds": 14.6,
+    "error": ""
+  }
+]

--- a/bench/context_rot/run.py
+++ b/bench/context_rot/run.py
@@ -1,0 +1,190 @@
+"""Sweep context length with the task held constant. See `PREREGISTRATION.md`.
+
+    python bench/context_rot/run.py [--repeats 10] [--out rows.json]
+
+A single model call per row, deliberately: an agent loop adds attempts, tool calls and retries, and
+every one of those is variance that has nothing to do with length. What is wanted is a fact about the
+model, not about the harness around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import re
+import sys
+import time
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+from chimera.config import get_settings  # noqa: E402
+from chimera.core.agent import DEFAULT_SYSTEM_PROMPT  # noqa: E402
+from chimera.providers.gateway import LLMGateway, Message  # noqa: E402
+
+LENGTHS = [4_000, 16_000, 64_000, 200_000, 400_000, 786_000]
+MODELS = [
+    "openrouter/deepseek/deepseek-v4-flash-0731",
+    "openrouter/z-ai/glm-5.3-flash",
+]
+
+#: Only used to ASSEMBLE the padding; what is reported is always the provider's own count.
+#: Calibrated on a smoke run rather than guessed: at 3.6 the 786k target arrived as 703,554, and
+#: the point of that target is that it IS the length where `context_budget=0.6` finally fires.
+CHARS_PER_TOKEN = 4.05
+
+#: Words, deliberately, and not an opaque identifier. The first version asked the model to echo
+#: a dash-separated code after an equals sign, and the answers it produced tripped this
+#: repository's secret scanner — correctly, because that is the shape of a credential
+#: assignment and a scanner cannot know this one means nothing. The fix is to stop writing that
+#: shape into the repository, not to add an allowlist: weakening a security gate so one bench's
+#: fixture can pass is a trade nobody would make on purpose.
+FACT = "marlin four four zero two"
+
+BRIEF = (
+    "Rules for everything you write in this session, and they hold for every later message:\n"
+    "  1. Every Python file you produce starts with the exact line '# (c) Bruno 2026'.\n"
+    "  2. Every function name you define starts with 'bee_'.\n"
+    "  3. You never call print(); return values instead.\n"
+    f"Also record this build marker, which I will ask for later: {FACT}\n"
+    "Acknowledge and wait."
+)
+
+REQUEST = (
+    "Write one small Python function that returns the median of a list of numbers. "
+    "Reply with the file contents only, in a single ```python block. "
+    "After the block, on its own line, write: BUILD MARKER: <the marker I gave you>"
+)
+
+
+def padding(target_tokens: int) -> list[Message]:
+    """Plausible prior conversation, built from this repository's own source.
+
+    Real text rather than a repeated filler string: a repeated span is compressible and a model may
+    treat it differently from novel content, which would make the sweep measure the filler.
+    """
+    files = sorted(p for p in (REPO / "chimera").rglob("*.py") if p.stat().st_size > 2_000)
+    random.Random(11).shuffle(files)
+    want = int(target_tokens * CHARS_PER_TOKEN)
+    turns: list[Message] = []
+    used = 0
+    index = 0
+    while used < want and files:
+        source = files[index % len(files)]
+        index += 1
+        try:
+            body = source.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        chunk = body[: max(2_000, min(len(body), want - used))]
+        used += len(chunk)
+        rel = source.relative_to(REPO).as_posix()
+        turns.append(Message(role="user", content=f"For reference, here is {rel}:\n\n{chunk}"))
+        turns.append(Message(role="assistant", content=f"Noted {rel}."))
+    return turns
+
+
+RULE_1 = re.compile(r"^\s*#\s*\(c\)\s*Bruno\s*2026", re.M)
+RULE_2 = re.compile(r"^\s*def\s+(\w+)", re.M)
+
+
+def score(answer: str) -> tuple[bool, bool, dict[str, bool]]:
+    """(rule, fact, per-rule detail). All three rules must hold for RULE to pass."""
+    block = answer
+    fenced = re.search(r"```(?:python)?\s*(.*?)```", answer, re.S)
+    if fenced:
+        block = fenced.group(1)
+    names = RULE_2.findall(block)
+    detail = {
+        "header": bool(RULE_1.search(block)),
+        "prefix": bool(names) and all(n.startswith("bee_") for n in names),
+        "no_print": "print(" not in block,
+    }
+    return all(detail.values()), FACT in answer, detail
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repeats", type=int, default=10)
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parent / "rows.json"))
+    args = ap.parse_args()
+
+    # The gateway is still built, and only for its side effect: it is what registers the
+    # OpenRouter key and base with litellm. Calling litellm directly below without this would
+    # fail on credentials, and that dependency is easier to see written down than discovered.
+    LLMGateway(get_settings())
+    rows: list[dict] = []
+    pads = {n: padding(n) for n in LENGTHS}
+    total = len(MODELS) * len(LENGTHS) * args.repeats
+    done = 0
+
+    for model in MODELS:
+        for length in LENGTHS:
+            for rep in range(args.repeats):
+                done += 1
+                messages = [
+                    Message(role="system", content=DEFAULT_SYSTEM_PROMPT),
+                    Message(role="user", content=BRIEF),
+                    Message(role="assistant", content="Understood. Waiting."),
+                    *pads[length],
+                    Message(role="user", content=REQUEST),
+                ]
+                started = time.time()
+                row: dict = {
+                    "model": model, "target_tokens": length, "rep": rep,
+                    "rule": False, "fact": False, "detail": {}, "prompt_tokens": 0,
+                    "seconds": 0.0, "error": "", "answer_head": "", "provider": "",
+                }
+                try:
+                    # Straight to litellm here, not through the gateway, for one field the
+                    # gateway does not keep: OpenRouter routes a slug to whichever backend it
+                    # picks, and `provider` says which one answered. Two runs of this same cell
+                    # disagreed by 7/10 against 2/15, and a backend that handles 790k
+                    # differently is the first hypothesis a contradiction that size deserves.
+                    import litellm
+
+                    raw = litellm.completion(
+                        model=model,
+                        messages=[{"role": m.role, "content": m.content} for m in messages],
+                        temperature=0.0,
+                    )
+                    payload = raw.model_dump() if hasattr(raw, "model_dump") else dict(raw)
+                    row["provider"] = str(payload.get("provider") or "")
+
+                    class _R:  # what the scorer below expects
+                        content = (payload["choices"][0]["message"].get("content") or "")
+                        prompt_tokens = (payload.get("usage") or {}).get("prompt_tokens", 0)
+
+                    result = _R()
+                    answer = result.content or ""
+                    rule, fact, detail = score(answer)
+                    row.update(
+                        rule=rule, fact=fact, detail=detail,
+                        # The provider's own count, never the padding estimate: a target of 786k that
+                        # arrives as 400k is a different measurement than the one registered.
+                        prompt_tokens=int(getattr(result, "prompt_tokens", 0) or 0),
+                        answer_head=answer[:400],
+                    )
+                except Exception as exc:  # noqa: BLE001 — a dead cell is a result, not a crash
+                    row["error"] = str(exc)[:220]
+                row["seconds"] = round(time.time() - started, 1)
+                rows.append(row)
+                print(
+                    f"  [{done:3}/{total}] {model.split('/')[-1][:24]:24} alvo={length:7} "
+                    f"real={row['prompt_tokens']:7} regra={row['rule']!s:5} fato={row['fact']!s:5} "
+                    f"{row['provider'][:14]:14} "
+                    f"{row['seconds']:5.1f}s" + (f"  ERRO {row['error'][:60]}" if row["error"] else "")
+                )
+                Path(args.out).write_text(
+                    json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"
+                )
+    print(f"\n  {len(rows)} linhas em {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chimera/providers/gateway.py
+++ b/chimera/providers/gateway.py
@@ -125,6 +125,28 @@ class CompletionResult(BaseModel):
     now, and a response cut off at the output ceiling therefore arrived 200 OK and indistinguishable
     from a complete one."""
 
+    provider: str = ""
+    """Which BACKEND served this call, when the router reports one — not which model answered.
+
+    OpenRouter routes a slug to whichever provider it picks, and providers of the same slug differ:
+    in how much context they honour, in latency, and in what they do at the edge of a window.
+    Without this a receipt cannot tell "the model behaved differently" from "a different machine
+    answered", and those need different responses.
+
+    Found the expensive way. `bench/context_rot` measured the same prompt at ~792k tokens giving 70%
+    instruction-following in one batch, 13% in another and 100% across forty later calls, all at
+    temperature 0 — and the first hypothesis, that the router had moved, could not be tested at all,
+    because nothing had been recording where the answers came from.
+
+    Recording it settled it. **Three consecutive calls to one slug came back from `Wafer`,
+    `Inceptron` and `DigitalOcean`** — the router picks per call, so a slug names a rotating pool
+    rather than a machine. Every measurement this project makes "of a model" is a measurement of
+    that pool, and every receipt that names only the model is naming the pool too.
+
+    **Empty on the streaming path**, where the chunks carry no provider, and empty is not "none was
+    reported" — it is "this path cannot see it". Said here rather than left for a reader to infer
+    from a field that is always blank on one route."""
+
     truncated: bool = False
     """True when generation stopped because it ran out of room, rather than because it was done.
 
@@ -722,7 +744,15 @@ class LLMGateway:
                 drop_params=True,
                 **call_kwargs,
             )
+            provider = ""
             for chunk in response:
+                # Taken from the first chunk that carries one rather than assumed to be on the
+                # first chunk at all. Measured: none of them carry it today, so this stays empty
+                # on this path — kept because it costs nothing and starts working the day the
+                # router puts it on a chunk, and because a reader comparing the two paths needs
+                # to see that the absence was looked for rather than overlooked.
+                if not provider:
+                    provider = str(getattr(chunk, "provider", "") or "")
                 razao = self._consume_chunk(chunk, content, tool_acc, usage, think, on_delta)
                 if razao:
                     finish_reason = razao
@@ -760,6 +790,7 @@ class LLMGateway:
             cache_write_tokens=usage.get("cache_write_tokens"),
             finish_reason=finish_reason,
             truncated=finish_reason == "length",
+            provider=provider,
         )
 
     @staticmethod
@@ -855,6 +886,7 @@ class LLMGateway:
             cache_write_tokens=cache_write_tokens,
             finish_reason=finish_reason,
             truncated=finish_reason == "length",
+            provider=str(getattr(response, "provider", "") or ""),
         )
 
     @staticmethod

--- a/tests/test_the_summariser_for_a_compaction_that_never_fires.py
+++ b/tests/test_the_summariser_for_a_compaction_that_never_fires.py
@@ -163,3 +163,37 @@ def test_the_agent_builds_no_summariser_unless_asked(monkeypatch: Any) -> None:
         Agent(_Backend(), ToolRegistry(), AgentConfig(summarise_compaction=True))._summarise
         is not None
     )
+
+
+# --- a slug is not a machine ----------------------------------------------------------------------
+
+
+def test_the_result_records_which_backend_served_it() -> None:
+    """A receipt that names the model names a rotating pool, and until now could not say which.
+
+    Measured while chasing a contradiction in `bench/context_rot`: three consecutive calls to one
+    OpenRouter slug came back from `Wafer`, `Inceptron` and `DigitalOcean`. The router picks per
+    call, so "the same model gave a different answer" and "a different machine answered" are
+    different events that looked identical in every record this project kept.
+    """
+    from chimera.providers.gateway import CompletionResult, LLMGateway
+
+    class _Response:
+        provider = "Wafer"
+        choices: list[Any] = []
+        usage = None
+
+    assert CompletionResult(content="", model="m").provider == ""
+    normalised = LLMGateway._normalize(_Response(), "openrouter/x/y")
+    assert normalised.provider == "Wafer"
+
+
+def test_a_router_that_says_nothing_leaves_it_empty() -> None:
+    """Empty means "not reported", and it must not become a guess about which backend it was."""
+    from chimera.providers.gateway import LLMGateway
+
+    class _Silent:
+        choices: list[Any] = []
+        usage = None
+
+    assert LLMGateway._normalize(_Silent(), "openrouter/x/y").provider == ""


### PR DESCRIPTION
`bench/compaction` ended by naming the measurement this project needed: **at what context length does the model start getting the task wrong**, so a compaction trigger could be set from the model instead of from the vendor's advertised maximum. This is that measurement. It does not publish a curve.

## The sweep looked clean

| model | 4k | 16k | 64k | 200k | 400k | **786k** |
|---|---|---|---|---|---|---|
| `deepseek-v4-flash-0731` RULE | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 | **7/10** |
| `deepseek-v4-flash-0731` FACT | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 | 10/10 |
| `glm-5.3-flash` RULE | 10/10 | 10/10 | 9/10 | 10/10 | 10/10 | 10/10 |

The shipped default holds three rules perfectly to 400k and drops at **786k** — the exact length where `context_budget=0.6` would finally compact — while **retrieval stays at 100%**. That is the separation the design existed to make: a needle-in-a-haystack probe would have called the model healthy at the point it stopped obeying. All three failures were the *same* rule, and it was the *first* one stated.

**Do not use that table.**

## It did not reproduce

| batch | n | RULE | FACT | prompt tokens |
|---|---:|---:|---:|---:|
| sweep, 786k | 10 | **7/10** | 10/10 | 791,933 |
| replication | 15 | **2/15** | **2/15** | 791,951 |
| provider diagnostic | 24 | **24/24** | 24/24 | 791,951 |
| A/B — gateway | 8 | **8/8** | 8/8 | 791,951 |
| A/B — raw litellm | 8 | **8/8** | 8/8 | 791,951 |

7/10 against 10/10 is Fisher p ≈ 0.10, so the point was replicated rather than reported. The replication's failures are not broken output — read with human eyes they are correct, complete median functions that ignore every rule.

Ruled out, each with a measurement:

- **Sampling** — temperature 0.0 throughout, so the variation cannot come from decoding.
- **Prompt length** — 791,951 tokens in the replication and in every passing batch since.
- **The code path** — recording the provider meant calling litellm directly instead of `gateway.complete`, which changed two things at once. An **interleaved** A/B, alternating call by call so a drift in load could not land on one arm: 8/8 and 8/8.
- **A single bad backend** — the 24-call diagnostic all came from one provider and all passed.

## What explains it: a slug is not a machine

Instrumenting the field this run found missing answered it. **Three consecutive calls to the same slug:**

```
call 0  provider='Wafer'
call 1  provider='Inceptron'
call 2  provider='DigitalOcean'
```

OpenRouter routes **per call**. `openrouter/deepseek/deepseek-v4-flash-0731` does not name a machine; it names a rotating pool, and its members need not agree about what happens at 790,000 tokens — which is where the disagreement appeared and nowhere else.

Not a full attribution: the failing batches ran before the field existed, so their backend is unrecoverable. What it does establish is that **the confound was present in every batch**, including the sweep whose curve looked clean.

## Why this matters past this bench

**Every measurement in this repository that names a model is a measurement of a pool.** `bench/edit_format_by_model` compared "families"; the parallel-tools census reported a 23-point spread "between model families"; `bench/rag` names an embedder. None recorded which backend answered, because until this commit nothing could.

And for the question that prompted it: **a compaction trigger set from that sweep would have been set from noise.** The run measured 70% and, had it stopped there, would have shipped a knee that forty later calls contradict.

The low end is not exempt either — 4k–400k came back 10/10 in a single pass and was never replicated, so "no degradation below 400k" is one observation, not a floor.

## What ships

`CompletionResult.provider`, populated from the router's own response on the non-streaming path. **Empty on the streaming path** — the chunks do not carry it — and the field's docstring says so, rather than leaving a reader to infer it from a value that is always blank on one route. Two tests: it records what the router reports, and a silent router leaves it empty rather than guessing.

## Cost

185 calls, 72,381,094 input tokens, **US$ 5.07** — against "estimated under two dollars" pre-registered. The estimate covered the 120-call sweep; the 65 calls after it were the investigation the contradiction demanded, and they were worth more than the sweep. Reported as measured.

## What would answer the original question

Repeated sampling of the same cell **across days**, with the provider recorded from the first call. The variance to characterise is between sessions and between backends; a design that samples one afternoon cannot see either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
