### PR TITLE
bench(loop): the 23-point spread was between backends, not between families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`StepRecord.provider`, so a trace records which backend served each step.** `CompletionResult`
+  gained the field first; this carries it into `traces.jsonl`, which is what every census this
+  project runs reads.
+
+### Changed
+
+- **The 23-point spread `bench/parallel_tools` attributed to model families is retracted.** Pinning
+  four backends of a **single** slug and running the same thirty tasks against each measured a
+  **35.9-point** spread — larger than the between-family figure, with non-overlapping intervals:
+
+  | backend | multi-call rate | 95% CI |
+  |---|---:|---|
+  | `Baidu` | 63.5% | [52.1, 73.6] |
+  | `OpenInference` | **27.6%** | [18.8, 38.6] |
+  | `Relace` | 58.5% | [47.7, 68.6] |
+  | `Wafer` | 57.7% | [46.6, 68.0] |
+
+  The four use the same batch vocabulary, so this is not different work at similar rates — it is the
+  same work with a different number of tools asked for per turn.
+
+  **The bench's verdict is untouched**: parallel tool calls died on tool *latency*, 4.3 ms saved per
+  run against a 5,578 ms step, and that argument never used the batching rate. What is retracted is
+  the finding it carried forward. What replaces it is the shape rather than the number: **a
+  measurement that averages over an unrecorded dimension is averaging over it**, and the serving
+  backend was such a dimension in every measurement this repository had made.
+
+  Observing the router could not have found this: 120 consecutive runs all landed on one backend,
+  while `bench/context_rot` saw five rotate across a handful of calls. The arms had to be pinned.
+
+  And the pool behind that one slug has **30 endpoints**, spanning **5× in context window**
+  (262,144 → 1,310,720) and **8.8× in input price** ($0.050 → $0.440/M). `catalog.py` records one
+  number per axis.
+
 - **`CompletionResult.provider` — which backend served the call, not which model answered.**
   OpenRouter routes a slug per call: three consecutive calls to
   `openrouter/deepseek/deepseek-v4-flash-0731` came back from **`Wafer`, `Inceptron` and

