### PR TITLE
feat(loop): a run says how it ended, what it paid per change, and can stop at a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **A run can be told to stop at a number.** `chimera solve --max-usd` caps what the whole run may
+  spend, across every attempt. The ceiling itself was built, tested and shipped after a measured
+  incident — a run asking for $0.000002 spent $0.0129 because each attempt started again at zero —
+  and then `solve` shipped **twenty-nine flags with none about money**, so the worker's `max_usd` was
+  never set, `_run_budget` returned `None` on every terminal invocation, and the entire
+  `stopped_reason="spend"` path was unreachable from a terminal. The escalated worker shares that
+  config and is inside the same ceiling.
+- **A run says how it ended.** New `ending` on the result, the receipt and `GET /api/runs`, set at
+  **every** return: `success` · `no_op` · `exhausted` · `cancelled` · `spend` · `paused` · `denied`.
+  `stopped_reason` is written at two sites, so a run that used up its attempts, one a person refused,
+  and one that succeeded while changing nothing on disk all persisted the same blank — *"how many
+  runs stopped at the cap this month"* had no answer. It is a **new field** rather than a wider
+  vocabulary for `stopped_reason`, because the turn loop already writes its own values (`final`,
+  `max_steps`, `tool_loop`…) into the same receipt, and overloading one name for two loops makes it
+  mean three things. **`no_op`** is the one worth having: the diff gate already computed it to block
+  hollow learning, and the receipt never carried the verdict, so a verified success with an empty
+  diff — correct when the task was a question, a defect when it was not — read as an ordinary
+  success.
+- **What a run paid per unit of delivered work.** `cost_per_accepted_change`: money over attempts
+  that verified, were not reverted, and actually changed the tree. Every term had been on the receipt
+  for releases and nothing divided one by the other. It reports three numbers, because `per_change`
+  is empty for two opposite reasons that must not collapse into one blank — nothing was accepted, or
+  a leg was unpriced. `chimera solve` prints both lines.
+
+### Notes
+
+- **`blocked` and `stalled` are deliberately not implemented.** Nothing in the loop can set them
+  truthfully: the stagnation detector injects a pivot and re-plans, and has never stopped a run, so
+  an ending named `stalled` would assert a cause the code does not have. Stagnation is reported
+  **beside** the ending in `stagnant`, where `null` means *nothing was watching* and is not `false`.
+- The Runs screen does not draw `ending` yet — it is on the wire and in `runs.jsonl`, and nothing
+  renders it.
+
 ## [0.51.0] - 2026-09-06
 
 ### Added

--- a/apps/desktop/openapi.json
+++ b/apps/desktop/openapi.json
@@ -6924,9 +6924,25 @@
             ],
             "title": "Delivered Matches Verified"
           },
