### PR TITLE
docs(changelog): close 0.52.0 — the version bump does not do this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.52.0] - 2026-09-08
 
 ### Added
 


### PR DESCRIPTION
## What
One line: `## [Unreleased]` becomes `## [0.52.0] - 2026-09-08`.

## Why it is a separate PR
`scripts/cut_release.py` does not touch `CHANGELOG.md` — grep it, the filename does not appear. The 0.51.0 release commit (`bfe0737`, #364) changed 9 files including the changelog; ours (#393) changed 8. That one line was done by hand last time, and nothing in the script or its docstring says so, which is why it was missed here.

Merging this before the GitHub Release is created keeps the published notes and the repository saying the same thing.

## Worth fixing properly, separately
`cut_release.py` should close the section itself, or its docstring should list the manual step. Right now the omission is silent: `check_only_expected_files_changed` passes because it verifies the files that *did* change, not the one that should have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
