### PR TITLE
chore(release): 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-09-12
+
 ### Added
 
 - **The blind panel's one-run lead did not replicate, and the judge series ends on two nulls.** #442 recorded, unregistered, that the blind panel scored 11 pp above the named one on facts the judge cannot recall; #444's bounded rerun on the same items took it to −0.9 pp. `bench/judge_blind_qa` addendum 2 is the fresh-sample test, registered with that in view: a second, disjoint slice of 400 SimpleQA questions, 40 items kept, 360 runs under the shipped engine, US$ 0.24 in all. `blind` − `named` per item **−1.3 pp**, [−8.3, +6.2] (9 items up, 12 down, 19 equal); pooled with the bounded first sample, 78 items, **−1.1 pp**, [−6.2, +3.8]. Vendor spread 8 pp with overlapping intervals, position flat, a vendor named in 2 of 240 analyses. All three registered predictions held; the observation is closed as not replicated; `blind_panel` keeps the justification it already had — zero cost on every corpus measured and effects that could not be shown on any of them. The series ends unless a corpus of a different kind is built: a prose turn where nothing is checkable, which this design cannot grade.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chimera-desktop"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chimera-desktop"
-version = "0.53.0"
+version = "0.54.0"
 description = "Chimera Agent — native desktop shell"
 authors = ["Bruno Campidelli"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Chimera",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "identifier": "app.chimera.desktop",
   "build": {
     "frontendDist": "../dist"

--- a/chimera/_benchmark_snapshot.json
+++ b/chimera/_benchmark_snapshot.json
@@ -54,7 +54,7 @@
       "treatment_rate": 0.025
     }
   ],
-  "generated_for": "0.53.0",
+  "generated_for": "0.54.0",
   "internal_lift": {
     "baseline_rate": 0.48,
     "ci": [

--- a/chimera/_cli_snapshot.json
+++ b/chimera/_cli_snapshot.json
@@ -5745,7 +5745,7 @@
       "path": "workflow"
     }
   ],
-  "generated_for": "0.53.0",
+  "generated_for": "0.54.0",
   "help": "Self-evolving AI agent with an LLM-Fusion reasoning core.",
   "name": "chimera"
 }

--- a/chimera/_maturity_snapshot.json
+++ b/chimera/_maturity_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_for": "0.53.0",
+  "generated_for": "0.54.0",
   "level": "GA",
   "proven": 37,
   "ratio": 1.0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "chimera-agent"
-version = "0.53.0"
+version = "0.54.0"
 description = "An open-source, self-evolving AI agent whose reasoning core is an LLM-Fusion engine (panel -> judge -> synthesizer)."
 readme = "README.md"
 # The bound stays, and its REASON changed. It used to track the litellm ceiling below (<1.92, which

--- a/uv.lock
+++ b/uv.lock
@@ -496,7 +496,7 @@ wheels = [
 
 [[package]]
 name = "chimera-agent"
-version = "0.53.0"
+version = "0.54.0"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
Version bump to `0.54.0` (`0.54.0` for the desktop shell).

Cut by `scripts/cut_release.py`: the three snapshots are regenerated rather than string-replaced, and the script refuses to continue if they come out stamped for a different version than the one being cut.

Merging this changes numbers in the repository. Publishing is a separate act: create the GitHub Release afterwards, which is what triggers the wheel and the installers.
