### PR TITLE
fix(evolve): the tuning gate decides on evidence, and its table says what it actually kept

### DIFF
--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -1926,6 +1926,17 @@
               ],
               "required": false,
               "type": "int"
+            },
+            {
+              "default": "3",
+              "help": "Suite runs per candidate \u2014 one samples, two alert, three decide. Multiplies cost.",
+              "kind": "option",
+              "name": "k",
+              "opts": [
+                "--k"
+              ],
+              "required": false,
+              "type": "int"
             }
           ],
           "path": "evolve tune"

--- a/chimera/cli/main.py
+++ b/chimera/cli/main.py
@@ -6801,6 +6801,11 @@ def evolve_tune(
     rounds: int = typer.Option(2, "--rounds", help="Meta-search rounds."),
     model: str = typer.Option(None, "--model", help="Base model for the spec."),
     max_steps: int = typer.Option(8, "--max-steps", help="Initial runtime step budget."),
+    k: int = typer.Option(
+        3,
+        "--k",
+        help="Suite runs per candidate — one samples, two alert, three decide. Multiplies cost.",
+    ),
 ) -> None:
     """Self-optimize the agent spec (OpenJarvis meta-search) against the daily scenarios.
 
@@ -6829,10 +6834,20 @@ def evolve_tune(
             system_prompt=spec.system_prompt or DEFAULT_SYSTEM_PROMPT,
         )
 
-    scorer = scenario_scorer(_spec_builder, daily_scenarios())
+    scenarios = daily_scenarios()
+    scorer = scenario_scorer(_spec_builder, scenarios, k=k)
     initial = AgentSpec(model=model, max_steps=max_steps)
     try:
-        result = search_spec(initial, scorer, model_proposer(gateway, model), rounds=rounds)
+        result = search_spec(
+            initial,
+            scorer,
+            model_proposer(gateway, model),
+            rounds=rounds,
+            # The number the gate needs to be a decision instead of a comparison. Without it the
+            # promotion rule is `>` on a fraction quantised in steps of 1/len(scenarios), and a
+            # candidate identical to the incumbent cleared that 29.6% of the time.
+            trials=len(scenarios) * max(1, k),
+        )
     except MissingCredentialsError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
@@ -6840,11 +6855,23 @@ def evolve_tune(
     table = Table(title="Spec meta-search", show_header=True)
     table.add_column("round")
     table.add_column("score")
+    table.add_column("no regression")
     table.add_column("kept")
     for index, step in enumerate(result.history):
-        table.add_row(str(index), f"{step.score:.3f}", "✓" if step.accepted else "·")
+        # Two columns because they are two facts, and printing the first under the second's heading
+        # is what let a TIE — the most common outcome against a saturated ruler — read as "kept".
+        table.add_row(
+            str(index),
+            f"{step.score:.3f}",
+            "✓" if step.accepted else "·",
+            "✓" if step.advanced else "·",
+        )
     console.print(table)
     console.print(f"[green]best score[/green] {result.best_score:.3f}")
+    if result.undecidable:
+        # Loud, because "nothing was promoted" and "nothing could have been promoted" look identical
+        # in the table above and call for opposite responses.
+        console.print(f"[yellow]the gate could not decide:[/yellow] {result.undecidable}")
     console.print(f"[dim]best spec:[/dim] {result.best.to_dict()}")
 
 

--- a/chimera/ecosystem/spec.py
+++ b/chimera/ecosystem/spec.py
@@ -47,6 +47,14 @@ class SearchStep:
     spec: AgentSpec
     score: float
     accepted: bool
+    """Did not regress (``>=``). A report about the candidate, not about what the search did."""
+    advanced: bool = False
+    """The search replaced its incumbent with this candidate.
+
+    Separate from ``accepted`` because the two are not the same and were being printed as if they
+    were: the column headed "kept" showed ``accepted``, so a **tie** — the most common outcome
+    against a saturated ruler — printed ✓ over an incumbent that had not moved.
+    """
 
 
 @dataclass
@@ -54,23 +62,93 @@ class SpecSearchResult:
     best: AgentSpec
     best_score: float
     history: list[SearchStep]
+    undecidable: str = ""
+    """Why no candidate could have been promoted, or ``""`` when some could.
+
+    Empty is not "the gate works" — it is "the gate is answerable". A gate whose ceiling sits below
+    the bar it has to clear will refuse everything forever and look exactly like a search that found
+    nothing worth keeping, which is the failure this field exists to make impossible to mistake.
+    """
 
 
 def search_spec(
-    initial: AgentSpec, scorer: Scorer, proposer: Proposer, *, rounds: int = 3
+    initial: AgentSpec,
+    scorer: Scorer,
+    proposer: Proposer,
+    *,
+    rounds: int = 3,
+    trials: int | None = None,
+    z: float = 1.959963984540054,
 ) -> SpecSearchResult:
-    """Propose → evaluate → keep-on-non-regression, for ``rounds`` rounds."""
+    """Propose → evaluate → keep-on-improvement, for ``rounds`` rounds.
+
+    ``trials`` is the number of independent trials each score is a rate over, and supplying it is
+    what turns the comparison into a decision. Without it the gate is ``score > best_score`` on a
+    bare fraction, which is what shipped: against the scenario suite that fraction is quantised in
+    steps of 1/8 and six of its eight scenarios are saturated, so one scenario of difference — one
+    coin — promoted a candidate. A candidate **identical to the incumbent** cleared that gate 29.6%
+    of the time.
+
+    With ``trials``, a candidate is promoted only when the Newcombe interval for the difference in
+    pass rates excludes zero (:func:`chimera.eval.anytime.proportion_diff_ci`, already the gate in
+    ``bench_ab``, ``continuous``, ``paired`` and ``auto_evolve``). That module's own docstring
+    measured this exact failure — *"best-of-3 accepted a candidate whose true pass rate was 0.3
+    51.8% of the time"* — and this is the one selection gate it had never been pointed at.
+
+    **This does not make the gate work; it makes it say that it does not decide.** On the published
+    numbers no achievable candidate clears it, and that is reported in ``undecidable`` rather than
+    left to look like an unlucky search.
+    """
+    from chimera.eval.anytime import proportion_diff_ci
+
     best = initial
     best_score = scorer(initial)
-    history = [SearchStep(initial, best_score, True)]
+    history = [SearchStep(initial, best_score, True, True)]
+
+    def beats(score: float, incumbent: float) -> bool:
+        if trials is None or trials <= 0:
+            return score > incumbent
+        lower, _ = proportion_diff_ci(
+            round(score * trials), trials, round(incumbent * trials), trials, z
+        )
+        return lower > 0.0
+
     for _ in range(max(0, rounds)):
         candidate = proposer(best, best_score)
         score = scorer(candidate)
-        accepted = score >= best_score  # non-regression acceptance gate
-        history.append(SearchStep(candidate, score, accepted))
-        if score > best_score:  # advance only on a strict improvement
+        accepted = score >= best_score  # non-regression: a report, not a decision
+        advanced = beats(score, best_score)
+        history.append(SearchStep(candidate, score, accepted, advanced))
+        if advanced:
             best, best_score = candidate, score
-    return SpecSearchResult(best=best, best_score=best_score, history=history)
+    return SpecSearchResult(
+        best=best,
+        best_score=best_score,
+        history=history,
+        undecidable=_undecidable_reason(best_score, trials, z),
+    )
+
+
+def _undecidable_reason(incumbent: float, trials: int | None, z: float) -> str:
+    """Whether a **perfect** candidate could clear the gate against ``incumbent``, and why not.
+
+    Asked of the best case rather than of the run that happened: "nothing was promoted" and "nothing
+    could have been promoted" are different sentences, and only one of them is about the candidates.
+    Mirrors what ``auto_evolve`` does with :func:`chimera.eval.anytime.best_possible_wilson`, in the
+    shape a two-proportion gate needs.
+    """
+    if trials is None or trials <= 0:
+        return ""
+    from chimera.eval.anytime import proportion_diff_ci
+
+    lower, _ = proportion_diff_ci(trials, trials, round(incumbent * trials), trials, z)
+    if lower > 0.0:
+        return ""
+    return (
+        f"no candidate can clear this gate: a perfect {trials}/{trials} against an incumbent at "
+        f"{incumbent:.3f} still leaves the difference interval touching zero (lower={lower:+.3f}). "
+        f"Raise the trial count or use a ruler the incumbent has not already saturated."
+    )
 
 
 def model_proposer(backend: object, model: str | None = None) -> Proposer:

--- a/chimera/eval/spec_tuning.py
+++ b/chimera/eval/spec_tuning.py
@@ -28,18 +28,34 @@ def scenario_scorer(
     scenarios: list[Scenario],
     *,
     seed: int = 0,
+    k: int = 1,
 ) -> Callable[[AgentSpec], float]:
-    """A Scorer: build a session builder from the spec, run the suite, return the pass rate.
+    """A Scorer: build a session builder from the spec, run the suite ``k`` times, pool the rate.
 
     ``seed`` is fixed across candidates on purpose. The scenarios generate their expected values per
     run, and scoring two specs against *different* generated values would measure the draw and not
     the spec — §2g, "mesmos itens? mesma régua? mesmo n?". Every candidate in one search therefore
     faces the identical eight tasks.
+
+    ``k`` is the number that was missing, and its absence is why this scorer could not decide
+    anything. The sibling command that *measures* the same suite has taken ``--k`` with a default of
+    3 since it was written — *"one samples, two alert, three decide"* (`chimera/cli/main.py`) — and
+    the one that *selects* ran each candidate once. A single run of eight scenarios where six are
+    saturated is the reading of two coins.
+
+    The k runs use the **same** seed rather than k different ones, deliberately: the seed fixes the
+    fixture draw, and the noise this needs to see is the model's own sampling at ``temperature=0.7``.
+    Varying it would replace a paired comparison with an unpaired one and lose the very power that
+    replication is being added for.
     """
 
     def score(spec: AgentSpec) -> float:
