### PR TITLE
bench(context): there is no knee, and there is a bad endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   bench: every measurement in this repository that names a model is a measurement of a pool, and none
   of them recorded which backend answered, because until this commit nothing could.
 
+  **Answered, with the backend pinned: there is no knee, and there is a bad endpoint.** 320 calls,
+  US$ 10.91. Held to one backend, the model scores **200/200 on every rule from 4,587 to 953,392
+  tokens** — it does not degrade in this probe at any length reachable on this slug. What varies is
+  the pool: of eight endpoints tested at 792k, six are perfect, one scores 7/10, and `DigitalOcean`
+  scores **0/10 — while already scoring 8/10 at 4,587 tokens**, where there is no context pressure at
+  all. So `context_budget` stays what it always was, a defence against the provider's hard window and
+  not against a measured decay; the risk the run actually found is that a router picks the machine
+  per call. `bench/context_rot/RESULTS_pinned.md`.
+
   185 calls, 72.4M input tokens, **US$ 5.07** measured against "under two dollars" estimated — the
   65 calls past the sweep were the investigation, and they were worth more than the sweep.
 

--- a/bench/context_rot/PREREGISTRATION_pinned.md
+++ b/bench/context_rot/PREREGISTRATION_pinned.md
@@ -1,0 +1,216 @@
+# Where does the model start getting it wrong — with the machine held still
+
+**Written before any run of this design. No outcome of it was seen first.**
+
+[`RESULTS.md`](RESULTS.md) spent US$ 5.07 and published no knee. The reason was not sample size and
+not sampling noise — temperature was 0.0 throughout and the prompt was identical to the token. The
+same cell returned **70%, then 13%, then 100%** across forty calls, and instrumenting the response
+showed why: three consecutive calls to one slug came back from `Wafer`, `Inceptron` and
+`DigitalOcean`. OpenRouter routes per call, and the pool behind
+`openrouter/deepseek/deepseek-v4-flash-0731` has **30 endpoints** whose context windows span 262,144
+to 1,310,720 and whose prices span 8.8x.
+
+So the earlier design was measuring a rotating population and calling it a model. This one holds the
+machine still.
+
+## The manipulation
+
+`provider: {order: [NAME], allow_fallbacks: false}` in `extra_body`, already verified working in
+[`../parallel_tools/run_backends.py`](../parallel_tools/run_backends.py): asking for `Baidu`
+returned `Baidu`, asking for `Wafer` returned `Wafer`. `allow_fallbacks: false` is not optional — with
+fallbacks on, an arm silently becomes whatever answered, which is the confound itself wearing the
+manipulation's name.
+
+Two facts about the pool decide the shape below, read from the endpoints API on 2026-09-05:
+
+- **28 of the 30 endpoints serve at least 800k**, so the length where the earlier run broke is
+  reachable on almost all of them. `Reka` and `CoreWeave` serve 262,144 and are therefore not
+  pinnable at the long end — the router answers `No endpoints found` rather than truncating, which is
+  a clean refusal and is reported as an absent cell, never as a zero.
+- **Input price spans $0.050 to $0.440 per M.** At 792k tokens that is 4 cents against 35 cents *per
+  call*. Volume goes on the cheap end; the expensive ones appear only where the question needs them.
+
+## Phase A — the gate, and it is the point of this design
+
+Nothing is swept until one pinned cell is shown to reproduce.
+
+`Baidu` ($0.050/M, already characterised in the backends bench at 63.5% batching), at the length that
+broke — target 786k, which arrives at ~792k by the provider's own count. **n = 20, twice, separated
+by at least two hours.**
+
+- **PINNING IS NOT ENOUGH — STOP, NO CURVE** if Fisher exact between the two batches gives p < 0.05.
+  Then a knee cannot be measured this way either, that is the finding, and the run ends here having
+  spent under two dollars.
+- **PROCEED** if p >= 0.05.
+
+**What this gate can and cannot detect, stated before it runs.** It is powered for the *magnitude*
+that killed the earlier run — 10/10 against 2/15 is Fisher p < 0.001 — and it is not powered for
+drift of a few points. A pass therefore means *"not that disease"*, not *"stable"*, and the results
+document must say so in those words rather than upgrading it in the retelling.
+
+## Phase B — the ladder, on the pinned backend
+
+Lengths **4k, 16k, 64k, 200k, 400k, 600k, 792k, 950k**. Two are new: 600k, to put a point between
+400k and the break, and 950k, because the earlier sweep stopped at the compaction trigger rather than
+at the model's limit and so could not see past it. n = 20 per cell.
+
+**Interleaved, not blocked by length.** The order of calls cycles through the lengths so that a drift
+in backend load over the hour cannot land on one length and be read as that length's behaviour. This
+is the same discipline that settled the code-path question in the earlier run, applied to the sweep
+itself.
+
+Both probes are kept, and the separation is the reason this bench exists:
+
+- **RULE** — three standing instructions given once, at the top, then buried under the padding: a
+  fixed header line, a name prefix, no `print`. Scored by regex on the returned file.
+- **FACT** — a marker word to echo back. Retrieval.
+
+The earlier run found RULE degrading while FACT stayed at 100%, which is precisely the case a
+needle-in-a-haystack probe reports as healthy. Whatever happens to that observation now, the two are
+scored and reported separately and never averaged into one number.
+
+### Decision rule, fixed now
+
+Let `r(L)` be the RULE rate at length `L`, and `r0` the rate at 4k.
+
+- **A KNEE IS PUBLISHED AT L** if `r0 - r(L) >= 30` percentage points with Fisher exact p < 0.05
+  against 4k, **and** every length below L is within 10 points of `r0`. The knee is the smallest such
+  L.
+- **NO KNEE BELOW 950k** if no L qualifies. That is a real result and gets written as one: it says
+  the trigger cannot be set from this probe below the length tested, not that the model is fine.
+- **NO CLAIM** for any cell with fewer than 15 usable rows after the gates below.
+
+## Phase C — is the knee the model's, or the machine's
+
+The knee length plus the two lengths bracketing it, repeated on three more pinned backends chosen
+from the cheap end: `OpenInference` ($0.050), `Relace` ($0.065), `Sail Research` ($0.065). n = 20.
+
+- **THE KNEE IS A PROPERTY OF THE BACKEND** if the knee position differs between backends, or if
+  `r` at the knee length spreads at least 20 points across them.
+- **THE KNEE IS A PROPERTY OF THE MODEL** if all four agree on position and spread under 20 points.
+
+This phase is the one that decides whether the number is usable in the product at all. A compaction
+trigger read off a single backend is a number about a machine the user may never be routed to.
+
+## Gates before any aggregate is believed
+
+- **Every row carries the backend that answered, and it must equal the one asked for.** A row where
+  they differ is dropped, counted, and named — it means `allow_fallbacks` did not hold and the arm is
+  contaminated.
+- **Prompt length is the provider's own count**, never the padding estimate. A cell whose realised
+  length drifts more than 2% from its target is reported at its realised length.
+- **Errors are counted separately and never scored as failures.** A refusal, a rate-limit and a wrong
+  answer are three different things, and folding them together is how a rate becomes meaningless.
+- **The failing answers are read with human eyes** before any explanation is offered for them. The
+  earlier run's "failures" were correct, complete functions that had forgotten the rules — which is a
+  different phenomenon from broken output, and only reading them showed that.
+
+## What this cannot show
+
+- **One model, one probe, one task shape.** Three standing formatting rules under a long prompt. It
+  does not measure reasoning, retrieval beyond one marker, or multi-turn behaviour.
+- **Pinning fixes the name, not the machine.** A backend may itself front several hosts, change
+  quantisation, or reconfigure between batches. If Phase A passes, that says those did not vary
+  enough to matter over two hours — not that they cannot.
+- **It cannot rehabilitate the earlier sweep.** Those rows have no backend and never will.
+- **Prices, windows and pool membership were read on 2026-09-05** and are the router's, not a
+  contract.
+- **A knee found here is this backend's knee at this date.** Phase C is what says how far that
+  generalises, and its answer may well be "not at all" — which is itself the useful result, because
+  it would mean no single trigger is right for a slug.
+
+## Cost
+
+Phase A is about 40 calls x 792k x $0.050/M, roughly **$1.60**. Phase B is about 160 calls and 60.5M
+tokens, roughly **$3.10**. Phase C is about 180 calls on cheap backends, roughly **$7.50**. Estimated
+**under $13 total**, reported as measured — the earlier run pre-registered "under two dollars" and
+spent $5.07, so this figure is written as an estimate that has been wrong before.
+
+## Result
+
+`bench/context_rot/RESULTS_pinned.md`, including the phase that stopped it if Phase A fails.
+
+---
+
+## Amendment: Phase C needs an anchor that does not depend on Phase B finding a knee
+
+Written after Phase A batch 1 and before batch 2, the ladder, or any cross-backend call.
+
+**What had been seen.** One batch: 20 calls pinned to `Baidu` at 792,019 tokens, **20/20 RULE and
+20/20 FACT**, zero errors, zero rows where the answering backend differed from the one asked for,
+US$ 0.79. Nothing about the outcome the Phase A rule decides — that rule compares two batches, and
+the second does not exist yet. Nothing about the ladder, and nothing about any other backend.
+
+**The gap.** Phase C above is defined as *"the knee length plus the two lengths bracketing it"*. If
+Phase B returns NO KNEE BELOW 950k — a result the rules above explicitly allow — then Phase C has no
+anchor and is undefined. That is the branch where the original question is still open, so it is
+exactly the branch that must not be left without a plan.
+
+**The fix, and the reason it is the right one.** Phase C runs at **792k regardless of what Phase B
+finds**. That length is not arbitrary and is not chosen from this run's data: it is where
+[`RESULTS.md`](RESULTS.md) recorded 70%, then 13%, then 100%, and that contradiction is the thing
+this whole design exists to explain. A cell that needs explaining does not stop needing it because a
+different backend behaved well.
+
+**What that reframes.** `Baidu` being stable would be consistent with the earlier instability without
+explaining it — the failing batches ran before the provider field existed, so the machine that served
+them is unrecoverable, and it need not have been this one. Under this amendment Phase C stops being
+only *"does the knee move between backends"* and becomes the sharper question: **is there a backend
+that fails at 792k?** If one of the four comes back near 13% while `Baidu` is at 100%, that is a
+direct account of the earlier contradiction, and a stronger result than a knee.
+
+**What it still cannot do.** It cannot identify which backend served those batches — that is gone.
+Finding a backend that fails at this length would make the earlier numbers *explicable*, not
+*attributed*, and the results document must keep that distinction rather than let a plausible
+mechanism harden into a claim about rows that carry no provider.
+
+---
+
+## Amendment 2: Phase C spends its budget on breadth, not depth
+
+Written after Phase B and before any cross-backend call.
+
+**What had been seen.** Phase A: 40/40 RULE and 40/40 FACT on `Baidu` at 792,019 tokens, two batches
+two hours apart, Fisher p = 1.0 — the gate passes. Phase B: the eight-length ladder on `Baidu`,
+**160/160 RULE and 160/160 FACT** from 4,587 to 953,392 tokens, zero errors, zero rows answered by a
+backend other than the one asked for, US$ 3.04. By the pre-registered rule that is **NO KNEE BELOW
+950k**. Nothing about any backend other than `Baidu` had been observed.
+
+**The instrument was checked before this was written**, because a perfect result and a broken ruler
+look identical. Today's scorer was fed a synthetic answer of the exact shape `RESULTS.md` describes
+for the real failures — a correct, complete median function with no header line and no name prefix —
+and it returns `rule=False` with `header` and `prefix` both false. Those are precisely the two flags,
+and the only two, that the 13 real failures in `rows_replica.json` recorded. The instrument can
+exhibit the effect, so 200/200 is a measurement rather than a silence.
+
+**The change.** Phase C was written as three backends at n = 20. It runs instead as **eight backends
+at n = 10**, at 792k, for the same money.
+
+**Why, and it is a power argument rather than a preference.** The effect being hunted is enormous —
+a backend near 13% against `Baidu` at 200/200. Fisher exact against 20/20 gives **p = 0.00040 at
+n = 5** and **p < 0.00001 at n = 10**. Depth past ten buys no ability to see that effect. What the
+budget can still buy is coverage: the pool has **28 endpoints serving this length**, and three of
+them is 11% of it. Testing three deeply and finding nothing would license the sentence *"no backend
+fails"* on a sample that could not have found one outside its three. That is the same error this
+bench exists to stop making, one level up in the design.
+
+Costed at 792,019 tokens per call against each endpoint's published input price: eight backends at
+n = 10 is **US$ 5.11**, three at n = 20 is US$ 2.85, and the Phase C budget above was US$ 7.50.
+
+**The eight, chosen to span the price range** rather than to be cheap, because price is the only
+visible proxy for a different serving stack: `OpenInference` ($0.050), `Relace`, `Sail Research`,
+`AkashML` ($0.065), `DigitalOcean`, `DeepInfra` ($0.080), `Wafer` ($0.100), `Together` ($0.140).
+`Baidu` is not repeated — it has 200 calls already.
+
+**Decision rule for Phase C, restated for this shape.** Over backends returning at least 8 usable
+rows:
+
+- **A BACKEND FAILS AT THIS LENGTH** if its RULE rate is below `Baidu`'s with Fisher p < 0.05. Each
+  such backend is named with its rate, never pooled into an average.
+- **THE POOL AGREES AT THIS LENGTH** if no backend qualifies. Written with the coverage attached —
+  *eight of twenty-eight* — because the remaining twenty are unmeasured, not shown to be fine.
+- **A backend that refuses, rate-limits or returns fewer than 8 usable rows is reported as absent**,
+  with the reason, and never as a zero.
+
+**What it still cannot do**, unchanged from Amendment 1: it cannot attribute the earlier batches to
+any backend. Those rows carry no provider and never will.

