### PR TITLE
chore(release): 0.51.0rc1

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chimera-desktop"
-version = "0.50.0"
+version = "0.51.0-rc.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.50.0"
+version = "0.51.0-rc.1"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.50.0",
+  "version": "0.51.0-rc.1",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.50.0",
+  "generated_for": "0.51.0rc1",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5578,7 +5578,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.50.0",
+  "generated_for": "0.51.0rc1",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.50.0",
+  "generated_for": "0.51.0rc1",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.50.0"
+version = "0.51.0rc1"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # The bound stays, and its REASON changed. It used to track the litellm ceiling below (<1.92, which

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.50.0"
+version = "0.51.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Prerelease of the governance fix in #361, cut as an `rc` rather than a stable.

## Why an rc

`RELEASING.md`: **one stable a week**, and 0.50.0 was cut today. That rule exists because this
project once shipped nine releases in a day, three of them patches debugging the previous release's
updater in public.

An rc is safe by verification rather than assumption — the document records all three checked
against the live services: a prerelease never becomes GitHub's *latest*, so the desktop updater
never offers it; `pip install chimera-agent` still resolves to the stable without `--pre`; and the
release CI still attaches installers and a `latest.json` to the rc's own page.

**And this change has a half no test reaches.** A narrowed tool call now waits up to 300 s for a
person. That was verified on the dev server with a real parked call (refused from the button in
132 s, not the 240 s timeout) — but not in the packaged app, on a real turn. An rc is where that
gets found.

## What it carries

Everything in #361: `ask` actually asks, the durable question with its card and two routes, the
exfiltration through an allowed tool closed, `edit_batch` in both governance sets, the Security
screen showing the defence's cost beside what it blocks, and the two `RESULTS.md` those bench
directories never had.

## The bump

| file | grammar | value |
|---|---|---|
| `pyproject.toml`, `uv.lock` | PEP 440 | `0.51.0rc1` |
| `Cargo.toml`, `Cargo.lock`, `tauri.conf.json` | semver | `0.51.0-rc.1` |

Three snapshots regenerated (`maturity`, `benchmark`, `cli` — the third embeds the version too and
CI checks it). **CHANGELOG deliberately untouched**: an rc previews `[Unreleased]`; the stable names
and dates it.

Dry-run on the release commit: [34001324559](https://github.com/brcampidelli/chimera-agent/actions/runs/34001324559).

🤖 Generated with [Claude Code](https://claude.com/claude-code)