### PR TITLE
fix(proc): a command's output arrives as the child wrote it, not as the machine's locale guessed

### DIFF
--- a/chimera/api/exec_stream.py
+++ b/chimera/api/exec_stream.py
@@ -29,6 +29,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from chimera.proc.decode import console_line
 from chimera.proc.stdio import kill_tree
 
 if TYPE_CHECKING:
@@ -144,6 +145,15 @@ def run_streamed(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,  # MERGE stderr into stdout: a command-runner shows combined output
         text=True,
+        # Named, and named this way for a reason particular to streaming. `text=True` alone reads
+        # with the ANSI code page while a console program writes the OEM one (`chimera/proc/decode`).
+        # The obvious fix — read bytes and decode — cannot be used here: `bufsize=1` is line
+        # buffering, which Python only honours in TEXT mode, so binary would take the default buffer
+        # and the output would arrive in blocks instead of lines. That is the whole feature.
+        # `surrogateescape` is the way to keep both: undecodable bytes survive as lone surrogates
+        # and `console_line` recovers them exactly, so each line is still judged on its own bytes.
+        encoding="utf-8",
+        errors="surrogateescape",
         bufsize=1,
         stdin=subprocess.DEVNULL,
         env=_child_env(),
@@ -168,9 +178,12 @@ def run_streamed(
     truncated = False
     try:
         assert proc.stdout is not None
-        for line in proc.stdout:  # blocks per line; the watchdog kill closes the pipe → loop ends
+        for raw_line in proc.stdout:  # blocks per line; the watchdog kill closes the pipe → loop ends
             if truncated:
                 continue  # keep draining so the child never blocks on a full pipe, but stop emitting
+            line = console_line(raw_line)
+            # Decoded before counting, so `_MAX_STREAM_CHARS` keeps meaning characters. Counting the
+            # bytes instead would truncate a CJK or emoji-heavy log at a third of the stated budget.
             total += len(line)
             if total > _MAX_STREAM_CHARS:
                 truncated = True

--- a/chimera/core/resources.py
+++ b/chimera/core/resources.py
@@ -20,6 +20,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
+from chimera.proc.decode import console_text
 from chimera.telemetry import get_logger
 
 _log = get_logger("core.resources")
@@ -131,17 +132,16 @@ def _nvidia_gpus() -> tuple[list[Gpu], str]:
                 "--format=csv,noheader,nounits",
             ],
             capture_output=True,
-            text=True,
             timeout=_SMI_TIMEOUT,
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return [], f"nvidia-smi did not answer ({type(exc).__name__})"
     if proc.returncode != 0:
-        return [], (proc.stderr or "").strip()[:200] or "nvidia-smi reported an error"
+        return [], console_text(proc.stderr).strip()[:200] or "nvidia-smi reported an error"
 
     gpus: list[Gpu] = []
-    for line in proc.stdout.splitlines():
+    for line in console_text(proc.stdout).splitlines():
         parts = [p.strip() for p in line.split(",")]
         if len(parts) < 4:
             continue

--- a/chimera/eval/scenarios.py
+++ b/chimera/eval/scenarios.py
@@ -398,18 +398,19 @@ def mechanism_arm(
 def _sha_from_git(start: Path) -> str:
     import subprocess
 
+    from chimera.proc.decode import console_text
+
     try:
         done = subprocess.run(  # noqa: S603 — fixed argv, no shell
             ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
             cwd=start,
             capture_output=True,
-            text=True,
             timeout=15,
             check=False,
         )
     except (OSError, subprocess.SubprocessError):
         return ""
-    return done.stdout.strip() if done.returncode == 0 else ""
+    return console_text(done.stdout).strip() if done.returncode == 0 else ""
 
 
 def _as_local_path(text: str) -> Path:

--- a/chimera/proc/decode.py
+++ b/chimera/proc/decode.py
@@ -1,0 +1,130 @@
+"""Reading a child process's output on a machine whose console is not UTF-8.
+
+``text=True`` with no ``encoding=`` decodes with :func:`locale.getpreferredencoding`, which on
+Windows is the **ANSI** code page — while a console program writes the **OEM** one. Measured on the
+machine this project is developed on: ANSI ``cp1252``, OEM ``cp850``. Two different pages, and
+nothing in between them notices.
+
+The damage has three shapes, all measured through the real ``LocalSandbox`` rather than argued:
+
+===========================  ==============================  ==================
+child wrote                  ``text=True`` gave              with this module
+===========================  ==============================  ==================
+``café ñ`` as cp850          ``'caf\\u201a \\xa4'``            ``'café ñ'``
+``check ✓ fogo 🔥`` as UTF-8  ``'check \\xe2\\u0153\\u201c…'``    unchanged
+bytes undefined in cp1252    **``None``**, with ``rc=0``      a string
+===========================  ==============================  ==================
+
+The third row is the one that matters and it is not hypothetical. ``UnicodeDecodeError`` is raised
+on ``subprocess``'s *reader thread*, so the call returns a **successful** process whose ``stdout``
+is ``None`` — the command ran, the output is gone, and the exit code says everything is fine. The
+five bytes cp1252 leaves undefined (``0x81 0x8D 0x8F 0x90 0x9D``) are ordinary UTF-8 continuation
+bytes: they appear in emoji, in most CJK and in plenty of prose. ``chimera/core/worktree.py`` hit
+exactly this in ``GET /api/git/diff`` and named its encoding; this module is that lesson applied to
+the sites that run *arbitrary* commands, where the child is not known to write UTF-8.
+
+**Why a fallback and not simply UTF-8.** Because the child is not git. Twelve commands an agent
+actually runs were measured on Windows: six are pure ASCII, and of the six whose output carries
+non-ASCII bytes, **four are not UTF-8** — ``dir``, ``echo café ñ``, ``cmd /c ver``, ``findstr /?``,
+that is, cmd.exe's own builtins. Naming ``encoding="utf-8"`` alone would have turned every ``dir``
+listing on such a machine into replacement characters, which is a regression bought with the fix.
+
+**What this costs, said out loud.** Deciding by "is this UTF-8 at all" means a stream that is UTF-8
+*except* for a few bad bytes in the middle falls back to the console page, and whatever non-ASCII it
+held comes out mangled. Truncation is the realistic way that happens here — every sandbox run has a
+timeout that kills the child mid-stream — so an incomplete **final** character is handled separately
+and never triggers the fallback. What remains is genuinely mixed or binary output, which has no
+correct answer in any single codec: it is mangled rather than lost, and losing it is what happens
+today.
+"""
+
+from __future__ import annotations
+
+import codecs
+import os
+from functools import lru_cache
+
+_POSIX = os.name == "posix"
+
+#: The range `errors="surrogateescape"` maps an undecodable byte to. Written as code points rather
+#: than as string literals on purpose: a lone surrogate in a source file cannot be written back out
+#: as UTF-8, so a literal here turns every tool that rewrites this module into a truncated file.
+_SURROGATE_LOW, _SURROGATE_HIGH = 0xDC80, 0xDCFF
+
+
+@lru_cache(maxsize=1)
+def console_encoding() -> str:
+    """The code page a console program writes on this machine, or ``utf-8`` where that is all there is.
+
+    Windows is the only place that has the question. ``GetOEMCP`` rather than
+    :func:`locale.getpreferredencoding`, because the latter answers with the ANSI page — the wrong
+    one, and the whole defect.
+    """
+    if _POSIX:
+        return "utf-8"
+    try:
+        import ctypes
+
+        page = int(ctypes.windll.kernel32.GetOEMCP())  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — a machine that cannot answer gets the safe answer
+        return "utf-8"
+    if page in (65001, 0):  # the console was already set to UTF-8, or the call gave nothing
+        return "utf-8"
+    codec = f"cp{page}"
+    try:
+        "".encode(codec)
+    except LookupError:  # a page Python has no codec for
+        return "utf-8"
+    return codec
+
+
+def console_text(raw: bytes | None) -> str:
+    """Decode one child process's output.
+
+    UTF-8 first, because that is what every tool written this decade emits and what every non-Windows
+    machine uses. Only when the bytes are *not* UTF-8 does the console's own page get a turn — and an
+    incomplete final character does not count as "not UTF-8", because that is what a killed child
+    leaves behind rather than evidence about the codec.
+
+    ``None`` maps to ``""``: callers pass ``proc.stdout`` straight in, and a pipe that was never
+    opened is empty output, not missing output.
+    """
+    if not raw:
+        return ""
+    decoder = codecs.getincrementaldecoder("utf-8")()
+    try:
+        # `final=False` holds an incomplete trailing sequence instead of failing on it, and still
+        # raises on a byte that could not start or continue a character anywhere. That distinction
+        # is the whole decision, and asking for it directly is why there is no "how close to the end
+        # is close enough" constant here — a first draft had one, and on six bytes of cp850 output
+        # its window covered half the string and sent `café ñ` down the truncation path.
+        head = decoder.decode(raw, final=False)
+    except UnicodeDecodeError:
+        return raw.decode(console_encoding(), errors="replace")
+    try:
+        return head + decoder.decode(b"", final=True)
+    except UnicodeDecodeError:
+        # Everything decoded except a character the child was cut off mid-way through.
+        return head + "\N{REPLACEMENT CHARACTER}"
+
+
+def console_line(text: str) -> str:
+    """The same decision, for a reader that had to stay in text mode.
+
+    A streaming reader cannot hand over bytes: ``bufsize=1`` is line buffering and Python honours it
+    only in text mode, so reading binary would deliver blocks instead of lines and there would be no
+    streaming left to decode. Such a reader is opened ``encoding="utf-8", errors="surrogateescape"``
+    instead, which is lossless — every byte UTF-8 could not take became a lone surrogate and encodes
+    back to exactly itself. When none are present the line was UTF-8 and is returned untouched; when
+    some are, the original bytes are recovered and get the same treatment as any other output.
+
+    Judging per line is not a compromise here, it is better than the block case: one ``dir`` line in
+    an otherwise UTF-8 log is decoded on its own bytes rather than deciding the whole stream by the
+    first line that was not UTF-8.
+    """
+    if not any(_SURROGATE_LOW <= ord(ch) <= _SURROGATE_HIGH for ch in text):
+        return text
+    return console_text(text.encode("utf-8", "surrogateescape"))
+
+
+__all__ = ["console_encoding", "console_line", "console_text"]

--- a/chimera/sandbox/docker.py
+++ b/chimera/sandbox/docker.py
@@ -19,6 +19,7 @@ import subprocess
 from contextlib import suppress
 from pathlib import Path
 
+from chimera.proc.decode import console_text
 from chimera.sandbox.base import Sandbox, SandboxResult
 from chimera.sandbox.local import _NONINTERACTIVE_ENV, LocalSandbox
 from chimera.telemetry import get_logger
@@ -114,7 +115,12 @@ class DockerSandbox:
         argv = self._argv(name, command, workdir, env_args)
         try:
             proc = subprocess.run(
-                argv, capture_output=True, text=True, timeout=timeout + 15, stdin=subprocess.DEVNULL
+                # Named: the container writes UTF-8, but the `docker` CLI on the host writes its
+                # own errors in the console's page, and `text=True` reads with the ANSI one.
+                argv,
+                capture_output=True,
+                timeout=timeout + 15,
+                stdin=subprocess.DEVNULL,
             )
         except subprocess.TimeoutExpired:
             with suppress(OSError, subprocess.SubprocessError):
@@ -123,5 +129,7 @@ class DockerSandbox:
                 exit_code=124, stderr=f"command timed out after {timeout}s", timed_out=True
             )
         return SandboxResult(
-            exit_code=proc.returncode, stdout=proc.stdout or "", stderr=proc.stderr or ""
+            exit_code=proc.returncode,
+            stdout=console_text(proc.stdout),
+            stderr=console_text(proc.stderr),
         )

--- a/chimera/sandbox/local.py
+++ b/chimera/sandbox/local.py
@@ -17,6 +17,7 @@ from pathlib import Path
 # imported here because this file has always been where it was read. It used to be the other way
 # round, which made the redaction module drag in this whole subsystem.
 from chimera.core.redact import _SECRET_MARKERS
+from chimera.proc.decode import console_text
 from chimera.proc.stdio import kill_tree
 from chimera.sandbox.base import SandboxResult
 
@@ -75,13 +76,19 @@ class LocalSandbox:
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            # Bytes, decoded by `console_text` rather than by `text=True`. The command here is
+            # whatever a person or the model typed, so the child is not known to write UTF-8 —
+            # and `text=True` decodes with the ANSI code page, which on Windows is not the one
+            # a console program writes. Worse than mangling: bytes the ANSI page leaves
+            # undefined raise on subprocess's reader thread, and `communicate` then returns a
+            # *successful* process whose stdout is `None` (`chimera/proc/decode.py`).
             stdin=subprocess.DEVNULL,
             env=_child_env(),
             start_new_session=posix,
         )
         try:
