### PR TITLE
fix(catalog): the default model's price reads today's index — 0.04/0.08, where the row said 0.065/0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **The default model's catalogue price said what the index said nine days ago.** The `-m integration` check that runs on `main` went red on the #442 merge commit: `deepseek-v4-flash-0731` read 0.065/0.18 in the catalogue and **0.04/0.08** on the live index — the same route-of-the-day movement #421 recorded for `deepseek-chat-v3.1`, now on the model that is the product default and the fusion judge. The row carries today's reading and a note that says both dates; a receipt should be priced from the live index, and the table is the fallback.
 - **Three catalogue entries said what the index said on another day.** The `-m integration` check that runs on `main` went red on the 0.53.0 commit: `glm-5.3-flash` had **doubled** to 0.15/0.50, `deepseek-chat-v3.1` read 0.25/0.95 against a catalogue 0.55/1.65, and `glm-4.6` promised a 204k window where the provider serves 198,000. The second is the interesting one — the note beside it argued *"a price does not halve and double back overnight, so the survey misread it"*, and the index has now done exactly that twice in a week: OpenRouter quotes whichever route it currently prefers, so a static figure for that model is right on some days by construction. All three carry today's readings and a note that says so; a receipt should be priced from the live index, and the table is the fallback.
 
 

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -90,8 +90,8 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-v4-flash-0731", "mid", "DeepSeek",
-        0.065, 0.18, tools=True, context_k=1048,
-        notes="the product default and the fusion judge since 2026-09-03. Same vendor as the chat-v3.1 it replaced, at 0.065/0.18 against 0.25/0.95 (3.8x cheaper in, 5.3x out) with eight times the window. Wrote a file on the first ask in a live probe, in 72s",
+        0.04, 0.08, tools=True, context_k=1048,
+        notes="the product default and the fusion judge since 2026-09-03. Same vendor as the chat-v3.1 it replaced, at a fraction of 0.25/0.95 with eight times the window. Wrote a file on the first ask in a live probe, in 72s. Price read off the index on 2026-09-12 (0.04/0.08); on 2026-09-03 it read 0.065/0.18 — OpenRouter quotes whichever route it prefers that day, so a receipt should be priced from the live index and this row is the fallback (#421)",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-5.3-flash", "mid", "Zhipu (GLM)",


### PR DESCRIPTION
## What

The `-m integration` check that runs on `main` went red on the #442 merge commit (`09c5b0a`): `deepseek-v4-flash-0731` — the product default and the fusion judge — read 0.065/0.18 in the catalogue and **0.04/0.08** on the live OpenRouter index (read 2026-09-12; the row's figure was read 2026-09-03). The same route-of-the-day movement #421 recorded for `deepseek-chat-v3.1`. The row now carries today's reading and a note naming both dates; a receipt should be priced from the live index, and the table is the fallback.

Not caused by #442, which touched `bench/` and the changelog only; the job runs on `main` and read the index on the day it ran.

## Verified

Catalogue tests green locally (127); full suite in WSL from a clean copy: **6306 passed, 18 skipped, 10 xfailed**; the live check itself runs on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)