--- a/bench/parallel_tools/PREREGISTRATION_backends.md
+++ b/bench/parallel_tools/PREREGISTRATION_backends.md
@@ -1,0 +1,123 @@
+# Was the 23-point spread between families, or between backends? — pre-registration
+
+**Written before any run. No outcome was seen first.**
+
+[`RESULTS.md`](RESULTS.md) closed the parallel-tool-call question on a measurement of tool-latency,
+and carried one finding forward as the thing worth keeping:
+
+> `deepseek-v4-flash-0731` and `gemini-3.8-flash` differ by 23 percentage points in how they use a
+> tool-calling API, and any measurement of loop behaviour that averages over models is averaging
+> over that.
+
+`bench/context_rot` then found that a slug is not a machine: three consecutive calls to
+`openrouter/deepseek/deepseek-v4-flash-0731` were answered by **`Wafer`, `Inceptron` and
+`DigitalOcean`**. OpenRouter routes per call. So "the model batches 23.3% of the time" was measured
+over a *pool*, and the census could not have known which member answered — nothing recorded it.
+
+This asks the question that decides whether that carried-forward finding survives.
+
+---
+
+## What is not being done, and why
+
+**Not a re-run of the census.** That census read 137 runs accumulated over weeks of ordinary use, and
+none of them carry a provider. Retrofitting is impossible and reproducing that corpus would take
+weeks and buy the same confound at a different scale.
+
+The confound is testable much more cheaply, because it needs only **one** slug: if backends serving
+a single model batch at different rates, then a spread measured *between* slugs cannot be attributed
+to the slugs. One model, many backends, one question.
+
+## Design
+
+N short exploratory agent runs against a fixed small workspace, all on
+`openrouter/deepseek/deepseek-v4-flash-0731` — the slug the original census reported at 23.3%, and
+the one already observed rotating across at least five backends.
+
+Each step records the batch size (`len(tool_calls)`) and the serving provider, which
+`StepRecord.provider` now carries. Tasks are read-only exploration, because that is where the
+original census found its multi-call batches (`list_dir + read_file`, `grep + grep`, `glob + glob`).
+
+## Primary outcome and decision rule, fixed now
+
+**The share of tool-calling steps carrying two or more calls, per backend**, over backends with at
+least **30** tool-calling steps.
+
+- **THE FAMILY ATTRIBUTION IS UNSAFE** if the max−min spread between qualifying backends reaches
+  **≥ 10 percentage points**. Ten, not twenty-three: if backends inside one slug already differ by
+  under half the between-family figure, that figure cannot be read as a fact about families, and
+  `RESULTS.md` must be amended to say so.
+- **THE FAMILY ATTRIBUTION SURVIVES** if the spread is under 10 points — backends of one slug agree,
+  so a between-slug difference is about the slug.
+- **NO CLAIM** if fewer than two backends reach 30 steps. A spread computed over one backend, or over
+  cells of five, is a spread about nothing.
+
+## Gates before the aggregate is believed
+
+- **How many backends answered, and how the steps split between them.** A run that lands 95% on one
+  backend cannot compare backends, whatever the totals say.
+- **Batch shapes, printed per backend.** Two backends at the same *rate* that batch entirely
+  different tool pairs are not agreeing, and a single percentage would hide that.
+- **The steps that carry no provider** are counted and reported, never folded into a backend.
+
+## What this cannot show
+
+- **One slug, one task shape.** Read-only exploration on a small workspace. A backend that differs on
+  writing, or under a long context, is invisible here.
+- **It cannot rehabilitate the old census.** Whatever this finds, the 137 runs behind
+  `RESULTS.md` have no provider and never will. This can only say whether the finding they carried
+  is safe to keep quoting.
+- **Backend identity is a name from the router**, not a machine. Two names may be one operator, or
+  one name may front several.
+- **Routing is not under control.** Which backends appear, and in what proportion, is OpenRouter's
+  decision on the day. A backend absent today is not a backend that does not exist.
+
+## Cost
+
+N ≈ 120 short runs on a cent-per-million model. Estimated **under one dollar**, reported as measured.
+
+## Result
+
+`bench/parallel_tools/RESULTS_backends.md`, and an amendment to `RESULTS.md` if the rule says the
+attribution is unsafe.
+
+---
+
+## Amendment: observing the router cannot sample backends
+
+Made after the observational run and before any comparison existed.
+
+120 consecutive runs produced **321 tool-calling steps, all from one backend (`Baidu`)**. By the rule
+above that is NO CLAIM — fewer than two backends reached thirty steps — and it is also a fact about
+the instrument: routing is per-call in one session and sticky across another, so *watching* it does
+not sample the pool. `bench/context_rot` saw five backends rotate across a handful of calls; this saw
+one across a hundred and twenty.
+
+The router can be **pinned** instead. OpenRouter accepts `provider: {order: [...],
+allow_fallbacks: false}`, verified working: asking for `Baidu` returned `Baidu` and asking for
+`Wafer` returned `Wafer`.
+
+So the design changes from observing routing to **fixing it**: the same task set run against several
+named backends, one at a time. That is a stronger comparison than the original — same items, same
+ruler, only the backend varies — and it is the only one available, since observation cannot reach
+more than one cell.
+
+**What had been seen when this was written.** One number: `Baidu` batched on 65.4% of its 321 steps.
+No between-backend comparison existed, which is what the decision rule is about, so nothing about the
+outcome under test had been observed. It is stated anyway.
+
+That 65.4% is **not comparable to the 23.3% the original census reported for this slug**, and the
+reason is worth writing down rather than discovering later: this bench runs read-only exploration on
+a five-file package, chosen precisely because that is where batches happen, while the census read
+real mixed usage including writes. Different items, different mix — comparing them would be the
+error this project keeps finding in its own work.
+
+### The rule, restated for pinned arms
+
+Unchanged in substance. Over backends with at least 30 tool-calling steps **in this run**, on the
+same tasks:
+
+- **UNSAFE** if max−min reaches **≥ 10 percentage points**.
+- **SURVIVES** if under 10.
+- **NO CLAIM** if fewer than two backends yield 30 steps — a backend that rate-limits or refuses is
+  reported as absent, never as a zero.

