### PR TITLE
fix(catalog): a row knows every price the index has quoted for it, and the live check stops reddening on the flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A catalogue row knows every price the index has quoted for it, and the live check stops reddening on the flip.** Three release days in a row the `-m integration` check on `main` went red because OpenRouter quotes whichever route it prefers that day and a slug served by two providers flips between two prices: `deepseek-chat-v3.1` (#421), `deepseek-v4-flash-0731` (#443), and `glm-5.3-flash` twice on 2026-09-12 alone — 0.15 in the morning, 0.075 by the release. Updating the figure each time was the wrong fix. `CatalogEntry.also_seen` carries the other (input, output) prices a row has been seen at; the live check accepts any of them and still reddens on a price the row has never seen. The three rows carry their history; a receipt is priced from the live index and the row is the fallback, as before.
+
 ## [0.54.0] - 2026-09-12
 
 ### Added

--- a/chimera/providers/catalog.py
+++ b/chimera/providers/catalog.py
@@ -41,7 +41,29 @@ class CatalogEntry:
     context_k: int
     """Approximate context window, thousands of tokens."""
     notes: str = ""
+    also_seen: tuple[tuple[float, float], ...] = ()
+    """Other (input, output) prices the live index has quoted for this slug on other days.
 
+    OpenRouter quotes whichever route it prefers that day, and a slug served by two providers at
+    two prices flips between them — `deepseek-chat-v3.1` on 2026-09-04 and 2026-09-10,
+    `glm-5.3-flash` twice on 2026-09-12 alone. A row that carries only today's figure is right on
+    some days by construction, and the live check went red on three release days for it. The row
+    now names every price it has been seen at; the live check accepts any of them, and still
+    reddens on a price the row has never seen. A receipt is priced from the live index; the row
+    is the fallback."""
+
+
+
+def price_is_known(entry: CatalogEntry, live_input_per_m: float, *, tolerance: float = 0.5) -> bool:
+    """Whether a live input price is within `tolerance` of any price this row has been seen at.
+
+    The live check's question. `entry.input_per_m` first, then every `also_seen` price; a price
+    outside ±tolerance (as a ratio band `[1 - tolerance/1.5, 1 + tolerance]`, i.e. 0.67–1.5 at the
+    default) of all of them is one the row has never seen, and that is what the check is for.
+    """
+    lo, hi = 1 - tolerance / 1.5, 1 + tolerance
+    known = [entry.input_per_m, *(seen[0] for seen in entry.also_seen)]
+    return any(k is not None and k > 0 and lo <= live_input_per_m / k <= hi for k in known)
 
 # Curated multi-vendor suggestions per tier. DATA ONLY — extend/correct freely; `chimera models`
 # renders this and `resolve_tiers` picks defaults from it.
@@ -90,12 +112,12 @@ CATALOG: tuple[CatalogEntry, ...] = (
     # --- mid: the daily workhorses. Reliable tools, cents per task. ---
     CatalogEntry(
         "openrouter/deepseek/deepseek-v4-flash-0731", "mid", "DeepSeek",
-        0.04, 0.08, tools=True, context_k=1048,
+        0.04, 0.08, tools=True, context_k=1048, also_seen=((0.065, 0.18),),
         notes="the product default and the fusion judge since 2026-09-03. Same vendor as the chat-v3.1 it replaced, at a fraction of 0.25/0.95 with eight times the window. Wrote a file on the first ask in a live probe, in 72s. Price read off the index on 2026-09-12 (0.04/0.08); on 2026-09-03 it read 0.065/0.18 — OpenRouter quotes whichever route it prefers that day, so a receipt should be priced from the live index and this row is the fallback (#421)",
     ),
     CatalogEntry(
         "openrouter/z-ai/glm-5.3-flash", "mid", "Zhipu (GLM)",
-        0.15, 0.50, tools=True, context_k=1048,
+        0.15, 0.50, tools=True, context_k=1048, also_seen=((0.075, 0.25),),
         notes="a third-party agentic index of 58.2, within a point of claude-opus-5 at 33x the\n"
         "        input price. Read 0.075/0.25 here until the live check on 2026-09-10 found it\n"
         "        DOUBLED to 0.15/0.50 — still the best price-to-index in this tier, by half the\n"
@@ -105,7 +127,7 @@ CATALOG: tuple[CatalogEntry, ...] = (
     ),
     CatalogEntry(
         "openrouter/deepseek/deepseek-chat-v3.1", "mid", "DeepSeek",
-        0.25, 0.95, tools=True, context_k=161,
+        0.25, 0.95, tools=True, context_k=161, also_seen=((0.55, 1.65),),
         notes="proven in this repo's benches. This price OSCILLATES, and the note that used to\n"
         "        stand here said it could not: a survey on 2026-09-03 read 0.25/0.95, the live\n"
         "        index on 2026-09-04 read 0.55/1.65, and the reasoning 'a price does not halve and\n"

--- a/tests/test_a_catalogue_row_knows_its_other_price.py
+++ b/tests/test_a_catalogue_row_knows_its_other_price.py
@@ -1,0 +1,36 @@
+"""A catalogue row carries every price the live index has quoted for it, and the live check accepts
+any of them — a slug served by two routes flips between two figures, and three release days went
+red on the flip (#421, #443, and `glm-5.3-flash` twice on 2026-09-12). The check is for a price the
+row has never seen."""
+
+from __future__ import annotations
+
+from chimera.providers.catalog import CATALOG, CatalogEntry, price_is_known
+
+
+def _row(**kw: object) -> CatalogEntry:
+    base: dict[str, object] = {"slug": "x/y", "tier": "mid", "vendor": "v", "input_per_m": 0.15,
+                               "output_per_m": 0.5, "tools": True, "context_k": 100}
+    base.update(kw)
+    return CatalogEntry(**base)  # type: ignore[arg-type]
+
+
+def test_the_catalogue_price_itself_is_known_within_the_band() -> None:
+    assert price_is_known(_row(), 0.15)
+    assert price_is_known(_row(), 0.11)  # 0.73x
+    assert not price_is_known(_row(), 0.075)  # exactly the halving that reddened the check
+
+
+def test_an_also_seen_price_is_known_and_an_unseen_one_is_not() -> None:
+    row = _row(also_seen=((0.075, 0.25),))
+    assert price_is_known(row, 0.075)
+    assert price_is_known(row, 0.15)
+    assert not price_is_known(row, 0.02)
+    assert not price_is_known(row, 0.40)
+
+
+def test_the_three_flipping_rows_carry_their_history() -> None:
+    by = {e.slug: e for e in CATALOG}
+    assert price_is_known(by["openrouter/z-ai/glm-5.3-flash"], 0.075)
+    assert price_is_known(by["openrouter/deepseek/deepseek-chat-v3.1"], 0.55)
+    assert price_is_known(by["openrouter/deepseek/deepseek-v4-flash-0731"], 0.065)

--- a/tests/test_catalog_is_live.py
+++ b/tests/test_catalog_is_live.py
@@ -114,7 +114,7 @@ def test_the_catalogue_prices_are_not_wildly_stale(live_slugs: set[str]) -> None
     anyway, and this file is `-m integration`, so a real market move reddens a run somebody chose
     rather than the build.
     """
-    from chimera.providers.catalog import CATALOG
+    from chimera.providers.catalog import CATALOG, price_is_known
 
     live = {m.slug: m for m in openrouter_models()[0]}
     wrong: list[str] = []
@@ -126,7 +126,10 @@ def test_the_catalogue_prices_are_not_wildly_stale(live_slugs: set[str]) -> None
         # knowing and cannot be expressed as a ratio.
         if (entry.input_per_m == 0) != (current.input_per_m == 0):
             wrong.append(f"{entry.slug}: {entry.input_per_m} vs {current.input_per_m} (free tier changed)")
-        elif entry.input_per_m > 0 and not (0.67 <= current.input_per_m / entry.input_per_m <= 1.5):
+        elif entry.input_per_m > 0 and not price_is_known(entry, current.input_per_m):
+            # Any price the row has been seen at passes (`CatalogEntry.also_seen`): a slug served by
+            # two routes flips between two figures, and the check is for a price the row has never
+            # seen, not for the flip.
             wrong.append(f"{entry.slug}: catalogue {entry.input_per_m}, live {current.input_per_m}")
     assert not wrong, f"catalogue prices are off by more than half: {wrong}"
 


### PR DESCRIPTION
## What

Three release days in a row the `-m integration` check on `main` went red because OpenRouter quotes whichever route it prefers that day, and a slug served by two providers flips between two prices: `deepseek-chat-v3.1` (#421), `deepseek-v4-flash-0731` (#443), and `glm-5.3-flash` **twice on 2026-09-12** — 0.15 in the morning, 0.075 by the time 0.54.0 was cut (red on the #447 and #448 merge commits). Updating the figure each time was the wrong fix.

- `CatalogEntry.also_seen`: the other (input, output) prices a row has been seen at. The three rows carry their history.
- `price_is_known(entry, live)`: the live check's question, extracted — any price the row has been seen at passes (0.67–1.5×), and a price the row has never seen still reddens, which is what the check is for.
- A receipt is priced from the live index; the row is the fallback, as before.

## Verified

`tests/test_a_catalogue_row_knows_its_other_price.py` (3): the catalogue price within the band, an also-seen price known and an unseen one not, the three flipping rows carrying their history. The live check itself passes locally against today's index (7 passed). Full suite in WSL from a clean copy: **6323 passed, 18 skipped, 10 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)