### PR TITLE
feat(eval): a single run is a sample — pass^k, flip rate, ICC(1), mechanism-active scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **A single run is a sample; `chimera.eval.replicated` makes it a measurement.** `ReplicatedArm`
+  takes `k` runs per task and reports `pass^k` (the fraction of tasks that pass *every* run — what a
+  user experiences), the per-task **flip rate** (the noise floor: how much a task moves with nothing
+  changed), **ICC(1)** (how much of the variance is a task property at all), and **mechanism-active**
+  scoring (score only the trials where the mechanism under test actually fired; zero such trials is
+  reported as *not measured*, never as 0%). `compare_replicated` pairs two arms on per-task `pass^k`
+  through the existing `compare_paired`, so twenty callers keep their numbers, and the report says
+  beside the CI whether |Δ| is **inside the arms' own noise floor** — the shape 2606.20695 found in
+  seven of ten published multi-agent architectures. The seeds rule is printed, not remembered: one
+  run is a sample, two alert, three decide. First measured example: the LoopsBench pilot run twice,
+  same configuration — `pass@1` 12.5% both times, `pass^2` **0.0%**, flip rate 25%, ICC **−0.08**.
+
 - **A run can be told to stop at a number.** `chimera solve --max-usd` caps what the whole run may
   spend, across every attempt. The ceiling itself was built, tested and shipped after a measured
   incident — a run asking for $0.000002 spent $0.0129 because each attempt started again at zero —

--- a/bench/PLAN-study16-eight-axes.md
+++ b/bench/PLAN-study16-eight-axes.md
@@ -18,11 +18,15 @@ report headline effects below their own noise floor.** Every item below is unrea
 **What exists.** `chimera/eval/paired.py` — `PairedResult`, `compare_paired`, `run_paired_experiment`,
 `format_report`. Paired McNemar/Wilson over one run per arm.
 