--- a/bench/parallel_tools/RESULTS.md
+++ b/bench/parallel_tools/RESULTS.md
@@ -91,10 +91,39 @@ saving would have to grow by roughly three orders of magnitude — which no plau
 mix or corpus size produces, because the ceiling is bounded by tool latency and tool latency is
 milliseconds.
 
+## Amendment, 2026-09-04: the per-model table compares pools, not models
+
+Every figure in the table above was measured without recording which **backend** answered, because
+nothing in this project recorded one until `bench/context_rot` found that a slug is not a machine.
+OpenRouter routes per call, and the pool behind this one slug has **30 endpoints**.
+
+[`RESULTS_backends.md`](RESULTS_backends.md) pinned four of them and ran the same thirty tasks
+against each:
+
+| backend | rate | 95% CI |
+|---|---:|---|
+| `Baidu` | 63.5% | [52.1, 73.6] |
+| `OpenInference` | **27.6%** | [18.8, 38.6] |
+| `Relace` | 58.5% | [47.7, 68.6] |
+| `Wafer` | 57.7% | [46.6, 68.0] |
+
+**35.9 points, inside one slug** — larger than the 23 points this file attributed to the difference
+between two model families, with non-overlapping intervals. The per-model table stands as a record of
+what those pools did; it does not support a claim about the models.
+
+**The verdict of this file is untouched.** The front died on tool *latency* — 4.3 ms saved per run
+against a 5,578 ms step — and that argument never used the batching rate. A model that batched on
+every turn would still be saving milliseconds against seconds.
+
 ## What to do instead
 
-Nothing, here. The finding worth carrying out of this is the one about the aggregate: `deepseek-v4-
-flash-0731` and `gemini-3.8-flash` differ by 23 percentage points in how they use a tool-calling
-API, and any measurement of loop behaviour that averages over models is averaging over that.
+Nothing, here. The finding this file used to carry forward was that `deepseek-v4-flash-0731` and
+`gemini-3.8-flash` differ by 23 points in how they use a tool-calling API. **That is retracted**: the
+amendment above measures 35.9 points between backends of one slug, so the between-slug figure cannot
+be read as a fact about the slugs.
+
+What survives is the shape of the mistake rather than the number: **any measurement of loop behaviour
+that averages over an unrecorded dimension is averaging over it**, and until 2026-09-04 the serving
+backend was such a dimension in every measurement this repository had made.
 
 Reproduce with `python scripts/count_tool_batches.py`.

