### PR TITLE
fix(release): a prerelease cannot be promoted, and the step tried anyway

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -415,8 +415,14 @@ jobs:
       # `--latest=false` still fires `release: published`, so this workflow triggers exactly as
       # before. A DRAFT would not have: drafts fire no release event at all, which is why the
       # obvious "create it as a draft" version of this fix does not work.
+      # A PRERELEASE is never promoted, and the API is what says so: `gh release edit --latest`
+      # answers `HTTP 422: Latest release cannot be draft or prerelease`. This step was written for
+      # the 404 window a stable opens between publish and manifest, and v0.51.0rc1 was the first rc
+      # to reach it — a step that cannot succeed on the path it is on, which turned a release where
+      # everything worked into a red run. A red release run that means nothing is how a red release
+      # run that means something gets ignored.
       - name: Mark the release as latest, now that the manifest is attached
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && github.event.release.prerelease == false
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
@@ -426,7 +432,14 @@ jobs:
         # Reads the JOB's env, set above. Not `secrets.…` (unparseable in a step `if`, and it takes
         # the whole workflow file down with it), and not the step's own `env` (not in scope for the
         # `if`, which is evaluated first — the condition would be empty on every run).
-        if: github.event_name == 'release' && env.SITE_TOKEN != ''
+        # `prerelease == false` for the same reason, stated separately because the reason is
+        # different: the download page must not advertise an rc. It was already skipped for
+        # v0.51.0rc1 — but as a consequence of the step above failing, which is the right outcome
+        # reached by an accident, and an accident is not a rule.
+        if: >-
+          github.event_name == 'release'
+          && github.event.release.prerelease == false
+          && env.SITE_TOKEN != ''
         continue-on-error: true
         env:
           TAG: ${{ github.event.release.tag_name }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -41,6 +41,13 @@ this project ever published — not merely predicted:
   own release page** — useful for testing, invisible to everyone else. (All four platforms plus the
   `.sig` files landed on the rc's page.)
 
+The promote step below is skipped for a prerelease, and the API is what enforces it: `gh release
+edit --latest` answers **`HTTP 422: Latest release cannot be draft or prerelease`**. `v0.51.0rc1`
+was the first rc to reach that step after it was added, and it turned a release where every
+platform built into a red run — so the condition now says `prerelease == false` rather than leaving
+GitHub to refuse. The website is skipped on the same condition and for a different reason: the
+download page must not advertise an rc.
+
 An rc is also the cheapest place to discover that a *release mechanism* is broken. `v0.36.0rc1` is what
 proved the semver prerelease spelling survives a real Cargo/Tauri build — a thing no local check in this
 repo can tell you, since the desktop is only ever built in CI.


### PR DESCRIPTION
## What happened

`v0.51.0rc1` built all four platforms, uploaded every asset, attached a valid `latest.json` — and
the release run is **red**. The manifest job's last-but-one step:

```
Mark the release as latest, now that the manifest is attached
HTTP 422: Validation Failed
Latest release cannot be draft or prerelease.
```

The step was written for the window a **stable** opens between `gh release create --latest=false`
and the manifest landing ~25 minutes later, when `releases/latest/download/latest.json` would 404 for
every installed app. It ran on `github.event_name == 'release'`, which covers a prerelease too, and
`v0.51.0rc1` is the first rc since it was added.

**A step that cannot succeed on the path it is on.** GitHub refusing is correct — a prerelease must
never become *latest* — so the condition should say so rather than leaving the API to say it.

## Why this is not cosmetic

A red release run that means nothing is how a red release run that means something gets ignored.
This repository's `RELEASING.md` opens with nine releases in one day, three of them patches
debugging the previous release's updater in public; the whole document exists so a release signal
stays worth reading.

There is also real collateral: **"Tell the website a release is out" was skipped**. Skipping is right
for an rc — the download page must not advertise a prerelease — but it happened as a consequence of
the previous step failing, not as a decision. The right outcome by accident is not a rule.

## The change

| step | condition before | after |
|---|---|---|
| Mark the release as latest | `github.event_name == 'release'` | `… && github.event.release.prerelease == false` |
| Tell the website a release is out | `… && env.SITE_TOKEN != ''` | `… && github.event.release.prerelease == false && …` |

Both reasons are written at their own step, because they are different reasons that happen to share
a condition. `RELEASING.md` gains the rule in the section where a reader has just learned that a
prerelease never becomes *latest*.

Nothing about a stable release changes: `prerelease == false` is true for every one of them.

## Verified

- `tests/test_workflow_invariants.py` — 22 passed (SHA pinning, permissions, no `pull_request_target`,
  every job bounded, no secret reachable from a PR).
- The YAML parses and both conditions read back as intended.
- Not re-run end to end: the path this fixes only exists on a real prerelease, and cutting one to
  test it is the thing being fixed. The next rc is the test, and it is a one-line revert if wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)