-        with tempfile.TemporaryDirectory(prefix="chimera-tune-") as tmp:
-            report = run_suite(make_builder(spec), scenarios, root=Path(tmp), seed=seed)
-        return report.pass_rate
+        passed = total = 0
+        for _ in range(max(1, k)):
+            with tempfile.TemporaryDirectory(prefix="chimera-tune-") as tmp:
+                report = run_suite(make_builder(spec), scenarios, root=Path(tmp), seed=seed)
+            passed += report.passed
+            total += report.total
+        return passed / total if total else 0.0
 
     return score

--- a/tests/test_the_tuning_gate_says_what_it_decides.py
+++ b/tests/test_the_tuning_gate_says_what_it_decides.py
@@ -1,0 +1,156 @@
+"""The spec meta-search promotes on evidence, and its table says what actually happened.
+
+Two defects, and the second is what hid the first.
+
+**It selected on noise.** `search_spec` promoted a candidate on `score > best_score` — a bare
+fraction over eight scenarios, quantised in steps of 1/8. Six of those eight are saturated
+(`bench/scenarios/RESULTS.md`), so the score is the reading of two coins, and the scorer ran the
+suite **once**: `run_suite`'s own docstring says "Run every scenario once", while the sibling
+command that merely *measures* the same suite has taken `--k` with a default of 3 since it was
+written — *"one samples, two alert, three decide"*. k=3 in the command that measures, k=1 in the
+command that selects.
+
+**And the table said "kept" about the wrong field.** `accepted` is `>=`, the advance is `>`, and the
+column headed "kept" printed `accepted` — so a tie, the most common outcome against a saturated
+ruler, printed ✓ over an incumbent that had not moved.
+
+The remedy was already in this repository with the measured number in its docstring:
+`chimera/eval/anytime.py` records that *"best-of-3 accepted a candidate whose true pass rate was 0.3
+51.8% of the time"*. It is imported by `bench_ab`, `continuous`, `paired`, `auto_evolve` and
+`collective` — every gate except this one.
+
+**None of this makes the gate work.** On the published numbers it promotes nothing, which is the
+honest answer, and `undecidable` is how it says so instead of looking like an unlucky search.
+"""
+
+from __future__ import annotations
+
+import random
+
+from chimera.ecosystem.spec import AgentSpec, SpecSearchResult, search_spec
+
+#: The scenario suite this gate scores against: eight scenarios, six of them saturated, so exactly
+#: two contribute any variance at all (`bench/scenarios/RESULTS.md`).
+SCENARIOS = 8
+
+
+def _search(scores: list[float], **kwargs: object) -> SpecSearchResult:
+    """Drive the search with a scripted sequence of scores — the first is the incumbent's."""
+    remaining = list(scores)
+
+    def scorer(_spec: AgentSpec) -> float:
+        return remaining.pop(0)
+
+    def proposer(spec: AgentSpec, _score: float) -> AgentSpec:
+        return AgentSpec(max_steps=spec.max_steps + 1)
+
+    return search_spec(
+        AgentSpec(max_steps=5), scorer, proposer, rounds=len(scores) - 1, **kwargs  # type: ignore[arg-type]
+    )
+
+
+# --------------------------------------------------------------------------- the table
+
+
+def test_a_tie_no_longer_reads_as_kept() -> None:
+    """The one-line half. A candidate that merely did not regress is reported as exactly that."""
+    result = _search([0.875, 0.875])
+    step = result.history[1]
+
+    assert step.accepted is True, "it did not regress, and that stays true"
+    assert step.advanced is False, "but nothing was kept — the incumbent is unchanged"
+    assert result.best.max_steps == 5
+
+
+def test_a_real_improvement_is_both() -> None:
+    """The control: a field that were always False would pass the test above and mean nothing."""
+    step = _search([0.500, 0.875]).history[1]
+    assert (step.accepted, step.advanced) == (True, True)
+
+
+def test_a_regression_is_neither() -> None:
+    step = _search([0.875, 0.500]).history[1]
+    assert (step.accepted, step.advanced) == (False, False)
+
+
+# --------------------------------------------------------------------------- the gate
+
+
+def test_without_trials_the_old_rule_is_kept_exactly() -> None:
+    """`trials=None` is every existing caller, and it has to be byte-identical.
+
+    The statistical gate is opt-in for the same reason the rest of this project's guards are: a
+    change that silently rewires a caller who did not ask for it is how a fix becomes an incident.
+    """
+    result = _search([0.500, 0.625])  # one scenario of difference, no trial count given
+    assert result.history[1].advanced is True
+    assert result.undecidable == ""
+
+
+def test_one_scenario_of_difference_no_longer_promotes() -> None:
+    """The defect itself. 4/8 against 5/8 is one coin, and it used to be a promotion."""
+    result = _search([0.500, 0.625], trials=SCENARIOS)
+    assert result.history[1].advanced is False
+    assert result.best.max_steps == 5
+
+
+def test_the_gate_says_when_no_candidate_could_have_won() -> None:
+    """"Nothing was promoted" and "nothing could have been promoted" are different sentences.
+
+    Against an incumbent already at 7/8, a **perfect** 8/8 still leaves the difference interval
+    touching zero — so a run that promotes nothing is not evidence about the candidates, and the
+    table alone cannot tell the two apart.
+    """
+    result = _search([0.875, 1.000], trials=SCENARIOS)
+    assert result.history[1].advanced is False
+    assert "no candidate can clear this gate" in result.undecidable
+    assert "8/8" in result.undecidable
+
+
+def test_a_decidable_gate_says_nothing() -> None:
+    """The control for the field above: it must not fire whenever the search simply found nothing.
+
+    With enough trials and a low incumbent, a perfect candidate *can* clear the bar, so the run is
+    a statement about the candidates again.
+    """
+    result = _search([0.100, 0.100], trials=400)
+    assert result.undecidable == ""
+
+
+def test_replication_is_what_makes_a_real_gain_detectable() -> None:
+    """The point of `--k`, stated as a test rather than as a claim in a docstring.
+
+    The same two pass rates — 0.750 against 0.958 — are undetectable over eight trials and
+    significant over forty. Nothing about the candidate changed; the sample did.
+    """
+    assert _search([0.750, 0.958], trials=SCENARIOS).history[1].advanced is False
+    assert _search([0.750, 0.958], trials=SCENARIOS * 5).history[1].advanced is True
+
+
+# --------------------------------------------------------------------------- the number that named the defect
+
+
+def test_a_candidate_identical_to_the_incumbent_stops_being_promoted() -> None:
+    """Simulated against the suite's own measured noise, because the defect was a rate, not a case.
+
+    Six of eight scenarios are frozen and two flip; with the two independent at p=2/3 the score
+    takes three values, and under the shipped `>` rule a NULL candidate — byte-identical to the
+    incumbent, which `model_proposer` really does return when the model's JSON does not parse —
+    was promoted whenever its coins landed better than the incumbent's. The rate is ~29.6%.
+
+    Under the gate it is zero, and that is the assertion: not "lower", zero. One coin cannot clear a
+    Newcombe interval at n=8 no matter how it lands.
+    """
+    rng = random.Random(20260910)
+
+    def draw() -> float:
+        return (6 + sum(rng.random() < 2 / 3 for _ in range(2))) / SCENARIOS
+
+    old = new = 0
+    for _ in range(4000):
+        incumbent, candidate = draw(), draw()
+        old += candidate > incumbent
+        new += _search([incumbent, candidate], trials=SCENARIOS).history[1].advanced
+
+    assert 0.24 < old / 4000 < 0.36, "the null promotion rate the old rule had, reproduced"
+    assert new == 0, "and no null candidate clears the interval, ever"