--- a/bench/parallel_tools/RESULTS_backends.md
+++ b/bench/parallel_tools/RESULTS_backends.md
@@ -1,0 +1,99 @@
+# The 23-point spread was not between families
+
+Run 2026-09-04 against [`PREREGISTRATION_backends.md`](PREREGISTRATION_backends.md) and its
+amendment. **Verdict: the family attribution in [`RESULTS.md`](RESULTS.md) is unsafe.**
+
+## The measurement
+
+One slug — `openrouter/deepseek/deepseek-v4-flash-0731` — the same thirty read-only exploration
+tasks, run four times with the backend **pinned** each time.
+
+| pinned backend | answered by | steps | multi-call | rate | 95% CI |
+|---|---|---:|---:|---:|---|
+| `Baidu` | Baidu | 74 | 47 | **63.5%** | [52.1, 73.6] |
+| `OpenInference` | OpenInference | 76 | 21 | **27.6%** | [18.8, 38.6] |
+| `Relace` | Relace | 82 | 48 | **58.5%** | [47.7, 68.6] |
+| `Wafer` | Wafer | 78 | 45 | **57.7%** | [46.6, 68.0] |
+
+**Spread: 35.9 percentage points**, between four machines serving *the same model*. The
+pre-registered threshold was 10. `OpenInference`'s interval does not overlap any of the other three.
+
+For comparison, the figure `RESULTS.md` carried forward as its lasting finding was a **23-point**
+spread, and it attributed that to model families.
+
+## What the gates said
+
+Every arm was answered by the backend it asked for — the manipulation held, and `allow_fallbacks:
+false` is why. No step carried an empty provider.
+
+The batch **shapes** are the same vocabulary across all four: `grep + list_dir`, four `read_file`
+calls at once, `glob + list_dir`. So this is not four backends doing different work at similar rates;
+it is four backends doing the same work and asking for a different number of tools per turn.
+
+```
+Baidu          sizes {1:27, 2:30, 3:2, 4:13, 5:2}
+OpenInference  sizes {1:55, 2:6,  3:2, 4:9,  5:4}
+Relace         sizes {1:34, 2:31, 3:7, 4:10}
+Wafer          sizes {1:33, 2:29, 3:1, 4:12, 5:3}
+```
+
+`OpenInference` reaches the same batch sizes as the others — it just does it far less often.
+
+## What follows for `RESULTS.md`
+
+Its census read 137 runs with no provider recorded, because nothing recorded one. Its headline
+per-model table therefore compares pools, not models, and its carried-forward finding —
+
+> `deepseek-v4-flash-0731` and `gemini-3.8-flash` differ by 23 percentage points in how they use a
+> tool-calling API
+
+— cannot be read as a fact about those two models, because backends of a *single* one differ by more.
+
+`RESULTS.md` is amended rather than deleted. **Its actual verdict is untouched**: the front died on
+tool latency — 4.3 ms saved per run against a 5,578 ms step — and that argument never depended on the
+batching rate. A model that batched on every single turn would still be saving milliseconds against
+seconds.
+
+## One coincidence, named and not claimed
+
+`OpenInference` measures **27.6%** here. The original census measured **23.3%** for this slug. It is
+tempting to conclude the census was mostly served by OpenInference and that its number was a backend
+number all along.
+
+That is not claimable. The census has no provider field and never will, its task mix was real usage
+including writes while this is read-only exploration on a five-file package, and two numbers landing
+near each other is not evidence of a shared cause. Recorded because leaving it out would look like it
+had not been noticed.
+
+## What this cannot show
+
+- **One slug, one task shape, one day.** Read-only exploration on a small workspace. Whether the same
+  spread appears for writes, for long contexts, or on another model is unmeasured.
+- **Four backends of thirty.** The pool for this slug has thirty endpoints; four were pinned. A wider
+  or narrower spread across the rest is unknown.
+- **It cannot rehabilitate the old census** — that data has no provider and cannot acquire one.
+- **Backend identity is a name from the router.** Two names may be one operator; one name may front
+  several machines.
+- **Nothing about *why*.** A different quantisation, a different serving stack, a different sampler
+  default — all would look like this and none is visible from here.
+
+## Cost
+
+240 short agent runs across all arms, on a model at $0.065/M in. **Under ten cents**, measured. The
+observational run that produced no claim cost about four.
+
+## The larger fact behind it
+
+The pool for this one slug has **30 endpoints**, and they are not interchangeable:
+
+| axis | spread across the 30 |
+|---|---|
+| context window | 262,144 → 1,310,720 (**5×**) |
+| input price | $0.050 → $0.440 per M (**8.8×**) |
+| tool-batching rate | 27.6% → 63.5% (**measured here, on four of them**) |
+
+`chimera/providers/catalog.py` records **one** number per axis per slug. Two endpoints
+(`CoreWeave`, `Reka`) serve 262,144 tokens, so a compaction trigger computed from 1,048,576 is wrong
+for any call that lands there — which is a sharper version of the window correction made in #346,
+where `context_k` was set from `top_provider.context_length`: that is one provider's number, not the
+pool's minimum.

--- a/bench/parallel_tools/backend_Baidu.json
+++ b/bench/parallel_tools/backend_Baidu.json
@@ -1,0 +1,749 @@
+[
+  {
+    "run": 0,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  }
+]

--- a/bench/parallel_tools/backend_OpenInference.json
+++ b/bench/parallel_tools/backend_OpenInference.json
@@ -1,0 +1,739 @@
+[
+  {
+    "run": 0,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 4,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 4,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 4,
+    "provider": "OpenInference",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 1,
+    "provider": "OpenInference",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 2,
+    "provider": "OpenInference",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 3,
+    "provider": "OpenInference",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  }
+]

