### PR TITLE
fix(catalog): three entries said what the index said on another day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Three catalogue entries said what the index said on another day.** The `-m integration` check that runs on `main` went red on the 0.53.0 commit: `glm-5.3-flash` had **doubled** to 0.15/0.50, `deepseek-chat-v3.1` read 0.25/0.95 against a catalogue 0.55/1.65, and `glm-4.6` promised a 204k window where the provider serves 198,000. The second is the interesting one — the note beside it argued *"a price does not halve and double back overnight, so the survey misread it"*, and the index has now done exactly that twice in a week: OpenRouter quotes whichever route it currently prefers, so a static figure for that model is right on some days by construction. All three carry today's readings and a note that says so; a receipt should be priced from the live index, and the table is the fallback.
+
+
 ## [0.53.0] - 2026-09-10
 
 ### Added

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -95,24 +95,36 @@ CATALOG: tuple[CatalogEntry, ...] = (
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-5.3-flash", "mid", "Zhipu (GLM)",
-        0.075, 0.25, tools=True, context_k=1048,
-        notes="the best price-to-index here by a distance: 0.075/0.25 with a third-party agentic index of 58.2, within a point of claude-opus-5 at 66x the input price. NOT the default, and the reason is measured: on the same one-file probe it took 257s against 72s for the slug above. Reach for it when the window or the index matters more than latency",
+        0.15, 0.50, tools=True, context_k=1048,
+        notes="a third-party agentic index of 58.2, within a point of claude-opus-5 at 33x the\n"
+        "        input price. Read 0.075/0.25 here until the live check on 2026-09-10 found it\n"
+        "        DOUBLED to 0.15/0.50 — still the best price-to-index in this tier, by half the\n"
+        "        margin the earlier note claimed. NOT the default, and the reason is measured: on\n"
+        "        the same one-file probe it took 257s against 72s for the slug above. Reach for it\n"
+        "        when the window or the index matters more than latency",
     ),
     CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
-        0.55, 1.65, tools=True, context_k=161,
-        notes="proven in this repo's benches. Priced 0.25/0.95 here for one day: a survey on\n"
-        "        2026-09-03 recorded that, and the live index on 2026-09-04 says 0.55/1.65 — the\n"
-        "        value it had before. A price does not halve and double back overnight, so the\n"
-        "        survey misread it. Restored, and the misreading is left in this note rather than\n"
-        "        deleted: it feeds `register_catalog_prices`, so every receipt for this model\n"
-        "        under-reported by 2.2x in and 1.7x out for as long as it stood. context_k is now\n"
+        0.25, 0.95, tools=True, context_k=161,
+        notes="proven in this repo's benches. This price OSCILLATES, and the note that used to\n"
+        "        stand here said it could not: a survey on 2026-09-03 read 0.25/0.95, the live\n"
+        "        index on 2026-09-04 read 0.55/1.65, and the reasoning 'a price does not halve and\n"
+        "        double back overnight, so the survey misread it' restored the higher figure. On\n"
+        "        2026-09-10 the index read 0.25/0.95 again — the thing the note said does not\n"
+        "        happen. OpenRouter quotes whichever route it currently prefers, and this model\n"
+        "        has more than one, so a static figure is right on some days by construction.\n"
+        "        Set to today's reading; a receipt for this model should be priced from the live\n"
+        "        index (`register_catalog_prices` is the fallback, not the source). context_k is\n"
         "        the window the provider SERVES (161k), not the 163,840 advertised",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-4.6", "mid", "Zhipu (GLM)",
-        0.55, 2.20, tools=True, context_k=204,
-        notes="strong agentic mid. Priced 0.50/2.00 here until a live check on 2026-09-03 measured\n        0.55/2.20 — this one went UP, which is the case a drift check has to be able to see:\n        anything written assuming prices only fall would have read this as still correct",
+        0.43, 1.75, tools=True, context_k=198,
+        notes="strong agentic mid. Priced 0.50/2.00 here until a live check on 2026-09-03 measured\n"
+        "        0.55/2.20 — UP, the case a drift check has to be able to see — and 0.43/1.75 on\n"
+        "        2026-09-10, down again. The window is the served 198,000 now: 204k was the\n"
+        "        advertised figure, and a catalogue window may be smaller than the provider's,\n"
+        "        never larger",
     ),
     CatalogEntry(
         "openrouter/google/gemini-2.5-flash", "mid", "Google",


### PR DESCRIPTION
## What went red on `89222aa`

The release commit shows **13 / 16** on GitHub. Fifteen real checks and one `verdict` job that only reads the others. Thirteen passed, `mutation testing` was skipped as designed, and **one** job failed: `live integration (real provider)` — the `-m integration` catalogue check that runs only on `main`, because it asks OpenRouter a question over the network. The verdict job went red because that one did. Nothing else on the commit failed, and the release workflows (PyPI, four installers, the manifest) were green.

Two tests, three entries:

| slug | catalogue | live 2026-09-10 | what |
|---|---|---|---|
| `z-ai/glm-5.3-flash` | 0.075 / 0.25 | **0.15 / 0.50** | doubled |
| `deepseek/deepseek-chat-v3.1` | 0.55 / 1.65 | **0.25 / 0.95** | halved — see below |
| `z-ai/glm-4.6` | 204k window | **198,000** served | promised more than the provider serves (price also 0.43/1.75, within tolerance) |

## The one worth reading

`deepseek-chat-v3.1` carried a note written on 2026-09-04: a survey had read 0.25/0.95 the day before, the index then read 0.55/1.65, and the note reasoned *"a price does not halve and double back overnight, so the survey misread it"* — and restored the higher figure.

The index has now halved and doubled back **twice in a week**. The survey did not misread anything: OpenRouter quotes whichever route it currently prefers, this model has more than one, and a static figure for it is right on some days by construction. The note now records that, and points at the live index as the source with the table as the fallback — which is what the catalogue's own header already says.

## Verification

- `pytest -m integration tests/test_catalog_is_live.py`: **7 passed** (was 2 failed, 5 passed).
- The ten offline files that read `CATALOG`: **186 passed**.
- `ruff` clean.

## Not changed

The 50% tolerance and the "window may be smaller, never larger" rule stay as they are — both did their job here. And a note for the release runbook, rather than a change: this job runs on `main` only, so the PR's green does not cover it. I published 0.53.0 off the PR's checks and the installer dry run without looking at the merge commit's own run; the failure does not gate a release, but it was there to be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