### PR DESCRIPTION
## What

`chimera evolve tune` selected on noise, and its table said "kept" about the wrong field. Two
defects, and the second is what hid the first.

## It selected on noise

`search_spec` promoted a candidate on `score > best_score` — a bare fraction over eight scenarios,
quantised in steps of 1/8, **six of which are saturated** (`bench/scenarios/RESULTS.md`). The score
is the reading of two coins.

And the scorer ran the suite **once**. `run_suite`'s own docstring says *"Run every scenario once"*,
while the sibling command that merely *measures* the same suite has taken `--k` with a default of 3
since it was written — *"one samples, two alert, three decide"*. **k=3 in the command that measures,
k=1 in the command that selects**, from the same module.

Simulated against the suite's measured noise (six scenarios frozen, two flipping at p≈2/3), a
candidate **byte-identical to the incumbent** cleared the old gate about **30%** of the time. That is
not a hypothetical candidate: `model_proposer` returns the same spec unchanged when the model's JSON
does not parse.

## And the table said "kept" about the wrong field

```python
accepted = score >= best_score   # what the column headed "kept" printed
if score > best_score:           # what actually replaced the incumbent
```

A **tie** — the most likely outcome against a saturated ruler — printed ✓ under "kept" over an
incumbent that had not moved. Now two columns, because they are two facts: "no regression" is a
report about the candidate, "kept" is a statement about the search.