--- a/bench/parallel_tools/backend_Relace.json
+++ b/bench/parallel_tools/backend_Relace.json
@@ -1,0 +1,815 @@
+[
+  {
+    "run": 0,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 4,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 5,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 4,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 5,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 4,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 5,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "grep"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 6,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 4,
+    "provider": "Relace",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 1,
+    "provider": "Relace",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 2,
+    "provider": "Relace",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 3,
+    "provider": "Relace",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  }
+]

--- a/bench/parallel_tools/backend_Wafer.json
+++ b/bench/parallel_tools/backend_Wafer.json
@@ -1,0 +1,783 @@
+[
+  {
+    "run": 0,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 4,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 5,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 4,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 4,
+    "provider": "Wafer",
+    "calls": 5,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 4,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 5,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 1,
+    "provider": "Wafer",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 2,
+    "provider": "Wafer",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 3,
+    "provider": "Wafer",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  }
+]

--- a/bench/parallel_tools/backend_rows.json
+++ b/bench/parallel_tools/backend_rows.json
@@ -1,0 +1,3245 @@
+[
+  {
+    "run": 0,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 0,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 1,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 2,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 3,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 4,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 5,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 6,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 7,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 8,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 9,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "list_dir",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 10,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 11,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 12,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 13,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 14,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 15,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 16,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "grep",
+      "grep",
+      "grep",
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 17,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 18,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 19,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 20,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 21,
+    "step": 5,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 22,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 23,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 24,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 25,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 26,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 27,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 28,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 29,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 30,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 30,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 31,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 31,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 31,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 32,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 33,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 33,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 34,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 34,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 34,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 34,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 35,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 35,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 35,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 36,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 36,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 37,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 37,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 37,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 37,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 38,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 39,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 39,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 40,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 40,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 40,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 40,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 41,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 41,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 41,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 42,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 42,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 43,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 43,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 43,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 44,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 45,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 45,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 45,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 46,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 46,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 46,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 46,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 47,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 47,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 47,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 48,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 48,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 49,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 49,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 50,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 50,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 51,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 51,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 52,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 52,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 52,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 52,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 53,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 53,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 54,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 54,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 55,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 55,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 56,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 56,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 57,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 57,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 57,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 57,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "read_file"
+    ]
+  },
+  {
+    "run": 58,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 58,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 58,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 59,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 59,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 59,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 60,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 60,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 61,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 61,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 62,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 62,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 62,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 63,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 63,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 64,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 64,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 64,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 64,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 65,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 65,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 65,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 66,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 66,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 67,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 67,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 67,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 67,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 68,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 68,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 69,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 69,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 70,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 70,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 71,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 71,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 71,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 72,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 72,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 73,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 73,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 74,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 74,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 74,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 75,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 75,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 75,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 76,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 76,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 76,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 76,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 77,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 77,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 78,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 78,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 79,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 79,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 79,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 80,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 80,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 80,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 81,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 81,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 81,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 81,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 82,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 82,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 82,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 83,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 83,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 83,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 84,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 84,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 85,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 85,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 85,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 86,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 86,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 87,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 87,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 88,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 88,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 88,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "read_file"
+    ]
+  },
+  {
+    "run": 88,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 89,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 89,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 90,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 90,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 90,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 91,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 91,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 92,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 92,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 93,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 93,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 93,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 94,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 94,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 94,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 94,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "grep"
+    ]
+  },
+  {
+    "run": 94,
+    "step": 5,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 95,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 95,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 96,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 96,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 97,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 97,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 98,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 98,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 98,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 99,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 99,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 100,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 100,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 100,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 101,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 101,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 5,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 102,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 102,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 103,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 103,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 104,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 104,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 105,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 105,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 105,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 106,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 106,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 106,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 107,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 107,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 107,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 108,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 108,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 109,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 109,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 110,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 110,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 110,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 111,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 111,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 111,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 5,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 112,
+    "step": 6,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "grep"
+    ]
+  },
+  {
+    "run": 113,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 113,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 113,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 114,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 114,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "read_file"
+    ]
+  },
+  {
+    "run": 115,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 115,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 115,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 116,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "glob",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 116,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "grep",
+      "list_dir"
+    ]
+  },
+  {
+    "run": 116,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 117,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 117,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 117,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "grep"
+    ]
+  },
+  {
+    "run": 117,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "glob"
+    ]
+  },
+  {
+    "run": 118,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 118,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 118,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 118,
+    "step": 4,
+    "provider": "Baidu",
+    "calls": 3,
+    "names": [
+      "grep",
+      "read_file",
+      "read_file"
+    ]
+  },
+  {
+    "run": 119,
+    "step": 1,
+    "provider": "Baidu",
+    "calls": 1,
+    "names": [
+      "list_dir"
+    ]
+  },
+  {
+    "run": 119,
+    "step": 2,
+    "provider": "Baidu",
+    "calls": 2,
+    "names": [
+      "list_dir",
+      "read_file"
+    ]
+  },
+  {
+    "run": 119,
+    "step": 3,
+    "provider": "Baidu",
+    "calls": 4,
+    "names": [
+      "read_file",
+      "read_file",
+      "read_file",
+      "read_file"
+    ]
+  }
+]