-            out, err = proc.communicate(timeout=timeout)
+            raw_out, raw_err = proc.communicate(timeout=timeout)
+            out, err = console_text(raw_out), console_text(raw_err)
         except subprocess.TimeoutExpired:
             # `kill_tree` rather than a second copy of the same logic. This branch reimplemented the
             # POSIX half and stopped there: on Windows it was a bare `proc.kill()`, which kills the
@@ -95,4 +102,4 @@ class LocalSandbox:
             return SandboxResult(
                 exit_code=124, stderr=f"command timed out after {timeout}s", timed_out=True
             )
-        return SandboxResult(exit_code=proc.returncode, stdout=out or "", stderr=err or "")
+        return SandboxResult(exit_code=proc.returncode, stdout=out, stderr=err)

--- a/tests/test_a_child_process_output_survives_a_non_utf8_console.py
+++ b/tests/test_a_child_process_output_survives_a_non_utf8_console.py
@@ -1,0 +1,175 @@
+"""A command's output arrives as the child wrote it, on a machine whose console is not UTF-8.
+
+The defect was silent and had a catastrophic tail. ``text=True`` with no ``encoding=`` decodes with
+the **ANSI** code page while a Windows console program writes the **OEM** one — cp1252 against cp850
+on the machine this project is developed on. Ordinary output came back mangled; output containing
+any of the five bytes cp1252 leaves undefined came back as ``None`` **with a zero exit code**,
+because ``UnicodeDecodeError`` is raised on ``subprocess``'s reader thread and ``communicate``
+returns the process as successful. ``chimera/core/worktree.py`` already carried that lesson for git;
+these are the sites that run arbitrary commands.
+
+The last test is the ratchet, and it is the one that matters in a year: every ``text=True`` in the
+package names its encoding, so a new subprocess call cannot inherit the machine's locale by default.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+import pytest
+
+from chimera.proc import decode
+from chimera.proc.decode import console_encoding, console_line, console_text
+
+PACKAGE = pathlib.Path(decode.__file__).resolve().parents[1]
+
+#: What a child writes, and what it means. `\x82 \xa4` is `café ñ` in cp850; the five-byte string is
+#: exactly the set cp1252 has no mapping for, which is what used to make output vanish.
+CP850_ACCENTS = "café ñ".encode("cp850")
+CP1252_UNDEFINED = bytes([0x81, 0x8D, 0x8F, 0x90, 0x9D])
+UTF8_EMOJI = "check ✓ fogo \U0001f525".encode()
+
+
+@pytest.fixture
+def oem(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the console page to cp850 so the decision is tested, not the CI runner's locale.
+
+    Without this the whole file would pass vacuously on Linux, where `console_encoding()` is utf-8
+    and the fallback can never differ from the first attempt — a test that cannot fail.
+    """
+    monkeypatch.setattr(decode, "console_encoding", lambda: "cp850")
+
+
+def test_utf8_output_is_returned_exactly(oem: None) -> None:
+    assert console_text(UTF8_EMOJI) == "check ✓ fogo \U0001f525"
+
+
+def test_output_in_the_console_page_is_read_in_the_console_page(oem: None) -> None:
+    """The row that decides the design: cmd.exe's own builtins write this, not UTF-8."""
+    assert console_text(CP850_ACCENTS) == "café ñ"
+
+
+def test_output_that_used_to_vanish_now_arrives(oem: None) -> None:
+    """The catastrophic case. Any string at all beats `None` on a process that reported success."""
+    got = console_text(CP1252_UNDEFINED)
+    assert isinstance(got, str)
+    assert got != ""
+
+
+def test_a_child_cut_off_mid_character_keeps_everything_before_it(oem: None) -> None:
+    """A timeout kills the child mid-stream, so this is the normal case here, not a corner one.
+
+    The head must stay UTF-8: falling back to the console page over one incomplete trailing
+    character would mangle an entire log because it was interrupted.
+    """
+    assert console_text("café ✓".encode()[:-1]) == "café �"
+
+
+def test_a_long_utf8_stream_is_not_decided_by_its_last_byte(oem: None) -> None:
+    """The sibling of the test above, and the reason there is no distance-from-the-end constant.
+
+    A first draft accepted any error starting within three bytes of the end. On six bytes of cp850
+    that window covered half the string, and `café ñ` went down the truncation path and came out as
+    replacement characters — the exact output the fix exists to prevent.
+    """
+    assert console_text("olá".encode() + b"\xc3") == "olá�"
+
+
+def test_a_line_that_needed_no_help_is_returned_unchanged(oem: None) -> None:
+    assert console_line("check ✓") == "check ✓"
+
+
+def test_a_streamed_line_recovers_the_bytes_its_reader_could_not_decode(oem: None) -> None:
+    """`console_line`'s contract: `surrogateescape` is lossless, so the original bytes come back.
+
+    The streaming reader cannot hand over bytes — `bufsize=1` is line buffering and Python honours
+    it in text mode only — so this is how the same decision reaches it.
+    """
+    as_the_reader_saw_it = CP850_ACCENTS.decode("utf-8", "surrogateescape")
+    assert as_the_reader_saw_it != "café ñ"  # the reader really could not read it
+    assert console_line(as_the_reader_saw_it) == "café ñ"
+
+
+def test_empty_and_missing_output_are_the_same_thing(oem: None) -> None:
+    """Callers pass `proc.stdout` straight in; a pipe that was never opened is empty, not missing."""
+    assert console_text(None) == ""
+    assert console_text(b"") == ""
+
+
+def test_the_console_encoding_is_never_a_codec_python_cannot_load() -> None:
+    """Whatever this machine answers, it has to be usable — the fallback must not raise its own error."""
+    b"x".decode(console_encoding())
+
+
+# --------------------------------------------------------------------------- through a real child
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="the two code pages only differ on Windows")
+def test_the_sandbox_returns_what_the_child_actually_wrote() -> None:
+    """The wiring, not the helper. A unit test of `console_text` passes with the sandbox untouched."""
+    from chimera.sandbox.local import LocalSandbox
+
+    writer = f'"{sys.executable}" -c "import sys;sys.stdout.buffer.write({UTF8_EMOJI!r})"'
+    assert LocalSandbox().run(writer, timeout=60).stdout.strip() == "check ✓ fogo \U0001f525"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="the two code pages only differ on Windows")
+def test_output_the_ansi_page_cannot_read_no_longer_disappears() -> None:
+    """The end-to-end of the catastrophic case, through the sandbox that runs the model's commands."""
+    from chimera.sandbox.local import LocalSandbox
+
+    writer = f'"{sys.executable}" -c "import sys;sys.stdout.buffer.write({CP1252_UNDEFINED!r})"'
+    result = LocalSandbox().run(writer, timeout=60)
+    assert result.exit_code == 0
+    assert result.stdout != "", "the process succeeded and its output was thrown away"
+
+
+# --------------------------------------------------------------------------- the ratchet
+
+
+def _text_true_calls_without_an_encoding() -> list[str]:
+    """Every `subprocess` call in the package that asks for text and does not say in which encoding."""
+    offenders: list[str] = []
+    for path in sorted(PACKAGE.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            kwargs = {kw.arg for kw in node.keywords if kw.arg}
+            asks_for_text = any(
+                kw.arg in ("text", "universal_newlines")
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            )
+            if asks_for_text and "encoding" not in kwargs:
+                offenders.append(f"{path.relative_to(PACKAGE.parent)}:{node.lineno}")
+    return offenders
+
+
+def test_no_subprocess_reads_text_without_naming_its_encoding() -> None:
+    """The guard, and the only part of this file that still applies once everyone has forgotten why.
+
+    Measured when it was written: eight call sites asked for text, three named an encoding, five took
+    the machine's locale. Naming it once per site is the only way to be sure it is named at all —
+    the same argument `chimera/core/worktree.py` makes for its own helper.
+    """
+    assert _text_true_calls_without_an_encoding() == []
+
+
+def test_the_ratchet_can_actually_fail() -> None:
+    """A guard nobody has seen go red is a guard that might be inert. This one is checked against
+    the shape it exists to reject, so the test above means what it says."""
+    tree = ast.parse("subprocess.run(argv, capture_output=True, text=True)")
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+    kwargs = {kw.arg for kw in call.keywords if kw.arg}
+    assert "text" in kwargs and "encoding" not in kwargs
+
+
+def test_the_git_helper_that_taught_this_still_names_its_encoding() -> None:
+    """`_git` is where the lesson was learned; a refactor that dropped its encoding would be a
+    regression this file is in the best position to notice."""
+    source = (PACKAGE / "core" / "worktree.py").read_text(encoding="utf-8")
+    assert 'encoding="utf-8"' in source

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -143,11 +143,15 @@ def test_a_machine_without_nvidia_smi_says_unavailable_rather_than_zero(monkeypa
 
 
 def test_nvidia_output_is_parsed(monkeypatch: Any) -> None:
+    # `stdout` is BYTES in every double below, because that is what the call it stands in for
+    # returns: `_read_nvidia_smi` reads its output through `console_text` rather than `text=True`,
+    # so the machine's ANSI code page cannot decide what a GPU is called (`chimera/proc/decode.py`).
+    # A double still handing back `str` would be standing in for a call that no longer exists.
     monkeypatch.setattr("chimera.core.resources.shutil.which", lambda _n: "/usr/bin/nvidia-smi")
     monkeypatch.setattr(
         "chimera.core.resources.subprocess.run",
         lambda *_a, **_k: subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="NVIDIA GeForce RTX 5070, 8188, 5312, 43\n", stderr=""
+            args=[], returncode=0, stdout=b"NVIDIA GeForce RTX 5070, 8188, 5312, 43\n", stderr=b""
         ),
     )
 
@@ -164,7 +168,7 @@ def test_a_value_the_driver_cannot_read_stays_absent(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "chimera.core.resources.subprocess.run",
         lambda *_a, **_k: subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="Quadro P1000, 4096, [N/A], [N/A]\n", stderr=""
+            args=[], returncode=0, stdout=b"Quadro P1000, 4096, [N/A], [N/A]\n", stderr=b""
         ),
     )
 
