### PR TITLE
bench: the first ruler we did not write, and the −5% that does not replicate

### DIFF
--- a/bench/PLAN-study16-eight-axes.md
+++ b/bench/PLAN-study16-eight-axes.md
@@ -1,0 +1,305 @@
+# Working plan from study 16 — eight axes, one gate, and what each can and cannot show
+
+Written 2026-09-07 after the eight-axis literature sweep (memory: `chimera-study-16-eight-axis-sweep`).
+Every claim about Chimera below was checked against the code today, by file and line, because the
+sweep itself produced three apparatus errors — a grep that declared a gap where a prompt clause
+existed, and two silent fetch truncations, one of which became a confident false statement. The
+lesson of the day, in every context it appeared in: **the instrument fails quietly and the number
+comes out looking like a result.** This plan is ordered so that the instrument is fixed first.
+
+## 0. The gate: a reporting protocol, before any axis
+
+**Why first.** Six independent papers (2602.11619, 2606.20695, 2512.06710, 2608.14711, 2607.02577,
+2608.22331) plus two of our own measurements (`bench/loopsbench` 25% flip between identical runs;
+`bench/retry_lift` +6% / −4% on the same comparison) say a single-run agent number is a sample, not
+a measurement. 2606.20695 quantifies the consequence: **seven of ten recent multi-agent architectures
+report headline effects below their own noise floor.** Every item below is unreadable until this exists.
+
+**What exists.** `chimera/eval/paired.py` — `PairedResult`, `compare_paired`, `run_paired_experiment`,
+`format_report`. Paired McNemar/Wilson over one run per arm.
+
+**What changes.**
+- Extend `PairedResult` to take **k runs per task per arm** and report: `pass^k`, per-task flip rate,
+  ICC across runs, and — the published fix from 2606.20695 — **mechanism-active pass^k**: score only
+  the trials where the mechanism under test was *logically active* (§2r, "reportar quanto ela agiu",
+  as a protocol).
+- A standing rule in every `PREREGISTRATION.md`: **three seeds decide; two alert; one is a sample.**
+  A +18pp p=0.012 result vanished at the second seed in 2606.20695; our own +6%/−4% is the same shape.
+- One caveat 2608.22331 adds that nobody else measured: **prompt-perturbation noise is 11×–58×
+  larger than rerun noise at temperature 0.** So the floor must be published from
+  semantics-preserving perturbations, not from reruns alone. `pass^k` over reruns *understates* it.
+
+**Cost.** Code only; re-scoring `bench/loopsbench` p5+p6 is free. **What it cannot show:** nothing
+about any effect — it is the ruler, and it has to exist before the ruler is pointed at anything.
+
+---
+
+## 1 + 7. Loop and self-healing — our two recovery policies are the two losing baselines
+
+**The fact in the code.** After a failed attempt the retry gets *generic* feedback — manager prose
+plus verifier output, joined at `chimera/core/autonomous.py:1263-1264`. Escalation to a stronger
+model is unconditional from attempt 2 onward (`:886-887`): `if index > 1 and self.escalate_worker`.
+There is no classification of *what kind* of failure happened. The one targeted path that exists is
+the build-error route.
+
+**What the literature measured.** 2606.01416, 100-task fault injection, **matched recovery budget**:
+recovery targeted at the failure class **98.8%** · retry-only **94.5%** · full replanning **93.8%** —
+targeted wins at every budget and the gap is **widest at one recovery attempt**. We ship exactly the
+two losing arms. 2607.19338 adds that unconditional escalation is the baseline a budget-calibrated
+router beats at **35% of its recovery cost**. 2605.08563 adds that retries are **not independent**:
+the IID model overestimated pass@3 by **17.4 pp**.
+
+**Step 0 — free, today: the retry-contamination probe on our own receipts.** The desktop's
+`runs.jsonl` (`%APPDATA%\app.chimera.desktop\data\`, 88 receipts, 21 with ≥2 attempts) already holds
+attempt-conditional outcomes:
+
+| attempt | after the previous one failed |
+|---|---|
+| 2nd | 4 succeeded / 17 failed (19%) |
+| 3rd | **0 succeeded / 11 failed (0%)** |
+
+Under independence at p≈0.19 the third attempt should recover ~2 of 11. It recovered none. n=11 —
+suggestive (p≈0.10), not decisive — but it is the direction 2605.08563 predicts, it cost nothing,
+and it says `max_attempts=3` is paying for a third attempt this install has never seen succeed.
+**Publish as a probe with the n stated**, then fit T\* properly when the k-run protocol produces more.
+
+**Step 1 — a failure classifier, then class-targeted recovery. Size M.** After a failed attempt,
+classify before feeding back. Classes we can already detect from what `Attempt` carries: build
+error (exists), failing test (verifier output), hollow success (`diff_productive is False` — the
+diff gate already computes it), tool-skip / result-ignore / fabrication (2607.04686's taxonomy, all
+visible in `tool_names` + the transcript), timeout. Route each to a *specific* recovery — the failing
+test's assertion, the diff that was reverted (`bench/retry_lift`'s I2, which was never given a clean
+run), a forced-action prompt for hollow success — instead of one generic retry.
+
+**Step 2 — the matched-budget sweep. Size M, real spend.** Arms: retry-only (today) · replan-on-
+stagnation (today) · class-targeted (step 1), at recovery budget 1, 2, 3. Use 2606.27009's
+methodology to make it affordable: **generate each trajectory once, replay every policy over the
+identical drafts, cache the judge** — strictly paired at low cost. Add 2603.01548's deterministic
+control (reroute on tool failure, LLM only for "no feasible path": matched ReAct at **93% fewer
+control-plane calls**).
+
+**Registered expectation.** Targeted ≥ retry-only at budget 1, or the paper does not transfer to
+coding tasks. **What it cannot show:** anything at n=8 — this needs the k-run protocol and a venue
+with a middle (§4 below).
+
+---
+
+## 2. Tool calling — the benches measure the adapter, and the obvious gap must stay open
+
+**The fact in the code.** Tool schemas leave through `chimera/tools/registry.py:51
+to_openai_schema(compact=)`; `compact` calls `schema_compact.compact_schemas`, which prunes prose and
+annotations *without changing the JSON shape*. Schema-constrained decoding: **absent** (341 files,
+8 hits, none about decoding). `tools/defer.py` and `mcp_defer.py` exist and ship off.
+
+**Step 1 — interface preflight. Size S, ~1 day, no spend.** 2609.03966: changing *only* the serving
+adapter moves the same model between **0.00 and 0.96** on BFCL v4, and a 2×2 over chat template ×
+parser puts both main effects at exactly zero. Add a test in `chimera/providers/` that sends a
+known tool-inducing prompt through each configured adapter and asserts **emitted == parsed**. Then
+**re-read `bench/tool_defer`** (−26% tokens, completion 60%→50%, p=0.125) and `bench/parallel_tools`
+with the preflight passed and a perturbation floor attached — today neither has an honest denominator.
+
+**Step 2 — the readout-vs-input test. Size S, one day, pre-registered.** 2606.16364: on real BFCL
+failures the model attends most to the *correct* tool 80% of the time and picks wrong anyway;
+reordering / duplicating the gold tool recovers **≤23%** of failures, readout-side fixes recover
+59–91%. **Prediction to register: reordering and duplicating the gold tool in our catalogue recovers
+≤23%.** If it holds, we stop spending on retrieval and ordering — which is where `defer.py` and the
+"crowded harness" intuition would have sent us.
+
+**Step 3 — TSCG at the API boundary, A/B on the weakest FUSION member first. Size S/M.** 2605.04107:
+JSON schema is a machine-parsing format, not an LLM-reading one; a deterministic schema→language
+compiler with **no model access** takes Phi-4 14B from **0% to 84.4%** at 20 tools, and its companion
+2605.26165 publishes the null that bounds it — **+20.5 pp at an 8K budget, ≤1 pp at 32K**. The hook
+is exactly `to_openai_schema`. Register: gain on the smallest panel member, ~nothing on
+deepseek-chat-v3.1.
+
+**Do not build:** schema-constrained decoding. 2606.25605 — with JSON-schema constraints and tool
+calling both on, several open models **stop invoking tools entirely** (the grammar mask makes
+tool-call tokens unreachable); 2608.13959 — grammar constraints negative on abstention in 4 of 6
+cells, worst **−29.5 pts**. If it is ever tested: **constraint ON, on a subset, paired, before any
+full run** — it acts during generation, so a pre-hoc estimate measures the opportunity, never the
+damage (§2r, §2v).
+
+---
+
+## 3. Context — compaction is dead code, and that may be correct
+
+**The fact in the code.** `ContextBudget` triggers at a **fraction** of the window
+(`context_budget.py:43 DEFAULT_TRIGGER = 0.8`, `window_tokens()` from a hand-checked catalogue). The
+CLI defaults `context_budget=None`; the desktop sends 0.6, which on the default 1,310,000-token
+window means compacting at **786,000 tokens**. `bench/compaction`: **0 compactions in 137 traced
+runs**, median peak 6,826 tokens. The summariser is written, tested, and has never run in anger.
+
+**What the literature says.** 2606.00408: the gain from dropping stale context follows an
+**asymmetric inverted-U** against the model's own capability and **collapses when the model is
+saturated**. `bench/context_rot` found **no knee** from 4,587 to 953,392 tokens once the provider
+endpoint was pinned. We are, very likely, in the flat part. 2608.31057: calibration gains do not
+transfer to held-out tasks, and equal token budgets hide unequal delivered context.
+
+**Step 1 — measure before touching the code. Size S.** Compaction on/off × two model tiers (a weak
+one, the production one), paired, on a venue where context *actually grows* — ArbiGraph long chains
+(§ venues). **Registered expectation: a null at the production tier**, and "compaction is correctly
+off for our tier" is a better sentence than the shrug we have.
+
+**Step 2 — instrument before any keep-policy. Size S, no spend.** Split the trace into
+*stored state / delivered context / management cost / outcome* (2608.31057). Without it a future
+compaction A/B compares two things measured differently (§2g).
+
+**Step 3 — if compaction is ever enabled: absolute budgets and constraint pinning, together.**
+Fraction-of-window is the wrong shape at 1M+ windows. And 2606.22528 (ConstraintRot): prohibited
+actions rise **0% → 30%** after compaction, 0% when the constraint survives the summary; **our taint
+ledger and write posture live in context.** Pinning is moot while compaction never fires — build it
+*with* any re-enablement, never as a separate item.
+
+---
+
+## 4. Sub-agents — multi-agent loses when the repair budget is held fixed
+
+**The fact in the code.** `bench/hierarchy`'s single-agent arm is real but on **single-shot reading
+of ~1–2k-token documents** (70% vs 80%, n=10, not significant, and the hierarchy cost **47% MORE
+tokens**). The delegation "savings vs counterfactual" in `orchestration/receipts.py:54-58` is a
+`counterfactual_tokens` **estimate**, flagged as such — not a measured single-agent arm with the same
+repair budget. On coding tasks the question has never been asked.
+
+**What the literature measured.** 2609.04898 (RefactorBench, environment fixed): single agent
+**86%** vs sub-agents **66%**, and **no task passes under delegation that fails under retrieval**.
+2609.03718 (info access *and repair budget* fixed): single 96.4% vs multi 88.2%; execution-feedback
+repair 71.8→96.4, scripted reflection adds nothing. 2607.16133: under infinite relay bandwidth
+MAS ≡ SAS, so all MAS advantage lives in the compression trade-off, and gains **reverse for stronger
+models** — FUSION is the strong regime. 2608.00243: a 3-judge panel vs one judge, +8.5 to −4.4 pp,
+one reliable loss. The clean win, 2607.28430 (+29.8 pp), names its condition: **task difficulty**.
+
+**Step 1 — RefactorPlatform's question on our own coding path. Size M.** `sequential_write` crew vs
+one agent, **same tasks, same information access, same repair budget**, k runs each. The one number
+to publish: **how many tasks pass under delegation and fail under the single agent?** Registered
+expectation: ~0, as they found. If so, `sequential_write` is dead weight on that suite and the
+`counterfactual_tokens` estimate has been flattering it.
+
+**Step 2 — the capacity-asymmetry config. Size S to change, M to measure.** 2607.07548: scaling the
+**decomposer** = +11 EM, scaling the **executor** = +2.6 EM; a 1.7B executor matches frontier at 37%
+fewer tokens. Point FUSION at `classify_task` + the decomposer only; run worktree workers on a cheap
+model. The only change in the sweep with a measured prior on **both** accuracy and the token bill.
+
+**What it cannot show:** anything before ICC exists (2512.06710: n=8–32 resamples). Gate on §0.
+
+---
+
+## 5. Guardrails — the "100%" is honest offline and unmeasured live
+
+**The fact in the code.** `bench/injection` runs the ledger against **stub tools with no model in
+the loop**; its `undefended` arm (recomputed today: `block_rate=0.000`) is "no ledger", not "the
+model alone". So the 100% attack-block is **purely the ledger, measured in isolation** — which is
+honest. What is unmeasured is the **live path**, where a model may refuse before the ledger sees a
+call, and 2608.08641 shows the guard's credited share on such a path runs "from none of it to
+essentially all of it".
+
+**Step 1 — the live split. Size S, some spend.** Add a live arm: model + ledger, and record for
+every blocked attack *who* blocked it (a ledger block replaces the response, so the counts are
+disjoint — free to recover). Report guard-only / model-only / both.
+
+**Step 2 — authorization-equivalence pairs. Size S, hours.** 2608.29942: holding the committed
+action and its effect fixed and changing only whether a value came from the user or a legitimate
+tool result shifts the verdict toward "attack" in **24/24** cases. Add matched rows where the *same*
+write draws its value from the user vs from a tool result. **Registered prediction: we escalate
+both** — in which case the query-string rule measures provenance while claiming authority.
+
+**Step 3 — `bench/memory_poison`: replace the regex with behavioural replay. Size M.** 2608.11392:
+"a presence check is not a safety check" — a rule surviving compaction as degraded residue leads
+to the prohibited action **+34 / +57 points** more often. We published that bench as a failure with
+no code change; this is the honest place to fix a gate.
+
+**Watch:** 2607.13083 (Phantom Guardrails) — a self-improving harness enabled a guardrail for a
+provably nonexistent failure class in **15/60** runs. We are a self-evolving agent that can add
+guardrails. Any skill-card or rule that *adds* a restriction needs a suppression-independent
+acceptance test.
+
+---
+
+## 6. Hooks — audit, do not build
+
+The published research is red-team: 2609.03884 compromised **all seven** evaluated harnesses (up to
+92.5%, Defender 0% recall) — through hooks that bind **shell commands** to runtime events. Ours are
+in-process Python (`Agent.run` callbacks, the governance wrapper); the specific exploit does not
+apply. 2606.21856 states our rule verbatim — governance "should be enforced by execution hooks rather
+than entrusted to the LLM", **+48.9 pp** — and 2605.13471 names the sleeper-channel shape (untrusted
+input persisting as memory / skill / **cron job** and firing later through a different surface).
+
+**One audit, size S:** the hook-*update* trust path, and the cron and skill-card ingress as sleeper
+channels. No construction.
+
+---
+
+## 8. Proactive questioning — the clause exists; the detector does not
+
+**The fact in the code.** `chimera/core/agent.py:65-80`, inside `DEFAULT_SYSTEM_PROMPT`: *when the
+request has no technology, no audience and nowhere for the result to live, ask the questions that
+actually block you, at most three, and stop.* Backed by a paired observation (the bakery request
+that produced five files nobody asked for). Delivery exists: `governance/pending.py` — durable
+question, silence refuses. **What does not exist is detection as a separate pass** — the model
+decides inside the same generation that would otherwise start building.
+
+**What the literature measured.** 2603.26233 (underspecified SWE-bench Verified): an
+uncertainty-aware scaffold that **decouples underspecification detection from execution** reaches
+69.40% with well-calibrated question spend. 2606.27669: detection and clarification are distinct
+capabilities that do not co-occur; searching instead of asking often loses to guessing. And the
+pair that decides the design: 2509.09309 (N=761, N=571 preregistered) — **unsolicited** help raises
+user self-threat and lowers acceptance; 2510.18880 (N=163, blinded) — **solicited** context-seeking is
+welcomed even when it defers the answer. **The trigger condition is the experiment.**
+
+**Step 1 — an underspecification detector as a pre-loop gate. Size M.** A separate, cheap pass that
+scores ambiguity before `AutonomousAgent.run` starts, delivering through `pending.py`, **flag-gated
+and off by default** (recall the learn→use disconnect: skill cards shipped off and the wire sat cut).
+Metrics from 2603.00187 / 2607.00711: Average Turns to Clarify, Key Question Coverage, turn-discounted
+question rate. Venue: the underspecified SWE-bench Verified variant.
+
+**What it cannot show:** the annoyance cost, which is a user study, not a bench. Report the question
+rate beside the success rate and say the cost half is unmeasured.
+
+---
+
+## Venues — the band problem has two real answers now
+
+`bench/learning_lift` failed three times to author a suite in a 40–60% band (always 84–92%), and
+`bench/terminal_bench` floored at 7.5%/2.5%. Two external suites change that:
+
+| venue | status | what it gives | limit |
+|---|---|---|---|
+| **ArbiGraph** (2607.20764) | `pavelgolikov/ArbiGraph`, **MIT**, Python, pushed 2026-09-07 | difficulty as **dials** (topology JSON, distractors, value type), exact automatic verification, math / GSM / Python-tracing | needs our own runner (theirs assumes local GPU); a lift here is about **context retention**, not repo work |
+| **Harness-Bench** (2605.27922) | `Qihoo360/harness-bench`, 97★, 5 MB, **no license file** | **106 sandboxed offline tasks**, model/budget/protocol fixed while the harness varies — the venue for the 2^k factorial (2605.05716) | no license ⇒ run privately, cite, do not redistribute; verify task quality before trusting |
+| **LoopsBench** (2608.00267) | running; 8-task pilot | third-party ruler with a middle (1/8 → 12.5%) | 2h budgets, US$3/task; 2 of 8 tasks ungraded once |
+
+**The scaffold A/B**, as a 2^k factorial over diff gate / stagnation detector / progress ledger /
+escalation (2605.05716: all-in is consistently suboptimal, 56.3% submodularity violations), belongs
+on Harness-Bench — offline, repeatable, and it **dissolves the band problem** instead of solving it.
+
+---
+
+## Sequence and cost
+
+| # | item | size | spend | depends on | registered expectation |
+|---|---|---|---|---|---|
+| 0 | k-run protocol: pass^k, mechanism-active, ICC, 3 seeds | S | none | — | — |
+| 1 | retry-contamination probe from the 88 receipts | S | none | — | 3rd attempt ≈ 0 recovery (observed 0/11) |
+| 2 | interface preflight + re-read `tool_defer` / `parallel_tools` | S | none | — | some adapter shows emitted ≠ parsed |
+| 3 | live guard/model split + authorization-equivalence pairs | S | small | — | we escalate both |
+| 4 | readout-vs-input test (reorder/duplicate gold) | S | small | 2 | ≤23% recovery |
+| 5 | stand up ArbiGraph runner; calibration ladder to ~50% | M | small | 0 | a topology that lands in 40–60% |
+| 6 | compaction on/off × tier on ArbiGraph long chains | S | small | 0, 5 | null at production tier |
+| 7 | failure classifier + class-targeted recovery | M | none to build | — | — |
+| 8 | matched-budget sweep: retry / replan / targeted / deterministic | M | real | 0, 5, 7 | targeted ≥ retry at budget 1 |
+| 9 | RefactorPlatform question on `sequential_write`, same repair budget | M | real | 0 | ~0 tasks rescued by delegation |
+| 10 | 2^k scaffold factorial on Harness-Bench | L | real | 0, 2 | at least one component negative-marginal |
+| 11 | underspecification detector, off by default | M | small | 0 | question rate up, success up on the underspecified variant |
+| 12 | TSCG on the weakest FUSION member | S/M | small | 2 | gain on the small model, ~0 on deepseek |
+| — | hook-update / sleeper-channel audit | S | none | — | — |
+
+**Not on the list, on purpose:** schema-constrained decoding (two measured nulls); a general hook
+surface (red-team literature, we are on the defended side); uncertainty-gated retry (2608.14659:
+harmful in every configuration); the sqlite-vec semantic memory (gated behind a flat-file baseline —
+2609.00006 found none of eleven production harnesses uses embeddings for code retrieval).
+
+**The one caveat on the whole plan.** 2605.28591: a model trained on documents *describing* benchmark
+structure shifts by >20 pp, and the shift **persists on responses with no verbalised awareness**. Every
+public venue above is subject to it, pre-registration does not control for it, and paired arms are
+equally contaminated (§2aa). The cheapest test, and the only one that can invalidate work already
+published: run a pilot twice, canonical framing vs re-skinned as an ordinary repo request, and check
+whether the difference exceeds the noise floor from §0. It is item 0.5, and it should run before 10.

--- a/bench/loopsbench/PREREGISTRATION.md
+++ b/bench/loopsbench/PREREGISTRATION.md
@@ -1,0 +1,297 @@
+# LoopsBench — the first ruler we did not write
+
+Registered **2026-09-06, before any task ran**. Amendments are appended with what had already been
+seen when they were written.
+
+## Why this bench
+
+Every suite this project authored to measure the loop has failed to produce a discriminating middle,
+from one side or the other:
+
+| suite | outcome | the problem |
+|---|---|---|
+| `bench/learning_lift` | 84-92% across **three** attempts to build a 40-60% band | ceiling — everything passes |
+| `bench/terminal_bench` | 7.5% / 2.5%, **37 of 40 failing both arms** | floor — nothing passes |
+
+A ruler with no middle cannot say whether the loop helps, in either direction. LoopsBench
+(arXiv 2608.00267, `microsoft/Loopsbench`, MIT) is the first one we did not author: 112 tasks, 8
+languages, median dependency depth 6, and a published best of **25.00%** (Opus-4.7 + Claude Code +
+outer continuation). It is used **unmodified** — `--agent-import-path` is an upstream feature, so our
+agent lives in our repo and nothing is forked.
+
+## 🔴 What this run cannot answer, stated first
+
+**Our number will not be comparable to the published 25.00%.** That figure is Opus-4.7 driving Claude
+Code. This run is `deepseek-chat-v3.1` driving Chimera. Two things differ at once, so any difference
+measures the pair, not the loop — the §2g error this project has made four times in two days
+(*same items? same ruler? same n?*). Anyone who reads a number here against 25% is reading the model.
+
+What it **can** answer, and all it can answer:
+
+1. Does the harness run our agent end to end on this machine — install, solve, grade?
+2. At this model, on these 8 tasks, is the loop **above the floor at all**?
+3. Is the plumbing in place for a real paired A/B later, where model and bench are held fixed and
+   only the loop varies?
+
+## Phase 0 — the oracle, before any model is loaded
+
+`--agent oracle` applies each task's own reference solution. **If the oracle does not resolve a task,
+the defect is in the apparatus and no model number from it means anything.** This is the guard that
+caught a closed-world evaluator in a previous project, where 35 of 85 references were impossible by
+construction and the measured rate read 23.5% against a real 57.6%.
+
+**Gate: the oracle must resolve ≥ 1 of the pilot tasks before a single paid task runs.** If it
+resolves none, this document records that and the phase stops at US$ 0.
+
+## Phase 1 — the arm
+
+One arm. Not an A/B: with no idea yet whether we clear the floor, a second arm doubles the cost of
+finding out that neither moves.
+
+| | |
+|---|---|
+| agent | `chimera_loopsbench_agent:ChimeraAgent` (this directory, on `PYTHONPATH`) |
+| model | `openrouter/deepseek/deepseek-chat-v3.1` |
+| flags | `--repo-map --progress-ledger --checklist --max-attempts 1 --no-remember --no-collect --no-evolve-skills` |
+| attempts | 1 |
+| isolation | `CHIMERA_HOME=/chimera/home` per container — no memory or skill carried between tasks, so the 8 rows stay independent |
+
+`--max-attempts 1` deliberately: the retry lever is the thing a later A/B should vary, and leaving it
+at 1 here keeps this run inside the per-task budget with no timeout confound. Same reasoning, and the
+same setting, as the Terminal-Bench arms.
+
+### Amendment 1 — written after Phase 0 passed, before any paid task ran
+
+Two defaults in the arm above would have guaranteed the predicted 0/8 **for reasons that have
+nothing to do with the loop**, which is the §2q failure: an instrument that cannot exhibit the effect
+produces no evidence about it. Both are changed here, before spending, and the change is recorded
+rather than made quietly.
+
+1. **`--max-steps 8` → `60`.** `chimera solve` defaults to eight tool-calling steps. LoopsBench is
+   explicitly a *long-horizon* benchmark — multi-module implementations behind a dependency DAG, with
+   two-hour budgets. Eight steps cannot finish one of these tasks under any loop. Terminal-Bench
+   comparability was the reason to leave it alone; measuring on *this* bench is the reason not to.
+2. **The solve's inner timeout no longer binds.** The adapter shipped with a 1500 s cap, which on a
+   7200 s task would have truncated the arm at 21% of its allowance and called the result a miss. It
+   is raised so the **task's own `max_agent_timeout_sec` is the binding constraint**, minus 60 s to
+   leave room to write the log out. The mirror of the Terminal-Bench rule *"never silently inflate
+   the budget"* — never silently deflate it either.
+
+Concurrency is **2**. Not higher: the Terminal-Bench run at 5 produced a result flip on a trivial
+task that took a controlled serial repeat to attribute to variance rather than contention. Not 1:
+eight tasks at their full budgets is 11.5 hours of wall clock.
+
+### Amendment 2 — the first run was discarded, and why
+
+Written **after seeing** the first trial of the paid run fail and reading its log; the run was
+stopped at 12.5% and its numbers are not reported anywhere as a result.
+
+`task_compiler_fdmj_llvm` came back failed. The artifact beside it was `chimera_install-failed.log`,
+not a solve log — so the failure was **`agent_installation_failed`, not a miss**. Two defects were
+stacked in it, and both were mine:
+
+1. **`--break-system-packages` on pip 22.** That option arrived in pip 23; older pip treats it as an
+   unknown option and exits, rather than warning. The image ships Python 3.10.12 / pip 22.0.2, so
+   every install there died on the flag. Fixed by asking pip what it supports before passing it.
+2. **The one the fix uncovered: `chimera-agent` requires Python ≥ 3.11** and that image has 3.10, so
+   even with the flag gone PyPI correctly answers *"no matching distribution"*.
+
+**The second one had a tempting wrong answer: drop the incompatible tasks.** That would have
+selected the subset toward containers that happen to carry a new interpreter — a selection nobody
+registered, on the one bench in this project whose entire value is that we did not choose its tasks.
+The arm brings its own interpreter instead: `pip install uv` (from PyPI — `astral.sh` answers
+urllib with HTTP 403 and these images have no curl, measured both ways in the image that failed),
+then `uv venv --python 3.12` and install into it.
+
+**Verified by running the adapter's own `_INSTALL` string** — the one that ships, not a
+reimplementation — in both image shapes: the 3.10 image reports `CHIMERA_INSTALL_OK_UV`, the 3.12
+image `CHIMERA_INSTALL_OK_SYSPY`, and both `CHIMERA_LAUNCHER_OK`.
+
+⭐ **The lesson this run is now carrying:** the harness told the truth and the summary did not. The
+status board read `Failed: 1 · Pass Rate 0.0%`, which is exactly what a genuine miss looks like. Only
+the per-trial artifact name distinguished them. **A pass rate that pools installation failures with
+misses is measuring the adapter and reporting it as the loop** — the same shape as the closed-world
+evaluator that read 23.5% where the truth was 57.6%. `RESULTS.md` will report the two separately,
+and any task that ends in an install failure is excluded from the denominator and named.
+
+### Amendment 3 — the second run was discarded too, for a defect the pass rate could not show
+
+Written after reading the artifacts of run `chimera-p2` at 75% (6 failed, 0 passed) and before its
+replacement `chimera-p3` was launched. `p2` is discarded and reported nowhere as a result.
+
+The triage Amendment 2 promised turned up something that did not fit: four tasks carried **both** a
+`chimera_install-failed.log` and a `chimera_solve.log` with real content. The directory layout
+resolved it:
+
+```
+round-01/chimera_solve.log            <- the agent ran, and produced diffs
+round-02/chimera_install-failed.log   <- the next round died
+```
+
+**LoopsBench's outer loop re-invokes the agent in the same container** — round-01, 02, 03 against one
+workspace — so the install script runs each round, and `uv venv` refuses an existing environment
+(*"A virtual environment already exists"*). On the four tasks whose image ships Python < 3.11, the
+agent therefore worked **one round instead of three**.
+
+⭐ **The reason this is the most important entry in this document:** the shortfall was **invisible in
+the metric**. `Pass Rate: 0.0%` reads identically whether the agent had one round or three, and the
+run would have been published as evidence that the loop cannot do these tasks when half the arm had
+been cut to a third of its budget. Nothing errored, nothing looked wrong, and the number was right
+there on the status board — the same family as every §2 defect in the project's lessons file: *dado
+some, nada reclama, o número sai*.
+
+Fixed by making the install **idempotent**: if `/chimera/run --help` already works, exit 0 without
+reinstalling. Better than `uv venv --clear`, which would re-download a 32 MB interpreter every round.
+**Verified the way the defect appears** — the shipped `_INSTALL` run twice in one container, both
+image shapes: round-01 `OK_UV` / `OK_SYSPY`, round-02 `ALREADY_PRESENT`, rc=0 throughout.
+
+Two runs are now discarded for adapter defects, neither of which the harness reported as anything
+but a failed task. That is the cost of the rule this project keeps: **a number whose apparatus has
+not been checked is not a result**, and checking it is what found both.
+
+### Amendment 4 — run p3 discarded; the agent had neither a shell nor, for part of it, a model
+
+Written after run `chimera-p3` completed 0/8 and its artifacts were read. `p3` is discarded.
+
+Two independent things were wrong, and **the summary table showed neither**:
+
+| | rounds |
+|---|---|
+| **no shell** — Chimera refused to execute the agent's commands | 10 of 21 |
+| **no model** — the provider key hit its spend ceiling mid-run (HTTP 403) | 9 of 21 |
+| **rounds with both a model and a shell** | **3 of 21** |
+
+`task_db_storage_index_labs` and `task_sql_engine_myjql` ran all three rounds with **no model at
+all**; `task_dbcompiler` ran all three unable to execute a single command.
+
+**The shell one is the instructive defect.** `CHIMERA_HOST_EXEC` defaults to `ask`; task images have
+no bubblewrap, so there is no OS sandbox, and a container has no TTY to answer the question — so
+Chimera correctly refused to run anything. On a benchmark whose tasks are *"build with `make all` and
+pass the tests"*, the agent could edit files and execute nothing, and the model still wrote confident
+completion summaries the verifier contradicted. Set to `allow`, which is right **here and nowhere
+else**: the container is the sandbox and is destroyed after grading.
+
+**A third thing surfaced while proving the fix.** With execution restored, the agent ran the command
+and wrote the file — and Chimera's own verify-or-revert **reverted the work**, so the grader saw an
+empty tree. Without a `--verify` command the loop falls back to the Manager's judgement of prose,
+which `autonomous.py` itself says must not veto artifacts. With `--max-attempts 1` the Manager cannot
+do the one thing it is for — feedback on a retry, because there is no retry — so its only remaining
+effect is that veto. `--no-manager` is added, and it also puts this arm on the same footing as every
+built-in LoopsBench agent: Claude Code and Codex have no internal reviewer reverting work either, and
+the benchmark's own tests are the judge.
+
+**Positive proof, not the absence of a warning.** The fixes were verified with a real solve in a task
+container on a task whose answer cannot be guessed — *run `uname -sr` and write its output to a
+file*. Result: `rc=0`, `success after 1 attempt(s)`, and `proof.txt` containing
+`Linux 6.6.87.2-microsoft-standard-WSL2`, the exact string. The command ran **and** the artifact
+survived to be graded.
+
+⚠️ **Four runs, four discarded, none of them reported as a result — and the harness never
+complained once.** `Pass Rate: 0.0%` is exactly what a loop that cannot do the work looks like.
+Every one of the four defects was found by opening the artifact of a failure instead of reading the
+table above it. That is the whole cost, and the whole justification, of the rule this project keeps.
+
+### Amendment 5 — run p4 discarded: the loop threw the work away before the grader looked
+
+Run `chimera-p4` finished **0/7** (one task excluded, install) with the apparatus finally clean:
+**23 of 23 rounds had both a model and a shell**, zero install failures, zero refusals. And it still
+cannot be reported, for a reason that is not a bug in the adapter at all.
+
+**Chimera's verify-or-revert rolled the tree back before LoopsBench ran the tests.** The flag for
+exactly this exists, and its own help says so: *"On failure, leave the last attempt's edits on disk
+**for an external grader** (don't revert)."* LoopsBench **is** the external grader. It was not
+passed. `bench/terminal_bench` does not pass it either, so the omission is older than this run and
+may have shaped that scoreboard too.
+
+**Proved by a paired test, because the first attempt to prove it proved nothing.** A single run with
+the flag came back `success`, so nothing was reverted and the flag never executed — a green result
+that tested the wrong path. The real test forces failure with `--verify false` and runs the same
+task twice, changing only the flag:
+
+| arm | loop verdict | `proof.txt` |
+|---|---|---|
+| without `--keep-workspace` | failed, reverted | **absent** |
+| with `--keep-workspace` | failed, reverted | **`HELLO_FROM_AGENT`** |
+
+⭐ **And it corrected how the previous amendment counted.** Both arms log `trabalho revertido` — the
+revert happens either way and the flag restores afterwards. So the marker I had been counting across
+runs was never the signal; whether the file survives is. A metric read off a log line that both
+outcomes produce is not a measurement, and it took a paired test to see that.
+
+### Run 6 — the repeat, registered 2026-09-07 before it ran
+
+`chimera-p5` gave **1 of 8**. Nothing in this project knows how much that number moves on its own,
+because no arm has ever been run twice here. Run 6 is `p5` again — same tasks, same model, same
+flags, same concurrency, new run-id — and it exists to answer one question: **how big is the noise?**
+
+There is no seed to fix. LoopsBench does not expose one and the model samples above zero
+temperature, so "a second seed" means a second identical run and the variation is whatever the pair
+(model, loop) produces on its own.
+
+**Why this before the A/B everyone wants.** At 1/8, a scaffolding-on/off comparison would resolve to
+"one task different", and one task is not distinguishable from nothing at n=8. §2m cost this project
+a gate that could not decide because its threshold sat below the apparatus's own variance; §2x
+showed two runs produce a *difference*, not an estimate of variance. This run buys the number that
+sizes every comparison after it.
+
+**Registered prediction: 0 to 2 of 8.** Binomial noise alone at p≈0.125, n=8 has a standard
+deviation of about 0.94 tasks, so a repeat landing anywhere in 0–2 is consistent with no change at
+all. **A repeat at 3+ or a second run resolving a *different* task would be the interesting
+outcome** — the first would say the estimate is unstable, the second that which task wins is close
+to a coin flip.
+
+**What it cannot do:** two runs alert, three decide. Whatever comes back, the honest output is a
+range and an order of magnitude, not a variance estimate. If the two disagree by more than one task,
+the third run stops being optional.
+
+## The subset — 8 tasks, chosen by rule
+
+**Rule, declared before looking at any result:** `difficulty == easy`, ordered by
+`(max_agent_timeout_sec ASC, task_id ASC)`, take the first 8. Timeout ascending because a 30-minute
+task and a 2-hour task are not the same experiment; alphabetical breaks ties so no task was picked
+for looking winnable.
+
+| # | task | budget | units |
+|---|---|---:|---:|
+| 1 | `task_db_storage_index_labs` | 1800s | 10 |
+| 2 | `task_sql_engine_myjql` | 1800s | 5 |
+| 3 | `task_xjqkl` | 3600s | 6 |
+| 4 | `task_os_c_fs_labs` | 5400s | 7 |
+| 5 | `task_compiler_fdmj_llvm` | 7200s | 7 |
+| 6 | `task_cs61b_extra_java_bundle` | 7200s | 22 |
+| 7 | `task_dbcompiler` | 7200s | 24 |
+| 8 | `task_ml_four_assignments` | 7200s | 10 |
+
+There are 17 `easy` tasks in the set; these are the 8 cheapest by budget. **"Easy" is the
+benchmark's word, not a claim of ours** — the median task here still carries a two-hour ceiling and
+5-24 separately-tested units, and the dataset is 52 hard / 43 medium / 17 easy.
+
+## Prediction, registered before running
+
+**0/8 to 1/8 resolved.** Reasoning, not hedging: the same model on Terminal-Bench resolved 7.5% of 40
+tasks with 37 failing both arms, and LoopsBench tasks are substantially larger (multi-module
+implementations behind a dependency DAG) with a published ceiling of 25% for a *frontier* model on a
+mature loop.
+
+**A 0/8 is a real outcome and will be published as one.** It would say the pair (this model, this
+loop) is below this bench's usable range — which is information about where the instrument can be
+pointed, and is exactly the thing three self-authored suites could not tell us. It would **not** say
+the loop does not work, and this document exists so that reading cannot be made later.
+
+n=8 gives a Wilson interval of roughly ±30pp. This is a **pilot**, and its job is to decide whether a
+larger run is worth paying for — not to produce a rate anyone should quote.
+
+## Cost
+
+Phase 0 is US$ 0 (the oracle calls no model). Phase 1 spends real money on `deepseek-chat-v3.1`; the
+wall-clock ceiling of the 8 budgets summed is **11.5 hours** if every task exhausts its limit, less
+under concurrency. The per-task spend is not known in advance and will be reported as measured, per
+task, in `RESULTS.md` — including the tasks that spent money and resolved nothing, which is the half
+a scoreboard is tempted to leave out.
+
+## What gets published
+
+`RESULTS.md` beside this file, whatever the outcome, with: the oracle's verdict, the per-task rows,
+the failure mode of every unresolved task (a harness `agent_installation_failed` and a genuine miss
+are different facts), the measured spend, and the log of at least one failure read with actual eyes —
+because a rate with no read log is a number with no diagnosis.

--- a/bench/loopsbench/RESULTS.md
+++ b/bench/loopsbench/RESULTS.md
@@ -1,0 +1,183 @@
+# The first ruler we did not write — and the five runs it took to earn a number
+
+Run `chimera-p5`, 2026-09-07, against [`PREREGISTRATION.md`](PREREGISTRATION.md) and its five
+amendments. LoopsBench (arXiv 2608.00267, `microsoft/Loopsbench`, MIT) used **unmodified**:
+`--agent-import-path` is an upstream feature, so our agent lives in our repo and nothing is forked.
+
+**Cost: US$ 25.49**, every leg priced, no unpriced estimate anywhere in it.
+
+## The number
+
+| | |
+|---|---|
+| resolved | **1 of 8** — `task_ml_four_assignments`, **16 of 16 tests passed** |
+| as the harness reports it | **12.50%** |
+| among tasks that got a verdict | **1 of 6 = 16.7%** (see below) |
+| registered prediction | **0/8 to 1/8** |
+
+Two tasks — `task_dbcompiler` and `task_sql_engine_myjql` — carry `is_resolved: null` with no test
+results. Their test panes show pytest collecting and failing (`collected 13 items`, `FFF`) and then
+cutting off: **the grading phase was truncated, so the harness has no verdict**, and it correctly
+declines to invent one. They were failing at the point of truncation, so the honest reading is that
+the true rate sits between the two figures and closer to the first. Both are reported rather than
+whichever flatters.
+
+## 🔴 What this number is not
+
+**It is not comparable to the published 25.00%.** That figure is Opus-4.7 driving Claude Code across
+all 112 tasks. This is `deepseek-chat-v3.1` driving Chimera across 8. **Three** things differ at once
+— model, loop, and subset — so any difference measures the bundle. Registered before the run for
+exactly this reason, and repeated here because a number and a number on the same page invite the
+comparison whether or not it is licensed.
+
+What it does say: **the pair (this model, this loop) is inside this bench's usable range, not below
+it.** That alone is what three self-authored suites could never produce — `learning_lift` hit
+84–92% across three attempts to build a 40–60% band, and `terminal_bench` floored at 7.5% / 2.5%
+with 37 of 40 failing both arms. A ruler with no middle cannot answer whether the loop helps. This
+one has a middle, and we are in it.
+
+## The apparatus, which is most of what happened here
+
+**Five runs. Four discarded. Every one of them for a defect that produced `Pass Rate: 0.0%` —
+exactly what a loop that cannot do the work looks like.** Not one was reported as a result, and not
+one was announced by the harness: each was found by opening the artifact of a failure instead of
+reading the table above it.
+
+| run | discarded because | how it was found |
+|---|---|---|
+| p1 | `--break-system-packages` on pip 22 — the option did not exist until pip 23 and older pip *hard-fails* on it | the failed task's artifact was `chimera_install-failed.log`, not a solve log |
+| p2 | `uv venv` refuses an existing environment, so the outer loop's rounds 2–3 died: **one round of agent work instead of three** | a task carrying *both* an install-failure log and a solve log with real content |
+| p3 | **10 of 21 rounds had no shell** (`CHIMERA_HOST_EXEC=ask`, no bubblewrap, no TTY) and **9 of 21 had no model** (key hit its ceiling mid-run) | reading a solve log with actual eyes |
+| p4 | **20 of 23 rounds** logged `trabalho revertido`: verify-or-revert rolled the tree back before the tests ran | checking whether the work reached the grader at all |
+| **p5** | — | **24 of 24 rounds with a model and a shell, 0 install failures** |
+
+⭐ **The p4 defect is the one worth keeping.** It was not a bug in the adapter. `--keep-workspace`
+exists in Chimera for exactly this, and its help says so: *"On failure, leave the last attempt's
+edits on disk **for an external grader** (don't revert)."* LoopsBench **is** the external grader, and
+the flag was not passed. **`bench/terminal_bench` does not pass it either**, so the 7.5% / 2.5% in
+that scoreboard was measured with the same handicap and should be re-read in that light.
+
+⭐⭐ **And the metric that was not a metric.** Across p3 and p4 the revert was counted by grepping
+`trabalho revertido` out of the solve log. The paired test that finally settled the flag — same task,
+same model, same image, failure forced with `--verify false`, only the flag changed — showed **both
+arms log that line**. The revert happens either way; the flag restores afterwards. The signal is
+whether the file survives, and it is the opposite of what the log line suggested:
+
+| arm | loop verdict | `proof.txt` |
+|---|---|---|
+| without `--keep-workspace` | failed, "reverted" | **absent** |
+| with `--keep-workspace` | failed, "reverted" | **`HELLO_FROM_AGENT`** |
+
+A quantity read off a line that both outcomes produce is not a measurement. It took a paired test to
+see that, which is the same lesson this project has now learned in four different costumes.
+
+## The arm
+
+| | |
+|---|---|
+| agent | `chimera_loopsbench_agent:ChimeraAgent` (this directory, `--agent-import-path`) |
+| model | `openrouter/deepseek/deepseek-chat-v3.1` |
+| flags | `--repo-map --progress-ledger --checklist --max-attempts 1 --max-steps 60 --no-remember --no-collect --no-evolve-skills --no-manager --keep-workspace` |
+| install | always a private venv via `uv` — three different images broke three different ways installing into the system Python |
+| isolation | `CHIMERA_HOME=/chimera/home` per container; nothing carries between tasks |
+| concurrency | 2 · attempts 1 · 3 outer rounds per task (the harness's own loop) |
+
+`--max-steps 60` rather than the shipped default of 8: eight tool calls cannot finish a multi-module
+implementation behind a dependency DAG under any loop, and leaving it would have measured the step
+limit. `--no-manager` because with one attempt the reviewer cannot do the thing it is for — feedback
+on a retry — so its only remaining effect is a prose veto over an artifact, which this codebase's own
+`autonomous.py` says must not happen; it also puts this arm on the same footing as every built-in
+LoopsBench agent, none of which has an internal reviewer.
+
+## The subset, and what "easy" means here
+
+Eight tasks, chosen before any result by rule: `difficulty == easy`, ordered by
+`(max_agent_timeout_sec ASC, task_id ASC)`, first 8 of the 17 easy ones. The dataset is **52 hard /
+43 medium / 17 easy**, and "easy" still means two-hour budgets and 5–24 separately tested units.
+
+| task | budget | units | verdict | wall clock | cost |
+|---|---:|---:|---|---:|---:|
+| `task_ml_four_assignments` | 7200s | 10 | **RESOLVED 16/16** | 33.5 min | $5.46 |
+| `task_compiler_fdmj_llvm` | 7200s | 7 | failed, tests ran | 30.2 min | $2.77 |
+| `task_cs61b_extra_java_bundle` | 7200s | 22 | failed, tests ran | 26.2 min | $1.35 |
+| `task_os_c_fs_labs` | 5400s | 7 | failed, tests ran | 43.9 min | $3.72 |
+| `task_xjqkl` | 3600s | 6 | failed, no test detail | 22.9 min | $5.25 |
+| `task_db_storage_index_labs` | 1800s | 10 | failed, no test detail | 24.1 min | $3.41 |
+| `task_dbcompiler` | 7200s | 24 | **not graded** (tests truncated) | 44.2 min | $3.54 |
+| `task_sql_engine_myjql` | 1800s | 5 | **not graded** (tests truncated) | 29.8 min | — |
+
+`task_sql_engine_myjql` produced no receipt block, so its spend is not in the total: **US$ 25.49 is a
+floor, not the full cost.** Reported as a floor rather than padded with an estimate.
+
+## What this cannot show
+
+- **n = 8.** The Wilson interval on 1/8 is roughly ±30 pp. This is a pilot whose job was to decide
+  whether a larger run is worth paying for. It is not a rate anyone should quote.
+- **One model, one loop, one subset, one seed.** No arm was repeated, so nothing here separates the
+  result from run-to-run variance — a lesson this project has paid for twice (§2m, §2x).
+- **The eight easiest tasks in the set.** Nothing here speaks to the 52 hard ones.
+- **Two of eight were not graded.** The denominator is honestly ambiguous, and both readings are on
+  the table above rather than one of them being chosen.
+- **No A/B.** This measures Chimera on LoopsBench; it does not measure what Chimera's scaffolding
+  contributes, which needs a bare-agent arm on the same tasks with the same model.
+
+## The repeat — same rate, different task, and it kills the A/B at this n
+
+Run `chimera-p6`, registered before it ran as the variance check: `p5` again, verified identical by
+diff except the run-id. Both apparatus-clean — **24 and 22 rounds, zero install failures, zero
+rounds without a model or a shell.**
+
+| | p5 | p6 |
+|---|---|---|
+| resolved | **1 of 8** | **1 of 8** |
+| accuracy | 12.50% | 12.50% |
+| which one | `task_ml_four_assignments` | `task_sql_engine_myjql` |
+
+**The rate is identical and the overlap is zero.**
+
+| | count |
+|---|---:|
+| passed in **both** runs | **0** |
+| passed only in p5 | 1 |
+| passed only in p6 | 1 |
+| failed in both | 6 |
+| **discordant between two identical runs** | **2 of 8 = 25%** |
+
+`task_ml_four_assignments` passed 16/16 tests in p5 and failed in p6. `task_sql_engine_myjql` was
+one of the two ungraded rows in p5 and passed in p6. Nothing about the configuration changed.
+
+⭐ **A stable rate hiding an unstable outcome is the worst shape for a paired comparison**, and this
+is exactly why the A/B was not run first. A scaffolding-on/off test compares tasks pairwise; with
+25% of pairs flipping on their own, the discordant column — the only column McNemar reads — is
+noise. Sizing it crudely against that noise floor:
+
+| effect to detect | tasks per arm |
+|---|---:|
+| +10 pp | ~97 |
+| +15 pp | ~43 |
+| +20 pp | ~25 |
+
+(normal approximation over discordant pairs; an order of magnitude, not a plan)
+
+An A/B at n=8 could not have detected anything short of a 30-point effect, and would have returned
+"one task different" — which reads as a result and is not one. **The 8-task pilot cost US$ 25 and
+bought the knowledge that the experiment everyone wanted needs 25–97 tasks per arm.** LoopsBench has
+112, so that is affordable in the full set and was not affordable in the subset.
+
+⚠️ **Two runs alert, three decide** (§2x). The 25% is itself an estimate from two samples; what it
+supports is "n=8 is hopeless", not a variance figure anyone should carry into a power calculation
+without a third run.
+
+⭐ **One thing did stabilise:** six of eight tasks failed in both runs, and the three that failed
+earliest in both were the same three. The floor is consistent; the ceiling is a coin flip. That
+pattern says the discriminating middle on this subset is roughly **two tasks wide**, which is the
+real reason n=8 has no power — not the rate, the width of the band.
+
+## What is worth doing next, in order
+
+1. **Re-read `bench/terminal_bench` in light of `--keep-workspace`.** Its 7.5% / 2.5% was measured
+   with the loop discarding its own work before the grader looked. That scoreboard may be wrong in a
+   direction that flatters nobody.
+2. **A paired arm on these same 8 tasks** — same model, scaffolding on versus off. That is the
+   question the project actually wants answered, and this run built the apparatus for it.
+3. **Fix the grading truncation** on the two ungraded tasks, or report them as excluded by rule.

--- a/bench/loopsbench/chimera_loopsbench_agent.py
+++ b/bench/loopsbench/chimera_loopsbench_agent.py
@@ -1,0 +1,243 @@
+"""Chimera as a LoopsBench agent — a third-party ruler for our own loop.
+
+LoopsBench (arXiv 2608.00267, ``microsoft/Loopsbench``, MIT) is the first ruler we run that we did
+not write. That is the point: every suite this project authored for the loop landed at a ceiling
+(``bench/learning_lift``: 84-92% across three attempts to build a 40-60% band) or a floor
+(``bench/terminal_bench``: 7.5% / 2.5%, 37 of 40 failing both arms). A bench with no discriminating
+middle cannot answer whether the loop helps, in either direction.
+
+**Plugged in, not forked.** ``AgentFactory.get_agent_class`` takes an ``import_path`` of the form
+``module:ClassName``, so this file is ours, lives in our repo, and the upstream harness is used
+unmodified. Point ``--agent-import-path`` here with this directory on ``PYTHONPATH``.
+
+Everything below except the container handle is ported from
+``bench/terminal_bench/chimera_installed_agent.py``, which solved the same problem — get Chimera into
+a heterogeneous task container and run it without corrupting the harness's terminal. Its lessons are
+kept rather than re-derived:
+
+1. **Drive through ``exec_run``, not the tmux pane.** ``chimera solve`` renders a rich/textual UI;
+   writing that into the pane the harness reads is how a run becomes unparseable. Output goes to a
+   file and the pane never sees it. (LoopsBench hands us a ``TmuxSession``; we take its container.)
+2. **Network install first, ABI-correct by construction.** Task base images differ in Python
+   version, so a prebuilt wheelhouse is the *fallback*, never the default — a cp313 wheelhouse fails
+   on a cp312 image. The bootstrap chain exists because task images ship, variously, no pip, no
+   ensurepip, and neither curl nor wget.
+3. **``cd`` to the workspace the grader reads.** On Terminal-Bench this cost a false negative: the
+   agent wrote correct files where the tests never looked. LoopsBench task instructions say
+   ``Your working directory is /workspace``, so that is where the solve runs.
+4. **Copy the logs out before the container dies.** A task that scores 0 with no log is a number
+   with no diagnosis, and the container is torn down after grading.
+
+Config by env: ``OPENROUTER_API_KEY`` (required), ``CHIMERA_LB_MODEL``, ``CHIMERA_LB_FLAGS``,
+``CHIMERA_LB_SOLVE_TIMEOUT``.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+from typing import Any
+
+from loopsbench.agents.base_agent import AgentResult, BaseAgent
+from loopsbench.terminal.tmux_session import TmuxSession
+
+_MODEL = os.environ.get("CHIMERA_LB_MODEL", "openrouter/deepseek/deepseek-chat-v3.1")
+#: ``--max-steps 60``, not the shipped default of 8. A LoopsBench task is a multi-module
+#: implementation behind a dependency DAG with a two-hour budget; eight tool calls cannot finish one
+#: under any loop, so leaving the default would have measured the step limit and reported it as the
+#: loop. See Amendment 1 in PREREGISTRATION.md — registered before spending, not after seeing a zero.
+_FLAGS = os.environ.get(
+    "CHIMERA_LB_FLAGS",
+    "--repo-map --progress-ledger --checklist --max-attempts 1 --max-steps 60 "
+    "--no-remember --no-collect --no-evolve-skills --no-manager --keep-workspace",
+)
+#: ``--keep-workspace`` is not a tweak — it is the flag Chimera has for exactly this situation, and
+#: its own help says so: *"On failure, leave the last attempt's edits on disk for an external grader
+#: (don't revert)."* LoopsBench IS the external grader. Without it, verify-or-revert rolls the tree
+#: back before the task's tests run: measured on run p4, **20 of 23 rounds** logged
+#: ``trabalho revertido`` and the harness then graded a tree the agent had been made to undo.
+#: `bench/terminal_bench` does not pass it either, so this omission is older than this run.
+#: Ceiling on one solve. Set high on purpose so the **task's own** ``max_agent_timeout_sec`` is what
+#: binds: a 1500 s cap on a 7200 s task truncates the arm at 21% of its allowance and the miss reads
+#: as incapability. The mirror of the Terminal-Bench rule "never silently inflate the budget".
+_SOLVE_TIMEOUT = float(os.environ.get("CHIMERA_LB_SOLVE_TIMEOUT", "7200"))
+
+_WORKDIR = "/workspace"
+
+_INSTALL = r"""#!/bin/bash
+mkdir -p /chimera
+echo CHIMERA_INSTALL_START
+
+# 0. Idempotent, because LoopsBench's outer loop re-invokes the agent in the SAME container: the
+#    harness runs round-01, round-02, round-03 against one workspace, and this script runs each
+#    time. Measured on round-02 of the compiler task: `uv venv` refuses an existing environment
+#    ("A virtual environment already exists"), the install returned non-zero, and the round was
+#    recorded as agent_installation_failed — so a task got ONE round of agent work instead of three
+#    and the shortfall was invisible in the pass rate. Re-downloading a 32 MB interpreter every
+#    round would also be waste. If the launcher already works, there is nothing to install.
+if [ -x /chimera/run ] && /chimera/run --help >/dev/null 2>&1; then
+  echo CHIMERA_INSTALL_ALREADY_PRESENT
+  echo CHIMERA_LAUNCHER_OK
+  exit 0
+fi
+
+PY=$(command -v python3 || command -v python)
+L=/chimera/pip.log
+echo "python: $($PY -VV 2>&1)" >>$L
+
+# 1. Make sure pip exists at all. Task images ship, variously, no pip, no ensurepip, and neither
+#    curl nor wget — hence the chain rather than one command.
+if ! $PY -m pip --version >>$L 2>&1; then
+  $PY -m ensurepip --default-pip >>$L 2>&1 || \
+  { $PY -c "import urllib.request as u;u.urlretrieve('https://bootstrap.pypa.io/get-pip.py','/chimera/get-pip.py')" >>$L 2>&1 || \
+    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /chimera/get-pip.py 2>>$L || \
+    wget -qO /chimera/get-pip.py https://bootstrap.pypa.io/get-pip.py 2>>$L; \
+    $PY /chimera/get-pip.py >>$L 2>&1 || \
+    $PY /chimera/get-pip.py --break-system-packages >>$L 2>&1; } || true
+fi
+$PY -m pip --version >>$L 2>&1
+
+# 2. Pass --break-system-packages ONLY where pip understands it. pip < 23 does not have the option
+#    and treats it as a hard error, not a warning — so an image with an older pip fails every
+#    install with "no such option" and the harness records agent_installation_failed. Measured on
+#    task_compiler_fdmj_llvm: Python 3.10, pip 22.0.2. The flag exists for PEP-668 images, and every
+#    one of those is newer than pip 23 anyway, so asking pip what it supports costs nothing.
+BSP=""
+if $PY -m pip install --help 2>&1 | grep -q -- "--break-system-packages"; then
+  BSP="--break-system-packages"
+fi
+echo "BSP='$BSP'" >>$L
+
+# 3. chimera-agent requires Python >=3.11 and task images do not all ship one: measured, the
+#    compiler task's image is Python 3.10.12, where PyPI correctly reports "no matching
+#    distribution". Dropping such tasks would select the subset toward containers that happen to
+#    carry a new interpreter — a selection nobody registered, on a bench whose whole value is that
+#    we did not choose its tasks. So bring our own interpreter instead.
+#
+#    uv comes from PyPI, not from astral.sh: the install script there answers urllib with HTTP 403
+#    and these images have no curl, while pip reaches PyPI fine — measured, both ways, in the image
+#    that failed.
+#    ALWAYS a venv, never the container's system Python. Three different images broke three
+#    different ways when installing into the system interpreter, and each was found only by running
+#    it: pip 22 rejecting the flag, Python 3.10 having no compatible wheel, and — the third —
+#    `Cannot uninstall Pygments 2.17.2, RECORD file not found. Hint: The package was installed by
+#    debian`, where pip cannot replace a distro-packaged dependency. A private environment has none
+#    of these failure modes and does not depend on what a task image happens to ship, so it replaces
+#    the branch that tried to guess which images were safe.
+$PY -m pip install $BSP --quiet uv >>$L 2>&1 || { echo CHIMERA_UV_INSTALL_FAILED; exit 1; }
+UV=$($PY -c 'import uv;print(uv.find_uv_bin())' 2>>$L) || { echo CHIMERA_UV_BIN_MISSING; exit 1; }
+"$UV" venv --python 3.12 /chimera/venv >>$L 2>&1 || { echo CHIMERA_UV_VENV_FAILED; exit 1; }
+"$UV" pip install --python /chimera/venv/bin/python --quiet chimera-agent >>$L 2>&1 \
+  || { echo CHIMERA_UV_PIP_FAILED; exit 1; }
+echo "exec /chimera/venv/bin/chimera \"\$@\"" > /chimera/run
+echo CHIMERA_INSTALL_OK_UV
+
+# 4. A launcher rather than a bare `chimera`, because `pip install` puts the console script in
+#    /usr/local/bin on some images and ~/.local/bin on others, and the second is not always on PATH
+#    for a non-login shell. A run that installs correctly and then cannot find its own binary is the
+#    same zero as one that never installed, told apart by nothing.
+chmod +x /chimera/run
+/chimera/run --help >/dev/null 2>>$L && echo CHIMERA_LAUNCHER_OK || { echo CHIMERA_LAUNCHER_FAILED; exit 1; }
+"""
+
+
+class ChimeraAgent(BaseAgent):
+    """Install ``chimera-agent`` into the task container, then run one ``chimera solve``."""
+
+    def __init__(self, model_name: str | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._model_name = model_name or _MODEL
+        self._flags = str(kwargs.get("flags", _FLAGS))
+        if not os.environ.get("OPENROUTER_API_KEY"):
+            raise ValueError(
+                "OPENROUTER_API_KEY is not set. Refusing to start: every task would install "
+                "chimera, fail to reach a provider, and score 0 — a floor that looks like a "
+                "result. Set the key, or run --agent oracle to exercise the harness for free."
+            )
+
+    @staticmethod
+    def name() -> str:
+        return "chimera"
+
+    def get_trajectory_paths(self) -> list[str]:
+        return []
+
+    def _env(self) -> dict[str, str]:
+        return {
+            "OPENROUTER_API_KEY": os.environ.get("OPENROUTER_API_KEY", ""),
+            "CHIMERA_DEFAULT_MODEL": str(self._model_name),
+            # No memory, no skill evolution, no telemetry home shared across tasks: each task is an
+            # independent trial and anything carried between them would make the 8 rows dependent.
+            "CHIMERA_HOME": "/chimera/home",
+            # THE ONE THAT DECIDED A WHOLE RUN. `host_exec` defaults to "ask"; task images have no
+            # bubblewrap, so there is no OS sandbox, and there is no TTY to answer the question —
+            # so Chimera correctly refused to run a single command. Measured on run p3: **10 of 21
+            # rounds** carried "refusing to run the agent's commands", and two tasks carried it in
+            # all three. On a benchmark whose tasks are "build with `make all` and pass the tests",
+            # the agent could edit files and execute nothing, and the resulting 0/7 was a
+            # measurement of that, not of the loop.
+            #
+            # `allow` is right here and nowhere else: the container IS the sandbox, it is destroyed
+            # after grading, and "the host" from Chimera's point of view is that throwaway container.
+            "CHIMERA_HOST_EXEC": "allow",
+        }
+
+    def perform_task(
+        self,
+        instruction: str,
+        session: TmuxSession,
+        logging_dir: Path | None = None,
+        timeout_sec: float | None = None,
+    ) -> AgentResult:
+        container = session._container  # the harness's own handle; the oracle agent uses it too
+        env = self._env()
+
+        install_rc, _out = container.exec_run(["bash", "-lc", _INSTALL], environment=env)
+        if install_rc != 0:
+            self._dump_logs(container, env, logging_dir, tag="install-failed")
+            # Named, not swallowed: an install failure and a genuine 0 are different facts, and a
+            # run that cannot tell them apart reports infrastructure as incapability.
+            return AgentResult(failure_mode="agent_installation_failed")
+
+        budget = _SOLVE_TIMEOUT
+        if timeout_sec is not None and timeout_sec > 0:
+            # Stay inside the harness's own budget with room to write the log out.
+            budget = max(60.0, min(_SOLVE_TIMEOUT, float(timeout_sec) - 60.0))
+
+        solve = (
+            f"cd {_WORKDIR} 2>/dev/null; "
+            f"timeout {int(budget)} /chimera/run solve {shlex.quote(instruction)} "
+            f"--workspace . --model {self._model_name} {self._flags} "
+            f"< /dev/null > /chimera/solve.log 2>&1"
+        )
+        container.exec_run(["bash", "-lc", solve], environment=env)
+        self._dump_logs(container, env, logging_dir, tag="solve")
+
+        # Token counts are left at 0 deliberately: `chimera solve` reports its spend to its own
+        # receipt inside the container, and copying a number we have not verified crosses the
+        # boundary would put an unchecked figure into the harness's cost column. The receipt is in
+        # the dumped log; read it there rather than trusting a field nobody validated.
+        return AgentResult()
+
+    @staticmethod
+    def _dump_logs(
+        container: Any, env: dict[str, str], logging_dir: Path | None, *, tag: str
+    ) -> None:
+        """Copy the solve and pip logs out. Best effort — never fail a paid run over logging."""
+        if logging_dir is None:
+            return
+        try:
+            dump = (
+                "echo '--- SOLVE ---'; tail -c 20000 /chimera/solve.log 2>/dev/null; "
+                "echo; echo '--- PIP ---'; tail -c 4000 /chimera/pip.log 2>/dev/null; "
+                "echo; echo '--- RECEIPT ---'; "
+                "tail -c 4000 /chimera/home/runs.jsonl 2>/dev/null"
+            )
+            _rc, out = container.exec_run(["bash", "-lc", dump], environment=env)
+            ld = Path(str(logging_dir))
+            ld.mkdir(parents=True, exist_ok=True)
+            data = out if isinstance(out, bytes) else str(out).encode("utf-8", "replace")
+            (ld / f"chimera_{tag}.log").write_bytes(data)
+        except Exception:
+            pass

--- a/bench/terminal_bench/RESULTS.md
+++ b/bench/terminal_bench/RESULTS.md
@@ -1,5 +1,64 @@
 # Terminal-Bench A/B — Chimera scaffold vs raw model (same model)
 
+> ## ⚠️ Re-measured 2026-09-07 — the published −5.0% below does not replicate
+>
+> The run below (2026-07-08) was measured with two things missing from the adapter, found on
+> 2026-09-07 while running LoopsBench with the same adapter pattern (`bench/loopsbench/RESULTS.md`):
+>
+> 1. **`CHIMERA_HOST_EXEC` was unset** (default `ask`). Terminal-Bench images have no bubblewrap and a
+>    container has no TTY, so on any task where that path fired Chimera refused to run the agent's
+>    commands, warned once, and continued to a failure that reads as incapability. On LoopsBench the
+>    same omission cost **10 of 21 rounds** their shell. Whether it fired here cannot be recovered —
+>    the July logs did not survive — so the July numbers carry that as an unknown.
+> 2. **`--keep-workspace` was not passed.** Chimera's verify-or-revert rolled the tree back on a failed
+>    attempt, and Terminal-Bench then graded work the loop had just undone. Proved by paired test —
+>    same task, same model, failure forced with `--verify false`: without the flag the file is gone,
+>    with it the file is there.
+>
+> **Same 40 tasks, same model, same arms, same single attempt, both flags on:**
+>
+> | | baseline | chimera | paired Δ | 95% CI | discordant |
+> |---|---|---|---|---|---|
+> | **published 2026-07-08** | 7.5% (3/40) | 2.5% (1/40) | **−5.0%** | [−5.0%, +1.6%] | chimera +0 / baseline +2 |
+> | **re-run 2026-09-07** | 10.0% (4/40) | 10.0% (4/40) | **+0.0%** | [−7.0%, +7.0%] | chimera +2 / baseline +2 |
+>
+> Both pass: `fix-permissions`, `hello-world`. Only baseline: `get-bitcoin-nodes`,
+> `organization-json-generator`. Only chimera: `fix-git`, `path-tracing`. Not significant either way.
+>
+> **What this says.** The July direction — *the scaffold scores lower than the bare agent* — **does not
+> replicate** once the loop is allowed to execute commands and keep its work: the chimera arm went
+> 1 → 4 and the discordant pairs split 2–2. **It does not say the scaffold helps.** Δ = 0 with a
+> ±7-point interval, one seed, n=40, is inside the noise floor this project has since measured
+> (`bench/loopsbench`: 25% of task outcomes flip between identical runs) and inside what six
+> independent papers now report for single-run agent benchmarks. **Neither the old −5% nor the new 0
+> is a measurement of the scaffold; the old one was additionally a measurement of the adapter.**
+> The −5% should not be cited again as evidence the scaffold hurts.
+>
+> **Apparatus, triaged before the number** (the LoopsBench lesson): `refusing to run the agent` **0/78**
+> logs, key errors **0/78** — both fixes reached the container. Two rows are apparatus, named and
+> excluded from the honest denominator (n=38, Δ still 0): `fix-pandas-version` failed to *install* in
+> **both** arms (the image ships **Python 3.8.20**; `chimera-agent` needs ≥3.11 and this adapter had no
+> interpreter fallback — added after the run, not re-run), and `download-youtube` was `parse_error` /
+> ungraded in the baseline arm only. `trabalho revertido` appears in 14 and 20 logs; it is **not** a
+> signal — both arms log it and `--keep-workspace` restores afterwards (measured on 2026-09-07).
+>
+> **Cost is not recoverable per task**: this adapter copies the solve log and pip log out of the
+> container but not Chimera's `runs.jsonl`; **0 of 78** logs carry a price. The LoopsBench adapter
+> does copy it. Named as a gap, not estimated.
+>
+> **One failure read with eyes** — `get-bitcoin-nodes`, chimera arm, `failed after 1 attempt(s)`: the
+> model ended with *"1. Ensure Bitcoin Core is running with RPC enabled … 3. Run: `python
+> bitcoin_service.py`"* — a description of the steps instead of the steps. A genuine miss, of exactly
+> the shape the `insist_on_action` clause exists for, and the grader agreed.
+>
+> **What the re-run cannot show:** anything at one seed. The next honest version of this table has
+> k≥3 runs per arm, `pass^k`, per-task flip rate, and an ICC — the protocol in
+> `bench/PLAN-study16-eight-axes.md` §0 — and until then this row is a replication check of a
+> retracted direction, not a result.
+>
+> Raw results: `~/tbench/runs_ab2/{baseline,chimera}/` on the WSL box; per-task table reproduced by
+> `chimera.eval.paired.compare_paired` with a=2, b=2, c=2, d=34.
+
 **Honest-benchmark discipline:** the prediction below is registered BEFORE the run. The result is
 published regardless of outcome (win, loss, or null). No re-running to chase significance.
 

--- a/bench/terminal_bench/chimera_installed_agent.py
+++ b/bench/terminal_bench/chimera_installed_agent.py
@@ -101,10 +101,25 @@ fi
 if $PY -m pip install $BSP --quiet chimera-agent >>$L 2>&1; then
   echo CHIMERA_INSTALL_OK_NET
 else
-  echo "--- net install failed; falling back to offline wheelhouse ---" >>$L
-  tar xf /installed-agent/wheelhouse.tar -C /chimera/wh 2>>$L \\
-    && $PY -m pip install $BSP --no-index --find-links=/chimera/wh chimera-agent >>$L 2>&1 \\
-    && echo CHIMERA_INSTALL_OK_WH || { echo CHIMERA_INSTALL_FAILED; exit 1; }
+  # ADDED 2026-09-07, after the re-run: `fix-pandas-version` ships Python 3.8.20, chimera-agent needs
+  # >=3.11, so the net install correctly finds no wheel — and the only fallback was a wheelhouse that
+  # (a) is pinned to one ABI and (b) was not staged on this box. Both arms lost the task to
+  # `agent_installation_failed`. The LoopsBench adapter already solves this: bring our own interpreter
+  # with uv from PyPI (astral.sh answers urllib with 403 and these images have no curl), make a venv,
+  # install into it. Tried BEFORE the wheelhouse, which stays as the last, offline-only resort.
+  echo "--- net install failed; trying a private interpreter via uv ---" >>$L
+  if $PY -m pip install $BSP --quiet uv >>$L 2>&1 \\
+     && UV=$($PY -c 'import uv;print(uv.find_uv_bin())' 2>>$L) \\
+     && "$UV" venv --python 3.12 /chimera/venv >>$L 2>&1 \\
+     && "$UV" pip install --python /chimera/venv/bin/python --quiet chimera-agent >>$L 2>&1; then
+    ln -sf /chimera/venv/bin/chimera /usr/local/bin/chimera 2>>$L || true
+    echo CHIMERA_INSTALL_OK_UV
+  else
+    echo "--- uv path failed; falling back to offline wheelhouse ---" >>$L
+    tar xf /installed-agent/wheelhouse.tar -C /chimera/wh 2>>$L \\
+      && $PY -m pip install $BSP --no-index --find-links=/chimera/wh chimera-agent >>$L 2>&1 \\
+      && echo CHIMERA_INSTALL_OK_WH || { echo CHIMERA_INSTALL_FAILED; exit 1; }
+  fi
 fi
 """
 
@@ -125,6 +140,17 @@ class ChimeraInstalledAgent(AbstractInstalledAgent):
         return {
             "OPENROUTER_API_KEY": os.environ.get("OPENROUTER_API_KEY", ""),
             "CHIMERA_DEFAULT_MODEL": str(self._model_name),
+            # ADDED 2026-09-07, and the published 7.5% / 2.5% in RESULTS.md was measured WITHOUT it.
+            # `host_exec` defaults to "ask"; TB task images have no bubblewrap, so there is no OS
+            # sandbox, and a container has no TTY to answer with — so Chimera refuses to run the
+            # agent's commands, warns once, and the run continues to a failure that reads as
+            # incapability. Measured on LoopsBench, where the same omission cost 10 of 21 rounds
+            # their shell: `bench/loopsbench/RESULTS.md`. On a benchmark of terminal tasks, an agent
+            # that cannot execute a command is not being measured at all.
+            #
+            # `allow` is correct here and nowhere else: the container IS the sandbox and is destroyed
+            # after grading.
+            "CHIMERA_HOST_EXEC": "allow",
         }
 
     @property
@@ -147,9 +173,25 @@ class ChimeraInstalledAgent(AbstractInstalledAgent):
         container = session.container  # type: ignore[attr-defined]
         env = self._env
 
-        session.copy_to_container(  # type: ignore[attr-defined]
-            Path(_TAR), container_dir="/installed-agent", container_filename="wheelhouse.tar"
-        )
+        # The wheelhouse is the OFFLINE FALLBACK, not the install path: `_INSTALL` tries PyPI first
+        # precisely because a prebuilt wheelhouse is pinned to one Python ABI. So a missing or
+        # unreadable tarball must not be fatal — and it was, which turned an unrelated permission
+        # problem into `agent_installation_failed` on every task. Found by validating one task before
+        # the re-run rather than after it: the default path is `/root/tbench/wheelhouse.tar`, and this
+        # re-run is not executing as root.
+        try:
+            session.copy_to_container(  # type: ignore[attr-defined]
+                Path(_TAR), container_dir="/installed-agent", container_filename="wheelhouse.tar"
+            )
+        except Exception as exc:  # noqa: BLE001 — any copy failure means "no offline fallback"
+            _log_note = f"wheelhouse not staged ({exc}); network install must carry this run"
+            if logging_dir is not None:
+                try:
+                    ld = Path(str(logging_dir))
+                    ld.mkdir(parents=True, exist_ok=True)
+                    (ld / "chimera_wheelhouse.log").write_text(_log_note, encoding="utf-8")
+                except Exception:
+                    pass
         install_rc, _ = container.exec_run(["bash", "-lc", _INSTALL], environment=env)
         if install_rc != 0:
             from terminal_bench.agents.failure_mode import FailureMode
@@ -175,9 +217,20 @@ class ChimeraInstalledAgent(AbstractInstalledAgent):
         # — the Terminal-Bench client container's working directory is /app, and the task tests check
         # absolute paths under /app (e.g. hello-world asserts /app/hello.txt). exec_run defaults to the
         # image WORKDIR (often /), so without this the agent writes files where the grader never looks.
+        # ADDED 2026-09-07, and the published 7.5% / 2.5% was measured WITHOUT it. `--keep-workspace`
+        # is Chimera's own flag for exactly this, and its help says so: "On failure, leave the last
+        # attempt's edits on disk FOR AN EXTERNAL GRADER (don't revert)." Terminal-Bench IS the
+        # external grader. Without it, verify-or-revert rolls the tree back and TB then runs the
+        # task's tests against work the loop had just undone. Proved by paired test on LoopsBench —
+        # same task, same model, failure forced: without the flag the file is gone, with it the file
+        # is there (`bench/loopsbench/RESULTS.md`).
+        #
+        # Appended here rather than in `_FLAGS` so BOTH arms of the A/B get it: the arms differ by
+        # `CHIMERA_TB_FLAGS`, and a fix that lives in the default string would reach only one of them.
+        flags = _FLAGS if "--keep-workspace" in _FLAGS else f"{_FLAGS} --keep-workspace"
         solve = (
             f"cd /app 2>/dev/null; timeout {int(_SOLVE_TIMEOUT)} chimera solve {shlex.quote(instruction)} "
-            f"--workspace . --model {self._model_name} {_FLAGS} < /dev/null > /tmp/csolve.log 2>&1"
+            f"--workspace . --model {self._model_name} {flags} < /dev/null > /tmp/csolve.log 2>&1"
         )
         container.exec_run(["bash", "-lc", solve], environment=env)
 


### PR DESCRIPTION
Three things, all measurement, no change to the `chimera/` package.

## LoopsBench — the first third-party ruler with a middle

`bench/loopsbench/`: adapter (`--agent-import-path`, harness unmodified), pre-registration with five amendments, results. **Six runs to earn one number.** Five were discarded for apparatus defects — every one printed `Pass Rate: 0.0%`, indistinguishable from a loop that cannot do the work, and the harness announced none of them:

| run | discarded because |
|---|---|
| p1 | `--break-system-packages` on pip 22 — hard error, not a warning |
| p2 | `uv venv` refused the outer loop's second round: one round of work instead of three |
| p3 | **10 of 21 rounds had no shell** (`CHIMERA_HOST_EXEC=ask`, no bubblewrap, no TTY) and 9 of 21 had no model (key ceiling) |
| p4 | **20 of 23 rounds** reverted before grading — `--keep-workspace` exists for exactly this and was not passed |
| **p5** | — clean: 24/24 rounds with a model and a shell |

**p5: 1/8 = 12.5%**, 16/16 tests on the resolved task, US$25.49 all priced. **p6, the registered repeat: 1/8 again, a different task.** Zero overlap. 25% of outcomes flip between identical runs, so a paired A/B at n=8 could not have detected anything under ~30 points; crude sizing says 25–97 tasks per arm.

Not comparable to the published 25% (Opus-4.7 + Claude Code + all 112) — three things differ at once. What it says: the pair (this model, this loop) is *inside* this bench's usable range. Three self-authored suites never produced that.

## Terminal-Bench — the −5% does not replicate

Same 40 tasks, model, arms, single attempt, with the two flags the July adapter lacked:

| | baseline | chimera | Δ | discordant |
|---|---|---|---|---|
| published 2026-07-08 | 3/40 | 1/40 | **−5.0%** | 0 / 2 |
| re-run 2026-09-07 | 4/40 | 4/40 | **+0.0%** [−7.0, +7.0] | 2 / 2 |

Apparatus triaged before the number: 0/78 shell refusals, 0/78 key errors. Two rows named and excluded (`fix-pandas-version` — Python 3.8 image, install failed both arms; `download-youtube` — parse_error in baseline). The July direction was measured with the loop discarding its work; it should not be cited again. **Δ = 0 at one seed is not evidence the scaffold is neutral either** — the note at the top of `RESULTS.md` says both.

Adapter: `CHIMERA_HOST_EXEC=allow` (the container is the sandbox), `--keep-workspace` appended so both A/B arms get it, a tolerant wheelhouse copy, and a uv interpreter fallback proved on `python:3.8-slim` — the class that lost the task — not on the task image itself.

## The plan from the eight-axis sweep

`bench/PLAN-study16-eight-axes.md`. Every claim about Chimera checked by file and line today, because the sweep itself produced three apparatus errors (a grep that declared a gap where a prompt clause existed; two silent fetch truncations). Item 0 is a k-run reporting protocol — `pass^k`, mechanism-active, ICC, three seeds — and nothing below it is readable until it exists. Two free findings inside: the desktop's own receipts show **attempt 3 after a failed attempt 2 recovered 0 of 11**; and `bench/injection`'s "undefended" arm is *no ledger*, not *model alone*, so the offline 100% is purely the ledger and the guard-vs-model split has never been measured live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)