### PR TITLE
chore(release): 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.51.0] - 2026-09-06
 
 ### Added
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chimera-desktop"
-version = "0.51.0-rc.1"
+version = "0.51.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.51.0-rc.1"
+version = "0.51.0"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.51.0-rc.1",
+  "version": "0.51.0",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.51.0rc1",
+  "generated_for": "0.51.0",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5578,7 +5578,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.51.0rc1",
+  "generated_for": "0.51.0",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.51.0rc1",
+  "generated_for": "0.51.0",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.51.0rc1"
+version = "0.51.0"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # The bound stays, and its REASON changed. It used to track the litellm ceiling below (<1.92, which

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.51.0rc1"
+version = "0.51.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Promotes `v0.51.0rc1` to a stable release.

## What ships

The governance fix from #361, and the release-workflow fix from #363:

- **The setting named `ask` asks.** A narrowed tool call becomes a durable question — on the screen,
  with the ledger's reason, answerable there or with `chimera approve`, refused by silence after
  `CHIMERA_APPROVAL_WAIT`. Under the old default it was a silent refusal: **229** of them in one
  installed copy, across 24 of 137 runs.
- **Exfiltration through an allowed tool is closed** — a tainted run's `http_get` with a query string
  is a review. A heuristic, and measured as one.
- **`edit_batch` is a write tool** in both governance sets.
- **The Security screen shows the defence's cost** beside what it blocks.
- **A prerelease is no longer promoted to *latest***, which turned `v0.51.0rc1` — where all four
  platforms built — into a red run.
- Two bench directories got their first `RESULTS.md`.

## Gates

| step | result |
|---|---|
| Dry-run installers + manifest | [34037590541](https://github.com/brcampidelli/chimera-agent/actions/runs/34037590541) |
| `ruff check .` | clean |
| `pytest -q` | 5223 passed (4 pre-existing local env failures) |
| `npm run test` / `build` | 146 files · 1041 tests · built |
| OpenAPI drift | second dump byte-identical |

## The cadence, stated rather than glossed

`RELEASING.md` says one stable a week and 0.50.0 was yesterday. This is cut on the owner's explicit
call, and the trade is real: **`v0.51.0rc1` had been up for about thirty minutes and nobody had
tried the approval wait in the packaged app**, which is the one thing in this release no test
reaches. The rc existed to answer that and was not given the chance.

What is not at risk: `--latest=false` on creation means the updater keeps resolving to 0.50.0 until
the manifest is attached, and a build that dies halfway leaves 0.50.0 as latest rather than
promoting a broken release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)