--- a/bench/parallel_tools/run_backends.py
+++ b/bench/parallel_tools/run_backends.py
@@ -1,0 +1,159 @@
+"""Do backends of ONE slug batch tool calls at different rates? See `PREREGISTRATION_backends.md`.
+
+    python bench/parallel_tools/run_backends.py [--runs 120]
+
+Read-only exploration tasks, because that is where the original census found its multi-call batches.
+One model slug throughout: the question is about the pool behind it, so varying the slug would
+reintroduce exactly the confound under test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+from chimera.config import get_settings  # noqa: E402
+from chimera.core import Agent, AgentConfig  # noqa: E402
+from chimera.governance.allowlist import restrict_registry  # noqa: E402
+from chimera.providers.gateway import LLMGateway  # noqa: E402
+from chimera.tools.builtin import default_registry  # noqa: E402
+
+MODEL = "openrouter/deepseek/deepseek-v4-flash-0731"
+
+#: Read-only only. A write turns the run into a different experiment and can fail for reasons that
+#: have nothing to do with how many calls the model asked for in a turn.
+ALLOWED = ["read_file", "list_dir", "grep", "glob"]
+
+TASKS = [
+    "Find where the median is computed in this package and report the file and line.",
+    "List every function defined in this package and say which file each is in.",
+    "Which module imports the helpers module? Name the files.",
+    "Find every place the word 'budget' appears and summarise what each use is for.",
+    "Read the two smallest files here and say in one sentence what each does.",
+    "What does this package do? Answer from the code, naming the files you read.",
+]
+
+FILES = {
+    "pkg/__init__.py": "from pkg.helpers import bee_median\nfrom pkg.budget import bee_left\n",
+    "pkg/helpers.py": (
+        '"""Small numeric helpers."""\n\n\n'
+        "def bee_median(numbers):\n"
+        "    ordered = sorted(numbers)\n"
+        "    n = len(ordered)\n"
+        "    if not n:\n        return None\n"
+        "    mid = n // 2\n"
+        "    return ordered[mid] if n % 2 else (ordered[mid - 1] + ordered[mid]) / 2\n"
+    ),
+    "pkg/budget.py": (
+        '"""Spend accounting."""\n\nfrom pkg.helpers import bee_median\n\n\n'
+        "def bee_left(spent, cap):\n"
+        '    """How much budget has not been spent."""\n'
+        "    return cap - spent\n\n\n"
+        "def bee_typical(runs):\n"
+        '    """The typical spend across runs."""\n'
+        "    return bee_median([r['usd'] for r in runs])\n"
+    ),
+    "pkg/report.py": (
+        '"""Rendering."""\n\nfrom pkg.budget import bee_left\n\n\n'
+        "def bee_render(spent, cap):\n"
+        "    return f'{bee_left(spent, cap):.2f} left of {cap:.2f}'\n"
+    ),
+    "README.md": "A tiny package for numeric helpers and spend accounting.\n",
+}
+
+
+class _PinnedGateway:
+    """The gateway, with every call routed to one named backend.
+
+    A wrapper rather than a settings flag: pinning is this bench's manipulation, not a mode the
+    product should acquire because one measurement wanted it.
+    """
+
+    def __init__(self, inner: object, provider: str) -> None:
+        self.inner = inner
+        self.provider = provider
+
+    def complete(self, messages: object, **kwargs: object) -> object:
+        extra = dict(kwargs.pop("extra_body", {}) or {})  # type: ignore[arg-type]
+        extra["provider"] = {"order": [self.provider], "allow_fallbacks": False}
+        return self.inner.complete(messages, extra_body=extra, **kwargs)  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self.inner, name)
+
+
+def workspace() -> Path:
+    root = Path(tempfile.mkdtemp(prefix="backends-"))
+    for name, body in FILES.items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    return root
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=120)
+    ap.add_argument("--pin", default="", help="pin one OpenRouter backend by name")
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parent / "backend_rows.json"))
+    args = ap.parse_args()
+
+    gateway = LLMGateway(get_settings())
+    rows: list[dict] = []
+
+    for index in range(args.runs):
+        root = workspace()
+        task = TASKS[index % len(TASKS)]
+        # Pinned rather than observed: 120 consecutive runs all landed on one backend, so
+        # watching the router does not sample the pool. `allow_fallbacks: false` matters — with
+        # fallbacks the arm silently becomes whatever answered, which is the confound itself.
+        backend = gateway
+        if args.pin:
+            backend = _PinnedGateway(gateway, args.pin)
+        agent = Agent(
+            backend,
+            restrict_registry(default_registry(root), allow=ALLOWED),
+            AgentConfig(model=MODEL, max_steps=6, max_usd=0.05),
+        )
+        started = time.time()
+        try:
+            result = agent.run(task)
+            steps = [
+                {
+                    "run": index,
+                    "step": record.index,
+                    "provider": record.provider,
+                    "calls": len(record.tools),
+                    "names": sorted(t.name for t in record.tools),
+                }
+                for record in result.steplog.steps
+                if record.tools
+            ]
+            rows.extend(steps)
+            print(
+                f"  [{index + 1:3}/{args.runs}] passos-com-ferramenta={len(steps)} "
+                f"provedores={sorted({s['provider'] or '(vazio)' for s in steps})} "
+                f"usd={result.usd or 0:.4f} {time.time() - started:.0f}s"
+            )
+        except Exception as exc:  # noqa: BLE001 — a dead run is a row that is absent, not a crash
+            print(f"  [{index + 1:3}/{args.runs}] FALHOU {str(exc)[:80]}")
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        Path(args.out).write_text(json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8")
+
+    print(f"\n  {len(rows)} passos com ferramenta em {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/chimera/core/agent.py
+++ b/chimera/core/agent.py
@@ -649,6 +649,7 @@ class Agent:
                 # missed" are different facts, and collapsing them to 0 would invent a diagnosis.
                 cached_tokens=result.cache_read_tokens,
                 model=result.model,
+                provider=getattr(result, "provider", "") or "",
                 content=clip(result.content or "", 400),
                 elapsed_ms=call_ms,
             )

--- a/chimera/core/steplog.py
+++ b/chimera/core/steplog.py
@@ -105,6 +105,17 @@ class StepRecord:
     #: run's total time would divide by the tool calls, the verifier and the user's thinking time —
     #: producing a number that moves when the network is slow and calling it the model's speed.
     elapsed_ms: int = 0
+    #: Which BACKEND served this step, when the router reports one — beside `model`, not
+    #: instead of it.
+    #:
+    #: A slug is a pool. `bench/context_rot` measured three consecutive calls to one OpenRouter
+    #: slug answered by `Wafer`, `Inceptron` and `DigitalOcean`, so a trace that records only
+    #: the model records the pool and calls it a machine. Every census this project has run over
+    #: these traces — batch sizes per family, context peaks, cache hit rates — attributed to a
+    #: model what may belong to whichever backend happened to answer.
+    #:
+    #: Empty on the streaming path, where the chunks carry nothing to read it from.
+    provider: str = ""
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -114,6 +125,7 @@ class StepRecord:
             "cached_tokens": self.cached_tokens,
             "elapsed_ms": self.elapsed_ms,
             "model": self.model,
+            "provider": self.provider,
             "content": self.content,
             "compacted": self.compacted,
             "tools": [


### PR DESCRIPTION
`bench/parallel_tools` closed the parallel-tool-call question on tool latency, and carried one finding forward as the thing worth keeping:

> `deepseek-v4-flash-0731` and `gemini-3.8-flash` differ by 23 percentage points in how they use a tool-calling API, and any measurement of loop behaviour that averages over models is averaging over that.

`bench/context_rot` then found that **a slug is not a machine** — OpenRouter routes per call, and the census had no way to record which backend answered. So the finding needed testing rather than quoting.

## Observing the router cannot answer it

120 consecutive runs produced **321 tool-calling steps, all from one backend**. `bench/context_rot` had seen five rotate across a handful of calls; this saw one across a hundred and twenty. Routing is per-call in one session and sticky across another, so watching it does not sample the pool — and by the pre-registered rule that run was **NO CLAIM**, one backend being fewer than the two required.

The router can be **pinned** (`provider: {order, allow_fallbacks: false}`, verified). That is the stronger comparison anyway: same thirty tasks, same slug, only the backend varies.

## Four backends of one slug

| pinned backend | steps | multi-call | rate | 95% CI |
|---|---:|---:|---:|---|
| `Baidu` | 74 | 47 | **63.5%** | [52.1, 73.6] |
| `OpenInference` | 76 | 21 | **27.6%** | [18.8, 38.6] |
| `Relace` | 82 | 48 | **58.5%** | [47.7, 68.6] |
| `Wafer` | 78 | 45 | **57.7%** | [46.6, 68.0] |

**35.9 points**, inside one slug, against a pre-registered threshold of 10 — and larger than the 23 points attributed to the difference between two model families. `OpenInference`'s interval overlaps none of the others.

Every arm was answered by the backend it asked for. The batch **shapes** are the same vocabulary across all four — `grep + list_dir`, four `read_file` calls at once — so this is not four backends doing different work at similar rates. It is the same work, with a different number of tools asked per turn.

## What is retracted, and what is not

**The bench's verdict stands.** The front died on tool *latency*: 4.3 ms saved per run against a 5,578 ms median step. That argument never used the batching rate, and a model batching on every turn would still be saving milliseconds against seconds.

**The finding it carried forward is retracted.** What replaces it is the shape rather than the number: *a measurement that averages over an unrecorded dimension is averaging over it* — and the serving backend was such a dimension in every measurement this repository had made.

## A coincidence named and not claimed

`OpenInference` measures 27.6% here; the original census measured 23.3% for this slug. Tempting, and not claimable: the census has no provider field, its task mix was real usage including writes while this is read-only exploration on a five-file package, and two numbers landing near each other is not evidence of a shared cause. Recorded so it does not look unnoticed.

## The larger fact

The pool behind this one slug has **30 endpoints**, and they are not interchangeable:

| axis | spread across the 30 |
|---|---|
| context window | 262,144 → 1,310,720 (**5×**) |
| input price | $0.050 → $0.440 per M (**8.8×**) |
| tool-batching rate | 27.6% → 63.5% (measured on four) |

`catalog.py` records **one** number per axis. Two endpoints serve 262,144 tokens, so a compaction trigger computed from 1,048,576 is wrong for a call that lands there — a sharper version of the window fix in #346, where `context_k` was set from `top_provider.context_length`: that is one provider's number, not the pool's minimum.

## What ships

`StepRecord.provider`, so `traces.jsonl` — the file every census here reads — records which backend served each step.

## Cost and limits

240 short runs, **under ten cents** measured. One slug, one task shape, one day, four of thirty endpoints. It cannot rehabilitate the old census: that data has no provider and cannot acquire one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