+          "ending": {
+            "default": "unknown",
+            "title": "Ending",
+            "type": "string"
+          },
           "paused": {
             "title": "Paused",
             "type": "boolean"
+          },
+          "stagnant": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stagnant"
           },
           "stopped_reason": {
             "default": "",

--- a/apps/desktop/src/lib/api-schema.ts
+++ b/apps/desktop/src/lib/api-schema.ts
@@ -5735,8 +5735,15 @@ export interface components {
             attempts: components["schemas"]["AttemptReceiptOut"][];
             /** Delivered Matches Verified */
             delivered_matches_verified?: boolean | null;
+            /**
+             * Ending
+             * @default unknown
+             */
+            ending: string;
             /** Paused */
             paused: boolean;
+            /** Stagnant */
+            stagnant?: boolean | null;
             /**
              * Stopped Reason
              * @default

--- a/apps/desktop/src/test/code-api-mock.ts
+++ b/apps/desktop/src/test/code-api-mock.ts
@@ -334,6 +334,9 @@ export function receipt(over: Partial<RunReceipt> = {}): RunReceipt {
     // Same reason, same shape: a row from before the loop's stop reason reached the receipt. The
     // default is the OLD case on purpose, so a test that cares about a stop reason has to say so.
     stopped_reason: "",
+    // And the same again for the ending, which `stopped_reason` above could never carry: `unknown`
+    // is the row written before the field existed, which is what a fixture default should be.
+    ending: "unknown",
     ...over,
   };
 }

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -4766,6 +4766,16 @@
           "type": "int"
         },
         {
+          "help": "Stop the whole run once this much has been spent (all attempts together).",
+          "kind": "option",
+          "name": "max_usd",
+          "opts": [
+            "--max-usd"
+          ],
+          "required": false,
+          "type": "float"
+        },
+        {
           "help": "Fraction of the model's window to spend on the prompt before compacting (e.g. 0.6).",
           "kind": "option",
           "name": "context_budget",

--- a/chimera/api/runs.py
+++ b/chimera/api/runs.py
@@ -15,15 +15,16 @@ from __future__ import annotations
 
 import os
 import threading
+from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from pydantic import BaseModel
 
 from chimera.telemetry import get_logger
 
 if TYPE_CHECKING:
-    from chimera.core.autonomous import AutonomousResult
+    from chimera.core.autonomous import Attempt, AutonomousResult
 
 _log = get_logger("api.runs")
 
@@ -153,6 +154,21 @@ class RunReceipt(BaseModel):
     for the reason ``workspace`` and ``profile`` give above: attributing an outcome a run may not
     have had would put invented evidence into the one view whose job is to say what happened."""
 
+    ending: str = "unknown"
+    """How the solve loop ended: ``success`` | ``no_op`` | ``exhausted`` | ``cancelled`` | ``spend``
+    | ``paused`` | ``denied``. Set at every return; see ``AutonomousResult.ending``.
+
+    Distinct from ``stopped_reason`` above, which is the *turn* loop's vocabulary and is empty for
+    every ending the solve loop has that is not ``cancelled`` or ``spend``. Until this field the
+    durable record could not separate a run that finished from one that used up its attempts, nor
+    a success that changed a file from one that changed nothing: all three wrote ``success`` and a
+    blank. ``unknown`` marks a row written before the field existed."""
+
+    stagnant: bool | None = None
+    """Were the failures repeating when it ended? ``None`` = nobody looked (no detector, or an ending
+    that does not summarise failures), which is not ``False``. Recorded beside the ending, never as
+    the ending — nothing in the loop stops on stagnation."""
+
     attempts: list[AttemptReceipt] = []
     #: Which model-role configuration ran this — "economy" / "balanced" / "max", or ``null`` for a
     #: run that predates the field or named none. Null is kept as its own group rather than folded
@@ -175,7 +191,7 @@ class RunReceipt(BaseModel):
     usd: float | None = None
 
 
-def total_usd(attempts: list[AttemptReceipt]) -> float | None:
+def total_usd(attempts: Sequence[AttemptReceipt | Attempt]) -> float | None:
     """Sum the attempts' cost, or ``None`` if any single one is unknown.
 
     All-or-nothing on purpose. A partial sum is not a conservative estimate — it is a number that
@@ -188,6 +204,43 @@ def total_usd(attempts: list[AttemptReceipt]) -> float | None:
     if any(a.usd is None for a in attempts):
         return None
     return round(sum(a.usd or 0.0 for a in attempts), 6)
+
+
+class AcceptedChangeCost(NamedTuple):
+    """What the run paid, and how much of it landed. Three fields because one number cannot say it.
+
+    ``per_change`` is the whole point — dollars per unit of work that survived the deterministic
+    gate — and it is ``None`` for two unrelated reasons that must not collapse into each other:
+    nothing was accepted (``accepted == 0``, the denominator does not exist) or a leg was unpriced
+    (``usd is None``, see :func:`total_usd`). Reporting both alongside is what lets a reader tell
+    "this run bought nothing" from "we cannot say what this run cost", which are opposite verdicts.
+    """
+
+    accepted: int
+    usd: float | None
+    per_change: float | None
+
+
+def cost_per_accepted_change(
+    attempts: Sequence[AttemptReceipt | Attempt],
+) -> AcceptedChangeCost:
+    """Money over accepted changes: the ratio that says whether the retries were worth their price.
+
+    An attempt counts as accepted when the verifier passed it, it was not reverted, and it actually
+    changed the tree. All three, because each alone admits something that is not a delivered change:
+    ``verified`` without ``diff_productive`` is the hollow success the diff gate exists to catch, and
+    an attempt that verified and was then reverted delivered nothing by definition.
+
+    ``diff_productive is None`` — unknown, on rows written before the field — does **not** count. It
+    is the same refusal ``total_usd`` makes: guessing in the flattering direction is how a loop that
+    changed nothing comes to look cheap per change.
+    """
+    accepted = sum(
+        1 for a in attempts if a.verified and not a.reverted and a.diff_productive is True
+    )
+    usd = total_usd(attempts)
+    per = round(usd / accepted, 6) if (usd is not None and accepted > 0) else None
+    return AcceptedChangeCost(accepted=accepted, usd=usd, per_change=per)
 
 
 def build_receipt(
@@ -253,6 +306,8 @@ def build_receipt(
         # results from several call sites, and a required read would turn a new field into a crash
         # on the path that persists the run — after the work was already paid for.
         stopped_reason=str(getattr(result, "stopped_reason", "") or ""),
+        ending=str(getattr(result, "ending", "") or "unknown"),
+        stagnant=getattr(result, "stagnant", None),
         attempts=attempts,
         profile=profile,
         workspace=workspace,

--- a/chimera/api/schemas.py
+++ b/chimera/api/schemas.py
@@ -1319,6 +1319,22 @@ class RunReceiptOut(BaseModel):
     all carry ``success: false`` and are otherwise indistinguishable on screen. The chat turn's
     badge already makes this distinction from the ``done`` frame; the durable list could not."""
 
+    ending: str = "unknown"
+    """How the solve loop ended: ``success`` | ``no_op`` | ``exhausted`` | ``cancelled`` | ``spend``
+    | ``paused`` | ``denied``. ``unknown`` for a receipt written before the field existed.
+
+    On the wire for the reason the field above gives and does not finish. ``stopped_reason`` is the
+    *turn* loop's word, and the solve loop writes it at two sites only — so the run that used up its
+    attempts, the one whose answer a person refused, and the one that succeeded while changing
+    nothing on disk still arrive here as the same blank. This is the one field that separates them,
+    and it is set at every return rather than at the interesting ones."""
+
+    stagnant: bool | None = None
+    """Were the failures repeating when it ended? ``null`` = nobody looked — no detector was
+    configured, or the run stopped at an ending that does not summarise its failures — and that is
+    not ``false``. Reported beside the ending, never as the ending: no part of the loop stops on
+    stagnation, so an ``ending`` of ``stalled`` would name a cause the code does not have."""
+
     workspace: str = ""
     """The project this run happened in. Empty for a receipt written before the field existed.
 

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -3126,6 +3126,11 @@ def solve(
     model: str = typer.Option(None, "--model", "-m", help="Override the model slug."),
     max_attempts: int = typer.Option(3, "--max-attempts", help="Max verify-or-revert attempts."),
     max_steps: int = typer.Option(8, "--max-steps", help="Max tool-calling steps per attempt."),
+    max_usd: float = typer.Option(
+        None,
+        "--max-usd",
+        help="Stop the whole run once this much has been spent (all attempts together).",
+    ),
     context_budget: float = typer.Option(
         None,
         "--context-budget",
@@ -3464,6 +3469,12 @@ def solve(
             # the drift assessment. This is the only place the step log is persisted, so without it
             # every measurement the loop takes dies with the process.
             trace_path=settings.home / "traces.jsonl",
+            # The dollar ceiling for the RUN, not the turn. `AutonomousAgent._run_budget` reads this
+            # off the worker's config to build one `SpendBudget` spanning every attempt — without it
+            # that method returns None, `SpendCappedBackend` never wraps anything, and the whole
+            # `stopped_reason="spend"` path is unreachable from a terminal. All of it existed and
+            # none of it could be asked for: `solve` had twenty-nine flags and not one about money.
+            max_usd=max_usd,
         )
         worker = Agent(backend, registry, _worker_cfg)
         escalate_worker = (
@@ -3599,9 +3610,34 @@ def solve(
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
 
+    from chimera.api.runs import cost_per_accepted_change
+
     console.print(result.answer)
     status = "[green]success[/green]" if result.success else "[red]failed[/red]"
-    console.print(f"[dim]{status} after {len(result.attempts)} attempt(s)[/dim]")
+    # `ending` says WHICH of the endings this was; `success` alone cannot. A run that used up its
+    # attempts, one the person cancelled, one cut off at the dollar ceiling and one that succeeded
+    # while changing nothing on disk all printed the same two words before this.
+    console.print(
+        f"[dim]{status} after {len(result.attempts)} attempt(s) — "
+        f"ended: {getattr(result, 'ending', 'unknown')}[/dim]"
+    )
+    # Money over delivered work: the ratio that says whether the retries paid for themselves. Every
+    # term of it — per-attempt cost, verified, reverted, diff_productive — has been on the receipt
+    # for releases, and no surface ever divided one by the other. The two empty cases print apart on
+    # purpose: "bought nothing" and "cannot price it" are opposite verdicts, not one blank.
+    _cost = cost_per_accepted_change(result.attempts)
+    if _cost.per_change is not None and _cost.usd is not None:
+        console.print(
+            f"[dim]${_cost.usd:.4f} over {_cost.accepted} accepted change(s) — "
+            f"${_cost.per_change:.4f} each[/dim]"
+        )
+    elif _cost.usd is None:
+        console.print(
+            f"[dim]cost unknown (a leg had no price) · "
+            f"{_cost.accepted} accepted change(s)[/dim]"
+        )
+    else:
+        console.print(f"[dim]${_cost.usd:.4f} and nothing was accepted[/dim]")
 
     # The loud half, and the reason the approver exists at all. A refused call comes back as an
     # ordinary observation string, so the agent reads it like any tool result and carries on — the

--- a/chimera/core/autonomous.py
+++ b/chimera/core/autonomous.py
@@ -321,6 +321,41 @@ class AutonomousResult:
     paused: bool = False  # interrupted for human approval (see AutonomousAgent.pause_on_taint)
     stopped_reason: str = ""  # why the loop ended early; "cancelled" on a cooperative stop, else ""
 
+    ending: str = "unknown"
+    """How the loop ended, always one word, set at every return: ``success`` | ``no_op`` |
+    ``exhausted`` | ``cancelled`` | ``spend`` | ``paused`` | ``denied``.
+
+    ``stopped_reason`` cannot answer this and was never meant to: it is written at two sites and is
+    empty for every other ending, so a run that succeeded, a run that used up its attempts and a run
+    whose answer a person refused all left the same blank. The field beside it on the receipt carries
+    the *turn's* vocabulary (``final``, ``max_steps``, ``tool_loop``…), which is a different loop's
+    business; overloading either one would make two things that share a name mean three things.
+
+    ``no_op`` is a success whose accepted attempt changed nothing on disk — real when the task was a
+    question, and a defect when it was not, and indistinguishable from ``success`` until now.
+
+    ``unknown`` means a result built somewhere that does not set it. It is the default rather than a
+    plausible guess for the same reason ``workspace`` and ``profile`` give in ``runs.py``: naming an
+    ending a run may not have had puts invented evidence into the record whose only job is to say
+    what happened. Two states from the literature are deliberately absent — see ``stagnant`` below.
+    """
+
+    stagnant: bool | None = None
+    """Were the failures repeating themselves when the loop ended? ``None`` = nobody looked.
+
+    Two ways to get ``None``, and both are "not measured": no ``StagnationDetector`` was configured,
+    or the run stopped at an ending that does not summarise its failures — ``paused`` and ``denied``
+    are waiting on a person, not finished. ``None`` is not ``False``: a run nobody watched has not
+    been found un-stalled, and the two are different claims — the same distinction
+    ``delivered_matches_verified`` makes on the receipt.
+
+    This is a fact recorded *beside* the ending, never as the ending itself. The detector injects a
+    pivot and re-plans (``:1272``); it has never stopped a run, so an ``ending`` of ``stalled``
+    would assert a cause the code does not have. That is the exact defect — prose claiming what the
+    code does not do — that this session already fixed once elsewhere; ``blocked`` is absent for the
+    same reason, nothing here can set it truthfully.
+    """
+
 
 #: Char budget for the diff bodies handed to the reviewer. Enough to show what a small edit did
 #: without turning every review into a second copy of the repository.
@@ -582,6 +617,17 @@ class AutonomousAgent:
         except TypeError:  # signature lied (e.g. **kwargs-only) — fall back to the plain call
             return worker.run(prompt)
 
+    def _stagnant(self) -> bool | None:
+        """Were the failures repeating when the loop ended? ``None`` when nothing was watching.
+
+        ``assess`` is a pure read over the recorded signatures — the retry path already calls it once
+        per attempt — so asking again at the end costs nothing and changes nothing. It is reported
+        beside the ending and never as the ending: see ``AutonomousResult.stagnant``.
+        """
+        if self.stagnation is None:
+            return None
+        return bool(self.stagnation.assess().stagnant)
+
     def _run_budget(self) -> SpendBudget | None:
         """One ceiling for this whole run, read off the worker that will spend the money.
 
@@ -777,7 +823,8 @@ class AutonomousAgent:
                     self._clear_checkpoint(thread_id)
                     self._emit(_ev_final(False, ""))
                     return AutonomousResult(
-                        answer="", success=False, attempts=attempts, plan=plan
+                        answer="", success=False, attempts=attempts, plan=plan,
+                        ending="denied",
                     )
                 # HITL 'accept'/'edit': finalize the EXACT reviewed answer as-is (no re-run) —
                 # approval is of the specific output (edited or not), not a re-execution.
@@ -1200,7 +1247,8 @@ class AutonomousAgent:
                     reason = "tainted run" if run_tainted else "every run held for sign-off"
                     self._emit(_ev_status(f"paused for approval — {reason} (thread {thread_id})"))
                     return AutonomousResult(
-                        answer=answer, success=False, attempts=attempts, plan=plan, paused=True
+                        answer=answer, success=False, attempts=attempts, plan=plan, paused=True,
+                        ending="paused",
                     )
                 return self._finalize_success(
                     task, answer, attempts, prior_successes, plan, thread_id,
@@ -1319,7 +1367,10 @@ class AutonomousAgent:
             self.guard.restore(last_after)
         last = attempts[-1].answer if attempts else ""
         self._emit(_ev_final(False, last))
-        result = AutonomousResult(answer=last, success=False, attempts=attempts, plan=plan)
+        result = AutonomousResult(
+            answer=last, success=False, attempts=attempts, plan=plan, ending="exhausted",
+            stagnant=self._stagnant(),
+        )
         self._persist_receipt(result, task)
         return result
 
@@ -1360,7 +1411,8 @@ class AutonomousAgent:
         last = (getattr(agent_result, "answer", "") or "") or (attempts[-1].answer if attempts else "")
         self._emit(_ev_final(False, last))
         result = AutonomousResult(
-            answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="cancelled"
+            answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="cancelled",
+            ending="cancelled", stagnant=self._stagnant(),
         )
         self._persist_receipt(result, task)
         return result
@@ -1436,7 +1488,8 @@ class AutonomousAgent:
         last = agent_result.answer or (attempts[-1].answer if attempts else "")
         self._emit(_ev_final(False, last))
         result = AutonomousResult(
-            answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="spend"
+            answer=last, success=False, attempts=attempts, plan=plan, stopped_reason="spend",
+            ending="spend", stagnant=self._stagnant(),
         )
         self._persist_receipt(result, task)
         return result
@@ -1488,7 +1541,11 @@ class AutonomousAgent:
             self._record_card_outcome(True)
         self._clear_checkpoint(thread_id)
         self._emit(_ev_final(True, answer))
-        result = AutonomousResult(answer=answer, success=True, attempts=attempts, plan=plan)
+        result = AutonomousResult(
+            answer=answer, success=True, attempts=attempts, plan=plan,
+            ending="no_op" if productive is False else "success",
+            stagnant=self._stagnant(),
+        )
         self._persist_receipt(result, task)
         return result
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1314,6 +1314,7 @@ chimera solve [TASK]
 | `--model`, `-m` | Override the model slug. |  |
 | `--max-attempts` | Max verify-or-revert attempts. | `3` |
 | `--max-steps` | Max tool-calling steps per attempt. | `8` |
+| `--max-usd` | Stop the whole run once this much has been spent (all attempts together). |  |
 | `--context-budget` | Fraction of the model's window to spend on the prompt before compacting (e.g. 0.6). |  |
 | `--no-plan` | Skip the planning step. |  |
 | `--no-manager` | Skip Manager review. |  |

--- a/tests/test_the_loop_ended_and_would_not_say_how.py
+++ b/tests/test_the_loop_ended_and_would_not_say_how.py
@@ -1,0 +1,356 @@
+"""The loop had one ending, no price per unit of work, and no way to ask it to stop at a number.
+
+Three holes, one shape: the mechanism was built, tested and shipped, and the last wire was missing.
+
+1. **`--max-usd`.** ``SpendBudget``, ``SpendCappedBackend`` and the whole ``stopped_reason="spend"``
+   path exist and are covered by ``test_the_dollar_cap_is_the_runs.py`` — and ``chimera solve`` had
+   twenty-nine flags, not one of them about money, so ``_run_budget`` returned ``None`` on every
+   terminal invocation and none of it could run.
+2. **One ending.** ``stopped_reason`` is written at two sites, so a run that used up its attempts, a
+   run whose answer a person refused, and a run that succeeded while changing nothing on disk all
+   left the same blank in ``runs.jsonl``. "How many runs stopped at the cap this month" had no
+   answer, and neither did "how many of our successes were no-ops".
+3. **Cost per accepted change.** Every term — per-attempt ``usd``, ``verified``, ``reverted``,
+   ``diff_productive`` — has been on the receipt for releases, and nothing divided one by the other.
+
+Each assertion below was reverted on disk and confirmed to go red. Everything here is free: no model
+call, no network.
+
+Two states from the loop-engineering literature are deliberately NOT implemented, and the test that
+would have to exist for them is the reason: nothing in this loop can set ``blocked`` or ``stalled``
+truthfully. The stagnation detector injects a pivot and re-plans — it has never stopped a run — so
+an ending named ``stalled`` would assert a cause the code does not have. It is reported as a fact
+beside the ending instead, and ``None`` there means *nothing looked*, not *it did not happen*.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Any
+
+from chimera.api.runs import AttemptReceipt, build_receipt, cost_per_accepted_change
+from chimera.core import AutonomousAgent, AutonomousConfig, WorkspaceGuard
+from chimera.core.agent import AgentConfig, AgentResult
+from chimera.core.verify import VerificationResult
+from chimera.evolution import StagnationDetector
+
+_SOURCE = pathlib.Path(AutonomousAgent.__module__.replace(".", "/") + ".py")
+
+
+class _Worker:
+    """Answers, and optionally writes a file so the guard measures a real change."""
+
+    def __init__(self, *, workspace: pathlib.Path | None = None, writes: str | None = None) -> None:
+        self.config = AgentConfig(model="m")
+        self.workspace = workspace
+        self.writes = writes
+        self.runs = 0
+
+    def run(self, task: str, **kw: Any) -> AgentResult:
+        self.runs += 1
+        if self.workspace is not None and self.writes:
+            (self.workspace / self.writes).write_text(f"run {self.runs}\n", encoding="utf-8")
+        return AgentResult(answer="done", steps=1, stopped_reason="final")
+
+
+class _Pass:
+    def verify(self) -> VerificationResult:
+        return VerificationResult(True, "ok")
+
+
+class _Fail:
+    def verify(self) -> VerificationResult:
+        return VerificationResult(False, "tests failed")
+
+
+def _auto(worker: Any, **kw: Any) -> AutonomousAgent:
+    cfg = AutonomousConfig(
+        max_attempts=kw.pop("max_attempts", 1), use_planner=False, use_manager=False
+    )
+    return AutonomousAgent(worker, config=cfg, **kw)
+
+
+# --- 1. every return names its ending -------------------------------------------------------------
+
+
+def test_every_construction_of_a_result_names_its_ending() -> None:
+    """The guard that outlives this change: a seventh return site cannot forget.
+
+    Behavioural tests below cover the endings a free test can reach. This one covers the two that
+    need a checkpoint round trip (``paused``, ``denied``) and, more to the point, every ending
+    somebody adds next year. A field that is "always set" by convention is set until it isn't.
+    """
+    tree = ast.parse(_SOURCE.read_text(encoding="utf-8"))
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "AutonomousResult"
+    ]
+    assert len(calls) >= 6, f"expected the known return sites, found {len(calls)}"
+
+    missing = [
+        node.lineno for node in calls if not any(k.arg == "ending" for k in node.keywords)
+    ]
+    assert not missing, f"AutonomousResult built without an ending at line(s) {missing}"
+
+
+def test_the_default_is_unknown_and_not_a_plausible_guess() -> None:
+    """A result built somewhere that does not set it says so, rather than claiming an ending."""
+    from chimera.core.autonomous import AutonomousResult
+
+    assert AutonomousResult(answer="", success=False).ending == "unknown"
+
+
+# --- 2. the endings a free test can reach ---------------------------------------------------------
+
+
+def test_running_out_of_attempts_says_exhausted() -> None:
+    result = _auto(_Worker(), verifier=_Fail(), max_attempts=2).run("do it")
+
+    assert result.success is False
+    assert result.ending == "exhausted"
+    assert result.stopped_reason == "", "exhaustion is not an early stop; it must not borrow one"
+
+
+def test_a_success_that_changed_a_file_says_success(tmp_path: pathlib.Path) -> None:
+    worker = _Worker(workspace=tmp_path, writes="out.txt")
+    result = _auto(worker, verifier=_Pass(), guard=WorkspaceGuard(tmp_path)).run("do it")
+
+    assert result.success is True and result.ending == "success"
+
+
+def test_a_success_that_changed_nothing_says_no_op(tmp_path: pathlib.Path) -> None:
+    """The ending that did not exist, and the one worth having.
+
+    A verified success with an empty diff is right when the task was a question and a defect when it
+    was not — and until now both wrote ``success: true`` with nothing to tell them apart. The diff
+    gate already computed this to block hollow learning; the receipt just never carried the verdict.
+    """
+    result = _auto(_Worker(), verifier=_Pass(), guard=WorkspaceGuard(tmp_path)).run("answer me")
+
+    assert result.success is True, "a no-op is still a success — this is not a failure rename"
+    assert result.ending == "no_op"
+
+
+def test_an_unmeasured_diff_is_not_called_a_no_op() -> None:
+    """No guard means nobody measured the tree. That is ``success``, never ``no_op``.
+
+    ``no_op`` is a claim that nothing changed. Making it whenever we failed to look would put an
+    assertion nobody checked into the record — the same reason ``stagnant`` is ``None`` below.
+    """
+    result = _auto(_Worker(), verifier=_Pass()).run("answer me")
+
+    assert result.success is True and result.ending == "success"
+
+
+def test_a_cancelled_run_says_cancelled() -> None:
+    worker = _Worker()
+    auto = _auto(worker, verifier=_Fail(), should_stop=lambda: worker.runs >= 1, max_attempts=3)
+    result = auto.run("cancel me")
+
+    assert worker.runs == 1
+    assert result.ending == "cancelled" and result.stopped_reason == "cancelled"
+
+
+def test_a_run_stopped_on_money_says_spend() -> None:
+    """The ending that ``--max-usd`` makes reachable from a terminal for the first time."""
+
+    class _StoppedOnSpend:
+        def __init__(self) -> None:
+            self.config = AgentConfig(model="m", max_usd=0.001)
+
+        def run(self, task: str, **kw: Any) -> AgentResult:
+            return AgentResult(
+                answer="spend cap reached: $0.0030", steps=1, stopped_reason="spend"
+            )
+
+    result = _auto(_StoppedOnSpend(), max_attempts=3).run("do it")
+
+    assert result.ending == "spend" and result.stopped_reason == "spend"
+
+
+# --- 3. stagnant is a fact beside the ending, and None is not False -------------------------------
+
+
+def test_without_a_detector_stagnation_is_unknown_not_absent() -> None:
+    """``None`` means nothing watched. Reporting ``False`` would claim a measurement nobody made."""
+    result = _auto(_Worker(), verifier=_Fail(), max_attempts=2).run("do it")
+
+    assert result.stagnant is None
+
+
+def test_with_a_detector_the_repeated_failure_is_recorded() -> None:
+    """Two attempts failing the same way is what the detector is for — and it is still ``exhausted``.
+
+    The ending stays ``exhausted`` on purpose: the detector injected a pivot and the loop kept
+    going. Naming the ending ``stalled`` would say stagnation stopped the run, and it never has.
+    """
+    auto = _auto(
+        _Worker(),
+        verifier=_Fail(),
+        stagnation=StagnationDetector(window=2, signature_similarity=1.0),
+        max_attempts=3,
+    )
+    result = auto.run("do it")
+
+    assert result.ending == "exhausted"
+    assert result.stagnant is True, "identical failures three times running is the whole signal"
+
+
+# --- 4. the flag that makes the ceiling reachable -------------------------------------------------
+
+
+def test_solve_offers_a_flag_for_money() -> None:
+    """Twenty-nine flags and none about spending — the gap that made a built mechanism unreachable."""
+    import inspect
+
+    from chimera.cli.main import solve
+
+    assert "max_usd" in inspect.signature(solve).parameters
+
+
+def test_the_flag_is_handed_to_the_worker_it_is_supposed_to_cap() -> None:
+    """The wire between the two tests around this one, and the only one nothing was watching.
+
+    Found while sabotaging: deleting ``max_usd=max_usd`` from ``solve``'s ``AgentConfig`` left every
+    other assertion green. The flag would have existed, the budget would have been buildable, and
+    the two would not have been connected — a setting that accepts a number and ignores it, which
+    is the same shape as the approval mode that asked nobody.
+    """
+    import ast as _ast
+    import inspect
+
+    from chimera.cli import main
+
+    tree = _ast.parse(inspect.getsource(main.solve))
+    configs = [
+        node
+        for node in _ast.walk(tree)
+        if isinstance(node, _ast.Call)
+        and isinstance(node.func, _ast.Name)
+        and node.func.id == "AgentConfig"
+    ]
+    assert configs, "solve no longer builds an AgentConfig; this guard needs rewriting"
+    assert any(
+        kw.arg == "max_usd" and isinstance(kw.value, _ast.Name) and kw.value.id == "max_usd"
+        for cfg in configs
+        for kw in cfg.keywords
+    ), "solve takes --max-usd and never hands it to the worker"
+
+
+def test_a_cap_on_the_worker_becomes_a_budget_for_the_run() -> None:
+    """The wire itself: without ``max_usd`` this returns ``None`` and nothing is ever capped."""
+    assert _auto(_Worker())._run_budget() is None
+
+    capped = _Worker()
+    capped.config = AgentConfig(model="m", max_usd=2.50)
+    budget = _auto(capped)._run_budget()
+
+    assert budget is not None and budget.max_usd == 2.50
+
+
+# --- 5. money over delivered work -----------------------------------------------------------------
+
+
+def _leg(**kw: Any) -> AttemptReceipt:
+    base: dict[str, Any] = {
+        "verified": True,
+        "reverted": False,
+        "diff_productive": True,
+        "usd": 0.10,
+    }
+    return AttemptReceipt(**{**base, **kw})
+
+
+def test_the_ratio_is_money_over_what_survived_the_gate() -> None:
+    assert cost_per_accepted_change([_leg(), _leg()]) == (2, 0.2, 0.1)
+
+
+def test_reverted_work_is_paid_for_and_not_counted() -> None:
+    """It cost money — that is why it stays in the numerator — and it delivered nothing."""
+    cost = cost_per_accepted_change([_leg(), _leg(reverted=True)])
+
+    assert cost.accepted == 1 and cost.usd == 0.2 and cost.per_change == 0.2
+
+
+def test_a_verified_attempt_with_an_empty_diff_is_not_an_accepted_change() -> None:
+    """The hollow success the diff gate exists to catch does not get to flatter this ratio."""
+    assert cost_per_accepted_change([_leg(diff_productive=False)]).accepted == 0
+
+
+def test_an_unmeasured_diff_does_not_count_either() -> None:
+    """``None`` is unknown. Counting it would make the rows nobody measured the cheap ones."""
+    assert cost_per_accepted_change([_leg(diff_productive=None)]).accepted == 0
+
+
+def test_bought_nothing_and_cannot_be_priced_are_different_answers() -> None:
+    """Both leave ``per_change`` empty and they are opposite verdicts; the other two fields say which.
+
+    Collapsing them is the failure this shape exists to prevent: one run wasted its money, the other
+    may have spent it perfectly and used a model whose price we do not know.
+    """
+    nothing_accepted = cost_per_accepted_change([_leg(diff_productive=False)])
+    unpriced = cost_per_accepted_change([_leg(usd=None)])
+
+    assert nothing_accepted.per_change is None and unpriced.per_change is None
+    assert nothing_accepted.accepted == 0 and nothing_accepted.usd == 0.10
+    assert unpriced.accepted == 1 and unpriced.usd is None
+
+
+def test_one_unpriced_leg_refuses_the_whole_sum() -> None:
+    """Same all-or-nothing rule as ``total_usd``, because it IS ``total_usd`` — not a second copy.
+
+    A partial sum is not conservative: it is wrong in the one direction that makes whichever
+    configuration used a free tier look like the cheap one.
+    """
+    assert cost_per_accepted_change([_leg(), _leg(usd=None)]).usd is None
+
+
+# --- 6. it reaches the durable record -------------------------------------------------------------
+
+
+def test_the_receipt_carries_the_ending_and_the_stagnation(tmp_path: pathlib.Path) -> None:
+    """Persisted, not just returned: ``runs.jsonl`` is what a month-later question is asked of."""
+    result = _auto(_Worker(), verifier=_Fail(), max_attempts=2).run("do it")
+    receipt = build_receipt(result, "do it", None, "2026-09-06T00:00:00Z")
+
+    assert receipt.ending == "exhausted"
+    assert receipt.stagnant is None
+    assert '"ending":"exhausted"' in receipt.model_dump_json().replace(" ", "")
+
+
+def test_the_ending_survives_the_wire_to_the_screen(tmp_path: pathlib.Path) -> None:
+    """``RunReceiptOut`` is a curated projection, so a field on the receipt is not a field on the API.
+
+    That boundary is the reason this test exists rather than an assertion about the model's fields:
+    what can break is FastAPI's coercion dropping a name the DTO does not declare, and the Runs list
+    then rendering the same blank it rendered before — the whole defect, moved one layer out.
+    """
+    from chimera.api.runs import append_run
+
+    log = tmp_path / "runs.jsonl"
+    result = _auto(_Worker(), verifier=_Fail(), max_attempts=2).run("do it")
+    append_run(log, build_receipt(result, "do it", None, "2026-09-06T00:00:00Z"))
+
+    from chimera.api.schemas import RunReceiptOut
+
+    on_the_wire = RunReceiptOut.model_validate(
+        build_receipt(result, "do it", None, "2026-09-06T00:00:00Z").model_dump()
+    )
+
+    assert on_the_wire.ending == "exhausted"
+    assert on_the_wire.stagnant is None
+
+
+def test_a_receipt_from_a_result_that_predates_the_field_reads_unknown() -> None:
+    """``build_receipt`` is duck-typed by design; an old result must degrade, never raise."""
+
+    class _Old:
+        answer, success, paused, attempts, plan = "x", True, False, [], None
+
+    receipt = build_receipt(_Old(), "t", None, "2026-09-06T00:00:00Z")  # type: ignore[arg-type]
+
+    assert receipt.ending == "unknown" and receipt.stagnant is None


### PR DESCRIPTION
Three holes in the solve loop with one shape: the mechanism was built, tested and shipped, and the last wire was missing. No new measurement here — there is nothing to measure. Every part of this was already in the repository and unreachable.

## A run can be told to stop at a number

`SpendBudget`, `SpendCappedBackend` and the whole `stopped_reason="spend"` path exist, are covered by `test_the_dollar_cap_is_the_runs.py`, and were written for a real incident — a run asking for $0.000002 spent $0.0129 because each attempt started again at zero. `AutonomousAgent._run_budget` reads `max_usd` off the worker's config to build one budget spanning every attempt.

`chimera solve` had twenty-nine flags and not one about money, so that config field was never set and `_run_budget` returned `None` on every terminal invocation. `--max-usd` is the flag. It is threaded to the worker's `AgentConfig`, which is the whole change; the escalated worker shares that config and is inside the same ceiling.

## A run says how it ended

`stopped_reason` is written at exactly two sites. Everything else left it blank, so a run that used up its attempts, a run whose answer a person refused, a run that was cancelled and a run that succeeded while changing nothing on disk all persisted the same empty string. *"How many runs stopped at the cap this month"* had no answer, and neither did *"how many of our successes were no-ops"*.

New field `ending` on `AutonomousResult`, the receipt and `RunReceiptOut`, set at **every** return: `success` · `no_op` · `exhausted` · `cancelled` · `spend` · `paused` · `denied`. It is a new field rather than a new vocabulary for `stopped_reason` because two different loops already share that name — the turn loop's values (`final`, `max_steps`, `tool_loop`…) reach the same receipt, and the desktop maps them. Overloading it would make two things called one name mean three things.

`no_op` is the one worth having. The diff gate already computed it to block hollow learning; the receipt never carried the verdict, so a verified success with an empty diff — right when the task was a question, a defect when it was not — was indistinguishable from one that changed a file.

**Two endings from the literature are deliberately absent.** Nothing in this loop can set `blocked` or `stalled` truthfully. The stagnation detector injects a pivot and re-plans; it has never stopped a run, so an ending named `stalled` would assert a cause the code does not have — the exact defect (prose claiming what the code does not do) that #362 fixed elsewhere. Stagnation is reported as a fact **beside** the ending, in `stagnant: bool | None`, where `None` means *nothing was watching* and is not `False`.

## A run says what it paid per unit of delivered work

`cost_per_accepted_change` — money over attempts that verified, were not reverted, and actually changed the tree. Every term has been on the receipt for releases and nothing divided one by the other.

It returns three fields rather than one number because `per_change` is empty for two opposite reasons that must not collapse: nothing was accepted (the denominator does not exist) or a leg was unpriced. `diff_productive is None` does not count as accepted — the same refusal `total_usd` makes, since guessing in the flattering direction is how a loop that changed nothing comes to look cheap per change. `total_usd` is reused rather than re-derived: writing the all-or-nothing rule twice is how two copies drift apart.

`chimera solve` now prints both lines.

## Verification

- **12 guards sabotaged individually**, each confirmed to turn its owning test red, each edit byte-compared to confirm it landed before running. The per-guard results are in a comment below; the sweep script itself is not committed.
- One of those twelve exists **because** of the sweep: deleting `max_usd=max_usd` from `solve` left every other assertion green. The flag would have existed, the budget would have been buildable, and the two would not have been connected — a setting that accepts a number and ignores it, which is the shape of the approval mode that asked nobody.
- 22 new tests, no model call, no network. `ruff` and `mypy` clean on the touched files.
- **Four generated artefacts** the new flag forced open, all committed: `openapi.json`,
  `api-schema.ts`, `chimera/_cli_snapshot.json` and `docs/commands.md`. The last two were caught by
  their own drift gates rather than by me — a new flag with a stale `docs/commands.md` is
  documentation lying by omission.
- Desktop: 1041 tests pass and `tsc --noEmit` is clean. `tsc` caught a real one: `code-api-mock.ts`
  built a receipt without the now-required `ending`. It gets `"unknown"` — the pre-field row — per
  the convention that file states in its own comments, so a test that cares has to say so.
- Python suite: **5245 passed, 4 failed**, and the four are the ones this machine always fails.
  Their own output names the cause: a space in the checkout path breaks the command line
  (`'C:\Users\brcam\Desktop\Desenvolvendo' is not recognised as a command`). Unrelated to this
  change. A first run also failed `test_run_in_processes_timeout_bounds_a_hung_unit`, which passes
  alone — it bounds a hung unit by wall clock and the desktop suite was running beside it.

## What this does not show

- **No live run was made with `--max-usd`.** The chain is proved link by link and by composition:
  the flag reaches the worker's `AgentConfig` (AST guard), that config makes `_run_budget` return a
  budget instead of `None`, and `test_the_dollar_cap_is_the_runs.py` already proves the budget spans
  attempts and stops the run. Each link is tested; the whole chain end to end, against a provider,
  is not. Worth saying because a cap that does not fire is a cap in name only, and that is precisely
  the class of defect this PR is fixing three times over.
- **`no_op` depends on the diff gate having measured the tree.** With no `WorkspaceGuard` the
  productivity is unknown and the ending stays `success` — asserted, and deliberately not called
  `no_op`, since claiming nothing changed whenever we failed to look is the same defect wearing the
  other mask.

## What this does not do

- **The Runs screen does not render `ending` yet.** It is on the wire and in `runs.jsonl`; nothing draws it. Said out loud so nobody reads this as a screen change.
- **`paused` and `denied` are covered structurally, not behaviourally** — both need a checkpoint round trip. The AST guard asserts every `AutonomousResult` construction names an ending, which is also what catches the seventh return site somebody adds next year.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