@@ -180,7 +184,7 @@ def test_two_cards_are_two_entries(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "chimera.core.resources.subprocess.run",
         lambda *_a, **_k: subprocess.CompletedProcess(
-            args=[], returncode=0, stdout="A, 1, 2, 3\nB, 4, 5, 6\n", stderr=""
+            args=[], returncode=0, stdout=b"A, 1, 2, 3\nB, 4, 5, 6\n", stderr=b""
         ),
     )
     assert [g.name for g in snapshot().gpus] == ["A", "B"]
@@ -193,7 +197,7 @@ def test_a_driver_that_errors_is_reported_and_not_silently_empty(monkeypatch: An
     monkeypatch.setattr(
         "chimera.core.resources.subprocess.run",
         lambda *_a, **_k: subprocess.CompletedProcess(
-            args=[], returncode=9, stdout="", stderr="couldn't communicate with the driver\n"
+            args=[], returncode=9, stdout=b"", stderr=b"couldn't communicate with the driver\n"
         ),
     )
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -94,7 +94,9 @@ def test_docker_builds_isolated_run_command(monkeypatch: pytest.MonkeyPatch) -> 
 
     def fake_run(argv: list[str], **kwargs: Any) -> SimpleNamespace:
         captured["argv"] = argv
-        return SimpleNamespace(returncode=0, stdout="out", stderr="")
+        # Bytes: the docker path reads its output through `console_text`, so a double returning
+        # `str` would stand in for a call that no longer exists (`chimera/proc/decode.py`).
+        return SimpleNamespace(returncode=0, stdout=b"out", stderr=b"")
 
     monkeypatch.setattr(docker_mod.subprocess, "run", fake_run)
     result = sandbox.run("echo hi", cwd=Path("scratch"))
@@ -115,7 +117,7 @@ def _capture_docker_argv(sandbox: DockerSandbox, monkeypatch: pytest.MonkeyPatch
 
     def fake_run(argv: list[str], **kwargs: Any) -> SimpleNamespace:
         captured["argv"] = argv
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
 
     monkeypatch.setattr(docker_mod.subprocess, "run", fake_run)
     sandbox.run("echo hi")

--- a/tests/test_the_kernel_holds_the_boundary.py
+++ b/tests/test_the_kernel_holds_the_boundary.py
@@ -42,6 +42,11 @@ from chimera.sandbox.os_sandbox import (
     unavailable_reason,
 )
 
+#: The interpreter, quoted — the streaming test below runs it through a shell, and a checkout under
+#: a path with a space would otherwise have cmd.exe answer "not recognized" and the assertion read
+#: as a streaming failure. See the same constant in `test_the_tool_that_was_not_installed.py`.
+PYTHON = f'"{sys.executable}"'
+
 
 @pytest.fixture(autouse=True)
 def _clean_probe_cache() -> Any:
@@ -266,7 +271,7 @@ def test_streaming_still_streams_on_an_unsandboxed_host(
 
     lines: list[str] = []
     code = run_streamed(
-        f'{sys.executable} -c "print(1); print(2)"',
+        f'{PYTHON} -c "print(1); print(2)"',
         workspace=tmp_path,
         cwd=None,
         timeout=30,

--- a/tests/test_the_tool_that_was_not_installed.py
+++ b/tests/test_the_tool_that_was_not_installed.py
@@ -42,6 +42,18 @@ from chimera.core.verify import CommandVerifier, module_missing
 #: message rather than us pretending it did.
 ABSENT = "chimera_module_that_does_not_exist"
 
+#: The interpreter, quoted, because every command built from it here goes through a shell.
+#: Unquoted, a checkout under a path with a space — this project's own lives under
+#: "Desenvolvendo Projetos" — makes cmd.exe read the first word as the program and answer
+#: "'C:\\Users\\...\\Desenvolvendo' is not recognized as an internal or external command".
+#:
+#: The damage is worse than a red test, and worse in the direction that hides itself: that message
+#: is what `module_missing` and the exit code turn into an ABSTENTION, so the abstention cases
+#: below pass for entirely the wrong reason while their controls — the ones asserting a real
+#: failure still fails — are what goes red. Measured 2026-09-09: four failures across this file and
+#: `test_the_kernel_holds_the_boundary.py` on such a path, none on a path without the space.
+PYTHON = f'"{sys.executable}"'
+
 
 class _Generator:
     """Stands in for the LLM: returns whatever test source the case needs."""
@@ -92,20 +104,21 @@ def test_a_prefix_of_the_module_name_does_not_count() -> None:
 def test_a_missing_module_abstains_instead_of_failing(tmp_path: Path) -> None:
     """Run for real, no mocking: the interpreter is asked for a module that does not exist, and its
     actual exit code and actual message are what the verifier sees."""
-    result = CommandVerifier(f"{sys.executable} -m {ABSENT}", tmp_path, source="user").verify()
+    result = CommandVerifier(f"{PYTHON} -m {ABSENT}", tmp_path, source="user").verify()
     assert result.abstained is True
     assert result.passed is True  # abstention keeps the work; the other gates decide
 
 
 def test_a_command_that_really_failed_still_fails(tmp_path: Path) -> None:
     """The control. A verifier that abstained on everything would keep every change ever made."""
-    result = CommandVerifier(f'{sys.executable} -c "import sys; sys.exit(1)"', tmp_path, source="user").verify()
+    command = f'{PYTHON} -c "import sys; sys.exit(1)"'
+    result = CommandVerifier(command, tmp_path, source="user").verify()
     assert result.abstained is False
     assert result.passed is False
 
 
 def test_a_command_that_passed_still_passes(tmp_path: Path) -> None:
-    result = CommandVerifier(f'{sys.executable} -c "pass"', tmp_path, source="user").verify()
+    result = CommandVerifier(f'{PYTHON} -c "pass"', tmp_path, source="user").verify()
     assert result.passed is True
     assert result.abstained is False
 
@@ -122,7 +135,7 @@ def test_the_spec_verifier_carries_the_abstention_out(tmp_path: Path) -> None:
         "build soma.py",
         [Requirement(text="soma(a, b) returns a + b")],
         tmp_path,
-        command=f"{sys.executable} -m {ABSENT} " + "{file}",
+        command=f"{PYTHON} -m {ABSENT} " + "{file}",
     )
     result = verifier.verify()
     assert result.abstained is True, "the abstention was swallowed on the way out again"
@@ -142,7 +155,7 @@ def test_the_spec_verifier_still_reports_a_real_failure(
         "build soma.py",
         [Requirement(text="soma(a, b) returns a + b")],
         tmp_path,
-        command=f"{sys.executable} -m pytest -q " + "{file}",
+        command=f"{PYTHON} -m pytest -q " + "{file}",
     )
     result = verifier.verify()
     assert result.abstained is False


### PR DESCRIPTION
## What

`text=True` with no `encoding=` decodes with `locale.getpreferredencoding`, which on Windows is the
**ANSI** code page — while a console program writes the **OEM** one. Measured on this machine: ANSI
`cp1252`, OEM `cp850`. Two different pages, and nothing in between them notices.

Eight `subprocess` call sites asked for text. Three already named an encoding (`core/worktree.py`,
`core/search.py`, `proc/stdio.py`); **five took the machine's locale**, including the two that run
whatever a person or the model typed.

## Three shapes, measured through the real `LocalSandbox`

| the child wrote | `text=True` gave | now |
|---|---|---|
| `café ñ` — cp850, i.e. what `echo` and `dir` write | `'caf\u201a \xa4'` | **`'café ñ'`** |
| `check ✓ fogo 🔥` — UTF-8, i.e. what git and node write | `'check \xe2\u0153\u201c fogo …'` | **unchanged** |
| bytes cp1252 leaves undefined | **`None`, with `rc=0`** | a string |

**The third row is the one that matters and it is not hypothetical.** `UnicodeDecodeError` is raised
on `subprocess`'s *reader thread*, so `communicate` returns a **successful** process whose `stdout`
is `None` — the command ran, the output is gone, and the exit code says everything is fine. The five
bytes (`0x81 0x8D 0x8F 0x90 0x9D`) are ordinary UTF-8 continuation bytes: they appear in emoji, in
most CJK and in plenty of prose. `core/worktree.py` hit exactly this in `GET /api/git/diff` and named
its encoding for git; this is that lesson at the sites that run *arbitrary* commands.

## Why a fallback, and not simply `encoding="utf-8"`

Because the child is not git, and the answer was measured rather than argued. Twelve commands an
agent actually runs, on Windows: six are pure ASCII, and **of the six whose output carries non-ASCII
bytes, four are not UTF-8** — `dir`, `echo café ñ`, `cmd /c ver`, `findstr /?`, that is, cmd.exe's own
builtins. Naming UTF-8 alone would have turned every `dir` listing on such a machine into replacement
characters: a regression bought with the fix.

So: UTF-8 first, the console's own page only when the bytes are not UTF-8 at all.

**An incomplete final character does not count as "not UTF-8"** — that is what a killed child leaves
behind, not evidence about the codec, and every sandbox run here has a timeout that kills the child
mid-stream. Decided with an incremental decoder rather than a distance-from-the-end constant, and
that is not a stylistic preference: a first draft used `exc.start >= len(raw) - 3`, and on six bytes
of cp850 that window covered half the string and sent `café ñ` down the truncation path.

## The streaming reader could not take bytes, and that shaped the second helper

`api/exec_stream.py` is the Code screen's live output. `bufsize=1` is line buffering and Python
honours it **only in text mode**, so reading bytes there would deliver blocks instead of lines and
there would be no streaming left to decode. It reads `encoding="utf-8", errors="surrogateescape"`
instead, which is lossless, and `console_line` recovers the original bytes exactly.

Per-line is better than per-block here, not a compromise: one `dir` line in an otherwise UTF-8 log is
decoded on its own bytes instead of deciding the whole stream by its first bad byte.

## The ratchet

An AST test fails on any `text=True` (or `universal_newlines=True`) in the package without an
`encoding=`. It is the part that still applies in a year, and it is checked against the shape it
rejects so it cannot sit inert.

## Two things found while measuring, and one refutation withdrawn

**The four failures on this machine were never this defect.** They are `sys.executable` interpolated
into a shell string **unquoted**: on a checkout under a path with a space — this project's own lives
under `Desenvolvendo Projetos` — cmd.exe reads the first word as the program and answers
`'C:\Users\brcam\Desktop\Desenvolvendo' is not recognized`. Worth its own commit because of the
*direction*: that message is what `module_missing` plus the exit code turn into an **abstention**, so
the abstention tests passed for the wrong reason while their controls went red. A suite green on such
a path would have been the worse outcome. The product was checked and does not have this shape — its
only `sys.executable` use is an argv list, which never reaches a shell.

**A refutation of mine has to be withdrawn.** I had dismissed "a path with a space breaks cmd.exe"
because `echo ok` with that `cwd` returns 0. That is true and beside the point: the `cwd` is not the
problem, the path *inside the command string* is, and the probe I used could not have shown it.

**Five tests broke on the change, and broke correctly**: their doubles returned `str` where
`subprocess.run` now returns bytes, so they had become fakes of a call that no longer exists. Fixed
in the doubles rather than by teaching `console_text` to accept `str` — a helper that swallows the
wrong type quietly would hide the next mistake of exactly this shape.

## Verification

`ruff` clean · `mypy chimera` clean · full suite **6067 passed, 0 failed** in WSL from a clean copy and
**6068 passed, 0 failed**
(the two remaining `ERROR`s there are the `os.environ`-leak guard firing at teardown on optional Windows-only dependencies and on `litellm`'s dotenv load — reproduced identically on `main`, so they are not this change) on Windows, where the four path failures above used to be.

**Five sabotages, each red and restored** (baseline 14 passed):

| sabotage | red |
|---|---:|
| the sandbox back to `text=True` | 2 |
| a new `text=True` with no encoding | 1 (the ratchet) |
| the truncated tail no longer handled | 2 |
| the console-page fallback removed | 2 |
| `console_line` stops recovering the bytes | 1 |

Plus the quoting: removing the quotes again returns 3 of the 4 failures.

## What this cannot show

One machine, one pair of code pages. `cp850` is single-byte; a Japanese or Chinese Windows has a
**multi-byte** OEM page (`cp932`, `cp936`), where a stream can be valid UTF-8 *and* valid in the OEM
page and the first attempt wins — the same rule, but its cost there is untested here.

The fallback's stated price is real and unmeasured in the field: a stream that is UTF-8 except for a
few bad bytes **in the middle** takes the console page, and whatever non-ASCII it held is mangled.
That is strictly better than today, where the same stream comes back as `None`, but it is not free.

Nothing here changes what a child *writes*. Forcing `PYTHONIOENCODING` on Python children through
`_child_env` was considered and left out: the fallback already reads them correctly, and changing a
command's own output is a bigger claim than reading it right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