--- a/bench/context_rot/RESULTS.md
+++ b/bench/context_rot/RESULTS.md
@@ -1,5 +1,11 @@
 # No knee is published, because the measurement did not reproduce
 
+> **Superseded on 2026-09-05 by [`RESULTS_pinned.md`](RESULTS_pinned.md), which answers the question
+> this run could not.** Pinning the backend, the model holds every rule 200/200 from 4,587 to 953,392
+> tokens — there is no knee. What varies is the pool: two of eight endpoints behind this one slug do
+> not deliver the same behaviour, and one scores 0/10 at 792k while scoring 8/10 at 4,587. This
+> document's diagnosis was right and its verdict stands; what it could not do was measure past it.
+
 Run 2026-09-04 against [`PREREGISTRATION.md`](PREREGISTRATION.md). 185 model calls, 72.4M input
 tokens, **US$ 5.07** measured (pre-registered as "estimated under two dollars" — see Cost).
 

--- a/bench/context_rot/RESULTS_pinned.md
+++ b/bench/context_rot/RESULTS_pinned.md
@@ -1,0 +1,220 @@
+# The model does not degrade. A backend in the pool does.
+
+Run 2026-09-05 against [`PREREGISTRATION_pinned.md`](PREREGISTRATION_pinned.md) and its two
+amendments. **320 calls, 170,204,790 input tokens, US$ 10.91 measured** against US$ 13 estimated.
+
+Tables reproducible from the committed rows with `python bench/context_rot/analyse_pinned.py` — the
+analysis is a separate file from the runner on purpose, so re-reading a conclusion cannot re-spend.
+
+## The question, and why the last attempt could not answer it
+
+`bench/compaction` ended by asking for the length at which the model starts getting the task wrong,
+so a compaction trigger could be set from the model instead of from a vendor's advertised maximum.
+[`RESULTS.md`](RESULTS.md) spent US$ 5.07 trying and published no knee: the same cell at the same
+length, at temperature 0, returned **70%, then 13%, then 100%**. The cause turned out to be that
+`openrouter/deepseek/deepseek-v4-flash-0731` is not a machine — it is a pool of **30 endpoints**, and
+OpenRouter picks per call.
+
+This run holds the machine still with `provider: {order: [NAME], allow_fallbacks: false}`.
+
+**The manipulation was verified before it was trusted**, and the check was not the obvious one.
+Pinning `Baidu` and receiving `Baidu` proves nothing: 120 unpinned runs in `bench/parallel_tools` all
+landed on `Baidu`, so it is a sticky default. Worse, the free route was observed flipping between
+`Baidu` and `OpenInference` minute to minute, so any single pairing could be coincidence. The check
+that discriminates is to ask for backends the free route was not returning — `Wafer`, `Relace` and
+`Sail Research` were each requested and each answered. Across all 320 calls, **zero rows came back
+from a backend other than the one asked for**.
+
+## Phase A — the gate
+
+Nothing was swept until one pinned cell was shown to reproduce.
+
+| | n | RULE | FACT | errors | mis-routed | prompt tokens |
+|---|---:|---:|---:|---:|---:|---:|
+| batch 1 | 20 | **20/20** | 20/20 | 0 | 0 | 792,019 |
+| batch 2, +2h04 | 20 | **20/20** | 20/20 | 0 | 0 | 792,019 |
+
+Fisher exact **p = 1.0000** → PROCEED. As pre-registered, this means *"not that disease"* and not
+*"stable"*: the gate is powered for the magnitude that killed the earlier run, not for drift of a few
+points.
+
+## Phase B — the ladder, and there is no knee
+
+Pinned to `Baidu`, interleaved by repeat rather than blocked by length, so an hour of drift in
+backend load could not land on one cell and be read as that length's behaviour.
+
+| target | realised | n | RULE | FACT |
+|---:|---:|---:|:---:|:---:|
+| 4k | 4,587 | 20 | 20/20 | 20/20 |
+| 16k | 15,812 | 20 | 20/20 | 20/20 |
+| 64k | 62,829 | 20 | 20/20 | 20/20 |
+| 200k | 200,690 | 20 | 20/20 | 20/20 |
+| 400k | 403,942 | 20 | 20/20 | 20/20 |
+| 600k | 603,679 | 20 | 20/20 | 20/20 |
+| 786k | 792,019 | 20 | 20/20 | 20/20 |
+| **950k** | **953,392** | 20 | **20/20** | 20/20 |
+
+Zero errors, zero mis-routed rows. By the pre-registered rule: **NO KNEE BELOW 950k**. With Phase A
+that is **200/200 on a pinned backend**, at the length where the unpinned run measured 70%, 13% and
+100%.
+
+### The instrument was checked, because a perfect result and a broken ruler look identical
+
+Today's scorer was fed a synthetic answer of the exact shape `RESULTS.md` describes for the real
+failures — a correct, complete median function with no header line and no `bee_` prefix. It returns
+`rule=False` with `header` and `prefix` both false, and those are **precisely the two flags, and the
+only two**, that the 13 real failures in `rows_replica.json` recorded. It also separates the probes:
+an answer that obeys every rule but omits the marker scores `rule=True, fact=False`.
+
+The defect this rules out is one-directional and worth naming: the scorer requires the header regex
+**and** a `def` with the prefix, so it cannot pass an answer that broke a rule. 200/200 is a
+measurement, not a silence.
+
+## Phase C — the pool does not agree
+
+Eight backends at 792k, n = 10, spanning the published price range, compared against `Baidu`'s own
+40/40 from Phase A. Breadth over depth by Amendment 2: at n = 10 a backend near 13% against 40/40 is
+Fisher p < 0.00001, so depth buys nothing and coverage buys everything.
+
+| backend | $/M in | n | RULE | FACT | errors | Fisher vs Baidu |
+|---|---:|---:|:---:|:---:|---:|---|
+| `OpenInference` | 0.050 | 10 | 10/10 | 10/10 | 0 | 1.0000 |
+| `Relace` | 0.065 | 10 | 10/10 | 10/10 | 0 | 1.0000 |
+| `Sail Research` | 0.065 | 10 | **7/10** | **7/10** | 0 | 0.0061 |
+| `AkashML` | 0.065 | 8 | 8/8 | 8/8 | 2 rate-limit | 1.0000 |
+| `DigitalOcean` | 0.080 | 10 | **0/10** | **0/10** | 0 | **0.0000** |
+| `DeepInfra` | 0.080 | 10 | 10/10 | 10/10 | 0 | 1.0000 |
+| `Wafer` | 0.100 | 10 | 10/10 | 10/10 | 0 | 1.0000 |
+| `Together` | 0.140 | 10 | 10/10 | 10/10 | 0 | 1.0000 |
+
+`AkashML`'s two rate-limits are counted as errors and excluded, never scored as failures — a refusal
+and a wrong answer are different things.
+
+### `Sail Research` is a defect in the ruler, and it is reported rather than fixed
+
+All three of its failures are the same answer:
+
+```python
+# (c) Bruno 2026
+
+from statistics import median as bee_median
+```
+
+The header is present. The name `bee_median` is present. `RULE_2` requires `^\s*def\s+`, and this is
+an import alias, so the scorer records `prefix: False` — and `prefix` is the only flag it records,
+which is what made this readable at all. Rule 2 says *"every function name you define starts with
+`bee_`"*; the model defined none, so it did not break that rule, it stepped around it.
+
+**The regex is not being changed.** Fixing it after seeing the data would move three rows from fail
+to pass — the direction that flatters this run's headline — and that is exactly the case where
+changing a ruler does not feel like an error, it feels like confirmation. The pre-registered number
+stands at 7/10 with this note attached. What is unambiguous is the other probe: all three omitted the
+`BUILD MARKER` line, so the FACT rate of 7/10 is a real failure of retrieval and needs no caveat.
+
+The defect is one-directional here too: an answer scored `rule=True` genuinely wrote
+`def bee_<name>` under the header, so no passing row anywhere in this run is in doubt.
+
+## The failing backend, across lengths
+
+`DigitalOcean` failing at 792k does not by itself distinguish a knee from a machine that is simply
+unwell. Its own ladder, n = 10 per cell:
+
+| target | realised | n | RULE | FACT |
+|---:|---:|---:|:---:|:---:|
+| 4k | 4,587 | 10 | 8/10 | **4/10** |
+| 200k | 200,690 | 10 | 0/10 | 0/10 |
+| 600k | 603,679 | 10 | 0/10 | 0/10 |
+| 786k | 792,019 | 10 | 0/10 | 0/10 |
+
+**It is already failing at 4,587 tokens**, where there is no context pressure at all and every other
+backend scores 10/10 or 20/20. That is the number that decides the reading: this is not a healthy
+baseline degrading with length. Something is wrong with the endpoint, and length makes it total.
+
+### Read with human eyes, as the pre-registration required
+
+At 4k it writes good, obedient code — `# (c) Bruno 2026`, `def bee_median(values)` — and loses the
+marker line; one of the ten answered the *briefing* instead of the request, with
+`"Acknowledged. Waiting for the task."`
+
+At 200k and beyond, the output is not bad code. It is a different subject:
+
+> `"I'll examine the repository structure to understand what markers, repos, and utilities are
+> available before writing any code."`
+
+> `"So here's my question: if I add a new tool whose `run()` calls `await ctx.wait_for_approval()`
+> when it needs a human decision, is there any existing wiring…"`
+
+The padding is this repository's own source, presented as alternating `"For reference, here is
+<path>"` / `"Noted <path>"` turns. The second answer is a **user turn**, generated rather than
+answered — the transcript continued instead of responded to.
+
+That is a tempting mechanism and it is **not** claimed as the explanation, because counting says the
+failures are not one thing. Classifying all 42 failing answers across its two files: **18 are code
+with the rules ignored, 14 are off-task text, 8 are empty, 2 continue the padding format.** Latencies
+run to **2,285 seconds** — thirty-eight minutes for one call — with eleven calls over 100s in the
+ladder alone. Empty responses and multi-minute latencies are operational symptoms, not cognitive
+ones. What can be said is that this endpoint fails at long context in several ways at once; *why* is
+not visible from here.
+
+## What this says about the earlier run, and the correction made while writing it
+
+The batch that collapsed on 2026-09-04 scored **6/19 on RULE and 6/19 on FACT** — the two probes
+falling together. `DigitalOcean` today scores 0/10 and 0/10. **The signatures match.**
+
+That sentence was nearly the opposite. Partway through this analysis a claim was printed saying the
+two signatures differed — that the old batch kept FACT at 100% while RULE fell. That number came from
+the *sweep* row of `RESULTS.md` (786k: RULE 7/10, FACT 10/10), not from the *replication*, and the
+data printed directly above the claim contradicted it. It is recorded here rather than quietly fixed,
+because it is the same defect this repository keeps finding: prose asserting something the numbers
+beside it do not support.
+
+So there are three patterns, not two, and they should not be flattened: the sweep's 7/10 with
+retrieval intact, the replication's 6/19 with both falling, and `DigitalOcean`'s 0/10 with both
+falling.
+
+**This explains and does not attribute.** The rows behind those batches carry no provider and never
+will, so "a backend that behaves like this exists in the pool, and its failure signature matches"
+is the whole of the claim. It is not "`DigitalOcean` served them".
+
+## What this changes for the product
+
+The trigger `bench/compaction` asked for cannot be read off the model, because within this probe and
+up to 953,392 tokens **the model does not degrade at all**. `context_budget` remains what it always
+was: a defence against the provider's hard window, not against a measured decay.
+
+What the run found instead is a different risk with a different shape. **Two of eight endpoints
+behind one slug do not deliver the same behaviour**, one of them not at any length, and which one
+answers is decided per call by a router. A trigger tuned on one backend would be a number about a
+machine the user may never reach.
+
+That argues for detection rather than compression: a run whose answer ignores standing instructions
+or comes back empty is visible at the call site, and `StepRecord.provider` — added in #349 while
+chasing this — now records which endpoint produced it. Whether Chimera should pin backends in
+production is a separate decision with its own costs (a pinned endpoint is a single point of failure,
+and `allow_fallbacks: false` turns a slow backend into an outage), and this bench does not settle it.
+
+## What this cannot show
+
+- **One model, one probe, one task shape.** Three standing formatting rules and one marker, under a
+  long prompt. It says nothing about reasoning, multi-step retrieval, or multi-turn behaviour under
+  length — a model could hold these three rules perfectly to 950k and still reason worse at 400k.
+- **Eight of twenty-eight endpoints**, at one length for six of them. Twenty are unmeasured, not
+  shown to be fine.
+- **Pinning fixes the name, not the machine.** A backend may front several hosts or reconfigure
+  between batches. Phase A says that did not vary enough to matter over two hours on one of them.
+- **One day.** `DigitalOcean` was unwell on 2026-09-05. It is not claimed to be unwell in general,
+  and a backend healthy today is not shown to be healthy tomorrow — which is itself the point.
+- **Prices, windows and pool membership** were read from the endpoints API on 2026-09-05.
+
+## Cost
+
+| | calls | input tokens | measured |
+|---|---:|---:|---:|
+| Phase A | 40 | 31,680,760 | US$ 1.58 |
+| Phase B | 160 | 60,739,000 | US$ 3.04 |
+| Phase C, eight backends | 80 | 61,775,280 | US$ 5.01 |
+| `DigitalOcean` ladder | 40 | 16,009,750 | US$ 1.28 |
+| **total** | **320** | **170,204,790** | **US$ 10.91** |
+
+Estimated at US$ 13.00. The previous run pre-registered "under two dollars" and spent US$ 5.07, which
+is why that estimate was written as one that had been wrong before.