-**What changes.**
-- Extend `PairedResult` to take **k runs per task per arm** and report: `pass^k`, per-task flip rate,
-  ICC across runs, and — the published fix from 2606.20695 — **mechanism-active pass^k**: score only
-  the trials where the mechanism under test was *logically active* (§2r, "reportar quanto ela agiu",
-  as a protocol).
+**What changes.** *(Shipped 2026-09-08 as `chimera/eval/replicated.py` — see PR #376. Written here
+first as "extend `PairedResult`"; built instead as a sibling module, because `PairedResult` is
+constructed positionally by twenty bench scripts and four eval modules and every one of them keeps
+its numbers only if the class does not move.)*
+- `ReplicatedArm` takes **k runs per task per arm** and reports: `pass^k`, per-task flip rate,
+  ICC(1) across runs, and — the published fix from 2606.20695 — **mechanism-active pass^k**: score
+  only the trials where the mechanism under test was *logically active* (§2r, "reportar quanto ela
+  agiu", as a protocol). Zero active trials is `None` and prints `NOT MEASURED`, never 0%.
+  `compare_replicated` pairs two arms on per-task `pass^k` through the **untouched** `compare_paired`.
 - A standing rule in every `PREREGISTRATION.md`: **three seeds decide; two alert; one is a sample.**
   A +18pp p=0.012 result vanished at the second seed in 2606.20695; our own +6%/−4% is the same shape.
 - One caveat 2608.22331 adds that nobody else measured: **prompt-perturbation noise is 11×–58×

--- a/bench/loopsbench/RESULTS.md
+++ b/bench/loopsbench/RESULTS.md
@@ -173,6 +173,30 @@ earliest in both were the same three. The floor is consistent; the ceiling is a 
 pattern says the discriminating middle on this subset is roughly **two tasks wide**, which is the
 real reason n=8 has no power — not the rate, the width of the band.
 
+## The same two runs, read with the replicated protocol
+
+Item 0 of `bench/PLAN-study16-eight-axes.md` now exists: `chimera.eval.replicated` — `pass^k`,
+per-task flip rate, ICC(1), mechanism-active scoring, and the seeds rule said in the report. This
+is p5 + p6 read through it, from the two `results.json` files, not from a hand-typed table:
+
+```
+arm            pass@1   pass^2   flip   ICC(1)   mechanism-active
+chimera        12.5%    0.0%    25%   -0.08    not marked
+```
+
+Three things the single-run table above could not say:
+
+- **`pass^2` is 0.0%.** No task passed both times. `12.5%` is the mean over trials — the number a
+  single run pretends to be — and it is not what a user would experience.
+- **ICC(1) is negative (−0.08).** Within-task spread exceeds between-task spread: *which task
+  passes is not a property of the task.* Any per-task comparison built on this grid — including the
+  A/B this pilot was meant to size — has no signal to read, and the number says so directly instead
+  of leaving it to a paragraph.
+- **k=2 is an alert, not a verdict.** The report prints that line itself. Three runs decide.
+
+The protocol is the ruler every later bench in the plan is read against; this is its first
+measured example, and it is the pilot's own.
+
 ## What is worth doing next, in order
 
 1. **Re-read `bench/terminal_bench` in light of `--keep-workspace`.** Its 7.5% / 2.5% was measured

--- a/chimera/eval/__init__.py
+++ b/chimera/eval/__init__.py
@@ -94,6 +94,15 @@ if TYPE_CHECKING:
 # Exported name -> (submodule, attribute in that submodule). The attribute differs from the exported
 # name only where the original re-export renamed it (`compare as compare_ab`, etc.).
 _LAZY: dict[str, tuple[str, str]] = {
+    # The replicated-run protocol: pass^k, flip rate, ICC(1), mechanism-active scoring, and the
+    # seeds rule said in the report. Exported for the same reason as the two rulers below — a
+    # protocol that lives only in a bench directory is advice, not a tool.
+    "ReplicatedArm": ("replicated", "ReplicatedArm"),
+    "ReplicatedResult": ("replicated", "ReplicatedResult"),
+    "compare_replicated": ("replicated", "compare_replicated"),
+    "format_replicated_report": ("replicated", "format_replicated_report"),
+    "icc1": ("replicated", "icc1"),
+    "seeds_verdict": ("replicated", "seeds_verdict"),
     # The two rulers this package tells you to use, and did not export.
     #
     # `rag/__init__.py` points at `run_rag_bench` to say the retriever's existence is not a claim
@@ -197,6 +206,12 @@ def __dir__() -> list[str]:
 
 
 __all__ = [
+    "ReplicatedArm",
+    "ReplicatedResult",
+    "compare_replicated",
+    "format_replicated_report",
+    "icc1",
+    "seeds_verdict",
     "EvalTask",
     "EvolutionReport",
     "TaskOutcome",

--- a/chimera/eval/replicated.py
+++ b/chimera/eval/replicated.py
@@ -1,0 +1,292 @@
+"""Replicated runs — the reporting protocol that makes a single agent number into a measurement.
+
+A single run of an agent benchmark is a sample, not a measurement. Measured here: on LoopsBench the
+identical configuration run twice resolved **one task each time and a different task each time** —
+25% of outcomes flipped with nothing changed (`bench/loopsbench/RESULTS.md`). Measured elsewhere:
+identical agent + identical input gives 2.3–4.2 distinct action sequences per 10 runs
+(arXiv 2602.11619); configuration-equivalent protocols differ by [−3, +18] pp across two seeds and a
++18 pp p=0.012 result vanished at the second seed (2606.20695); 23 identical reruns of one tool
+benchmark spread 57.9–76.8% (2607.02577). Seven of ten recent multi-agent architectures report
+headline effects below their own noise floor (2606.20695). Ours included, until this module.
+
+Three things a replicated report carries that a single run cannot:
+
+1. **``pass^k``** (2601.06112, 2608.14711): the fraction of tasks that pass in *every* one of ``k``
+   runs. Strict on purpose — it is the number a user experiences, and it falls as ``k`` grows for
+   any task whose outcome is a coin flip.
+2. **The flip rate and ICC(1)** (2512.06710): how much of the variance is *between tasks* (a task
+   property) versus *within a task across runs* (noise). A negative or near-zero ICC says which task
+   passes is not a property of the task, and then no per-task comparison can be read.
+3. **Mechanism-active scoring** (2606.20695): score only the trials where the mechanism under test
+   was *logically active*. A retry policy measured on runs that never retried is measuring nothing
+   — §2r of the project's lessons file, "a intervenção reporta quanto ela agiu", as a protocol.
+
+The paired statistic itself is unchanged: :func:`chimera.eval.paired.compare_paired` stays the
+ruler, applied to per-task ``pass^k`` outcomes, so twenty existing callers keep their numbers and
+their meaning. What this module adds is the denominator those numbers were missing.
+
+The seeds rule, encoded rather than remembered: **one run is a sample, two alert, three decide**
+(§2x). ``seeds_verdict`` says which one a report is, in the report.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from chimera.eval.paired import PairedResult, compare_paired
+
+__all__ = [
+    "ReplicatedArm",
+    "ReplicatedResult",
+    "compare_replicated",
+    "format_replicated_report",
+    "icc1",
+    "seeds_verdict",
+]
+
+
+def seeds_verdict(k: int) -> str:
+    """One run is a sample, two alert, three decide. Said in the report, not in a memory file."""
+    if k <= 1:
+        return "a sample — one run cannot separate an effect from a reseed"
+    if k == 2:
+        return "an alert — two runs produce a difference, not a variance estimate"
+    return "decides — three or more runs bound the noise the comparison is read against"
+
+
+def icc1(runs: Sequence[Sequence[bool]]) -> tuple[float | None, str]:
+    """ICC(1) of a task × run grid of pass/fail, or ``None`` with the reason it cannot be computed.
+
+    One-way random effects: how much of the total variance is between tasks. With binary outcomes
+    it is the standard approximation (2512.06710 reports 0.30–0.77 on agentic suites and treats an
+    improvement as trustworthy only if ICC improves with it). It can be slightly negative when the
+    within-task spread exceeds the between-task spread — that is a real reading ("which task passes
+    is not a property of the task"), not an error, so it is returned as computed.
+
+    ``None`` is returned, never ``0.0``, when the grid cannot support the statistic: fewer than two
+    tasks or two runs (nothing to partition), or no variance anywhere (every trial identical).
+    """
+    n = len(runs)
+    if n < 2:
+        return None, "needs at least two tasks"
+    k = len(runs[0])
+    if k < 2:
+        return None, "needs at least two runs per task"
+    total = n * k
+    grand = sum(1 for row in runs for v in row if v) / total
+    means = [sum(1 for v in row if v) / k for row in runs]
+    msb = k * sum((m - grand) ** 2 for m in means) / (n - 1)
+    msw = sum(((1.0 if v else 0.0) - m) ** 2 for row, m in zip(runs, means, strict=True) for v in row)
+    msw /= n * (k - 1)
+    denom = msb + (k - 1) * msw
+    if denom == 0:
+        return None, "no variance at all — every trial identical"
+    return (msb - msw) / denom, ""
+
+
+@dataclass
+class ReplicatedArm:
+    """One arm run ``k`` times per task: ``runs[task][run]`` is pass/fail.
+
+    ``active``, same shape, marks the trials where the mechanism this arm exists to test actually
+    acted — the retry fired, the compaction ran, the delegation happened. Scores over the active
+    subset are what 2606.20695 calls mechanism-active, and a trial count of zero there is reported
+    as *not measured*, never as 0%.
+    """
+
+    name: str
+    runs: list[list[bool]]
+    active: list[list[bool]] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.runs:
+            raise ValueError(f"arm {self.name!r} has no tasks")
+        k = len(self.runs[0])
+        if k == 0:
+            raise ValueError(f"arm {self.name!r} has tasks with zero runs")
+        if any(len(row) != k for row in self.runs):
+            raise ValueError(
+                f"arm {self.name!r} is not rectangular — every task must have the same k, "
+                "or pass^k means different things on different rows"
+            )
+        if self.active is not None and (
+            len(self.active) != len(self.runs) or any(len(a) != k for a in self.active)
+        ):
+            raise ValueError(
+                f"arm {self.name!r}: `active` must have the same task × run shape as `runs`"
+            )
+
+    @property
+    def n(self) -> int:
+        return len(self.runs)
+
+    @property
+    def k(self) -> int:
+        return len(self.runs[0])
+
+    @property
+    def per_task_rate(self) -> list[float]:
+        return [sum(1 for v in row if v) / self.k for row in self.runs]
+
+    @property
+    def pass_at_1(self) -> float:
+        """Mean pass rate over every trial — the number a single run pretends to be."""
+        return sum(1 for row in self.runs for v in row if v) / (self.n * self.k)
+
+    @property
+    def pass_pow_k(self) -> float:
+        """Fraction of tasks that passed in EVERY run. Strict: it is what a user experiences."""
+        return sum(1 for row in self.runs if all(row)) / self.n
+
+    @property
+    def per_task_pow_k(self) -> list[bool]:
+        return [all(row) for row in self.runs]
+
+    @property
+    def flip_rate(self) -> float:
+        """Fraction of tasks whose outcome differed between runs of the SAME arm — the noise floor."""
+        return sum(1 for row in self.runs if any(row) and not all(row)) / self.n
+
+    @property
+    def icc(self) -> float | None:
+        return icc1(self.runs)[0]
+
+    @property
+    def icc_reason(self) -> str:
+        return icc1(self.runs)[1]
+
+    @property
+    def active_trials(self) -> int | None:
+        if self.active is None:
+            return None
+        return sum(1 for row in self.active for v in row if v)
+
+    @property
+    def active_pass_rate(self) -> float | None:
+        """Pass rate over the trials where the mechanism acted; ``None`` when nothing was marked.
+
+        ``None`` for an absent mask AND for a mask with zero active trials: a mechanism that never
+        fired has not been measured, and 0% would say it fired and lost every time.
+        """
+        if self.active is None:
+            return None
+        hits = total = 0
+        for row, act in zip(self.runs, self.active, strict=True):
+            for v, a in zip(row, act, strict=True):
+                if a:
+                    total += 1
+                    hits += 1 if v else 0
+        return hits / total if total else None
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "n": self.n,
+            "k": self.k,
+            "pass_at_1": round(self.pass_at_1, 4),
+            "pass_pow_k": round(self.pass_pow_k, 4),
+            "flip_rate": round(self.flip_rate, 4),
+            "icc": None if self.icc is None else round(self.icc, 4),
+            "icc_reason": self.icc_reason,
+            "active_trials": self.active_trials,
+            "active_pass_rate": (
+                None if self.active_pass_rate is None else round(self.active_pass_rate, 4)
+            ),
+        }
+
+
+@dataclass
+class ReplicatedResult:
+    """Two replicated arms compared paired on per-task ``pass^k``, with the noise floor beside it."""
+
+    baseline: ReplicatedArm
+    treatment: ReplicatedArm
+    paired: PairedResult = field(init=False)
+
+    def __post_init__(self) -> None:
+        if self.baseline.n != self.treatment.n:
+            raise ValueError(
+                f"arms must cover the same tasks (got {self.baseline.n} vs {self.treatment.n})"
+            )
+        self.paired = compare_paired(
+            self.baseline.per_task_pow_k,
+            self.treatment.per_task_pow_k,
+            baseline_name=self.baseline.name,
+            treatment_name=self.treatment.name,
+        )
+
+    @property
+    def k(self) -> int:
+        return min(self.baseline.k, self.treatment.k)
+
+    @property
+    def noise_floor(self) -> float:
+        """The larger flip rate of the two arms: how much a task moves with nothing changed."""
+        return max(self.baseline.flip_rate, self.treatment.flip_rate)
+
+    @property
+    def inside_noise_floor(self) -> bool:
+        """True when the paired delta is no larger than the arms' own run-to-run movement.
+
+        Reported BESIDE ``paired.significant``, never instead of it. A CI that excludes zero on a
+        delta smaller than the floor is what 2606.20695 found in seven of ten published systems.
+        """
+        return abs(self.paired.delta) <= self.noise_floor
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "k": self.k,
+            "seeds": seeds_verdict(self.k),
+            "baseline": self.baseline.summary(),
+            "treatment": self.treatment.summary(),
+            "paired_pow_k": self.paired.summary(),
+            "noise_floor": round(self.noise_floor, 4),
+            "inside_noise_floor": self.inside_noise_floor,
+        }
+
+
+def compare_replicated(baseline: ReplicatedArm, treatment: ReplicatedArm) -> ReplicatedResult:
+    """Compare two replicated arms. Task ``i`` must be the same task in both."""
+    return ReplicatedResult(baseline, treatment)
+
+
+def _fmt_icc(arm: ReplicatedArm) -> str:
+    if arm.icc is None:
+        return f"n/a ({arm.icc_reason})"
+    return f"{arm.icc:+.2f}"
+
+
+def _fmt_active(arm: ReplicatedArm) -> str:
+    if arm.active is None:
+        return "not marked"
+    if arm.active_trials == 0:
+        return "0 trials — NOT MEASURED (the mechanism never fired)"
+    assert arm.active_pass_rate is not None
+    return f"{arm.active_pass_rate:.1%} over {arm.active_trials} active trials"
+
+
+def format_replicated_report(result: ReplicatedResult) -> str:
+    """A compact rendering that puts the denominator next to every rate."""
+    b, t, p = result.baseline, result.treatment, result.paired
+    lo, hi = p.diff_ci
+    verdict = "significant (CI excludes 0)" if p.significant else "not significant (CI includes 0)"
+    floor = (
+        "INSIDE the noise floor — a task moves this much with nothing changed"
+        if result.inside_noise_floor
+        else "outside the noise floor"
+    )
+    width = max(len(b.name), len(t.name), 8)
+    lines = [
+        f"{'arm':<{width}}  pass@1   pass^{result.k}   flip   ICC(1)   mechanism-active",
+        f"{b.name:<{width}}  {b.pass_at_1:>5.1%}   {b.pass_pow_k:>5.1%}   {b.flip_rate:>4.0%}   "
+        f"{_fmt_icc(b):<7}  {_fmt_active(b)}",
+        f"{t.name:<{width}}  {t.pass_at_1:>5.1%}   {t.pass_pow_k:>5.1%}   {t.flip_rate:>4.0%}   "
+        f"{_fmt_icc(t):<7}  {_fmt_active(t)}",
+        "",
+        f"paired on pass^{result.k}   Δ {p.delta:+.1%}  95% CI [{lo:+.1%}, {hi:+.1%}]  "
+        f"discordant {t.name} +{p.treatment_only} / {b.name} +{p.baseline_only}",
+        f"verdict             {verdict}; |Δ| {abs(p.delta):.1%} vs floor {result.noise_floor:.1%}: {floor}",
+        f"runs per task       k={result.k}: {seeds_verdict(result.k)}",
+    ]
+    return "\n".join(lines)

--- a/tests/test_a_single_run_is_a_sample_not_a_measurement.py
+++ b/tests/test_a_single_run_is_a_sample_not_a_measurement.py
@@ -1,0 +1,193 @@
+"""A single run of an agent benchmark is a sample. This is the ruler that makes it a measurement.
+
+Anchored on real data: `bench/loopsbench` p5 and p6, the identical configuration run twice on the
+same eight tasks. Each resolved exactly one task, and a different one. That grid is reproduced here
+as a fixture so the numbers this module reports for it are pinned — pass@1 12.5%, pass^2 0%, flip
+rate 25%, ICC(1) negative — and cannot drift quietly.
+
+Every guard below was reverted on disk and its test confirmed red.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chimera.eval.replicated import (
+    ReplicatedArm,
+    compare_replicated,
+    format_replicated_report,
+    icc1,
+    seeds_verdict,
+)
+
+# The eight LoopsBench pilot tasks, alphabetical, as p5 and p6 graded them. Only two rows differ
+# between the runs, and they are different rows: that is the whole finding.
+P5_P6 = [
+    [False, False],  # task_compiler_fdmj_llvm
+    [False, False],  # task_cs61b_extra_java_bundle
+    [False, False],  # task_db_storage_index_labs
+    [False, False],  # task_dbcompiler
+    [True, False],  # task_ml_four_assignments  — resolved in p5 (16/16 tests), failed in p6
+    [False, False],  # task_os_c_fs_labs
+    [False, True],  # task_sql_engine_myjql     — ungraded in p5, resolved in p6
+    [False, False],  # task_xjqkl
+]
+
+
+# --- the real anchor --------------------------------------------------------------------------
+
+
+def test_the_loopsbench_repeat_pinned() -> None:
+    """Same rate twice, zero overlap: pass@1 holds at 12.5% while pass^2 is 0 and ICC is negative."""
+    arm = ReplicatedArm("chimera", P5_P6)
+    assert arm.n == 8 and arm.k == 2
+    assert arm.pass_at_1 == pytest.approx(0.125)
+    assert arm.pass_pow_k == 0.0
+    assert arm.flip_rate == pytest.approx(0.25)
+    icc = arm.icc
+    assert icc is not None
+    # Within-task spread exceeds between-task spread: which task passes is not a task property.
+    assert icc < 0.0
+    assert icc == pytest.approx(-0.0769, abs=1e-3)
+
+
+def test_a_single_run_reads_the_same_rate_and_hides_all_of_it() -> None:
+    """The number p5 alone reported is the pass@1 of the pair; nothing else survives k=1."""
+    one = ReplicatedArm("p5-only", [[row[0]] for row in P5_P6])
+    assert one.pass_at_1 == pytest.approx(0.125)
+    assert one.pass_pow_k == pytest.approx(0.125)  # with k=1 pass^k IS pass@1 — the illusion
+    assert one.flip_rate == 0.0  # a single run cannot flip, so it reports no noise at all
+    assert one.icc is None and "two runs" in one.icc_reason
+
+
+# --- pass^k is strict --------------------------------------------------------------------------
+
+
+def test_pass_pow_k_requires_every_run_to_pass() -> None:
+    arm = ReplicatedArm("a", [[True, True, True], [True, True, False], [False, False, False]])
+    assert arm.pass_pow_k == pytest.approx(1 / 3)
+    assert arm.pass_at_1 == pytest.approx(5 / 9)
+
+
+def test_flip_rate_counts_only_mixed_rows() -> None:
+    arm = ReplicatedArm("a", [[True, True], [False, False], [True, False], [False, True]])
+    assert arm.flip_rate == 0.5
+
+
+# --- ICC(1) --------------------------------------------------------------------------------------
+
+
+def test_icc_is_one_when_tasks_are_perfectly_consistent() -> None:
+    """All variance between tasks, none within: a task's outcome is a task property."""
+    val, reason = icc1([[True, True, True], [False, False, False], [True, True, True]])
+    assert reason == "" and val == pytest.approx(1.0)
+
+
+def test_icc_is_none_not_zero_when_it_cannot_be_computed() -> None:
+    assert icc1([[True, False]]) == (None, "needs at least two tasks")
+    assert icc1([[True], [False]]) == (None, "needs at least two runs per task")
+    val, reason = icc1([[True, True], [True, True]])
+    assert val is None and "no variance" in reason
+
+
+# --- mechanism-active scoring --------------------------------------------------------------------
+
+
+def test_active_scoring_uses_only_the_trials_where_the_mechanism_fired() -> None:
+    runs = [[True, False], [False, False], [True, True]]
+    active = [[True, False], [False, False], [True, False]]  # fired on 2 trials, both passed
+    arm = ReplicatedArm("retry", runs, active=active)
+    assert arm.active_trials == 2
+    assert arm.active_pass_rate == 1.0
+    assert arm.pass_at_1 == pytest.approx(3 / 6)  # the pooled rate says something else entirely
+
+
+def test_a_mechanism_that_never_fired_is_not_measured_not_zero() -> None:
+    """Zero active trials must not read as 0% — that would say it fired and lost every time."""
+    arm = ReplicatedArm("retry", [[True, False], [False, True]], active=[[False, False]] * 2)
+    assert arm.active_trials == 0
+    assert arm.active_pass_rate is None
+    assert "NOT MEASURED" in format_replicated_report(
+        compare_replicated(ReplicatedArm("base", [[True, False], [False, True]]), arm)
+    )
+
+
+def test_an_unmarked_arm_reports_no_active_rate_rather_than_pooling() -> None:
+    arm = ReplicatedArm("a", [[True, False]])
+    assert arm.active_trials is None and arm.active_pass_rate is None
+
+
+# --- shape guards --------------------------------------------------------------------------------
+
+
+def test_a_ragged_grid_is_refused() -> None:
+    with pytest.raises(ValueError, match="rectangular"):
+        ReplicatedArm("a", [[True, True], [True]])
+
+
+def test_an_active_mask_of_the_wrong_shape_is_refused() -> None:
+    with pytest.raises(ValueError, match="same task"):
+        ReplicatedArm("a", [[True, True]], active=[[True]])
+
+
+def test_arms_over_different_task_counts_are_refused() -> None:
+    with pytest.raises(ValueError, match="same tasks"):
+        compare_replicated(ReplicatedArm("b", [[True]]), ReplicatedArm("t", [[True], [False]]))
+
+
+# --- the paired comparison rides on the existing ruler -------------------------------------------
+
+
+def test_the_comparison_is_paired_on_per_task_pass_pow_k() -> None:
+    base = ReplicatedArm("base", [[True, True], [False, False], [True, False], [False, False]])
+    treat = ReplicatedArm("treat", [[True, True], [True, True], [False, False], [False, False]])
+    r = compare_replicated(base, treat)
+    # per-task pass^2: base [T,F,F,F], treat [T,T,F,F] -> one treatment-only win, no baseline-only
+    assert r.paired.both_pass == 1
+    assert r.paired.treatment_only == 1 and r.paired.baseline_only == 0
+    assert r.paired.delta == pytest.approx(0.25)
+
+
+def test_a_delta_no_larger_than_the_flip_rate_is_flagged_inside_the_floor() -> None:
+    """The 2606.20695 finding as a guard: seven of ten published effects sat below their own floor."""
+    base = ReplicatedArm("base", [[True, False], [False, False], [False, False], [False, False]])
+    treat = ReplicatedArm("treat", [[True, True], [False, False], [False, False], [False, False]])
+    r = compare_replicated(base, treat)
+    assert r.paired.delta == pytest.approx(0.25)  # treatment "wins" one task on pass^2
+    assert r.noise_floor == pytest.approx(0.25)  # and the baseline flipped that same fraction alone
+    assert r.inside_noise_floor is True
+    assert "INSIDE the noise floor" in format_replicated_report(r)
+
+
+def test_a_delta_clearing_the_floor_is_not_flagged() -> None:
+    base = ReplicatedArm("base", [[False, False]] * 4)
+    treat = ReplicatedArm("treat", [[True, True]] * 3 + [[False, False]])
+    r = compare_replicated(base, treat)
+    assert r.noise_floor == 0.0 and r.inside_noise_floor is False
+    assert "outside the noise floor" in format_replicated_report(r)
+
+
+# --- the seeds rule is in the report, not in a memory file --------------------------------------
+
+
+def test_the_seeds_rule_is_said_out_loud() -> None:
+    assert "sample" in seeds_verdict(1)
+    assert "alert" in seeds_verdict(2)
+    assert "decides" in seeds_verdict(3) and "decides" in seeds_verdict(10)
+
+
+def test_the_report_carries_every_denominator() -> None:
+    r = compare_replicated(ReplicatedArm("base", P5_P6), ReplicatedArm("chimera", P5_P6))
+    text = format_replicated_report(r)
+    assert "pass^2" in text and "12.5%" in text and "0.0%" in text
+    assert "flip" in text and "25%" in text
+    assert "ICC(1)" in text and "-0.08" in text
+    assert "k=2" in text and "alert" in text
+
+
+def test_summary_round_trips_the_numbers_and_keeps_none_as_none() -> None:
+    arm = ReplicatedArm("a", [[True, False]], active=[[False, False]])
+    s = arm.summary()
+    assert s["icc"] is None and s["active_trials"] == 0 and s["active_pass_rate"] is None
+    r = compare_replicated(ReplicatedArm("b", [[True, False]]), arm).summary()
+    assert r["k"] == 2 and "alert" in str(r["seeds"])


### PR DESCRIPTION
Item 0 of `bench/PLAN-study16-eight-axes.md`: the reporting protocol that every later bench is read through. Nothing below it in the plan is readable until this exists, so it ships first and alone.

## Why

A single run of an agent benchmark is a sample, not a measurement. Measured here: the LoopsBench pilot run twice with nothing changed resolved one task each time and **a different task each time** — 25% of outcomes flipped. Measured by others: identical agent + identical input gives 2.3–4.2 distinct action sequences per 10 runs (2602.11619); configuration-equivalent protocols differ by [−3, +18] pp across two seeds, and a +18 pp p=0.012 result vanished at seed two (2606.20695); 23 identical reruns of one tool benchmark spread 57.9–76.8% (2607.02577); prompt-perturbation noise is 11–58× rerun noise at temperature 0 (2608.22331). **Seven of ten recent multi-agent architectures report headline effects below their own noise floor** (2606.20695). Ours included, until this.

## What

`chimera/eval/replicated.py`, exported from `chimera.eval`:

- **`ReplicatedArm(name, runs[task][k], active=None)`** — `pass@1` (the mean a single run pretends to be), **`pass^k`** (fraction of tasks that pass *every* run — what a user experiences), **flip rate** (fraction of tasks whose outcome moved between runs of the same arm — the noise floor), **ICC(1)** (how much variance is a task property at all; `None` with the reason when it cannot be computed, never `0.0`).
- **Mechanism-active scoring** (2606.20695, our §2r as a protocol): pass `active[task][k]` marking the trials where the mechanism under test actually fired, and the arm reports the rate over those only. **Zero active trials is `None` and prints `NOT MEASURED`** — a retry policy scored on runs that never retried has not been measured, and 0% would say it fired and lost every time.
- **`compare_replicated`** pairs two arms on per-task `pass^k` through the *untouched* `compare_paired` — the same McNemar/Wilson ruler twenty callers already use — and adds `inside_noise_floor`: whether |Δ| is no larger than the arms' own flip rate. Reported **beside** `significant`, never instead of it.
- **`seeds_verdict(k)`** is printed in the report: one run is a sample, two alert, three decide (§2x). A rule that lives in a memory file is advice; one that prints in every report is a protocol.

`PairedResult` is not modified. Twenty bench scripts and four eval modules construct it positionally; they keep their numbers and their meaning.

## Verification

- 18 tests; **10 guards sabotaged individually**, each reverted on disk, byte-compared, and confirmed to turn its owning test red — including the one that matters most: a mechanism that never fired must read as `None`, not `0.0`.
- `ruff` and `mypy` clean. Existing `tests/test_paired.py` 15/15 unchanged.
- **First measured example is the pilot's own data**, read from the two `results.json` files rather than a typed table: `pass@1` 12.5% in both runs, **`pass^2` 0.0%**, flip rate 25%, **ICC(1) −0.08**. Negative ICC means within-task spread exceeds between-task spread — *which task passes is not a property of the task* — and the number says so directly. Pinned as a regression anchor in the tests.

## What this does not do

- It does not make any existing bench result more precise. It makes the imprecision visible, which is the prerequisite for the A/B in plan item 10 and for the k=5 pilot in item 1.
- ICC(1) on binary outcomes is the standard approximation (2512.06710 uses it, 0.30–0.77 on agentic suites); it is not a claim about the latent scale.
- The flip-rate floor is from reruns. 2608.22331 shows perturbation noise is larger; a perturbation arm is a later item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