## The gate

`search_spec` takes `trials=` and promotes only when the Newcombe interval for the difference in pass
rates excludes zero — `proportion_diff_ci` from `chimera/eval/anytime.py`. That module is already the
gate in `bench_ab`, `continuous`, `paired`, `auto_evolve` and `collective`, and its own docstring
measured this exact failure: *"best-of-3 accepted a candidate whose true pass rate was 0.3 **51.8%**
of the time, against 21.6% for a single candidate."* This was the one selection gate it had never
been pointed at.

`evolve tune` gains `--k` (default 3, matching the sibling). A suite pass costs about US$0.05, so k=3
is about US$0.42 for a default run — the replication was affordable all along; it was not wired.

## None of this makes the gate work

On the published numbers it promotes nothing, and **that is the correct output**. What it now also
does is *say* so: against an incumbent at 7/8, a **perfect** 8/8 candidate still leaves the difference
interval touching zero, so `SpecSearchResult.undecidable` carries the reason and the command prints
it. "Nothing was promoted" and "nothing could have been promoted" look identical in a table and call
for opposite responses — one is about the candidates, the other about the ruler.

Fixing the ruler is a separate, larger piece of work and is not attempted here.

## Verification

`ruff` clean · `mypy chimera` clean (350 files) · full suite in WSL from a clean copy:
**6082 passed, 0 failed**. `_cli_snapshot.json` and `docs/commands.md` regenerated for the new flag.

**`trials=None` keeps the old rule byte-identical** — asserted, not assumed, because every existing
caller of `search_spec` passes nothing. `tests/test_spec_search.py` is unchanged and green.

**Four sabotages, each red and restored** (baseline 9 passed):

| sabotage | red |
|---|---:|
| "kept" prints `accepted` again | 5 |
| the interval removed, the bare `>` back | 4 |
| the undecidable warning never fires | 1 |
| `k` ignored in the scorer | (its own family) |

The null-promotion rate is asserted as a **simulation against the suite's own measured noise**, not
as a claim: ~30% under the old rule, and **exactly zero** under the interval — one coin cannot clear
a Newcombe interval at n=8 however it lands.

## What this does not show

The simulation models the suite as six frozen scenarios plus two independent coins at p=2/3, which is
the shape `bench/scenarios/RESULTS.md` measured across seeds 1·2·3. The tuning gate runs at a **fixed
seed**, so that noise is transferred rather than measured there — the transfer is stated in the test's
docstring rather than hidden. What is measured at the fixed seed is that the noise survives it:
`count_lines` passed on seed 1 in the recorded run and failed on seed 1 in the replay.

Nothing here says whether `evolve tune` is worth running at all. It says the gate now reports what it
decided, and refuses to decide when it cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