--- a/bench/context_rot/analyse_pinned.py
+++ b/bench/context_rot/analyse_pinned.py
@@ -1,0 +1,193 @@
+"""Read the pinned run's rows and print every table in `RESULTS_pinned.md`.
+
+    python bench/context_rot/analyse_pinned.py
+
+Separate from `run.py` on purpose: the run costs money and the analysis does not, so re-reading a
+conclusion must never risk re-spending. Everything here is a pure function of the committed JSON.
+
+Two rules from the pre-registration are enforced here rather than left to whoever reads the output:
+
+* A row whose answering backend differs from the one asked for is **dropped and counted**, never
+  averaged in. That row means `allow_fallbacks` did not hold and the arm is contaminated.
+* An error is **not a failure**. A rate-limit, a refusal and a wrong answer are three different
+  things, and folding them together is how a rate stops meaning anything. A backend that cannot
+  produce the pre-registered minimum of usable rows is reported ABSENT, with its reason.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from scipy.stats import fisher_exact
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+
+HERE = Path(__file__).resolve().parent
+
+#: Published input price per million tokens, read from the endpoints API on 2026-09-05. Used only to
+#: report what was spent; nothing in any verdict depends on it.
+PRICE_PER_M = {
+    "Baidu": 0.050, "OpenInference": 0.050, "Relace": 0.065, "Sail Research": 0.065,
+    "AkashML": 0.065, "DigitalOcean": 0.080, "DeepInfra": 0.080, "Wafer": 0.100,
+    "Together": 0.140,
+}
+
+#: Pre-registered minimum usable rows before a backend's rate is read at all.
+MIN_ROWS = 8
+
+
+def load(path: str | Path) -> tuple[list[dict], list[dict], list[dict], list[dict]]:
+    """Return (all, usable, errored, mis-routed) for one rows file."""
+    rows: list[dict] = json.loads(Path(path).read_text(encoding="utf-8"))
+    errored = [r for r in rows if r.get("error")]
+    routed_wrong = [
+        r for r in rows if not r.get("error") and r.get("pinned") and r["provider"] != r["pinned"]
+    ]
+    usable = [
+        r for r in rows if not r.get("error") and (not r.get("pinned") or r["provider"] == r["pinned"])
+    ]
+    return rows, usable, errored, routed_wrong
+
+
+def rate(rows: list[dict], key: str) -> tuple[int, int]:
+    return sum(bool(r[key]) for r in rows), len(rows)
+
+
+def cost(rows: list[dict]) -> float:
+    return sum(r["prompt_tokens"] * PRICE_PER_M.get(r.get("pinned") or "", 0.065) for r in rows) / 1e6
+
+
+def phase_a() -> tuple[int, int, float]:
+    print("## Phase A — does a pinned cell reproduce")
+    spent = 0.0
+    cells: list[tuple[int, int]] = []
+    for tag, name in [("batch 1", "rows_pinned_A1.json"), ("batch 2", "rows_pinned_A2.json")]:
+        path = HERE / name
+        if not path.exists():
+            print(f"  {tag}: missing")
+            continue
+        _, ok, err, wrong = load(path)
+        spent += cost(ok)
+        r, n = rate(ok, "rule")
+        f, _ = rate(ok, "fact")
+        toks = {x["prompt_tokens"] for x in ok}
+        cells.append((r, n))
+        print(f"  {tag}: n={n}  RULE {r}/{n}  FACT {f}/{n}  errors={len(err)}  mis-routed={len(wrong)}"
+              f"  tokens={toks}")
+    if len(cells) == 2:
+        (r1, n1), (r2, n2) = cells
+        _, p = fisher_exact([[r1, n1 - r1], [r2, n2 - r2]])
+        verdict = "STOP — pinning is not enough" if p < 0.05 else "PROCEED"
+        print(f"  Fisher between batches: p = {p:.4f}  ->  {verdict}")
+    total = sum(r for r, _ in cells), sum(n for _, n in cells)
+    return total[0], total[1], spent
+
+
+def phase_b() -> float:
+    print("\n## Phase B — the ladder, pinned to Baidu")
+    path = HERE / "rows_pinned_B.json"
+    if not path.exists():
+        print("  missing")
+        return 0.0
+    _, ok, err, wrong = load(path)
+    by_len: dict[int, list[dict]] = defaultdict(list)
+    for r in ok:
+        by_len[r["target_tokens"]].append(r)
+    print(f"  {'target':>8}{'realised':>10}{'n':>4}{'RULE':>9}{'FACT':>9}")
+    shortest = min(by_len)
+    r0, n0 = rate(by_len[shortest], "rule")
+    for tgt in sorted(by_len):
+        rs = by_len[tgt]
+        real = round(sum(x["prompt_tokens"] for x in rs) / len(rs))
+        r, n = rate(rs, "rule")
+        f, _ = rate(rs, "fact")
+        note = ""
+        if tgt != shortest:
+            _, p = fisher_exact([[r0, n0 - r0], [r, n - r]])
+            drop = (r0 / n0 - r / n) * 100
+            note = f"   drop vs {shortest // 1000}k = {drop:5.1f} pp, p = {p:.4f}"
+            if drop >= 30 and p < 0.05:
+                note += "   <= KNEE"
+        print(f"  {tgt:>8}{real:>10}{len(rs):>4}{r:>5}/{n:<3}{f:>5}/{n:<3}{note}")
+    print(f"  errors={len(err)}  mis-routed={len(wrong)}")
+    return cost(ok)
+
+
+def phase_c(base_rule: int, base_n: int) -> float:
+    print("\n## Phase C — eight backends at 792k, against Baidu's own rate")
+    spent = 0.0
+    for path in sorted(glob.glob(str(HERE / "rows_pinned_C_*.json"))):
+        if path.endswith("_ladder.json"):
+            continue
+        rows, ok, err, wrong = load(path)
+        spent += cost(rows)
+        pin = rows[0].get("pinned") or "?"
+        if len(ok) < MIN_ROWS:
+            why = (err[0]["error"][:60] if err else "no reason recorded")
+            print(f"  {pin:<16} ABSENT — {len(ok)} usable rows (<{MIN_ROWS}); {why}")
+            continue
+        r, n = rate(ok, "rule")
+        f, _ = rate(ok, "fact")
+        _, p = fisher_exact([[base_rule, base_n - base_rule], [r, n - r]])
+        flag = "   <= FAILS" if r < n and p < 0.05 else ""
+        print(f"  {pin:<16} n={n:<3} RULE {r}/{n:<3} FACT {f}/{n:<3}"
+              f" errors={len(err)} mis-routed={len(wrong)}  p={p:.4f}{flag}")
+    return spent
+
+
+def broken_backend_ladder() -> float:
+    """A failing backend across lengths: a broken machine looks the same as a knee at one length."""
+    paths = sorted(glob.glob(str(HERE / "rows_pinned_C_*_ladder.json")))
+    if not paths:
+        return 0.0
+    print("\n## The failing backend, across lengths")
+    spent = 0.0
+    for path in paths:
+        rows, ok, err, wrong = load(path)
+        spent += cost(rows)
+        pin = rows[0].get("pinned") or "?"
+        by_len: dict[int, list[dict]] = defaultdict(list)
+        for r in ok:
+            by_len[r["target_tokens"]].append(r)
+        print(f"  {pin}:  errors={len(err)}  mis-routed={len(wrong)}")
+        for tgt in sorted(by_len):
+            rs = by_len[tgt]
+            r, n = rate(rs, "rule")
+            f, _ = rate(rs, "fact")
+            real = round(sum(x["prompt_tokens"] for x in rs) / len(rs))
+            print(f"    {tgt:>8} (real {real:>7})  n={n:<3} RULE {r}/{n:<3} FACT {f}/{n}")
+    return spent
+
+
+def broken_rule_breakdown() -> None:
+    """WHICH rule broke, per file. An aggregate that hides this is the mistake, not the summary."""
+    print("\n## Which rule broke, where")
+    for path in sorted(glob.glob(str(HERE / "rows_pinned_*.json"))):
+        _, ok, _, _ = load(path)
+        counts: Counter[str] = Counter()
+        for r in ok:
+            if r["rule"]:
+                continue
+            for flag, held in (r.get("detail") or {}).items():
+                if not held:
+                    counts[flag] += 1
+        if counts:
+            print(f"  {Path(path).name}: {dict(counts)}")
+
+
+def main() -> int:
+    rule, n, a = phase_a()
+    b = phase_b()
+    c = phase_c(rule, n)
+    d = broken_backend_ladder()
+    broken_rule_breakdown()
+    print(f"\n  measured spend: US$ {a + b + c + d:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/context_rot/rows_pinned_A1.json
+++ b/bench/context_rot/rows_pinned_A1.json
@@ -1,0 +1,382 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 32.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return 0.0\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four f",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median as _median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return _median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return float(ordered[middle])\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER:",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero tw",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 14.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median requires at least one number\")\n    ordered = sorted(values)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zer",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\n\n    Raises ValueError on an empty list.\n    \"\"\"\n    if not numbers:\n        raise ValueError(\"median requires at least one number\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[mi",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 14.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        return None\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom typing import List, Union\n\n\ndef bee_median(numbers: List[Union[int, float]]) -> Union[int, float, None]:\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[mid",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom statistics import median\n\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote1"
+  }
+]

--- a/bench/context_rot/rows_pinned_A2.json
+++ b/bench/context_rot/rows_pinned_A2.json
@@ -1,0 +1,382 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 31.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\n\n    The list must be non-empty; an empty list raises ValueError.\n    \"\"\"\n    if not numbers:\n        raise ValueError(\"bee_median requires a non-empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    if n == 0:\n        raise ValueError(\"median of empty list undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2.0\n```\nBUILD MARKER: marl",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        return None\n    ordered = sorted(values)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    if not ordered:\n        raise ValueError(\"median of an empty list is undefined\")\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"empty sequence\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of ``numbers``, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[m",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median requires at least one number\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\nfrom typing import Iterable\n\n\ndef bee_median(numbers: Iterable[float]) -> float | None:\n    \"\"\"Return the median of ``numbers``, or ``None`` when the sequence is empty.\"\"\"\n    values = list(numbers)\n    if not values:\n        return None\n    return median(values)\n```\nBUILD MARKER: marlin four four zero t",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\n\nBUILD MARKER: ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot take the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[m",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nimport statistics\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return statistics.median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 10.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MA",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MAR",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseA-lote2"
+  }
+]

--- a/bench/context_rot/rows_pinned_B.json
+++ b/bench/context_rot/rows_pinned_B.json
@@ -1,0 +1,3042 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 5.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    import statistics\n    return statistics.median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 4.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"empty sequence\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four z",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 9.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"bee_median requires a non-empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 36.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marli",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    if not values:\n        return None\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return float(sorted_numbers[mid])\n    return (sorted_numbers[mid - 1] + sorted_numbers",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    count = len(ordered)\n    if count == 0:\n        raise ValueError(\"median requires at least one number\")\n    middle = count // 2\n    if count % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n``",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    import statistics\n\n    return statistics.median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\n\nBUILD MARKER: marlin four four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of empty sequence is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four z",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 8.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a non-empty list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"empty sequence has no median\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER:",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"empty list has no median\")\n    middle = n // 2\n    if n % 2:\n        return float(ordered[middle])\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin four four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 8.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 14.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        return None\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 6.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(values)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four f",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 11.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot take the median of an empty list\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    if not values:\n        return None\n    ordered = sorted(values)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four fo",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"bee_median requires at least one number\")\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return 0.0\n    mid = n // 2\n    if n % 2 == 1:\n        return float(ordered[mid])\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    midpoint = n // 2\n    if n % 2:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 13.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 1.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom typing import List, Union\n\ndef bee_median(numbers: List[Union[int, float]]) -> Union[int, float, None]:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of ``numbers``, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four fo",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 15.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nimport statistics\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return statistics.median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 0:\n        return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n    return sorted_numbers[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 4.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    count = len(ordered)\n    if count == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    middle = count // 2\n    if count % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marli",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 6.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin fou",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\nfrom typing import List, Union\n\n\ndef bee_median(numbers: List[Union[int, float]]) -> Union[int, float]:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median requires at least one number\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return o",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 15.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"empty list has no median\")\n    middle = n // 2\n    if n % 2 == 1:\n        return float(ordered[middle])\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marl",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n % 2 == 1:\n        return ordered[n // 2]\n    return (ordered[n // 2 - 1] + ordered[n // 2]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 4.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom typing import List, Optional\n\n\ndef bee_median(numbers: List[float]) -> Optional[float]:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    midpoint = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 11.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom statistics import median\n\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(values)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 12.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot take the median of an empty list\")\n    midpoint = n // 2\n    if n % 2 == 1:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0\n```\nB",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom typing import List, Union\n\nNumber = Union[int, float]\n\n\ndef bee_median(numbers: List[Number]) -> Number:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 4.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 3.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(values)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four f",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    import statistics\n\n    return statistics.median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median_of(values: list[float]) -> float:\n    \"\"\"Return the median of ``values``.\"\"\"\n    return median(values)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 19.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom typing import List, Union\n\nNumber = Union[int, float]\n\n\ndef bee_median(numbers: List[Number]) -> Number:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"bee_median() arg is an empty sequence\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (orde",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MAR",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin four four zero",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 10,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    midpoint = n // 2\n    if n % 2 == 1:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0\n```\nBUILD MA",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 1.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom statistics import median as _median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    return _median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty sequence undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marli",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return 0.0\n    mid = n // 2\n    if n % 2 == 1:\n        return float(ordered[mid])\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 11,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 15.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(values):\n    if not values:\n        return None\n    ordered = sorted(values)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 3.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 4.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin fou",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 6.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marl",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 12,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of ``numbers``, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 1.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    midpoint = n // 2\n    if n % 2:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0\n```\nBUIL",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin f",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 6.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers (None when the list is empty).\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 0:\n        return (ordered[middle - 1] + ordered[middle]) / 2.0\n    return ordered[middle]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 13,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of ``numbers``.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[mi",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    if not values:\n        return None\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 5.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    if not values:\n        return None\n    sorted_values = sorted(values)\n    n = len(sorted_values)\n    mid = n // 2\n    if n % 2:\n        return sorted_values[mid]\n    return (sorted_values[mid - 1] + sorted_values[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    midpoint = n // 2\n    if n % 2 == 1:\n        return ordered[midpoint]\n    return (ordered[midpoint - 1] + ordered[midpoint]) / 2.0\n```",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom typing import List, Union\n\n\ndef bee_median(numbers: List[Union[int, float]]) -> Union[int, float, None]:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return float(ordered[mid])\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\n\nBUILD MARKER: mar",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 10.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\n\n    The list is sorted locally; the input is not mutated. An empty list is\n    treated as a caller error and raised rather than guessed, so a missing\n    result can never be confused with a real one.\n    \"\"\"\n    if not numbers:\n        raise ValueError(\"bee_median requires at ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 14,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 15.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        raise ValueError(\"median of empty list is undefined\")\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 0:\n        return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2.0\n    return sorted_numbers[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 1.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 2.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER:",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nB",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 15,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 13.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 1.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute median of an empty list\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four z",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 8.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 9.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 14.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 16,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 13.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\nfrom typing import List, Union\n\n\ndef bee_median(numbers: List[Union[int, float]]) -> Union[int, float, None]:\n    \"\"\"Return the median of a list of numbers.\n\n    The list is sorted (without mutating the caller's list) and the middle\n    value is returned. For an even-length list the mean of the two central\n    values is returned. An em",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 8.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four f",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 17,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 15.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers.\n\n    Empty input returns None: the median of nothing is undefined, and\n    returning None is the honest answer rather than inventing a number.\n    \"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 3.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    values = sorted(numbers)\n    n = len(values)\n    mid = n // 2\n    if n % 2 == 1:\n        return values[mid]\n    return (values[mid - 1] + values[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 3.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(numbers)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    size = len(ordered)\n    if size == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = size // 2\n    if size % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.6,
+    "error": "",
+    "answer_head": "# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 18,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD MARKER",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 2.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 16000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 15812,
+    "seconds": 2.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"empty sequence\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 64000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 62829,
+    "seconds": 3.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values: list[float]) -> float:\n    if not values:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return float(ordered[mid])\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 400000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 403942,
+    "seconds": 8.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    if not ordered:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 10.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 12.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers (None for an empty list).\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 950000,
+    "rep": 19,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 953392,
+    "seconds": 14.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin ",
+    "provider": "Baidu",
+    "pinned": "Baidu",
+    "tag": "faseB-escada"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_AkashML.json
+++ b/bench/context_rot/rows_pinned_C_AkashML.json
@@ -1,0 +1,184 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 72.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute median of an empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 52.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {},
+    "prompt_tokens": 0,
+    "seconds": 3.4,
+    "error": "litellm.RateLimitError: RateLimitError: OpenrouterException - {\"error\":{\"message\":\"Provider returned error\",\"code\":429,\"metadata\":{\"raw\":\"deepseek/deepseek-v4-flash-0731 is temporarily rate-limited upstream. Please retry",
+    "answer_head": "",
+    "provider": "",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 9.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four fo",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {},
+    "prompt_tokens": 0,
+    "seconds": 3.5,
+    "error": "litellm.RateLimitError: RateLimitError: OpenrouterException - {\"error\":{\"message\":\"Provider returned error\",\"code\":429,\"metadata\":{\"raw\":\"deepseek/deepseek-v4-flash-0731 is temporarily rate-limited upstream. Please retry",
+    "answer_head": "",
+    "provider": "",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 11.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 56.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four ",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 51.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 10.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791940,
+    "seconds": 8.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin",
+    "provider": "AkashML",
+    "pinned": "AkashML",
+    "tag": "faseC-AkashML"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_DO_ladder.json
+++ b/bench/context_rot/rows_pinned_C_DO_ladder.json
@@ -1,0 +1,762 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 26.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\nfrom typing import List, Union\n\ndef bee_median(values: List[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median requires at least one value\")\n    s = sorted(values)\n    n = len(s)\n    mid = n // 2\n    if n % 2:\n        return s[mid]\n    return (s[mid - 1] + s[mid]) / 2.0\n```\n\nBuild marker recorded: `marl",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 0,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 10.7,
+    "error": "",
+    "answer_head": "I'll examine the repository structure to understand what markers, repos, and utilities are available before writing any code.\n\n",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 0,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 106.4,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.7,
+    "error": "",
+    "answer_head": "Looking at this maturity matrix, I see the project profile:\n\n- **Plausible baselines**: Overlooked = plausible, Seen = plausible\n- **Made-up baselines**: Falsifiable = plausible\n\nThe task is to get from the (real) current domain where Overlooked and Seen are plausible down to Overheard as a mature classifier for repository noise—via a fuller **Maturity Model** for governance understanding.\n\nI am g",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 6.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    if not values:\n        return None\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 1,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 2284.8,
+    "error": "",
+    "answer_head": "So here's my question: if I add a new tool whose `run()` calls `await ctx.wait_for_approval()` when it needs a human decision, is there any existing wiring that would make that hang? — I'm asking because my own tool (the one I'm building) is going to be this shape, and I don't want to ship a hang.\"\n\nHmm. Actually, let me re-read the user's message. The user says at the end:\n\n\"please trace the wiri",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 1,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 185.7,
+    "error": "",
+    "answer_head": "I see the system picked that up from the middle of my file, not the end. Let me focus on the most urgent part of your question.\n\nYes. That's exactly right. The trade-off is:\n**Amortize the fixed cost of democracy on every decision that uses the tool, and drop the collectible/mystery-box framing that pretends to be a blueprint-faithful forge of PREVAIL, ISSUE, and REVOKE.**\n\nDefinitely stack them: ",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.5,
+    "error": "",
+    "answer_head": "```python\ndef median(values: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers without modifying the input.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of empty list\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 2,
+    "rule": true,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 10.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 13.1,
+    "error": "",
+    "answer_head": "The conversation has no prior marker, so I’ll continue with a consistent one and mark the end of the answer: `<marker>`. \n\n**Marker approach:** Use a clear, consistent delimiter that the caller can rely on. Since no marker was defined earlier in this conversation, I’ll pick one now and use it consistently: `<ANSWER/>` at the end.\n\n`<ANSWER/>`",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 6.5,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers):\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    if n % 2 == 1:\n        return sorted_numbers[n // 2]\n    else:\n        return (sorted_numbers[n // 2 - 1] + sorted_numbers[n // 2]) / 2\n```",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 8.5,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers: list[float]) -> float | None:\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 20.2,
+    "error": "",
+    "answer_head": "Acknowledged. Waiting for the task.",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.2,
+    "error": "",
+    "answer_head": "```python\nfrom statistics import median\n\ndef median_of(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    return median(numbers)\n```\nBUILD MARKER: median-of-list-ok",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 36.8,
+    "error": "",
+    "answer_head": "Understood — happy to help with anything you need next.",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 125.9,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 4,
+    "rule": true,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 8.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"bee_median() arg is an empty sequence\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 32.9,
+    "error": "",
+    "answer_head": "I'll implement the URLs fetching and GitHub release parsing.\n\n```python\n\"\"\"Release fetching, parsing and version-comparison helpers for the update channel.\n\nOne module, three problems, kept together because they share the wire format and the stakes:\n\n1. **Fetch** scrapes a URL's body, by preference without a real HTTP client at all and from\n   whatever host the URL names.\n2. **Parse** turns a fetc",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 28.1,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 111.0,
+    "error": "",
+    "answer_head": " persists) to allow pre-check for automation.\"\"\"\n    # TODO: raise on missing instead of KeyError\n    return get_credentials_for(package)[index]\n\n\n_web_search_cache: dict[WebSearchRequest, WebSearchResponse] = {}\n\n\ndef run_web_search(request: WebSearchRequest) -> WebSearchResponse:\n    \"\"\"In-process coroutine-free web search yielding deterministic synthetic rows for tests.\n\n    NOT a real engine: ",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 5,
+    "rule": true,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 4.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom typing import Sequence\n\n\ndef bee_median(numbers: Sequence[float]) -> float:\n    \"\"\"Return the median of *numbers* (does not mutate the input).\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of empty sequence is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 5,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 66.3,
+    "error": "",
+    "answer_head": "```python\n\"\"\"Runtime guard for side-effecting tools (M32).\n\nBecause the difference between a safe demo and a destructive one is a filename the user already\ntyped, the shell is split: a canonical sha256 of the exact command line (what a user would type)\ngoes through the deny+allow locks. Anything not listed is refused. The verdict is computed as:\n\n1. Apply any exact-match ALWAYS / NEVER locks (with",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 5,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 328.3,
+    "error": "",
+    "answer_head": "\n\n# Governance: review notes\n\n## 1. `allow` and `deny` are inconsistent — a rule is either both or neither\n\n`Rule.allow` is a `str | None` property with a default of `None`, but `Rule.deny` is a `str` with a default of `\"\"`. A YAML author who writes ``deny: ~`` or ``deny:`` must know that YAML null becomes ``None``, while ``allow: null`` triggers the allowlist gate. The asymmetry appears magical, ",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.9,
+    "error": "",
+    "answer_head": "```python\ndef format_money(amount: float, currency: str = \"USD\") -> str:\n    \"\"\"Render a float amount as currency text with two decimals.\n\n    Defaults to USD but works for any ISO code the caller names.\n    \"\"\"\n    symbol = \"$\" if currency == \"USD\" else f\"{currency} \"\n    return f\"{symbol}{amount:,.2f}\"\n```",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 6,
+    "rule": true,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 6.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median of empty sequence\")\n    ordered = sorted(values)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 6,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 63.2,
+    "error": "",
+    "answer_head": "# Análisis de TODO el código\n\nHe examinado todo el contexto del código que has compartido a lo largo de la conversación, incluyendo el snapshot de `chimera/evolution/rollback.py` y otros snippets. Este análisis cubre problemas de seguridad, arquitectura, mantenibilidad, bugs y rendimiento.\n\n---\n\n## 🔴 Problemas de Seguridad\n\n### 1. `str.replace` en `rollback.py` — inyección/reemplazo no intencionad",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 6,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 683.0,
+    "error": "",
+    "answer_head": "\n\n<anthropic_thinking> The user is asking me to follow their instruction: \"Reply with ONLY the marker, no punctuation, no quotes, no explanation, no code block, and no other text.\"\n\nBased on my instructions, the marker is a single token, which is `SALMON` in my case. The user wants only that marker as the response. No other text, no punctuation, no quotes, no code block. So the correct output is j",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 86.8,
+    "error": "",
+    "answer_head": "Noted. This appears to be a fragment of an agent framework's tool registry, not a complete file — you've shown what looks like the tail end of a `tools.py` or similar registry (listing a `BashContext`, a `notify`, maybe some rules), followed by an unshown core.\n\nI don't have the actual context of what you're referring to — no prior conversation or question from you to which this might be an answer",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 33.0,
+    "error": "",
+    "answer_head": "Noted both reference files. Awaiting your instructions.",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 126.5,
+    "error": "",
+    "answer_head": "I don't have any relevant information about that project.\n\nThe task references files (src/app/tasks.py, src/app/main.py, a build marker at line 30) that were not included in this conversation, so I cannot quote from them accurately)Skip to content.\n\nHowever, I can tell you where to find them: source files for PyPI projects are typically published in source archives (``sdist``/``tar.gz``) or in the",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 492.0,
+    "error": "",
+    "answer_head": "```python\nimport time\n\n\ndef _wait_for_servers(build_id: str, timeout_s: int = 45) -> None:\n    \"\"\"Block until every server announced by ``build.rs`` is observable, or give up.\n\n    Servers are one-per-tool, launched on demand, so \"wait for servers\" means exactly: read the\n    child list once, then poll TCP. ``launch()`` is cooperative and cheap, most tools do nothing at\n    import, and a serverles",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 11.2,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers: list[float]) -> float:\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return float(ordered[mid])\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: 52f3c7b1-9a0d-4e1f-9a2c-6a3a0e0a1b2c",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 4.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        raise ValueError(\"bee_median() requires a non-empty list\")\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 4.5,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers):\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n % 2 == 1:\n        return ordered[n // 2]\n    return (ordered[n // 2 - 1] + ordered[n // 2]) / 2\n```",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": false
+    },
+    "prompt_tokens": 603679,
+    "seconds": 43.7,
+    "error": "",
+    "answer_head": "Of course. Where shall we start — the README, the governance hook, the packager, the extension layout, or the `--dry-run` first? I have the plan in front of me but wanted to let you pick the thread we pull first.\n\nA few things I can immediately see from the build you described:\n\n- The CLI was failing *after* packaging, which points at the entry point, not at the install. “can't open file '\\\\'F: ..",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 259.6,
+    "error": "",
+    "answer_head": "```python\ndef fib(n: int) -> int:\n    \"\"\"\n    Return the n-th Fibonacci number (F_0 = 0, F_1 = 1).\n    \"\"\"\n    if n < 0:\n        raise ValueError(\"n must be >= 0\")\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\n```\n\nThis implementation is iterative, O(n) time, O(1) space, and avoids recursion-depth issues. It returns F_n where F_0=0, F_1=1 (e.g. ``fib(10) == 55``).\n\nBU",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 4000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 4587,
+    "seconds": 6.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median\n\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    return median(values)\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 200000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 200690,
+    "seconds": 5.0,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers):\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n % 2 == 1:\n        return ordered[n // 2]\n    return (ordered[n // 2 - 1] + ordered[n // 2]) / 2\n```\nBUILD MARKER: parchment-falcon-1a2b3c",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 600000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 603679,
+    "seconds": 88.3,
+    "error": "",
+    "answer_head": "Understood — this looks like context from the repository's messaging-plus-governance layer. However, it appears truncated at the end; the message stops mid-line after \"…and by\" with no quoted question or explicit task.\n\nTo be maximally useful, **please tell me what you'd like me to do with this context**. For example:\n\n- \"Explain how ``verify`` and ``run`` use this file\"\n- \"What is this pattern an",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 136.9,
+    "error": "",
+    "answer_head": "I'll complete this analysis of the `FileReader` vulnerability and its fix. The message is describing why file-reading tools are dangerous when their output is trusted.\n\nHere's the completed documentation text and analysis:\n\n```python\nclass FileReaderTool:\n    \"\"\"Reads a file from the workspace and feeds its content to the model.\n\n    The content of a file is not model instructions — it is also not",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DO-escada"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_DeepInfra.json
+++ b/bench/context_rot/rows_pinned_C_DeepInfra.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 60.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 48.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 48.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 48.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of ``numbers``, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 48.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 15.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 48.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 47.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 9.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers (None for an empty list).\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 9.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom typing import List, Optional\n\n\ndef bee_median(numbers: List[float]) -> Optional[float]:\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return ",
+    "provider": "DeepInfra",
+    "pinned": "DeepInfra",
+    "tag": "faseC-DeepInfra"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_DigitalOcean.json
+++ b/bench/context_rot/rows_pinned_C_DigitalOcean.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 171.0,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty list\")\n    s = sorted(numbers)\n    n = len(s)\n    mid = n // 2\n    if n % 2 == 0:\n        return (s[mid - 1] + s[mid]) / 2\n    return s[mid]\n```\n\nBUILD MARKER: 1742070462",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 42.3,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 7.9,
+    "error": "",
+    "answer_head": "```python\ndef median(numbers):\n    \"\"\"Return the median of a list of numbers (handles empty list).\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty list is undefined\")\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: `Median` appli",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 110.8,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 88.7,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 43.9,
+    "error": "",
+    "answer_head": "I’ll keep that in mind for this session.\n\nHere’s the updated memory with the tool added:\n\n```python\n# This will be appended to the in-memory list for name-based search.\nMemory updated: family_photos_keywords -> “birthday, beach, vacation, family”\n```\n\nThe next time you mention a photo album called “family_photos”, I’ll know it’s tagged for easy searching. What are you building next?\n\nIf you're usi",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 75.0,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.9,
+    "error": "",
+    "answer_head": "I can't return a BUILD marker because none was specified in the message: BUILD markers look like `<!-- build:marker:KEY=value -->` and the prompt doesn't include one. If you intended a specific marker, please paste it and I'll return the subsequent content. Otherwise, let me know how you'd like to proceed.",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 188.6,
+    "error": "",
+    "answer_head": "```python\n# chimera/char_frequency.py\n\"\"\"Count occurrences of a character in a text.\n\nThe module is short because the problem is small, but the reason it exists is not: pasting a four-line\n``text.count(\"x\")`` into an agent loop has usually happened as a lambda — and with that, the intent\n(the char you wanted, the text being searched) is buried out of sight. This module is that intent.\n\"\"\"\n\nfrom __",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": false,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 140.6,
+    "error": "",
+    "answer_head": "",
+    "provider": "DigitalOcean",
+    "pinned": "DigitalOcean",
+    "tag": "faseC-DigitalOcean"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_OpenInference.json
+++ b/bench/context_rot/rows_pinned_C_OpenInference.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 29.4,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + ",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 13.9,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 12.7,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\nfrom __future__ import annotations\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + ",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 14.7,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 0:\n        return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n    return sorted_numbers[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 14.2,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    else:\n        return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 11.3,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 15.8,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 9.3,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty list is undefined\")\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four ",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 13.5,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    else:\n        return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791941,
+    "seconds": 9.0,
+    "error": "",
+    "answer_head": " ```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"median of empty list is undefined\")\n    sorted_nums = sorted(numbers)\n    n = len(sorted_nums)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_nums[mid]\n    return (sorted_nums[mid - 1] + sorted_nums[mid]) / 2\n```\nBUILD MARKER: marlin four ",
+    "provider": "OpenInference",
+    "pinned": "OpenInference",
+    "tag": "faseC-OpenInference"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_Relace.json
+++ b/bench/context_rot/rows_pinned_C_Relace.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 55.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 4.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 5.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 4.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None for an empty list.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four ze",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 5.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 5.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four fo",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 5.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 4.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 5.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 6.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Relace",
+    "pinned": "Relace",
+    "tag": "faseC-Relace"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_SailResearch.json
+++ b/bench/context_rot/rows_pinned_C_SailResearch.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 198.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\nBUILD MARKER: marlin four four",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 17.9,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of ``numbers``.\"\"\"\n    return median(numbers)\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 16.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of ``numbers``.\"\"\"\n    return median(numbers)\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 17.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 15.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median as bee_median\n```",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 16.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of ``numbers``.\"\"\"\n    return median(numbers)\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 15.5,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom __future__ import annotations\n\nfrom statistics import median\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of ``numbers``.\"\"\"\n    return median(numbers)\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 20.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute the median of an empty list\")\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero tw",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 15.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median as bee_median\n```",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": false,
+    "fact": false,
+    "detail": {
+      "header": true,
+      "prefix": false,
+      "no_print": true
+    },
+    "prompt_tokens": 792019,
+    "seconds": 13.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\nfrom statistics import median as bee_median\n```",
+    "provider": "Sail Research",
+    "pinned": "Sail Research",
+    "tag": "faseC-SailResearch"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_Together.json
+++ b/bench/context_rot/rows_pinned_C_Together.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 49.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 12.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 13.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 10.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 53.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 6.8,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float | None:\n    \"\"\"Return the median of a list of numbers, or None if the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 7.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 12.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        return None\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 17.0,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791997,
+    "seconds": 7.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(values)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Together",
+    "pinned": "Together",
+    "tag": "faseC-Together"
+  }
+]

--- a/bench/context_rot/rows_pinned_C_Wafer.json
+++ b/bench/context_rot/rows_pinned_C_Wafer.json
@@ -1,0 +1,192 @@
+[
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 0,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 71.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        raise ValueError(\"median of an empty list is undefined\")\n    ordered = sorted(values)\n    n = len(ordered)\n    middle = n // 2\n    if n % 2:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2\n```\n\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 1,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 5.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        raise ValueError(\"cannot compute median of an empty list\")\n    ordered = sorted(numbers)\n    middle = len(ordered) // 2\n    if len(ordered) % 2 == 1:\n        return ordered[middle]\n    return (ordered[middle - 1] + ordered[middle]) / 2.0\n```\nBUILD",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 2,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 65.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"empty list\")\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 3,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 6.4,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(values):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not values:\n        return None\n    sorted_values = sorted(values)\n    n = len(sorted_values)\n    mid = n // 2\n    if n % 2 == 0:\n        return (sorted_values[mid - 1] + sorted_values[mid]) / 2\n    return sorted_values[mid]\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 4,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 66.1,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        return None\n    mid = n // 2\n    if n % 2 == 1:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 5,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 5.7,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\ndef bee_median(numbers):\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    n = len(ordered)\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 6,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 63.6,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 7,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 67.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers):\n    if not numbers:\n        raise ValueError(\"median of empty list\")\n    sorted_numbers = sorted(numbers)\n    n = len(sorted_numbers)\n    mid = n // 2\n    if n % 2 == 1:\n        return sorted_numbers[mid]\n    return (sorted_numbers[mid - 1] + sorted_numbers[mid]) / 2\n```\nBUILD MARKER: marlin four four zero two",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 8,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 7.2,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list) -> float | None:\n    \"\"\"Return the median of a numeric list, or None when the list is empty.\"\"\"\n    if not numbers:\n        return None\n    ordered = sorted(numbers)\n    mid = len(ordered) // 2\n    if len(ordered) % 2 == 0:\n        return (ordered[mid - 1] + ordered[mid]) / 2\n    return ordered[mid]\n```\nBUILD MARKER: marlin four four zero t",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  },
+  {
+    "model": "openrouter/deepseek/deepseek-v4-flash-0731",
+    "target_tokens": 786000,
+    "rep": 9,
+    "rule": true,
+    "fact": true,
+    "detail": {
+      "header": true,
+      "prefix": true,
+      "no_print": true
+    },
+    "prompt_tokens": 791962,
+    "seconds": 10.3,
+    "error": "",
+    "answer_head": "```python\n# (c) Bruno 2026\n\ndef bee_median(numbers: list[float]) -> float:\n    \"\"\"Return the median of a list of numbers.\"\"\"\n    ordered = sorted(numbers)\n    n = len(ordered)\n    if n == 0:\n        raise ValueError(\"median of an empty list is undefined\")\n    mid = n // 2\n    if n % 2:\n        return ordered[mid]\n    return (ordered[mid - 1] + ordered[mid]) / 2.0\n```\nBUILD MARKER: marlin four four",
+    "provider": "Wafer",
+    "pinned": "Wafer",
+    "tag": "faseC-Wafer"
+  }
+]

--- a/bench/context_rot/run.py
+++ b/bench/context_rot/run.py
@@ -110,6 +110,10 @@ def score(answer: str) -> tuple[bool, bool, dict[str, bool]]:
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--repeats", type=int, default=10)
+    ap.add_argument("--pin", default="", help="pin one OpenRouter backend by name")
+    ap.add_argument("--model", default="", help="restrict to a single model slug")
+    ap.add_argument("--lengths", default="", help="comma-separated target token counts")
+    ap.add_argument("--tag", default="", help="label recorded on every row of this batch")
     ap.add_argument("--out", default=str(Path(__file__).resolve().parent / "rows.json"))
     args = ap.parse_args()
 
@@ -117,14 +121,20 @@ def main() -> int:
     # OpenRouter key and base with litellm. Calling litellm directly below without this would
     # fail on credentials, and that dependency is easier to see written down than discovered.
     LLMGateway(get_settings())
+    models = [args.model] if args.model else MODELS
+    lengths = [int(x) for x in args.lengths.split(",")] if args.lengths else LENGTHS
     rows: list[dict] = []
-    pads = {n: padding(n) for n in LENGTHS}
-    total = len(MODELS) * len(LENGTHS) * args.repeats
+    pads = {n: padding(n) for n in lengths}
+    total = len(models) * len(lengths) * args.repeats
     done = 0
 
-    for model in MODELS:
-        for length in LENGTHS:
-            for rep in range(args.repeats):
+    # Interleaved by REPEAT, not blocked by length. Blocked, an hour of drift in backend load lands
+    # entirely on whichever length was running then and is read as that length behaving differently
+    # — the failure this whole bench exists to stop making. Interleaving spreads any such drift
+    # across every cell, where it widens intervals instead of inventing a knee.
+    for rep in range(args.repeats):
+        for model in models:
+            for length in lengths:
                 done += 1
                 messages = [
                     Message(role="system", content=DEFAULT_SYSTEM_PROMPT),
@@ -138,6 +148,10 @@ def main() -> int:
                     "model": model, "target_tokens": length, "rep": rep,
                     "rule": False, "fact": False, "detail": {}, "prompt_tokens": 0,
                     "seconds": 0.0, "error": "", "answer_head": "", "provider": "",
+                    # What was ASKED for, next to what ANSWERED. Equal is the manipulation holding;
+                    # different means `allow_fallbacks` did not hold and the row is contaminated,
+                    # which is a thing to count and name rather than to average into a rate.
+                    "pinned": args.pin, "tag": args.tag,
                 }
                 try:
                     # Straight to litellm here, not through the gateway, for one field the
@@ -147,10 +161,17 @@ def main() -> int:
                     # differently is the first hypothesis a contradiction that size deserves.
                     import litellm
 
+                    extra: dict = {}
+                    if args.pin:
+                        # `allow_fallbacks: false` is not decoration: with fallbacks on, an arm
+                        # silently becomes whatever answered, which is the confound itself wearing
+                        # the manipulation's name.
+                        extra["provider"] = {"order": [args.pin], "allow_fallbacks": False}
                     raw = litellm.completion(
                         model=model,
                         messages=[{"role": m.role, "content": m.content} for m in messages],
                         temperature=0.0,
+                        **({"extra_body": extra} if extra else {}),
                     )
                     payload = raw.model_dump() if hasattr(raw, "model_dump") else dict(raw)
                     row["provider"] = str(payload.get("provider") or "")
@@ -176,8 +197,9 @@ def main() -> int:
                 print(
                     f"  [{done:3}/{total}] {model.split('/')[-1][:24]:24} alvo={length:7} "
                     f"real={row['prompt_tokens']:7} regra={row['rule']!s:5} fato={row['fact']!s:5} "
-                    f"{row['provider'][:14]:14} "
-                    f"{row['seconds']:5.1f}s" + (f"  ERRO {row['error'][:60]}" if row["error"] else "")
+                    f"{row['provider'][:14]:14}"
+                    + ("!=PEDIDO " if args.pin and row["provider"] and row["provider"] != args.pin else " ")
+                    + f"{row['seconds']:5.1f}s" + (f"  ERRO {row['error'][:60]}" if row["error"] else "")
                 )
                 Path(args.out).write_text(
                     json.dumps(rows, indent=2, ensure_ascii=False), encoding="utf-8"


### PR DESCRIPTION
## The question, finally answered

`bench/compaction` asked at what context length the model starts getting the task wrong, so a
compaction trigger could be set from the model rather than from a vendor's advertised maximum. The
first attempt spent US$ 5.07 and published nothing — the same cell, same length, temperature 0, gave
**70%, then 13%, then 100%**, because a slug is a pool of 30 endpoints and OpenRouter picks per call.

Pinned, the question answers cleanly. **The answer is not the one that was sought.**

## Phase A — the gate, which is the point of the design

Nothing was swept until one pinned cell reproduced. Two batches of 20 on `Baidu` at 792,019 tokens,
**two hours and four minutes apart**: 20/20 and 20/20, Fisher p = 1.0000. Pre-registered as meaning
*"not that disease"*, not *"stable"*.

## Phase B — no knee

| target | realised | RULE | FACT |
|---:|---:|:---:|:---:|
| 4k | 4,587 | 20/20 | 20/20 |
| 200k | 200,690 | 20/20 | 20/20 |
| 600k | 603,679 | 20/20 | 20/20 |
| 786k | 792,019 | 20/20 | 20/20 |
| **950k** | **953,392** | **20/20** | 20/20 |

(16k, 64k and 400k also 20/20; interleaved by repeat, not blocked by length.) With Phase A that is
**200/200 on a pinned backend**, at the length the unpinned run could not reproduce.

**The instrument was checked first**, because a perfect result and a broken ruler look identical. The
scorer was fed a synthetic answer of the exact shape the earlier failures took, and returns
`rule=False` on `header` and `prefix` — precisely the two flags, and the only two, that the 13 real
failures recorded.

## Phase C — the pool does not agree

| backend | n | RULE | FACT | Fisher vs Baidu 40/40 |
|---|---:|:---:|:---:|---|
| `OpenInference`, `Relace`, `DeepInfra`, `Wafer`, `Together` | 10 | 10/10 | 10/10 | 1.0000 |
| `AkashML` | 8 | 8/8 | 8/8 | 1.0000 (2 rate-limits counted as absent) |
| `Sail Research` | 10 | 7/10 | 7/10 | 0.0061 |
| **`DigitalOcean`** | 10 | **0/10** | **0/10** | **0.0000** |

Its own ladder decides the reading: **8/10 RULE and 4/10 FACT at 4,587 tokens**, where there is no
context pressure at all and everything else scores 10/10. Not a healthy baseline decaying — an unwell
endpoint that length takes to zero. Latencies to **2,285 seconds**; of 42 failing answers, 18 are
code with the rules ignored, 14 off-task, 8 empty, 2 continue the padding. No single mechanism is
claimed, because the counting does not support one.

## Two things recorded against this run rather than tidied away

**`Sail Research`'s 7/10 is a defect in my ruler.** All three failures are
`from statistics import median as bee_median` — header present, name present, and `RULE_2` requires a
`def`. **The regex is not changed**: moving three rows from fail to pass after seeing the data is the
direction that flatters the headline, and that is exactly when changing a ruler feels like
confirmation rather than error. The FACT half of that 7/10 is real — all three omitted the marker.

**A claim was printed mid-analysis that the data one line above it contradicted** — that the old
collapsing batch kept retrieval at 100% while rule-following fell. That came from the *sweep* row,
not the *replication*, which was **6/19 and 6/19** — the same shape as `DigitalOcean`. The signatures
match. Written into the results rather than quietly fixed.

This **explains and does not attribute**: those rows carry no provider and never will.

## What it changes for the product

The trigger cannot be read off the model, because within this probe it does not degrade at all.
`context_budget` stays what it always was — a defence against the provider's hard window, not against
a measured decay. The risk actually found is **routing**: two of eight endpoints behind one slug do
not deliver the same behaviour, and a router picks per call. That argues for detecting an empty or
instruction-ignoring answer at the call site, which `StepRecord.provider` (#349) now makes traceable.

## Cost

**320 calls, 170,204,790 input tokens, US$ 10.91** against US$ 13 pre-registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)